### PR TITLE
ci: Run Rust tests on Ubuntu 24.04

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   changes:
     name: Paths filter
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.filter.outputs.src }}
     steps:
@@ -39,12 +39,12 @@ jobs:
       fail-fast: false
       matrix:
         rust_version: [stable]
-        os: [ubuntu-22.04, windows-latest, macos-14]
+        os: [ubuntu-24.04, windows-latest, macos-14]
         include:
           - rust_version: nightly
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - rust_version: beta
-            os: ubuntu-22.04
+            os: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     name: Lints with Rust ${{ matrix.rust_version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}
     strategy:
       fail-fast: false
@@ -157,7 +157,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     name: Check dependencies
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -181,12 +181,12 @@ jobs:
     strategy:
       matrix:
         rust_version: [stable]
-        os: [ubuntu-22.04, windows-latest, macos-14]
+        os: [ubuntu-24.04, windows-latest, macos-14]
         include:
           - rust_version: nightly
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - rust_version: beta
-            os: ubuntu-22.04
+            os: ubuntu-24.04
 
     steps:
       - name: No-op

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository ppa:kisak/kisak-mesa -y
           sudo apt-get update
           sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
 
@@ -82,9 +81,7 @@ jobs:
 
       - name: Run tests with image tests
         if: runner.os != 'macOS'
-        # TODO: Disallow retries in general once we can allow only after SIGABRT.
-        # See: https://github.com/nextest-rs/nextest/issues/1172
-        run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast --retries 2 -j 4 --features imgtests,lzma,jpegxr
+        run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features imgtests,lzma,jpegxr
         env:
           # This is to counteract the disabling by rust-cache.
           # See: https://github.com/Swatinem/rust-cache/issues/43


### PR DESCRIPTION
Currently available as beta on GHA: https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available/

Just want to see whether anything will break once we switch, plus whether we can clean up the tricks we did to get Lavapipe, and to tolerate SIGABRT.

A minor added benefit is that we won't lose CI if/when Launchpad is down (as has happened a couple times recently), and that nextest will alert us of genuinely flaky tests with higher probability (the retries hack won't hide them). Also, the Ubuntu jobs will be a bit faster.

Note that after merging this, the set of required checks will have to be updated by a repo admin to match.