### PR TITLE
frontend-utils: Set a useragent for requests

### DIFF
--- a/frontend-utils/src/backends/navigator.rs
+++ b/frontend-utils/src/backends/navigator.rs
@@ -81,7 +81,13 @@ impl<F: FutureSpawner, I: NavigatorInterface> ExternalNavigatorBackend<F, I> {
         content: Rc<PlayingContent>,
         interface: I,
     ) -> Self {
-        let mut builder = reqwest::ClientBuilder::new().cookie_store(true);
+        let mut builder = reqwest::ClientBuilder::new()
+            .cookie_store(true)
+            .user_agent(concat!(
+                "Ruffle/",
+                env!("CARGO_PKG_VERSION"),
+                " (https://ruffle.rs)"
+            ));
 
         if let Some(referer) = referer {
             let mut headers = header::HeaderMap::new();


### PR DESCRIPTION
This fixes loading AQ (eg https://game.aq.com/game/gamefiles/Loader3.swf?ver=a) - but it's also just good form.

Example useragent: `Ruffle/0.1.0 (https://ruffle.rs)`