### PR TITLE
web: Make embed instead of Ruffle instance with the API when using Flash

### DIFF
--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -25,7 +25,7 @@ let embeds: HTMLCollectionOf<HTMLEmbedElement>;
  *
  * @returns Whether this browser has a plugin indicating pre-existing Flash support.
  */
-function isFlashEnabledBrowser(): boolean {
+export function isFlashEnabledBrowser(): boolean {
     // If the user sets a configuration value not to favor Flash, pretend the browser does not support Flash so Ruffle takes effect.
     if ("favorFlash" in globalConfig && globalConfig["favorFlash"] === false) {
         return false;

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -3,7 +3,11 @@ import { loadRuffle } from "./load-ruffle";
 import { applyStaticStyles, ruffleShadowTemplate } from "./shadow-template";
 import { lookupElement } from "./register-element";
 import { DEFAULT_CONFIG } from "./config";
-import type { DataLoadOptions, URLLoadOptions } from "./load-options";
+import type {
+    BaseLoadOptions,
+    DataLoadOptions,
+    URLLoadOptions,
+} from "./load-options";
 import {
     AutoPlay,
     ContextMenu,
@@ -925,6 +929,25 @@ export class RufflePlayer extends HTMLElement {
         }
     }
 
+    private setAttibutesFromConfig(embed: HTMLElement, attributes: string[]) {
+        if (this.loadedConfig) {
+            for (const attribute of attributes) {
+                if (
+                    this.loadedConfig[attribute as keyof BaseLoadOptions] !==
+                    null
+                ) {
+                    // TS thinks these can be undefined, but they are not since loadedConfig uses DEFAULT_CONFIG as a fallback
+                    embed.setAttribute(
+                        attribute,
+                        this.loadedConfig[
+                            attribute as keyof BaseLoadOptions
+                        ]!.toString(),
+                    );
+                }
+            }
+        }
+    }
+
     /**
      * Loads a specified movie into this player.
      *
@@ -993,26 +1016,17 @@ export class RufflePlayer extends HTMLElement {
             ) {
                 this.swfUrl = new URL(options.url, document.baseURI);
                 const flashEmbed = document.createElement("embed");
-                // TS thinks these can be undefined, but it is not since loadedConfig uses DEFAULT_CONFIG as a fallback
-                if (this.loadedConfig.base !== null) {
-                    flashEmbed.setAttribute("base", this.loadedConfig.base!);
-                }
-                flashEmbed.setAttribute(
+                const attributes = [
+                    "base",
                     "allowScriptAccess",
-                    this.loadedConfig.allowScriptAccess!.toString(),
-                );
-                flashEmbed.setAttribute("wmode", this.loadedConfig.wmode!);
-                flashEmbed.setAttribute(
-                    "allowFullScreen",
-                    this.loadedConfig.allowFullscreen!.toString(),
-                );
-                flashEmbed.setAttribute(
+                    "wmode",
+                    "allowFullscreen",
                     "menu",
-                    this.loadedConfig.menu!.toString(),
-                );
-                flashEmbed.setAttribute("scale", this.loadedConfig.scale!);
-                flashEmbed.setAttribute("salign", this.loadedConfig.salign!);
-                flashEmbed.setAttribute("quality", this.loadedConfig.quality!);
+                    "scale",
+                    "salign",
+                    "quality",
+                ];
+                this.setAttibutesFromConfig(flashEmbed, attributes);
                 const sanitizedParameters = sanitizeParameters(
                     options.parameters,
                 );
@@ -1023,7 +1037,7 @@ export class RufflePlayer extends HTMLElement {
                     )
                     .join("&");
                 if (flashVars) {
-                    flashEmbed.setAttribute("FlashVars", flashVars);
+                    flashEmbed.setAttribute("flashvars", flashVars);
                 }
                 flashEmbed.src = this.swfUrl.href;
                 flashEmbed.width = "100%";

--- a/web/packages/demo/src/main.tsx
+++ b/web/packages/demo/src/main.tsx
@@ -24,6 +24,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
                 letterbox: Letterbox.On,
                 forceScale: true,
                 forceAlign: true,
+                favorFlash: false,
             }}
             allowSampleSwfs={true}
             allowUrlLoading={false}


### PR DESCRIPTION
This should work, but it's arguable if it's something we should be doing. It's still possible to use the Ruffle API without it creating a Flash embed on Flash-enabled browsers by setting the favorFlash configuration option to false.

If you load the SWF as data instead of by URL, we still use Ruffle since Flash embeds don't have a way to support that.