### PR TITLE
ci: Test with Node.js 22 instead of 21

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["20", "21"]
+        node_version: ["20", "22"]
         os: [ubuntu-22.04, windows-latest]
 
     steps:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ["20", "21"]
+        node_version: ["20", "22"]
         os: [ubuntu-22.04, windows-latest]
 
     steps:

--- a/web/README.md
+++ b/web/README.md
@@ -57,7 +57,7 @@ should work. Additionally, headless JREs should also work.
 
 Follow the instructions to [install Node.js](https://nodejs.org/) on your machine.
 
-We recommend using the currently active LTS 20, but we do also run tests with current Node.js 21.
+We recommend using the currently active LTS 20, but we do also run tests with current Node.js 22.
 
 Note that npm 7 or newer is required. It should come bundled with Node.js 15 or newer, but can be upgraded with older Node.js versions using `npm install -g npm` as root/Administrator.
 


### PR DESCRIPTION
It has been out for like three weeks now, and it is the next LTS release.

https://nodejs.org/en/blog/announcements/v22-release-announce
https://nodejs.org/en/about/previous-releases