### PR TITLE
web,chore: Run `npm audit fix` to resolve an `ip` vulnerability

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7286,11 +7286,18 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/ip": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-            "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
-            "devOptional": true
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "devOptional": true,
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/ip-regex": {
             "version": "4.3.0",
@@ -7944,6 +7951,12 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+            "devOptional": true
         },
         "node_modules/jsdoc-type-pratt-parser": {
             "version": "4.0.0",
@@ -9475,13 +9488,12 @@
             }
         },
         "node_modules/pac-resolver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
-            "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "devOptional": true,
             "dependencies": {
                 "degenerator": "^5.0.0",
-                "ip": "^1.1.8",
                 "netmask": "^2.0.2"
             },
             "engines": {
@@ -11329,16 +11341,16 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "devOptional": true,
             "dependencies": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
-                "node": ">= 10.13.0",
+                "node": ">= 10.0.0",
                 "npm": ">= 3.0.0"
             }
         },
@@ -11355,12 +11367,6 @@
             "engines": {
                 "node": ">= 14"
             }
-        },
-        "node_modules/socks/node_modules/ip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-            "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-            "devOptional": true
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -11460,6 +11466,12 @@
             "engines": {
                 "node": ">= 10.x"
             }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "devOptional": true
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",


### PR DESCRIPTION
This fixes this advisory:
https://github.com/ruffle-rs/ruffle/security/dependabot/71
https://github.com/advisories/GHSA-78xj-cgh5-2h22