### PR TITLE
avm1: Stub `bufferLength` and `bufferTime` on `NetStream`

### DIFF
--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -2,6 +2,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::{NativeObject, Object, TObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, ScriptObject, Value};
+use crate::avm1_stub;
 use crate::context::GcContext;
 use crate::streams::NetStream;
 
@@ -20,13 +21,42 @@ pub fn constructor<'gc>(
 }
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "bufferLength" => property(get_buffer_length);
+    "bufferTime" => property(get_buffer_time);
     "bytesLoaded" => property(get_bytes_loaded);
     "bytesTotal" => property(get_bytes_total);
     "time" => property(get_time);
     "play" => method(play; DONT_ENUM | DONT_DELETE);
     "pause" => method(pause; DONT_ENUM | DONT_DELETE);
     "seek" => method(seek; DONT_ENUM | DONT_DELETE);
+    "setBufferTime" => method(set_buffer_time; DONT_ENUM | DONT_DELETE);
 };
+
+fn get_buffer_length<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let NativeObject::NetStream(ns) = this.native() {
+        avm1_stub!(activation, "NetStream", "bufferLength");
+
+        return Ok(ns.buffer_time().into());
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn get_buffer_time<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let NativeObject::NetStream(ns) = this.native() {
+        return Ok(ns.buffer_time().into());
+    }
+
+    Ok(Value::Undefined)
+}
 
 fn get_bytes_loaded<'gc>(
     _activation: &mut Activation<'_, 'gc>,
@@ -104,6 +134,26 @@ fn seek<'gc>(
             .coerce_to_f64(activation)?;
 
         ns.seek(&mut activation.context, offset * 1000.0, false);
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn set_buffer_time<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let NativeObject::NetStream(ns) = this.native() {
+        avm1_stub!(activation, "NetStream", "setBufferTime");
+
+        let buffer_time = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_f64(activation)?;
+
+        ns.set_buffer_time(activation.context.gc_context, buffer_time);
     }
 
     Ok(Value::Undefined)

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -218,6 +218,10 @@ pub struct NetStreamData<'gc> {
     /// Seeks are only executed on the next stream tick.
     queued_seek_time: Option<f64>,
 
+    /// The number of seconds of video data that should be buffered. This is
+    /// currently unsupported and changing it has no effect.
+    buffer_time: f64,
+
     /// The last decoded bitmap.
     ///
     /// Any `Video`s on the stage will display the bitmap here when attached to
@@ -263,6 +267,7 @@ impl<'gc> NetStream<'gc> {
                 stream_type: None,
                 stream_time: 0.0,
                 queued_seek_time: None,
+                buffer_time: 0.1,
                 last_decoded_bitmap: None,
                 avm_object,
                 avm2_client: None,
@@ -360,7 +365,7 @@ impl<'gc> NetStream<'gc> {
     }
 
     pub fn report_error(self, _error: Error) {
-        //TODO: Report an `asyncError` to AVM1 or 2.
+        // TODO: Report an `asyncError` to AVM1 or 2.
     }
 
     pub fn bytes_loaded(self) -> usize {
@@ -376,6 +381,14 @@ impl<'gc> NetStream<'gc> {
 
     pub fn time(self) -> f64 {
         self.0.read().stream_time
+    }
+
+    pub fn buffer_time(self) -> f64 {
+        self.0.read().buffer_time
+    }
+
+    pub fn set_buffer_time(self, mc: &Mutation<'gc>, buffer_time: f64) {
+        self.0.write(mc).buffer_time = buffer_time;
     }
 
     /// Queue a seek to be executed on the next frame tick.


### PR DESCRIPTION
This should fully fix #12934.

`bufferLength` always reports that the buffer is fully filled, while `bufferTime` can be set but has no effect.