### PR TITLE
Revert "github: Add a Dependabot group just for bumping Cargo.lock"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,12 +41,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      cargo-lock:
-        patterns:
-          - "*"
-        update-types:
-          - "all"
-        dependency-type: "indirect"
     ignore:
       - dependency-name: "tracing-tracy"
       - dependency-name: "tracy-client"


### PR DESCRIPTION
This reverts commit 6c144a038f476c81521523973e005d8371f32131.

See https://github.com/ruffle-rs/ruffle/runs/25067106580. The only options for the dependency-type of a group are production and development: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups. This was done with the options for allow in mind: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow.

As for update-types, that should have been:
```
        update-types:
          - "major"
          - "minor"
          - "patch"
```