### PR TITLE
avm1: fix loadvars.send parameters

### DIFF
--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -163,7 +163,7 @@ fn send<'gc>(
     };
 
     let method_name = args
-        .get(1)
+        .get(2)
         .unwrap_or(&Value::Undefined)
         .coerce_to_string(activation)?;
     let method = NavigationMethod::from_method_str(&method_name).unwrap_or(NavigationMethod::Post);


### PR DESCRIPTION
The `LoadVars.send` signature is `send(url:String, target:String, [method:String]):Boolean`

There was a small mistake in the code that read the second parameter for target AND method.