### PR TITLE
avm2: Improve optimizations on static methods

### DIFF
--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -1300,5 +1300,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         activation,
     );
 
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -383,12 +383,13 @@ fn describe_internal_body<'gc>(
                 let declared_by = method.class;
 
                 if flags.contains(DescribeTypeFlags::HIDE_OBJECT)
-                    && declared_by == activation.avm2().classes().object
+                    && declared_by == Some(activation.avm2().classes().object)
                 {
                     continue;
                 }
 
                 let declared_by_name = declared_by
+                    .unwrap()
                     .inner_class_definition()
                     .name()
                     .to_qualified_name(activation.context.gc_context);
@@ -476,6 +477,7 @@ fn describe_internal_body<'gc>(
                 let accessor_type =
                     method_type.to_qualified_name_or_star(activation.context.gc_context);
                 let declared_by = defining_class
+                    .unwrap()
                     .inner_class_definition()
                     .name()
                     .to_qualified_name(activation.context.gc_context);

--- a/core/src/avm2/globals/boolean.rs
+++ b/core/src/avm2/globals/boolean.rs
@@ -170,5 +170,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         activation,
     );
 
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }

--- a/core/src/avm2/globals/class.rs
+++ b/core/src/avm2/globals/class.rs
@@ -75,5 +75,10 @@ pub fn create_class<'gc>(
         PUBLIC_INSTANCE_PROPERTIES,
     );
 
+    class_class.mark_traits_loaded(activation.context.gc_context);
+    class_class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class_class
 }

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -1392,5 +1392,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         activation,
     );
 
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }

--- a/core/src/avm2/globals/flash/text/ime/CompositionAttributeRange.as
+++ b/core/src/avm2/globals/flash/text/ime/CompositionAttributeRange.as
@@ -1,0 +1,19 @@
+package flash.text.ime {
+    public final class CompositionAttributeRange {
+        public var converted:Boolean;
+
+        public var relativeStart:int;
+        
+        public var relativeEnd:int;
+        
+        public var selected:Boolean;
+        
+        public function CompositionAttributeRange(relativeStart:int, relativeEnd:int, selected:Boolean, converted:Boolean) {
+            this.relativeStart = relativeStart;
+            this.relativeEnd = relativeEnd;
+            this.selected = selected;
+            this.converted = converted;
+        }
+    }
+}
+

--- a/core/src/avm2/globals/flash/text/ime/IIMEClient.as
+++ b/core/src/avm2/globals/flash/text/ime/IIMEClient.as
@@ -1,0 +1,25 @@
+package flash.text.ime {
+    import flash.geom.Rectangle;
+
+    public interface IIMEClient {
+        function confirmComposition(text:String = null, preserveSelection:Boolean = false):void;
+
+        function getTextBounds(startIndex:int, endIndex:int):Rectangle;
+
+        function getTextInRange(startIndex:int, endIndex:int):String;
+
+        function selectRange(anchorIndex:int, activeIndex:int):void;
+
+        function updateComposition(text:String, attributes:Vector.<CompositionAttributeRange>, compositionStartIndex:int, compositionEndIndex:int):void;
+
+        function get compositionStartIndex():int;
+        function get compositionEndIndex():int;
+
+        function get selectionAnchorIndex():int;
+
+        function get selectionActiveIndex():int;
+
+        function get verticalTextLayout():Boolean;
+    }
+}
+

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -268,5 +268,10 @@ pub fn create_class<'gc>(
         Method::from_builtin(class_call, "<Function call handler>", gc_context),
     );
 
+    function_class.mark_traits_loaded(activation.context.gc_context);
+    function_class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     function_class
 }

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -36,11 +36,18 @@ pub fn create_class<'gc>(
     object_class: Class<'gc>,
 ) -> Class<'gc> {
     let mc = activation.context.gc_context;
-    Class::new(
+    let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "global"),
         Some(object_class),
         Method::from_builtin(instance_init, "<global instance initializer>", mc),
         Method::from_builtin(class_init, "<global class initializer>", mc),
         mc,
-    )
+    );
+
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
+    class
 }

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -384,6 +384,9 @@ include "flash/text/engine/TextLineValidity.as"
 include "flash/text/engine/TextRotation.as"
 include "flash/text/engine/TypographicCase.as"
 
+include "flash/text/ime/CompositionAttributeRange.as"
+include "flash/text/ime/IIMEClient.as"
+
 include "flash/ui/ContextMenu.as"
 include "flash/ui/ContextMenuBuiltInItems.as"
 include "flash/ui/ContextMenuClipboardItems.as"

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -273,5 +273,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         AS3_INSTANCE_METHODS,
     );
 
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -217,5 +217,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         PUBLIC_INSTANCE_AND_PROTO_METHODS,
     );
 
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }

--- a/core/src/avm2/globals/number.rs
+++ b/core/src/avm2/globals/number.rs
@@ -432,5 +432,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         AS3_INSTANCE_METHODS,
     );
 
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -321,5 +321,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         INTERNAL_INIT_METHOD,
     );
 
+    object_class.mark_traits_loaded(activation.context.gc_context);
+    object_class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     object_class
 }

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -750,6 +750,11 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         PUBLIC_CLASS_METHODS,
     );
 
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }
 

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -276,5 +276,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         AS3_INSTANCE_METHODS,
     );
 
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -922,6 +922,12 @@ pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<
 
     class.set_attributes(mc, ClassAttributes::GENERIC | ClassAttributes::FINAL);
     class.set_instance_allocator(mc, generic_vector_allocator);
+
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }
 
@@ -1006,6 +1012,11 @@ pub fn create_builtin_class<'gc>(
         activation.avm2().as3_namespace,
         AS3_INSTANCE_METHODS,
     );
+
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
 
     class
 }

--- a/core/src/avm2/globals/void.rs
+++ b/core/src/avm2/globals/void.rs
@@ -29,5 +29,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         mc,
     );
 
+    class.mark_traits_loaded(activation.context.gc_context);
+    class
+        .init_vtable(&mut activation.context)
+        .expect("Native class's vtable should initialize");
+
     class
 }

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -602,12 +602,12 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
             return exec(
                 method,
-                scope,
+                scope.expect("Scope should exist here"),
                 self.into(),
-                Some(class),
+                class,
                 arguments,
                 activation,
-                class.into(), //Callee deliberately invalid.
+                ScriptObject::custom_object(activation.context.gc_context, None, None), // Callee deliberately invalid.
             );
         }
 

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -850,15 +850,9 @@ pub fn optimize<'gc>(
                             // is unlikely to cause any real problems with SWFs.
                             *op = Op::GetScriptGlobals { script };
 
-                            let script_globals = script.globals_if_init();
-
-                            if let Some(script_globals) = script_globals {
+                            if script.traits_loaded() {
                                 stack_push_done = true;
-                                if let Some(global_class) = script_globals.instance_of() {
-                                    stack.push_class_object(global_class);
-                                } else {
-                                    stack.push_any();
-                                }
+                                stack.push_class(script.global_class());
                             }
                         }
                     }

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -299,7 +299,7 @@ pub fn optimize<'gc>(
     }
 
     let mut has_simple_scoping = false;
-    if !jump_targets.contains_key(&0) || !jump_targets.contains_key(&1) {
+    if !jump_targets.contains_key(&0) && !jump_targets.contains_key(&1) {
         if matches!(code.get(0), Some(Op::GetLocal { index: 0 }))
             && matches!(code.get(1), Some(Op::PushScope))
         {

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -259,7 +259,7 @@ impl<'gc> TranslationUnit<'gc> {
 
         let global_obj = global_class.construct(activation, &[])?;
 
-        let mut script = Script::from_abc_index(
+        let script = Script::from_abc_index(
             self,
             script_index,
             global_obj,
@@ -524,7 +524,7 @@ impl<'gc> Script<'gc> {
     /// or double-borrows. It should be done before the script is actually
     /// executed.
     pub fn load_traits(
-        &mut self,
+        self,
         unit: TranslationUnit<'gc>,
         script_index: u32,
         activation: &mut Activation<'_, 'gc>,
@@ -548,7 +548,7 @@ impl<'gc> Script<'gc> {
             let newtrait = Trait::from_abc_trait(unit, abc_trait, activation)?;
             write
                 .domain
-                .export_definition(newtrait.name(), *self, activation.context.gc_context);
+                .export_definition(newtrait.name(), self, activation.context.gc_context);
             if let TraitKind::Class { class, .. } = newtrait.kind() {
                 write
                     .domain
@@ -604,7 +604,7 @@ impl<'gc> Script<'gc> {
     ///
     /// If the script has not yet been initialized, this will initialize it on
     /// the same stack.
-    pub fn globals(&self, context: &mut UpdateContext<'_, 'gc>) -> Result<Object<'gc>, Error<'gc>> {
+    pub fn globals(self, context: &mut UpdateContext<'_, 'gc>) -> Result<Object<'gc>, Error<'gc>> {
         let mut write = self.0.write(context.gc_context);
 
         if !write.initialized {
@@ -632,7 +632,7 @@ impl<'gc> Script<'gc> {
             );
             globals.install_instance_slots(context.gc_context);
 
-            Avm2::run_script_initializer(*self, context)?;
+            Avm2::run_script_initializer(self, context)?;
 
             Ok(globals)
         } else {

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -585,6 +585,10 @@ impl<'gc> Script<'gc> {
         self.0.read().translation_unit
     }
 
+    pub fn traits_loaded(self) -> bool {
+        self.0.read().traits_loaded
+    }
+
     pub fn global_class(self) -> Class<'gc> {
         self.0
             .read()
@@ -633,19 +637,6 @@ impl<'gc> Script<'gc> {
             Ok(globals)
         } else {
             Ok(write.globals)
-        }
-    }
-
-    /// Return the global scope for the script.
-    ///
-    /// If the script has not yet been initialized, this will return None.
-    pub fn globals_if_init(&self) -> Option<Object<'gc>> {
-        let read = self.0.read();
-
-        if !read.initialized {
-            None
-        } else {
-            Some(read.globals)
         }
     }
 


### PR DESCRIPTION
This is a little hacky, but it should be simplified once the class refactor is done.

Box2d stats:

```
FindPropStrict -> GetScriptGlobals : 62.18% (+17.02%)
FindPropStrict -> GetOuterScope : 7.76% (-0.11%)
FindPropStrict -> GetScopeObject : 8.24% (+6.55%)

FindProperty -> GetOuterScope : 2.83%
FindProperty -> GetScopeObject : 94.34% (+88.68%)

InitProperty -> SetSlot : 40.93% (+2.78%)
InitProperty -> SetSlotNoCoerce : 44.51% (+6.64%)

SetProperty -> SetSlot : 28.67% (+13.64%)
SetProperty -> SetSlotNoCoerce : 39.51% (+9.09%)
SetProperty -> CallMethod : 1.57%

GetProperty -> GetSlot : 67.31% (+7.62%)
GetProperty -> CallMethod : 0.34%

CallProperty -> CallMethod : 41.13% (+9.68%)
CallPropVoid -> CallMethod : 74.24% (+12.5%)

Coerce -> Nop : 49.78% (+2.83%)

CoerceD -> Nop : 81.34% (+2.98%)

CoerceB -> Nop : 8.11%

CoerceU -> Nop : 32.46%

CoerceI -> Nop : 2%

ReturnValue -> ReturnValueNoCoerce : 66.06% (+0.92%)
```