### PR TITLE
Revert "ci: Disable rust-lld on Rust nightly"

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -61,12 +61,6 @@ jobs:
           sudo apt-get update
           sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
 
-      # Needed after: https://github.com/rust-lang/rust/pull/124129
-      # Based on: https://github.com/dtolnay/linkme/pull/88
-      - name: Disable rust-lld
-        if: matrix.rust_version == 'nightly'
-        run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
-
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
This reverts commit 1b3701e1aa17c46be9b077ecade6ae9d6e975af1 (#16390), as it should no longer be needed, according to https://github.com/cross-rs/cross/issues/1496#issuecomment-2130454741.