### PR TITLE
ci: Disable rust-lld on Rust nightly

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -61,6 +61,12 @@ jobs:
           sudo apt-get update
           sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
 
+      # Needed after: https://github.com/rust-lang/rust/pull/124129
+      # Based on: https://github.com/dtolnay/linkme/pull/88
+      - name: Disable rust-lld
+        if: matrix.rust_version == 'nightly'
+        run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
+
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
This will probably fix the CI failures.

As per https://github.com/dtolnay/linkme/pull/88, following https://github.com/rust-lang/rust/pull/124129.