### PR TITLE
debug_ui: Improve EditText tab

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -788,10 +788,10 @@ impl<'gc> EditText<'gc> {
                 .drawing
                 .draw_command(DrawCommand::LineTo(Point::new(width, Twips::ZERO)));
             write.drawing.draw_command(DrawCommand::LineTo(Point::ZERO));
-
-            drop(write);
-            self.invalidate_cached_bitmap(gc_context);
         }
+
+        drop(write);
+        self.invalidate_cached_bitmap(gc_context);
     }
 
     /// Internal padding between the bounds of the EditText and the text.


### PR DESCRIPTION
This patch adds multiple properties and controls to EditText tab.

This includes for instance:
* border, border color,
* background, background color,
* editable, selectable, word wrap properties,
* autosize, max chars, restrict, etc.

Additionally this fixes a bug when the EditText's bitmap was not invalidated after disabling both border and background (causing them to render regardless).

| Before | After |
| ------ | ----- |
| <image src="https://github.com/ruffle-rs/ruffle/assets/1507072/34c04d5f-71da-4b2f-b6ca-2dd3c68990f1" width="300"/> | <image src="https://github.com/ruffle-rs/ruffle/assets/1507072/f3ffcc65-9a0a-4f2d-ae6c-e7e9c0f18c15" width="300"/> |
