### PR TITLE
web: Stub the PercentLoaded() JS method

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -2372,6 +2372,16 @@ export class RufflePlayer extends HTMLElement {
         // TODO: Move this to whatever function changes the ReadyState to Loaded when we have streaming support.
         this.dispatchEvent(new CustomEvent(RufflePlayer.LOADED_DATA));
     }
+
+    /** @ignore */
+    public PercentLoaded(): number {
+        // [NA] This is a stub - we need to research how this is actually implemented (is it just base swf loadedBytes?)
+        if (this._readyState === ReadyState.Loaded) {
+            return 100;
+        } else {
+            return 0;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Just returns 0 or 100 right now, I don't know exactly how it should work but this is enough to progress some stuff

Fixes #15023
Fixes #15021


(In the future we'll need to limit these to just the polyfill API I think)