### PR TITLE
chore: Bump h263-rs git reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "h263-rs"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=5c8d9d7d86f62b70ca484df006a75a9c8ff1985c#5c8d9d7d86f62b70ca484df006a75a9c8ff1985c"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=f0fa94c366a1d0383df99aa835add175658d6bad#f0fa94c366a1d0383df99aa835add175658d6bad"
 dependencies = [
  "bitflags 2.5.0",
  "lazy_static",
@@ -2372,16 +2372,16 @@ dependencies = [
 [[package]]
 name = "h263-rs-deblock"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=5c8d9d7d86f62b70ca484df006a75a9c8ff1985c#5c8d9d7d86f62b70ca484df006a75a9c8ff1985c"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=f0fa94c366a1d0383df99aa835add175658d6bad#f0fa94c366a1d0383df99aa835add175658d6bad"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "wide",
 ]
 
 [[package]]
 name = "h263-rs-yuv"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=5c8d9d7d86f62b70ca484df006a75a9c8ff1985c#5c8d9d7d86f62b70ca484df006a75a9c8ff1985c"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=f0fa94c366a1d0383df99aa835add175658d6bad#f0fa94c366a1d0383df99aa835add175658d6bad"
 dependencies = [
  "bytemuck",
  "wide",
@@ -2770,6 +2770,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,7 +2820,7 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 [[package]]
 name = "jpegxr"
 version = "0.3.1"
-source = "git+https://github.com/ruffle-rs/jpegxr?branch=ruffle#db88651220688d2883a90d5477048071507b0493"
+source = "git+https://github.com/ruffle-rs/jpegxr?rev=db88651220688d2883a90d5477048071507b0493#db88651220688d2883a90d5477048071507b0493"
 dependencies = [
  "bindgen",
  "cc",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,7 +59,7 @@ egui_extras = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c
 png = { version = "0.17.13", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }
-jpegxr = { git = "https://github.com/ruffle-rs/jpegxr", branch = "ruffle", optional = true }
+jpegxr = { git = "https://github.com/ruffle-rs/jpegxr", rev = "db88651220688d2883a90d5477048071507b0493", optional = true }
 image = { workspace = true, features = ["tiff"] }
 enum-map = { workspace = true }
 ttf-parser = "0.21"

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = { workspace = true, optional = true }
 enum-map = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 clap = { workspace = true, optional = true }
-h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "5c8d9d7d86f62b70ca484df006a75a9c8ff1985c"}
+h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "f0fa94c366a1d0383df99aa835add175658d6bad"}
 num-traits = { workspace = true }
 num-derive = { workspace = true }
 byteorder = "1.5"

--- a/video/software/Cargo.toml
+++ b/video/software/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = { workspace = true }
 flate2 = { workspace = true }
 log = { workspace = true }
 
-h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "5c8d9d7d86f62b70ca484df006a75a9c8ff1985c", optional = true }
-h263-rs-deblock = { git = "https://github.com/ruffle-rs/h263-rs", rev = "5c8d9d7d86f62b70ca484df006a75a9c8ff1985c", optional = true }
+h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "f0fa94c366a1d0383df99aa835add175658d6bad", optional = true }
+h263-rs-deblock = { git = "https://github.com/ruffle-rs/h263-rs", rev = "f0fa94c366a1d0383df99aa835add175658d6bad", optional = true }
 nihav_core = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "83c7e1094d603d9fc1212d39d99abb17f3a3226b", optional = true }
 nihav_codec_support = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "83c7e1094d603d9fc1212d39d99abb17f3a3226b", optional = true }
 nihav_duck = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "83c7e1094d603d9fc1212d39d99abb17f3a3226b", optional = true }


### PR DESCRIPTION
And refer to a specific jpegxr commit instead of just a branch.

This brings in https://github.com/ruffle-rs/h263-rs/pull/54, thereby duplicating the `itertools` dependency. The old, `0.12.1` version is only kept as a build dependency though, and it's fairly small anyway, so I think it should be fine.
Filed https://github.com/rust-lang/rust-bindgen/pull/2839 to rectify this anyway.