### PR TITLE
avm2: Introduce an E4XNamespace type (NFCI)

### DIFF
--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -219,7 +219,7 @@ pub fn namespace_internal_impl<'gc>(
         Ok(match node.namespace() {
             Some(ns) if prefix.is_empty() => {
                 let namespace = Namespace::package(
-                    ns,
+                    ns.uri,
                     ApiVersion::AllVersions,
                     &mut activation.context.borrow_gc(),
                 );

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -1,6 +1,6 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::api_version::ApiVersion;
-use crate::avm2::e4x::{E4XNode, E4XNodeKind};
+use crate::avm2::e4x::{E4XNamespace, E4XNode, E4XNodeKind};
 use crate::avm2::error::make_error_1089;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
@@ -175,7 +175,7 @@ impl<'gc> XmlListObject<'gc> {
                 if let Some(name) = last_node.local_name() {
                     let ns = match last_node.namespace() {
                         Some(ns) => Namespace::package(
-                            ns,
+                            ns.uri,
                             ApiVersion::AllVersions,
                             &mut activation.context.borrow_gc(),
                         ),
@@ -716,7 +716,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                             // 2.c.vi. Else let y.[[Class]] = "element"
                             Some(property) => E4XNode::element(
                                 activation.gc(),
-                                property.explicit_namespace(),
+                                property.explicit_namespace().map(E4XNamespace::new_uri),
                                 property.local_name().expect("Local name should exist"),
                                 r,
                             ),
@@ -786,7 +786,10 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                                         y.set_local_name(name, activation.gc());
                                     }
                                     if let Some(namespace) = target_property.explicit_namespace() {
-                                        y.set_namespace(namespace, activation.gc());
+                                        y.set_namespace(
+                                            E4XNamespace::new_uri(namespace),
+                                            activation.gc(),
+                                        );
                                     }
                                 }
                             }

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::api_version::ApiVersion;
-use crate::avm2::e4x::{string_to_multiname, E4XNode, E4XNodeKind};
+use crate::avm2::e4x::{string_to_multiname, E4XNamespace, E4XNode, E4XNodeKind};
 use crate::avm2::error::make_error_1087;
 use crate::avm2::multiname::NamespaceSet;
 use crate::avm2::object::script_object::ScriptObjectData;
@@ -161,7 +161,7 @@ impl<'gc> XmlObject<'gc> {
     pub fn namespace(&self, activation: &mut Activation<'_, 'gc>) -> Namespace<'gc> {
         match self.0.read().node.namespace() {
             Some(ns) => Namespace::package(
-                ns,
+                ns.uri,
                 ApiVersion::AllVersions,
                 &mut activation.context.borrow_gc(),
             ),
@@ -560,7 +560,7 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
                 // 12.b.iii. Create a new XML object y with y.[[Name]] = name, y.[[Class]] = "element" and y.[[Parent]] = x
                 let node = E4XNode::element(
                     activation.gc(),
-                    name.explicit_namespace(),
+                    name.explicit_namespace().map(E4XNamespace::new_uri),
                     name.local_name().unwrap(),
                     Some(*self_node),
                 );


### PR DESCRIPTION
In preparation of giving E4X elements a list of all their namespace (declarations) I am switching the namespace property on all objects to the newly introduced `E4XNamespace`. We don't yet use the new prefix information for anything, so this should not change any behavior.