### PR TITLE
desktop/frontend-utils: Show filename or bundle name in recent list

### DIFF
--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -7,7 +7,6 @@ mod widgets;
 
 pub use controller::GuiController;
 pub use movie::MovieView;
-use ruffle_frontend_utils::recents::Recent;
 use std::borrow::Cow;
 use url::Url;
 
@@ -185,17 +184,6 @@ impl RuffleGui {
         mut player: MutexGuard<Player>,
     ) {
         self.menu_bar.currently_opened = Some((movie_url.clone(), opt.clone()));
-        let recent_limit = self.preferences.recent_limit();
-        if let Err(e) = self.preferences.write_recents(|writer| {
-            writer.push(
-                Recent {
-                    url: movie_url.clone(),
-                },
-                recent_limit,
-            )
-        }) {
-            tracing::warn!("Couldn't update recents: {e}");
-        }
 
         // Update dialog state to reflect the newly-opened movie's options.
         self.dialogs

--- a/desktop/src/gui/menu_bar.rs
+++ b/desktop/src/gui/menu_bar.rs
@@ -225,7 +225,7 @@ impl MenuBar {
 
                     if let Some(recents) = &self.cached_recents {
                         for recent in recents {
-                            if ui.button(recent.url.as_str()).clicked() {
+                            if ui.button(&recent.name).clicked() {
                                 ui.close_menu();
                                 let _ = self.event_loop.send_event(RuffleEvent::OpenURL(
                                     recent.url.clone(),

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -17,6 +17,7 @@ use ruffle_frontend_utils::bundle::source::BundleSourceError;
 use ruffle_frontend_utils::bundle::{Bundle, BundleError};
 use ruffle_frontend_utils::content::PlayingContent;
 use ruffle_frontend_utils::player_options::PlayerOptions;
+use ruffle_frontend_utils::recents::Recent;
 use ruffle_render::backend::RenderBackend;
 use ruffle_render::quality::StageQuality;
 use ruffle_render_wgpu::backend::WgpuRenderBackend;
@@ -165,6 +166,19 @@ impl ActivePlayer {
                     }
                 }
             }
+        }
+
+        let recent_limit = preferences.recent_limit();
+        if let Err(e) = preferences.write_recents(|writer| {
+            writer.push(
+                Recent {
+                    url: movie_url.clone(),
+                    name: content.name(),
+                },
+                recent_limit,
+            )
+        }) {
+            tracing::warn!("Couldn't update recents: {e}");
         }
 
         let opt = match &content {

--- a/frontend-utils/src/recents.rs
+++ b/frontend-utils/src/recents.rs
@@ -9,6 +9,7 @@ use url::Url;
 #[derive(Clone, Debug, PartialEq)]
 pub struct Recent {
     pub url: Url,
+    pub name: String,
 }
 
 impl Recent {

--- a/frontend-utils/src/recents/read.rs
+++ b/frontend-utils/src/recents/read.rs
@@ -24,7 +24,11 @@ pub fn read_recents(input: &str) -> ParseDetails<Recents> {
                 None => Url::parse(crate::INVALID_URL).expect("Url is constant and valid"),
             };
 
-            result.push(Recent { url });
+            let name = recent
+                .parse_from_str(cx, "name")
+                .unwrap_or_else(|| crate::url_to_readable_name(&url).into_owned());
+
+            result.push(Recent { url, name });
         }
     });
 
@@ -65,6 +69,7 @@ mod tests {
         assert_eq!(
             &vec![Recent {
                 url: Url::parse(crate::INVALID_URL).unwrap(),
+                name: "".to_string(),
             }],
             result.values()
         );
@@ -77,6 +82,7 @@ mod tests {
         assert_eq!(
             &vec![Recent {
                 url: Url::parse(crate::INVALID_URL).unwrap(),
+                name: "".to_string()
             }],
             result.values()
         );
@@ -95,6 +101,23 @@ mod tests {
         assert_eq!(
             &vec![Recent {
                 url: Url::parse("https://ruffle.rs/logo-anim.swf").unwrap(),
+                name: "logo-anim.swf".to_string()
+            }],
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+    }
+
+    #[test]
+    fn name() {
+        let result = read_recents(
+            "[[recent]]\nurl = \"file:///name_test.swf\"\nname = \"This is not a test!\"",
+        );
+
+        assert_eq!(
+            &vec![Recent {
+                url: Url::parse("file:///name_test.swf").unwrap(),
+                name: "This is not a test!".to_string(),
             }],
             result.values()
         );
@@ -116,9 +139,11 @@ mod tests {
             &vec![
                 Recent {
                     url: Url::parse("file:///first.swf").unwrap(),
+                    name: "first.swf".to_string()
                 },
                 Recent {
                     url: Url::parse("file:///second.swf").unwrap(),
+                    name: "second.swf".to_string(),
                 }
             ],
             result.values()
@@ -149,18 +174,23 @@ mod tests {
             &vec![
                 Recent {
                     url: Url::parse("file:///first.swf").unwrap(),
+                    name: "first.swf".to_string()
                 },
                 Recent {
                     url: Url::parse(crate::INVALID_URL).unwrap(),
+                    name: "".to_string()
                 },
                 Recent {
                     url: Url::parse(crate::INVALID_URL).unwrap(),
+                    name: "".to_string()
                 },
                 Recent {
                     url: Url::parse(crate::INVALID_URL).unwrap(),
+                    name: "".to_string()
                 },
                 Recent {
                     url: Url::parse("file:///second.swf").unwrap(),
+                    name: "second.swf".to_string(),
                 },
             ],
             result.values()


### PR DESCRIPTION
This should lead to shorter recent entries in the GUI by only showing the filename or bundle name (depending on which was opened).

If name field is missing from `recents.toml`, which would be the case with files created by previous Ruffle versions, it falls back to the filename from the URL.