### PR TITLE
frontend-utils: Add bundle player options

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 /// Controls whether the content is letterboxed or pillarboxed when the
 /// player's aspect ratio does not match the movie's aspect ratio.
@@ -20,6 +21,22 @@ pub enum Letterbox {
     /// The content will always be letterboxed.
     #[serde(rename = "on")]
     On,
+}
+
+pub struct ParseEnumError;
+
+impl FromStr for Letterbox {
+    type Err = ParseEnumError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let letterbox = match s {
+            "off" => Letterbox::Off,
+            "fullscreen" => Letterbox::Fullscreen,
+            "on" => Letterbox::On,
+            _ => return Err(ParseEnumError),
+        };
+        Ok(letterbox)
+    }
 }
 
 /// The networking API access mode of the Ruffle player.

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -970,11 +970,11 @@ impl FromStr for StageScaleMode {
     type Err = ParseEnumError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let scale_mode = match s.to_ascii_lowercase().as_str() {
-            "exactfit" => StageScaleMode::ExactFit,
-            "noborder" => StageScaleMode::NoBorder,
-            "noscale" => StageScaleMode::NoScale,
-            "showall" => StageScaleMode::ShowAll,
+        let scale_mode = match s {
+            "exact_fit" => StageScaleMode::ExactFit,
+            "no_border" => StageScaleMode::NoBorder,
+            "no_scale" => StageScaleMode::NoScale,
+            "show_all" => StageScaleMode::ShowAll,
             _ => return Err(ParseEnumError),
         };
         Ok(scale_mode)
@@ -1082,21 +1082,21 @@ bitflags! {
 }
 
 impl FromStr for StageAlign {
-    type Err = std::convert::Infallible;
+    type Err = ParseEnumError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Chars get converted into flags.
-        // This means "tbbtlbltblbrllrbltlrtbl" is valid, resulting in "TBLR".
-        let mut align = StageAlign::default();
-        for c in s.bytes().map(|c| c.to_ascii_uppercase()) {
-            match c {
-                b'T' => align.insert(StageAlign::TOP),
-                b'B' => align.insert(StageAlign::BOTTOM),
-                b'L' => align.insert(StageAlign::LEFT),
-                b'R' => align.insert(StageAlign::RIGHT),
-                _ => (),
-            }
-        }
+        let align = match s {
+            "bottom" => StageAlign::BOTTOM,
+            "bottom_left" => StageAlign::BOTTOM | StageAlign::LEFT,
+            "bottom_right" => StageAlign::BOTTOM | StageAlign::RIGHT,
+            "left" => StageAlign::LEFT,
+            "right" => StageAlign::RIGHT,
+            "top" => StageAlign::TOP,
+            "top_left" => StageAlign::TOP | StageAlign::LEFT,
+            "top_right" => StageAlign::TOP | StageAlign::RIGHT,
+            "center" => StageAlign::empty(),
+            _ => return Err(ParseEnumError),
+        };
         Ok(align)
     }
 }

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -36,6 +36,7 @@ use ruffle_render::utils::{determine_jpeg_tag_format, JpegTagFormat};
 use slotmap::{new_key_type, SlotMap};
 use std::borrow::Borrow;
 use std::fmt;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 use swf::read::{extract_swz, read_compression_type};
@@ -72,6 +73,22 @@ pub enum LoadBehavior {
     /// done synchronously. Complex movies will visibly block the player from
     /// accepting user input and the application will appear to freeze.
     Blocking,
+}
+
+pub struct ParseEnumError;
+
+impl FromStr for LoadBehavior {
+    type Err = ParseEnumError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let behavior = match s {
+            "streaming" => LoadBehavior::Streaming,
+            "delayed" => LoadBehavior::Delayed,
+            "blocking" => LoadBehavior::Blocking,
+            _ => return Err(ParseEnumError),
+        };
+        Ok(behavior)
+    }
 }
 
 /// Enumeration of all content types that `Loader` can handle.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2772,7 +2772,7 @@ impl FromStr for PlayerRuntime {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let player_runtime = match s {
             "air" => PlayerRuntime::AIR,
-            "flashPlayer" => PlayerRuntime::FlashPlayer,
+            "flash_player" => PlayerRuntime::FlashPlayer,
             _ => return Err(ParseEnumError),
         };
         Ok(player_runtime)

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -84,7 +84,7 @@ pub struct Opt {
     pub quality: Option<StageQuality>,
 
     /// The alignment of the stage.
-    #[clap(long, short)]
+    #[clap(long, short, value_parser(parse_align))]
     pub align: Option<StageAlign>,
 
     /// Prevent movies from changing the stage alignment.
@@ -216,6 +216,12 @@ fn parse_movie_file_or_url(path: &str) -> Result<Url, Error> {
 
 fn parse_duration_seconds(value: &str) -> Result<Duration, Error> {
     Ok(Duration::from_secs_f64(value.parse()?))
+}
+
+fn parse_align(value: &str) -> Result<StageAlign, Error> {
+    value
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid stage alignment"))
 }
 
 fn parse_gamepad_button(mapping: &str) -> Result<(GamepadButton, KeyCode), Error> {

--- a/frontend-utils/src/bundle.rs
+++ b/frontend-utils/src/bundle.rs
@@ -148,7 +148,8 @@ mod tests {
         assert_eq!(
             BundleInformation {
                 name: "Cool Game!".to_string(),
-                url: Url::parse("file:///game.swf").unwrap()
+                url: Url::parse("file:///game.swf").unwrap(),
+                player: Default::default(),
             },
             result.information
         );

--- a/frontend-utils/src/bundle/README.md
+++ b/frontend-utils/src/bundle/README.md
@@ -12,6 +12,23 @@ A bundle can be a directory or a renamed zip file, and must contain at minimum a
     * [`[bundle]`](#bundle)
       * [`name` - The name of the bundle](#name---the-name-of-the-bundle)
       * [`url` - The url of the Flash content to open](#url---the-url-of-the-flash-content-to-open)
+    * [`[player]`](#player)
+      * [`[parameters]` - A list of parameters to pass to the starting movie](#parameters---a-list-of-parameters-to-pass-to-the-starting-movie)
+      * [`script_timeout` - Script execution timeout](#script_timeout---script-execution-timeout)
+      * [`base_url` - Base URL for relative file paths](#base_url---base-url-for-relative-file-paths)
+      * [`quality` - Quality that the content starts with](#quality---quality-that-the-content-starts-with)
+      * [`align` - Stage Alignment that the content starts with](#align---stage-alignment-that-the-content-starts-with)
+      * [`force_align` - Allow or disallow the content from changing its Stage Alignment](#force_align---allow-or-disallow-the-content-from-changing-its-stage-alignment)
+      * [`scale_mode` - Stage Scale Mode that the content starts with](#scale_mode---stage-scale-mode-that-the-content-starts-with)
+      * [`force_scale_mode` - Allow or disallow the content from changing its Stage Alignment](#force_scale_mode---allow-or-disallow-the-content-from-changing-its-stage-alignment)
+      * [`upgrade_http_to_https` - Whether to upgrade HTTP urls to HTTPS silently](#upgrade_http_to_https---whether-to-upgrade-http-urls-to-https-silently)
+      * [`load_behavior` - How Ruffle should load movies](#load_behavior---how-ruffle-should-load-movies)
+      * [`letterbox` - Controls visual letterboxing around the content](#letterbox---controls-visual-letterboxing-around-the-content)
+      * [`spoof_url` - URL to pretend the initial SWF is being loaded from](#spoof_url---url-to-pretend-the-initial-swf-is-being-loaded-from)
+      * [`version` - Version of the Flash Player to emulate](#version---version-of-the-flash-player-to-emulate)
+      * [`runtime` - Which type of runtime to emulate](#runtime---which-type-of-runtime-to-emulate)
+      * [`frame_rate` - Override the target frame rate of this movie](#frame_rate---override-the-target-frame-rate-of-this-movie)
+      * [`mock_external_interface` - Provide a mocked ExternalInterface](#mock_external_interface---provide-a-mocked-externalinterface)
 <!-- TOC -->
 
 ## Directory structure
@@ -62,3 +79,155 @@ This way, an internet connection is not required, and the bundle won't stop work
 
 Remember - the `content/` directory is accessible through `file:///` - so if you have a game at `content/game.swf`, you'll want to use `url = "file:///game.swf"`.
 
+
+### `[player]`
+This section contains player options, which change how Ruffle emulates the content in this bundle.
+
+These options may be overridden by users.
+
+#### `[parameters]` - A list of parameters to pass to the starting movie
+These are sometimes also called 'FlashVars' by Flash developers. This is appended to any parameters given in the query string of the `bundle.url`.
+
+All values must be strings.
+
+Example:
+```toml
+[player.parameters]
+key = "value"
+favourite_number = "5"
+```
+
+#### `script_timeout` - Script execution timeout
+How long a single script execution (e.g. a frame of ActionScript 3) can take, before it's considered to be stuck or broken.
+Value should be in seconds - fractional values are allowed.
+
+Example with a 5-second limit on scripts:
+```toml
+[player]
+script_timeout = 5
+```
+
+#### `base_url` - Base URL for relative file paths
+By default, this is the `bundle.url`, but some content may require something else.
+
+When content looks up a **relative** path, as opposed to an absolute path, it makes it relative to this base url instead.
+
+Example:
+```toml
+[player]
+base_url = "https://example.org"
+```
+
+#### `quality` - Quality that the content starts with
+The movie has the capacity to change this automatically at runtime, and the user may also change it at will.
+The default value generally depends on the users hardware, and it's advisable to leave it to do so unless content requires
+a specific quality for aesthetics.
+
+Whilst Flash [does technically support many quality modes](https://web.archive.org/web/20240420201659/https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display/StageQuality.html);
+Ruffle currently only implements `low`, `medium` and `high`.
+
+Example:
+```toml
+[player]
+quality = "low"
+```
+
+#### `align` - Stage Alignment that the content starts with
+The movie has the capacity to change this automatically at runtime, unless `player.force_align` is set to `true`.
+
+This controls the position of the movie after scaling to fill the viewport.
+
+This may be one of the following values:
+- `bottom`: Specifies that the Stage is aligned at the bottom.
+- `bottom_left`: Specifies that the Stage is aligned in the bottom-left corner.
+- `bottom_right`: Specifies that the Stage is aligned in the bottom-right corner.
+- `left`: Specifies that the Stage is aligned on the left.
+- `right`: Specifies that the Stage is aligned to the right.
+- `top`: Specifies that the Stage is aligned at the top.
+- `top_left`: Specifies that the Stage is aligned in the top-left corner.
+- `top_right`: Specifies that the Stage is aligned in the top-right corner.
+- `center` (Default): Specified that the Stage is aligned in the center.
+
+Example:
+```toml
+[player]
+align = "bottom_right"
+```
+
+#### `force_align` - Allow or disallow the content from changing its Stage Alignment
+If set to `true`, content may not change its own Stage Alignment value (see `player.align`). Default is `false`.
+
+#### `scale_mode` - Stage Scale Mode that the content starts with
+The movie has the capacity to change this automatically at runtime, unless `player.force_scale_mode` is set to `true`.
+
+This controls the behavior when the player viewport size differs from the SWF size.
+
+This may be one of the following values:
+- `exact_fit`: The movie will be stretched to fit the container.
+- `no_border`: The movie will maintain its aspect ratio, but will be cropped.
+- `no_scale`: The movie is not scaled to fit the container, and the content is assumed to adjust itself with scripts.
+- `show_all` (Default): The movie will scale to fill the container and maintain its aspect ratio, but will be letterboxed.
+
+Example:
+```toml
+[player]
+scale_mode = "no_border"
+```
+
+#### `force_scale_mode` - Allow or disallow the content from changing its Stage Alignment
+If set to `true`, content may not change its own Stage Scale Mode value (see `player.scale_mode`). Default is `false`.
+
+#### `upgrade_http_to_https` - Whether to upgrade HTTP urls to HTTPS silently
+If `true`, all `http://` URLs will be replaced with `https://`.
+
+#### `load_behavior` - How Ruffle should load movies
+Some movies expect to be streamed, or expect to load instantly. This allows you to work around any potential issues by
+forcing a specific loading behaviour.
+
+This may be one of the following values:
+- `streaming` (Default): Allow movies to execute before they have finished loading.
+- `delayed`: Delay execution of loaded movies until they have finished loading.
+- `blocking`: Block Ruffle until movies have finished loading.
+
+#### `letterbox` - Controls visual letterboxing around the content
+If the contents aspect ratio does not match the players aspect ratio, Ruffle may put up letterboxes for aesthetics and
+to hide objects that perhaps should not be visible.
+
+This may be one of the following values:
+- `off`: The content will not be letterboxed, everything will be visible.
+- `fullscreen`: The content will only be letterboxed if viewed in Full Screen and the aspect ratio doesn't match.
+- `on` (Default): The content will always be letterboxed if the aspect ratio doesn't match.
+
+#### `spoof_url` - URL to pretend the initial SWF is being loaded from
+If set to a valid URL, we will **pretend** that the `bundle.url` SWF is actually being loaded from this location instead.
+This is often required for site locks that check if the content is being loaded from the original domain.
+
+We do not *actually* load the URL, and all other assets/SWFs are not affected.
+
+#### `version` - Version of the Flash Player to emulate
+Whilst it's not common, some content depends on behaviour from specific Flash Players. You may set this to force Ruffle
+to try and emulate that behaviour.
+
+Default is likely to be `32`, but may be subject to change.
+
+#### `runtime` - Which type of runtime to emulate
+Unfortunately content does not indicate which runtime it wants, so if there's AIR content it must be called out by setting
+this value appropriately.
+
+This may be one of the following values:
+- `flash_player` (Default): The original Flash Player, no thrills.
+- `air`: The Adobe AIR runtime, an extension of Flash Player with more native capabilities.
+
+#### `frame_rate` - Override the target frame rate of this movie
+If set, the movies preferred frame rate is ignored and this value is used instead.
+May be used to speed up or slow down movies, but some content keeps its own time tracking and may not be affected. Value can both be an integer and a fractional value.
+
+Example:
+```toml
+[player]
+frame_rate = 30.0
+```
+
+#### `mock_external_interface` - Provide a mocked ExternalInterface
+Some content used JavaScript calls to query things like the page URL. By setting this value to `true`, Ruffle will provide
+a mocked up ExternalInterface that responds to some of the common JavaScript calls appropriately.

--- a/frontend-utils/src/parse.rs
+++ b/frontend-utils/src/parse.rs
@@ -245,6 +245,25 @@ pub trait ReadExt<'a> {
 
         result
     }
+
+    /// Similar to [`ReadExt::get_float`], but also returns integers as floats.
+    fn get_float_like(&'a self, cx: &mut ParseContext, key: &'static str) -> Option<f64> {
+        let mut result = None;
+        cx.push_key(key);
+
+        if let Some(item) = self.get_impl(key) {
+            if let Some(float) = item.as_float() {
+                result = Some(float);
+            } else if let Some(integer) = item.as_integer() {
+                result = Some(integer as f64)
+            } else {
+                cx.unexpected_type("float or integer", item.type_name());
+            }
+        }
+
+        cx.pop_key();
+        result
+    }
 }
 
 /// Extension trait to provide casting methods with warning capabilities.

--- a/frontend-utils/src/player_options.rs
+++ b/frontend-utils/src/player_options.rs
@@ -1,3 +1,6 @@
+mod read;
+pub use read::read_player_options;
+
 use ruffle_core::config::Letterbox;
 use ruffle_core::{LoadBehavior, PlayerRuntime, StageAlign, StageScaleMode};
 use ruffle_render::quality::StageQuality;

--- a/frontend-utils/src/player_options/read.rs
+++ b/frontend-utils/src/player_options/read.rs
@@ -1,0 +1,739 @@
+use crate::parse::{ItemExt, ParseContext, ReadExt};
+use crate::player_options::PlayerOptions;
+use std::time::Duration;
+use toml_edit::TableLike;
+
+pub fn read_player_options<'a>(
+    cx: &mut ParseContext<'a>,
+    table: &'a dyn TableLike,
+) -> PlayerOptions {
+    let mut result = PlayerOptions::default();
+
+    // Parameters (FlashVars) key-value table, all values must be strings.
+    table.get_table_like(cx, "parameters", |cx, parameters| {
+        for (key, value) in parameters.iter() {
+            cx.push_key(key);
+
+            if let Some(value) = value.as_str_or_warn(cx) {
+                result.parameters.push((key.to_owned(), value.to_owned()));
+            }
+
+            cx.pop_key();
+        }
+    });
+
+    // Script timeout in seconds (fractional-values are allowed)
+    result.max_execution_duration = table
+        .get_float_like(cx, "script_timeout")
+        .map(Duration::from_secs_f64);
+
+    // Base Url
+    result.base = table.parse_from_str(cx, "base_url");
+
+    // Quality
+    result.quality = table.parse_from_str(cx, "quality");
+
+    // Align
+    result.align = table.parse_from_str(cx, "align");
+
+    // Force Align
+    result.force_align = table.get_bool(cx, "force_align");
+
+    // Scale Mode
+    result.scale = table.parse_from_str(cx, "scale_mode");
+
+    // Force Scale Mode
+    result.force_scale = table.get_bool(cx, "force_scale_mode");
+
+    // Upgrade HTTP to HTTPS
+    result.upgrade_to_https = table.get_bool(cx, "upgrade_http_to_https");
+
+    // Load Behavior
+    result.load_behavior = table.parse_from_str(cx, "load_behavior");
+
+    // Letterbox
+    result.letterbox = table.parse_from_str(cx, "letterbox");
+
+    // Spoof Url
+    result.spoof_url = table.parse_from_str(cx, "spoof_url");
+
+    // Player version
+    result.player_version = table.get_integer(cx, "version").map(|x| x as u8);
+
+    // Player runtime
+    result.player_runtime = table.parse_from_str(cx, "runtime");
+
+    // Frame rate
+    result.frame_rate = table.get_float_like(cx, "frame_rate");
+
+    // Mock external interface
+    result.dummy_external_interface = table.get_bool(cx, "mock_external_interface");
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::{DocumentHolder, ParseDetails, ParseWarning};
+    use ruffle_core::config::Letterbox;
+    use ruffle_core::{LoadBehavior, PlayerRuntime, StageAlign, StageScaleMode};
+    use ruffle_render::quality::StageQuality;
+    use toml_edit::DocumentMut;
+    use url::Url;
+
+    fn read(input: &str) -> ParseDetails<PlayerOptions> {
+        let doc = input
+            .parse::<DocumentMut>()
+            .expect("Test input should be valid TOML");
+        let mut cx = ParseContext::default();
+
+        let options = read_player_options(&mut cx, doc.as_table());
+
+        ParseDetails {
+            warnings: cx.warnings,
+            result: DocumentHolder::new(options, doc),
+        }
+    }
+
+    #[test]
+    fn empty() {
+        let result = read("");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn parameters() {
+        let result = read("[parameters]");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+        let result = read(
+            r#"
+        [parameters]
+        value1 = "a_very_interesting_value"
+        value2 = true
+        "#,
+        );
+        assert_eq!(
+            &PlayerOptions {
+                parameters: vec![("value1".to_string(), "a_very_interesting_value".to_string())],
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "boolean",
+                path: "parameters.value2".to_string()
+            }],
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn script_timeout() {
+        let result = read("script_timeout = true");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "float or integer",
+                actual: "boolean",
+                path: "script_timeout".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("script_timeout = 5");
+        assert_eq!(
+            &PlayerOptions {
+                max_execution_duration: Some(Duration::from_secs(5)),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+        let result = read("script_timeout = 1.5");
+        assert_eq!(
+            &PlayerOptions {
+                max_execution_duration: Some(Duration::from_secs_f64(1.5)),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn base_url() {
+        let result = read("base_url = false");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "boolean",
+                path: "base_url".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("base_url = \"invalid\"");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnsupportedValue {
+                value: "invalid".to_string(),
+                path: "base_url".to_string(),
+            }],
+            result.warnings
+        );
+
+        let result = read("base_url = \"file:///example/path/\"");
+        assert_eq!(
+            &PlayerOptions {
+                base: Some(Url::parse("file:///example/path/").unwrap()),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn quality() {
+        let result = read("quality = false");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "boolean",
+                path: "quality".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("quality = \"fabulous\"");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnsupportedValue {
+                value: "fabulous".to_string(),
+                path: "quality".to_string(),
+            }],
+            result.warnings
+        );
+
+        fn assert_variant(variant: &str, quality: StageQuality) {
+            let result = read(&format!("quality = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    quality: Some(quality),
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+            // Check case-sensitivity.
+            let variant = variant.to_ascii_uppercase();
+            let result = read(&format!("quality = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    quality: None,
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(
+                vec![ParseWarning::UnsupportedValue {
+                    value: variant,
+                    path: "quality".to_string()
+                }],
+                result.warnings
+            );
+        }
+        assert_variant("high", StageQuality::High);
+        assert_variant("medium", StageQuality::Medium);
+        assert_variant("low", StageQuality::Low);
+    }
+
+    #[test]
+    fn align() {
+        let result = read("align = 1.0");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "float",
+                path: "align".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("align = \"corner\"");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnsupportedValue {
+                value: "corner".to_string(),
+                path: "align".to_string(),
+            }],
+            result.warnings
+        );
+
+        fn assert_variant(variant: &str, align: StageAlign) {
+            let result = read(&format!("align = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    align: Some(align),
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+            // Check case-sensitivity.
+            let variant = variant.to_ascii_uppercase();
+            let result: ParseDetails<PlayerOptions> = read(&format!("align = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    align: None,
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(
+                vec![ParseWarning::UnsupportedValue {
+                    value: variant,
+                    path: "align".to_string()
+                }],
+                result.warnings
+            );
+        }
+        assert_variant("bottom", StageAlign::BOTTOM);
+        assert_variant("bottom_left", StageAlign::BOTTOM | StageAlign::LEFT);
+        assert_variant("bottom_right", StageAlign::BOTTOM | StageAlign::RIGHT);
+        assert_variant("left", StageAlign::LEFT);
+        assert_variant("right", StageAlign::RIGHT);
+        assert_variant("top", StageAlign::TOP);
+        assert_variant("top_left", StageAlign::TOP | StageAlign::LEFT);
+        assert_variant("top_right", StageAlign::TOP | StageAlign::RIGHT);
+        assert_variant("center", StageAlign::empty())
+    }
+
+    #[test]
+    fn force_align() {
+        let result = read("force_align = 1");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "boolean",
+                actual: "integer",
+                path: "force_align".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("force_align = true");
+        assert_eq!(
+            &PlayerOptions {
+                force_align: Some(true),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn scale_mode() {
+        let result = read("scale_mode = true");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "boolean",
+                path: "scale_mode".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("scale_mode = \"invalid\"");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnsupportedValue {
+                value: "invalid".to_string(),
+                path: "scale_mode".to_string(),
+            }],
+            result.warnings
+        );
+
+        fn assert_variant(variant: &str, scale: StageScaleMode) {
+            let result = read(&format!("scale_mode = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    scale: Some(scale),
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+            // Check case-sensitivity.
+            let variant = variant.to_ascii_uppercase();
+            let result = read(&format!("scale_mode = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    scale: None,
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(
+                vec![ParseWarning::UnsupportedValue {
+                    value: variant,
+                    path: "scale_mode".to_string()
+                }],
+                result.warnings
+            );
+        }
+        assert_variant("exact_fit", StageScaleMode::ExactFit);
+        assert_variant("no_border", StageScaleMode::NoBorder);
+        assert_variant("no_scale", StageScaleMode::NoScale);
+        assert_variant("show_all", StageScaleMode::ShowAll);
+    }
+
+    #[test]
+    fn force_scale_mode() {
+        let result = read("force_scale_mode = 1");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "boolean",
+                actual: "integer",
+                path: "force_scale_mode".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("force_scale_mode = true");
+        assert_eq!(
+            &PlayerOptions {
+                force_scale: Some(true),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn upgrade_http_to_https() {
+        let result = read("upgrade_http_to_https = 1");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "boolean",
+                actual: "integer",
+                path: "upgrade_http_to_https".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("upgrade_http_to_https = true");
+        assert_eq!(
+            &PlayerOptions {
+                upgrade_to_https: Some(true),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn load_behavior() {
+        let result = read("load_behavior = true");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "boolean",
+                path: "load_behavior".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("load_behavior = \"fast\"");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnsupportedValue {
+                value: "fast".to_string(),
+                path: "load_behavior".to_string(),
+            }],
+            result.warnings
+        );
+
+        fn assert_variant(variant: &str, behavior: LoadBehavior) {
+            let result = read(&format!("load_behavior = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    load_behavior: Some(behavior),
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+            // Check case-sensitivity.
+            let variant = variant.to_ascii_uppercase();
+            let result = read(&format!("load_behavior = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    load_behavior: None,
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(
+                vec![ParseWarning::UnsupportedValue {
+                    value: variant,
+                    path: "load_behavior".to_string()
+                }],
+                result.warnings
+            );
+        }
+        assert_variant("streaming", LoadBehavior::Streaming);
+        assert_variant("delayed", LoadBehavior::Delayed);
+        assert_variant("blocking", LoadBehavior::Blocking);
+    }
+
+    #[test]
+    fn letterbox() {
+        let result = read("letterbox = true");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "boolean",
+                path: "letterbox".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("letterbox = \"invalid\"");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnsupportedValue {
+                value: "invalid".to_string(),
+                path: "letterbox".to_string(),
+            }],
+            result.warnings
+        );
+
+        fn assert_variant(variant: &str, letterbox: Letterbox) {
+            let result = read(&format!("letterbox = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    letterbox: Some(letterbox),
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+            // Check case-sensitivity.
+            let variant = variant.to_ascii_uppercase();
+            let result = read(&format!("letterbox = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    letterbox: None,
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(
+                vec![ParseWarning::UnsupportedValue {
+                    value: variant,
+                    path: "letterbox".to_string()
+                }],
+                result.warnings
+            );
+        }
+        assert_variant("on", Letterbox::On);
+        assert_variant("off", Letterbox::Off);
+        assert_variant("fullscreen", Letterbox::Fullscreen);
+    }
+
+    #[test]
+    fn spoof_url() {
+        let result = read("spoof_url = false");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "boolean",
+                path: "spoof_url".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("spoof_url = \"invalid\"");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnsupportedValue {
+                value: "invalid".to_string(),
+                path: "spoof_url".to_string(),
+            }],
+            result.warnings
+        );
+
+        let result = read("spoof_url = \"https://ruffle.rs/spoofed_file.swf\"");
+        assert_eq!(
+            &PlayerOptions {
+                spoof_url: Some(Url::parse("https://ruffle.rs/spoofed_file.swf").unwrap()),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn version() {
+        let result = read("version = \"air\"");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "integer",
+                actual: "string",
+                path: "version".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("version = 26");
+        assert_eq!(
+            &PlayerOptions {
+                player_version: Some(26),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn runtime() {
+        let result = read("runtime = true");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "boolean",
+                path: "runtime".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("runtime = \"invalid\"");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnsupportedValue {
+                value: "invalid".to_string(),
+                path: "runtime".to_string(),
+            }],
+            result.warnings
+        );
+
+        fn assert_variant(variant: &str, runtime: PlayerRuntime) {
+            let result = read(&format!("runtime = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    player_runtime: Some(runtime),
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+            // Check case-sensitivity.
+            let variant = variant.to_ascii_uppercase();
+            let result = read(&format!("runtime = \"{variant}\""));
+            assert_eq!(
+                &PlayerOptions {
+                    player_runtime: None,
+                    ..Default::default()
+                },
+                result.values()
+            );
+            assert_eq!(
+                vec![ParseWarning::UnsupportedValue {
+                    value: variant,
+                    path: "runtime".to_string()
+                }],
+                result.warnings
+            );
+        }
+        assert_variant("flash_player", PlayerRuntime::FlashPlayer);
+        assert_variant("air", PlayerRuntime::AIR);
+    }
+
+    #[test]
+    fn frame_rate() {
+        let result = read("frame_rate = true");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "float or integer",
+                actual: "boolean",
+                path: "frame_rate".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("frame_rate = 30");
+        assert_eq!(
+            &PlayerOptions {
+                frame_rate: Some(30.0),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+        let result = read("frame_rate = 5.0");
+        assert_eq!(
+            &PlayerOptions {
+                frame_rate: Some(5.0),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn mock_external_interface() {
+        let result = read("mock_external_interface = 1");
+        assert_eq!(&PlayerOptions::default(), result.values());
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "boolean",
+                actual: "integer",
+                path: "mock_external_interface".to_string()
+            }],
+            result.warnings
+        );
+
+        let result = read("mock_external_interface = true");
+        assert_eq!(
+            &PlayerOptions {
+                dummy_external_interface: Some(true),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+}

--- a/render/src/quality.rs
+++ b/render/src/quality.rs
@@ -99,15 +99,10 @@ impl FromStr for StageQuality {
     type Err = StageQualityError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let quality = match s.to_ascii_lowercase().as_str() {
+        let quality = match s {
             "low" => StageQuality::Low,
             "medium" => StageQuality::Medium,
             "high" => StageQuality::High,
-            "best" => StageQuality::Best,
-            "8x8" => StageQuality::High8x8,
-            "8x8linear" => StageQuality::High8x8Linear,
-            "16x16" => StageQuality::High16x16,
-            "16x16linear" => StageQuality::High16x16Linear,
             _ => return Err(StageQualityError),
         };
         Ok(quality)


### PR DESCRIPTION
Differences in the specification between the gist and this PR.

- Some examples in the gist referred to their old names, this has been fixed.
- Explicitly mentions that frame rate can be a floating-point value as well as an integer. (Changed for consistency, since script_timeout allows both)
- Fixed typo in `frame_rate` description (Maybe be -> May be).

cc @Dinnerbone