### PR TITLE
`github`: Make Dependabot also ignore "profiling", add a group to bump `Cargo.lock`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,4 @@ updates:
     ignore:
       - dependency-name: "tracing-tracy"
       - dependency-name: "tracy-client"
+      - dependency-name: "profiling"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      cargo-lock:
+        patterns:
+          - "*"
+        update-types:
+          - "all"
+        dependency-type: "indirect"
     ignore:
       - dependency-name: "tracing-tracy"
       - dependency-name: "tracy-client"


### PR DESCRIPTION
"profiling" ignore:
The other two ignored crates are indirect through this.

`Cargo.lock` bump:
Hopefully, now that it runs on GHA infra, it won't timeout.