### PR TITLE
github: Add a workaround for nextest failing on Windows

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -84,6 +84,9 @@ jobs:
           # Supposedly makes "Updating crates.io index" faster on Windows.
           # See: https://github.com/rust-lang/cargo/issues/9167
           CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
+          # Workaround for: https://github.com/nextest-rs/nextest/issues/1493
+          # See also: https://github.com/rust-lang/rustup/issues/3825
+          RUSTUP_WINDOWS_PATH_ADD_BIN: '1'
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 
       - name: Run tests without image tests


### PR DESCRIPTION
This will hopefully prevent CI failures like these:
https://github.com/ruffle-rs/ruffle/actions/runs/9103363884/job/25025064793
https://github.com/ruffle-rs/ruffle/actions/runs/9103952906/job/25026859930

Thanks for finding the issues linked from the code, @Dinnerbone!