### PR TITLE
web: Make config parsed by TS, not rust - and lots of other refactorings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4668,10 +4668,8 @@ dependencies = [
 name = "ruffle_web_common"
 version = "0.1.0"
 dependencies = [
- "js-sys",
  "tracing",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -41,7 +41,7 @@ impl FromStr for Letterbox {
 
 /// The networking API access mode of the Ruffle player.
 /// This setting is only used on web.
-#[derive(Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum NetworkingAccessMode {
     /// All networking APIs are permitted in the SWF file.
     #[serde(rename = "all")]

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2312,6 +2312,13 @@ impl PlayerBuilder {
         self
     }
 
+    /// Sets the audio backend of the player.
+    #[inline]
+    pub fn with_boxed_audio(mut self, audio: Box<dyn AudioBackend>) -> Self {
+        self.audio = Some(audio);
+        self
+    }
+
     /// Sets the logging backend of the player.
     #[inline]
     pub fn with_log(mut self, log: impl 'static + LogBackend) -> Self {

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -175,7 +175,11 @@ fn as_registry_data(handle: &BitmapHandle) -> &RegistryData {
 const MAX_GRADIENT_COLORS: usize = 15;
 
 impl WebGlRenderBackend {
-    pub fn new(canvas: &HtmlCanvasElement, is_transparent: bool) -> Result<Self, Error> {
+    pub fn new(
+        canvas: &HtmlCanvasElement,
+        is_transparent: bool,
+        quality: StageQuality,
+    ) -> Result<Self, Error> {
         // Create WebGL context.
         let options = [
             ("stencil", JsValue::TRUE),
@@ -200,13 +204,7 @@ impl WebGlRenderBackend {
                 .map_err(|_| Error::CantCreateGLContext)?;
 
             // Determine MSAA sample count.
-            // Default to 4x MSAA on desktop, 2x on mobile/tablets.
-            let mut msaa_sample_count = if ruffle_web_common::is_mobile_or_tablet() {
-                log::info!("Running on a mobile device; defaulting to 2x MSAA");
-                2
-            } else {
-                4
-            };
+            let mut msaa_sample_count = quality.sample_count().min(4);
 
             // Ensure that we don't exceed the max MSAA of this device.
             if let Ok(max_samples) = gl2.get_parameter(Gl2::MAX_SAMPLES) {

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -9,10 +9,5 @@ license = "MIT OR Apache-2.0"
 workspace = true
 
 [dependencies]
-js-sys = { workspace = true }
 tracing = { workspace = true }
 wasm-bindgen = { workspace = true }
-
-[dependencies.web-sys]
-version = "0.3.69"
-features = ["Window"]

--- a/web/common/src/lib.rs
+++ b/web/common/src/lib.rs
@@ -39,14 +39,3 @@ impl<T> JsResult<T> for Result<T, JsValue> {
         self.map_err(|value| JsError { value })
     }
 }
-
-/// Very bad way to guess if we're running on a tablet/mobile.
-pub fn is_mobile_or_tablet() -> bool {
-    if let Some(window) = web_sys::window() {
-        if let Ok(val) = js_sys::Reflect::get(&window, &JsValue::from("orientation")) {
-            return !val.is_undefined();
-        }
-    }
-
-    false
-}

--- a/web/packages/core/src/internal/builder.ts
+++ b/web/packages/core/src/internal/builder.ts
@@ -1,0 +1,150 @@
+import type { RuffleInstanceBuilder } from "../../dist/ruffle_web";
+import { BaseLoadOptions, Duration, SecsDuration } from "../load-options";
+
+/**
+ * Checks if the given value is explicitly `T` (not null, not undefined)
+ *
+ * @param value The value to test
+ * @returns true if the value isn't null or undefined
+ */
+function isExplicit<T>(value: T | undefined | null): value is T {
+    return value !== null && value !== undefined;
+}
+
+/**
+ * Configures the given RuffleInstanceBuilder for the general options provided.
+ *
+ * This is the translation layer between what we allow users to provide through e.g. `window.RufflePlayer.config`,
+ * which is quite relaxed and may evolve over time,
+ * and the actual values we accept inside Rust (which is quite strict).
+ *
+ * This allows us to change the rust side at will, and without needing to worry about backwards compatibility, parsing, etc.
+ *
+ * @param builder The builder to set the options on
+ * @param config The options to apply
+ */
+export function configureBuilder(
+    builder: RuffleInstanceBuilder,
+    config: BaseLoadOptions,
+) {
+    // Guard things for being explicitly set, so that we don't need to specify defaults in yet another place...
+
+    if (isExplicit(config.allowScriptAccess)) {
+        builder.setAllowScriptAccess(config.allowScriptAccess);
+    }
+    if (isExplicit(config.backgroundColor)) {
+        builder.setBackgroundColor(parseColor(config.backgroundColor));
+    }
+    if (isExplicit(config.upgradeToHttps)) {
+        builder.setUpgradeToHttps(config.upgradeToHttps);
+    }
+    if (isExplicit(config.compatibilityRules)) {
+        builder.setCompatibilityRules(config.compatibilityRules);
+    }
+    if (isExplicit(config.letterbox)) {
+        builder.setLetterbox(config.letterbox.toLowerCase());
+    }
+    if (isExplicit(config.base)) {
+        builder.setBaseUrl(config.base);
+    }
+    if (isExplicit(config.menu)) {
+        builder.setShowMenu(config.menu);
+    }
+    if (isExplicit(config.allowFullscreen)) {
+        builder.setAllowFullscreen(config.allowFullscreen);
+    }
+    if (isExplicit(config.salign)) {
+        builder.setStageAlign(config.salign.toLowerCase());
+    }
+    if (isExplicit(config.forceAlign)) {
+        builder.setForceAlign(config.forceAlign);
+    }
+    if (isExplicit(config.quality)) {
+        builder.setQuality(config.quality.toLowerCase());
+    }
+    if (isExplicit(config.scale)) {
+        builder.setScale(config.scale.toLowerCase());
+    }
+    if (isExplicit(config.forceScale)) {
+        builder.setForceScale(config.forceScale);
+    }
+    if (isExplicit(config.frameRate)) {
+        builder.setFrameRate(config.frameRate);
+    }
+    if (isExplicit(config.wmode)) {
+        builder.setWmode(config.wmode);
+    }
+    if (isExplicit(config.logLevel)) {
+        builder.setLogLevel(config.logLevel);
+    }
+    if (isExplicit(config.maxExecutionDuration)) {
+        builder.setMaxExecutionDuration(
+            parseDuration(config.maxExecutionDuration),
+        );
+    }
+    if (isExplicit(config.playerVersion)) {
+        builder.setPlayerVersion(config.playerVersion);
+    }
+    if (isExplicit(config.preferredRenderer)) {
+        builder.setPreferredRenderer(config.preferredRenderer);
+    }
+    if (isExplicit(config.openUrlMode)) {
+        builder.setOpenUrlMode(config.openUrlMode.toLowerCase());
+    }
+    if (isExplicit(config.allowNetworking)) {
+        builder.setAllowNetworking(config.allowNetworking.toLowerCase());
+    }
+    if (isExplicit(config.credentialAllowList)) {
+        builder.setCredentialAllowList(config.credentialAllowList);
+    }
+    if (isExplicit(config.playerRuntime)) {
+        builder.setPlayerRuntime(config.playerRuntime);
+    }
+
+    if (isExplicit(config.socketProxy)) {
+        for (const proxy of config.socketProxy) {
+            builder.addSocketProxy(proxy.host, proxy.port, proxy.proxyUrl);
+        }
+    }
+}
+
+/**
+ * Parses a color into an RGB value.
+ *
+ * @param color The color string to parse
+ * @returns A valid RGB number, or undefined if invalid
+ */
+export function parseColor(color: string): number | undefined {
+    if (color.startsWith("#")) {
+        color = color.substring(1);
+    }
+    if (color.length < 6) {
+        return undefined;
+    }
+    let result = 0;
+
+    for (let i = 0; i < 6; i++) {
+        const digit = parseInt(color[i]!, 16);
+        if (!isNaN(digit)) {
+            result = (result << 4) | digit;
+        } else {
+            result = result << 4;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Parses a duration into number of seconds.
+ *
+ * @param value The duration to parse
+ * @returns A valid number of seconds
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function parseDuration(value: Duration): SecsDuration {
+    if (typeof value === "number") {
+        return value;
+    }
+    return value.secs;
+}

--- a/web/packages/core/src/internal/builder.ts
+++ b/web/packages/core/src/internal/builder.ts
@@ -61,6 +61,9 @@ export function configureBuilder(
     }
     if (isExplicit(config.quality)) {
         builder.setQuality(config.quality.toLowerCase());
+    } else if (isMobileOrTablet()) {
+        console.log("Running on a mobile device; defaulting to low quality");
+        builder.setQuality("low");
     }
     if (isExplicit(config.scale)) {
         builder.setScale(config.scale.toLowerCase());
@@ -147,4 +150,14 @@ export function parseDuration(value: Duration): SecsDuration {
         return value;
     }
     return value.secs;
+}
+
+/**
+ * Very bad way to guess if we're running on a tablet/mobile.
+ *
+ * @returns True if we believe this may be a mobile or tablet device
+ */
+function isMobileOrTablet(): boolean {
+    // noinspection JSDeprecatedSymbols
+    return typeof window.orientation !== "undefined";
 }

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -308,17 +308,17 @@ export interface DefaultFonts {
     /**
      * `_ゴシック`, a Japanese Gothic font
      */
-    JapaneseGothic?: Array<string>;
+    japaneseGothic?: Array<string>;
 
     /**
      * `_等幅`, a Japanese Gothic Mono font
      */
-    JapaneseGothicMono?: Array<string>;
+    japaneseGothicMono?: Array<string>;
 
     /**
      * `_明朝`, a Japanese Mincho font
      */
-    JapaneseMincho?: Array<string>;
+    japaneseMincho?: Array<string>;
 }
 
 /**

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -715,17 +715,13 @@ export class RufflePlayer extends HTMLElement {
             throw e;
         });
         configureBuilder(builder, this.loadedConfig || {});
-        this.instance = await builder.build(this.container, this).catch((e) => {
-            console.error(`Serious error loading Ruffle: ${e}`);
-            this.panic(e);
-            throw e;
-        });
+        builder.setVolume(this.volumeSettings.get_volume());
 
         if (this.loadedConfig?.fontSources) {
             for (const url of this.loadedConfig.fontSources) {
                 try {
                     const response = await fetch(url);
-                    this.instance!.add_font(
+                    builder.addFont(
                         url,
                         new Uint8Array(await response.arrayBuffer()),
                     );
@@ -739,25 +735,29 @@ export class RufflePlayer extends HTMLElement {
         }
 
         if (this.loadedConfig?.defaultFonts?.sans) {
-            this.instance!.set_default_font(
+            builder.setDefaultFont(
                 "sans",
                 this.loadedConfig?.defaultFonts.sans,
             );
         }
         if (this.loadedConfig?.defaultFonts?.serif) {
-            this.instance!.set_default_font(
+            builder!.setDefaultFont(
                 "serif",
                 this.loadedConfig?.defaultFonts.serif,
             );
         }
         if (this.loadedConfig?.defaultFonts?.typewriter) {
-            this.instance!.set_default_font(
+            builder!.setDefaultFont(
                 "typewriter",
                 this.loadedConfig?.defaultFonts.typewriter,
             );
         }
 
-        this.instance!.set_volume(this.volumeSettings.get_volume());
+        this.instance = await builder.build(this.container, this).catch((e) => {
+            console.error(`Serious error loading Ruffle: ${e}`);
+            this.panic(e);
+            throw e;
+        });
 
         this.rendererDebugInfo = this.instance!.renderer_debug_info();
 

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -734,23 +734,15 @@ export class RufflePlayer extends HTMLElement {
             }
         }
 
-        if (this.loadedConfig?.defaultFonts?.sans) {
-            builder.setDefaultFont(
-                "sans",
-                this.loadedConfig?.defaultFonts.sans,
-            );
-        }
-        if (this.loadedConfig?.defaultFonts?.serif) {
-            builder!.setDefaultFont(
-                "serif",
-                this.loadedConfig?.defaultFonts.serif,
-            );
-        }
-        if (this.loadedConfig?.defaultFonts?.typewriter) {
-            builder!.setDefaultFont(
-                "typewriter",
-                this.loadedConfig?.defaultFonts.typewriter,
-            );
+        for (const key in this.loadedConfig?.defaultFonts) {
+            const names = (
+                this.loadedConfig.defaultFonts as {
+                    [key: string]: Array<string>;
+                }
+            )[key];
+            if (names) {
+                builder.setDefaultFont(key, names);
+            }
         }
 
         this.instance = await builder.build(this.container, this).catch((e) => {

--- a/web/packages/core/test/config.ts
+++ b/web/packages/core/test/config.ts
@@ -7,7 +7,7 @@ describe("Color parsing", function () {
     });
 
     it("should parse a valid RRGGBB hex, without hash", function () {
-        assert.strictEqual(parseColor("#1A2B3C"), 0x1a2b3c);
+        assert.strictEqual(parseColor("1A2B3C"), 0x1a2b3c);
     });
 
     it("should fail with not enough digits", function () {

--- a/web/packages/core/test/config.ts
+++ b/web/packages/core/test/config.ts
@@ -1,0 +1,30 @@
+import { strict as assert } from "assert";
+import { parseColor, parseDuration } from "../src/internal/builder";
+
+describe("Color parsing", function () {
+    it("should parse a valid RRGGBB hex, with hash", function () {
+        assert.strictEqual(parseColor("#A1B2C3"), 0xa1b2c3);
+    });
+
+    it("should parse a valid RRGGBB hex, without hash", function () {
+        assert.strictEqual(parseColor("#1A2B3C"), 0x1a2b3c);
+    });
+
+    it("should fail with not enough digits", function () {
+        assert.strictEqual(parseColor("123"), undefined);
+    });
+
+    it("should treat invalid hex as 0", function () {
+        assert.strictEqual(parseColor("#AX2Y3Z"), 0xa02030);
+    });
+});
+
+describe("Duration parsing", function () {
+    it("should accept number of seconds as number", function () {
+        assert.strictEqual(parseDuration(12.3), 12.3);
+    });
+
+    it("should accept a legacy style duration", function () {
+        assert.strictEqual(parseDuration({ secs: 12.3, nanos: 400000 }), 12.3);
+    });
+});

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -8,7 +8,11 @@ use ruffle_core::{swf, Color, DefaultFont, Player, PlayerRuntime, StageAlign, St
 use ruffle_render::quality::StageQuality;
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
+use tracing_subscriber::layer::{Layered, SubscriberExt};
+use tracing_subscriber::Registry;
+use tracing_wasm::{WASMLayer, WASMLayerConfigBuilder};
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlElement;
 
@@ -364,5 +368,15 @@ impl RuffleInstanceBuilder {
         for (default, names) in &self.default_fonts {
             player.set_default_font(*default, names.clone());
         }
+    }
+
+    pub fn create_log_subscriber(&self) -> Arc<Layered<WASMLayer, Registry>> {
+        let layer = WASMLayer::new(
+            WASMLayerConfigBuilder::new()
+                .set_report_logs_in_timings(cfg!(feature = "profiling"))
+                .set_max_level(self.log_level)
+                .build(),
+        );
+        Arc::new(tracing_subscriber::registry().with(layer))
     }
 }

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -1,0 +1,278 @@
+use crate::{set_panic_hook, JavascriptPlayer, RuffleHandle, SocketProxy, RUFFLE_GLOBAL_PANIC};
+use js_sys::Promise;
+use ruffle_core::backend::navigator::OpenURLMode;
+use ruffle_core::config::{Letterbox, NetworkingAccessMode};
+use ruffle_core::{Color, PlayerRuntime, StageAlign, StageScaleMode};
+use ruffle_render::quality::StageQuality;
+use std::str::FromStr;
+use std::time::Duration;
+use wasm_bindgen::prelude::*;
+use web_sys::HtmlElement;
+
+#[wasm_bindgen(inspectable)]
+#[derive(Debug, Clone)]
+pub struct RuffleInstanceBuilder {
+    pub(crate) allow_script_access: bool,
+    pub(crate) background_color: Option<Color>,
+    pub(crate) letterbox: Letterbox,
+    pub(crate) upgrade_to_https: bool,
+    pub(crate) compatibility_rules: bool,
+    pub(crate) base_url: Option<String>,
+    pub(crate) show_menu: bool,
+    pub(crate) allow_fullscreen: bool,
+    pub(crate) stage_align: StageAlign,
+    pub(crate) force_align: bool,
+    pub(crate) quality: Option<StageQuality>,
+    pub(crate) scale: Option<StageScaleMode>,
+    pub(crate) force_scale: bool,
+    pub(crate) frame_rate: Option<f64>,
+    pub(crate) wmode: Option<String>, // TODO: Enumify? `Player` is working in strings here too...
+    pub(crate) log_level: tracing::Level,
+    pub(crate) max_execution_duration: Duration,
+    pub(crate) player_version: Option<u8>,
+    pub(crate) preferred_renderer: Option<String>, // TODO: Enumify?
+    pub(crate) open_url_mode: OpenURLMode,
+    pub(crate) allow_networking: NetworkingAccessMode,
+    pub(crate) socket_proxy: Vec<SocketProxy>,
+    pub(crate) credential_allow_list: Vec<String>,
+    pub(crate) player_runtime: PlayerRuntime,
+    // TODO: Add font related options
+    // TODO: Add volume
+}
+
+impl Default for RuffleInstanceBuilder {
+    fn default() -> Self {
+        // Anything available in `BaseLoadOptions` should match the default we list in the docs there.
+        // Some options may be variable (eg allowScriptAccess based on URL) -
+        // those should be always overriding these values in JS
+
+        Self {
+            allow_script_access: false,
+            background_color: None,
+            letterbox: Letterbox::Fullscreen,
+            upgrade_to_https: true,
+            compatibility_rules: true,
+            base_url: None,
+            show_menu: true,
+            allow_fullscreen: false,
+            stage_align: StageAlign::empty(),
+            force_align: false,
+            quality: None,
+            scale: None,
+            force_scale: false,
+            frame_rate: None,
+            wmode: None,
+            log_level: tracing::Level::ERROR,
+            max_execution_duration: Duration::from_secs_f64(15.0),
+            player_version: None,
+            preferred_renderer: None,
+            open_url_mode: OpenURLMode::Allow,
+            allow_networking: NetworkingAccessMode::All,
+            socket_proxy: vec![],
+            credential_allow_list: vec![],
+            player_runtime: PlayerRuntime::FlashPlayer,
+        }
+    }
+}
+
+#[wasm_bindgen]
+impl RuffleInstanceBuilder {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[wasm_bindgen(js_name = "setAllowScriptAccess")]
+    pub fn set_allow_script_access(&mut self, value: bool) {
+        self.allow_script_access = value;
+    }
+
+    #[wasm_bindgen(js_name = "setBackgroundColor")]
+    pub fn set_background_color(&mut self, value: Option<u32>) {
+        self.background_color = value.map(|rgb| Color::from_rgb(rgb, 255));
+    }
+
+    #[wasm_bindgen(js_name = "setUpgradeToHttps")]
+    pub fn set_upgrade_to_https(&mut self, value: bool) {
+        self.upgrade_to_https = value;
+    }
+
+    #[wasm_bindgen(js_name = "setCompatibilityRules")]
+    pub fn set_compatibility_rules(&mut self, value: bool) {
+        self.compatibility_rules = value;
+    }
+
+    #[wasm_bindgen(js_name = "setLetterbox")]
+    pub fn set_letterbox(&mut self, value: &str) {
+        self.letterbox = match value {
+            "off" => Letterbox::Off,
+            "fullscreen" => Letterbox::Fullscreen,
+            "on" => Letterbox::On,
+            _ => return,
+        };
+    }
+
+    #[wasm_bindgen(js_name = "setBaseUrl")]
+    pub fn set_base_url(&mut self, value: Option<String>) {
+        self.base_url = value;
+    }
+
+    #[wasm_bindgen(js_name = "setShowMenu")]
+    pub fn set_show_menu(&mut self, value: bool) {
+        self.show_menu = value;
+    }
+
+    #[wasm_bindgen(js_name = "setAllowFullscreen")]
+    pub fn set_allow_fullscreen(&mut self, value: bool) {
+        self.allow_fullscreen = value;
+    }
+
+    #[wasm_bindgen(js_name = "setStageAlign")]
+    pub fn set_stage_align(&mut self, value: &str) {
+        // [NA] This is weird. Do we really need this?
+
+        // Chars get converted into flags.
+        // This means "tbbtlbltblbrllrbltlrtbl" is valid, resulting in "TBLR".
+        let mut align = StageAlign::default();
+        for c in value.bytes().map(|c| c.to_ascii_uppercase()) {
+            match c {
+                b'T' => align.insert(StageAlign::TOP),
+                b'B' => align.insert(StageAlign::BOTTOM),
+                b'L' => align.insert(StageAlign::LEFT),
+                b'R' => align.insert(StageAlign::RIGHT),
+                _ => (),
+            }
+        }
+        self.stage_align = align;
+    }
+
+    #[wasm_bindgen(js_name = "setForceAlign")]
+    pub fn set_force_align(&mut self, value: bool) {
+        self.force_align = value;
+    }
+
+    #[wasm_bindgen(js_name = "setQuality")]
+    pub fn set_quality(&mut self, value: &str) {
+        self.quality = match value {
+            "low" => Some(StageQuality::Low),
+            "medium" => Some(StageQuality::Medium),
+            "high" => Some(StageQuality::High),
+            "best" => Some(StageQuality::Best),
+            "8x8" => Some(StageQuality::High8x8),
+            "8x8linear" => Some(StageQuality::High8x8Linear),
+            "16x16" => Some(StageQuality::High16x16),
+            "16x16linear" => Some(StageQuality::High16x16Linear),
+            _ => return,
+        };
+    }
+
+    #[wasm_bindgen(js_name = "setScale")]
+    pub fn set_scale(&mut self, value: &str) {
+        self.scale = match value {
+            "exactfit" => Some(StageScaleMode::ExactFit),
+            "noborder" => Some(StageScaleMode::NoBorder),
+            "noscale" => Some(StageScaleMode::NoScale),
+            "showall" => Some(StageScaleMode::ShowAll),
+            _ => return,
+        };
+    }
+
+    #[wasm_bindgen(js_name = "setForceScale")]
+    pub fn set_force_scale(&mut self, value: bool) {
+        self.force_scale = value;
+    }
+
+    #[wasm_bindgen(js_name = "setFrameRate")]
+    pub fn set_frame_rate(&mut self, value: Option<f64>) {
+        self.frame_rate = value;
+    }
+
+    #[wasm_bindgen(js_name = "setWmode")]
+    pub fn set_wmode(&mut self, value: Option<String>) {
+        self.wmode = value;
+    }
+
+    #[wasm_bindgen(js_name = "setLogLevel")]
+    pub fn set_log_level(&mut self, value: &str) {
+        if let Ok(level) = tracing::Level::from_str(value) {
+            self.log_level = level;
+        }
+    }
+
+    #[wasm_bindgen(js_name = "setMaxExecutionDuration")]
+    pub fn set_max_execution_duration(&mut self, value: f64) {
+        self.max_execution_duration = Duration::from_secs_f64(value);
+    }
+
+    #[wasm_bindgen(js_name = "setPlayerVersion")]
+    pub fn set_player_version(&mut self, value: Option<u8>) {
+        self.player_version = value;
+    }
+
+    #[wasm_bindgen(js_name = "setPreferredRenderer")]
+    pub fn set_preferred_renderer(&mut self, value: Option<String>) {
+        self.preferred_renderer = value;
+    }
+
+    #[wasm_bindgen(js_name = "setOpenUrlMode")]
+    pub fn set_open_url_mode(&mut self, value: &str) {
+        self.open_url_mode = match value {
+            "allow" => OpenURLMode::Allow,
+            "confirm" => OpenURLMode::Confirm,
+            "deny" => OpenURLMode::Deny,
+            _ => return,
+        };
+    }
+
+    #[wasm_bindgen(js_name = "setAllowNetworking")]
+    pub fn set_allow_networking(&mut self, value: &str) {
+        self.allow_networking = match value {
+            "all" => NetworkingAccessMode::All,
+            "internal" => NetworkingAccessMode::Internal,
+            "none" => NetworkingAccessMode::None,
+            _ => return,
+        };
+    }
+
+    #[wasm_bindgen(js_name = "addSocketProxy")]
+    pub fn add_socket_proxy(&mut self, host: String, port: u16, proxy_url: String) {
+        self.socket_proxy.push(SocketProxy {
+            host,
+            port,
+            proxy_url,
+        })
+    }
+
+    #[wasm_bindgen(js_name = "setCredentialAllowList")]
+    pub fn set_credential_allow_list(&mut self, value: Vec<String>) {
+        self.credential_allow_list = value;
+    }
+
+    #[wasm_bindgen(js_name = "setPlayerRuntime")]
+    pub fn set_player_runtime(&mut self, value: &str) {
+        self.player_runtime = match value {
+            "air" => PlayerRuntime::AIR,
+            "flashPlayer" => PlayerRuntime::FlashPlayer,
+            _ => return,
+        };
+    }
+
+    // TODO: This should be split into two methods that either load url or load data
+    // Right now, that's done immediately afterwards in TS
+    pub async fn build(&self, parent: HtmlElement, js_player: JavascriptPlayer) -> Promise {
+        let copy = self.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            if RUFFLE_GLOBAL_PANIC.is_completed() {
+                // If an actual panic happened, then we can't trust the state it left us in.
+                // Prevent future players from loading so that they can inform the user about the error.
+                return Err("Ruffle is panicking!".into());
+            }
+            set_panic_hook();
+
+            let ruffle = RuffleHandle::new_internal(parent, js_player, copy)
+                .await
+                .map_err(|err| JsValue::from(format!("Error creating player: {}", err)))?;
+            Ok(JsValue::from(ruffle))
+        })
+    }
+}

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -1,6 +1,7 @@
 use crate::{set_panic_hook, JavascriptPlayer, RuffleHandle, SocketProxy, RUFFLE_GLOBAL_PANIC};
 use js_sys::Promise;
 use ruffle_core::backend::navigator::OpenURLMode;
+use ruffle_core::compatibility_rules::CompatibilityRules;
 use ruffle_core::config::{Letterbox, NetworkingAccessMode};
 use ruffle_core::{Color, PlayerRuntime, StageAlign, StageScaleMode};
 use ruffle_render::quality::StageQuality;
@@ -16,7 +17,7 @@ pub struct RuffleInstanceBuilder {
     pub(crate) background_color: Option<Color>,
     pub(crate) letterbox: Letterbox,
     pub(crate) upgrade_to_https: bool,
-    pub(crate) compatibility_rules: bool,
+    pub(crate) compatibility_rules: CompatibilityRules,
     pub(crate) base_url: Option<String>,
     pub(crate) show_menu: bool,
     pub(crate) allow_fullscreen: bool,
@@ -51,7 +52,7 @@ impl Default for RuffleInstanceBuilder {
             background_color: None,
             letterbox: Letterbox::Fullscreen,
             upgrade_to_https: true,
-            compatibility_rules: true,
+            compatibility_rules: CompatibilityRules::default(),
             base_url: None,
             show_menu: true,
             allow_fullscreen: false,
@@ -99,7 +100,11 @@ impl RuffleInstanceBuilder {
 
     #[wasm_bindgen(js_name = "setCompatibilityRules")]
     pub fn set_compatibility_rules(&mut self, value: bool) {
-        self.compatibility_rules = value;
+        self.compatibility_rules = if value {
+            CompatibilityRules::default()
+        } else {
+            CompatibilityRules::empty()
+        };
     }
 
     #[wasm_bindgen(js_name = "setLetterbox")]

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -362,7 +362,7 @@ impl RuffleInstanceBuilder {
                                     player.register_device_font(FontDefinition::FontFile {
                                         name: name.to_string(),
                                         is_bold: font.is_bold,
-                                        is_italic: font.is_bold,
+                                        is_italic: font.is_italic,
                                         data: data.to_vec(),
                                         index: 0,
                                     })

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -24,7 +24,7 @@ pub struct RuffleInstanceBuilder {
     pub(crate) stage_align: StageAlign,
     pub(crate) force_align: bool,
     pub(crate) quality: Option<StageQuality>,
-    pub(crate) scale: Option<StageScaleMode>,
+    pub(crate) scale: StageScaleMode,
     pub(crate) force_scale: bool,
     pub(crate) frame_rate: Option<f64>,
     pub(crate) wmode: Option<String>, // TODO: Enumify? `Player` is working in strings here too...
@@ -59,7 +59,7 @@ impl Default for RuffleInstanceBuilder {
             stage_align: StageAlign::empty(),
             force_align: false,
             quality: None,
-            scale: None,
+            scale: StageScaleMode::ShowAll,
             force_scale: false,
             frame_rate: None,
             wmode: None,
@@ -174,10 +174,10 @@ impl RuffleInstanceBuilder {
     #[wasm_bindgen(js_name = "setScale")]
     pub fn set_scale(&mut self, value: &str) {
         self.scale = match value {
-            "exactfit" => Some(StageScaleMode::ExactFit),
-            "noborder" => Some(StageScaleMode::NoBorder),
-            "noscale" => Some(StageScaleMode::NoScale),
-            "showall" => Some(StageScaleMode::ShowAll),
+            "exactfit" => StageScaleMode::ExactFit,
+            "noborder" => StageScaleMode::NoBorder,
+            "noscale" => StageScaleMode::NoScale,
+            "showall" => StageScaleMode::ShowAll,
             _ => return,
         };
     }

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{set_panic_hook, JavascriptPlayer, RuffleHandle, SocketProxy, RUFFLE_GLOBAL_PANIC};
+use crate::{JavascriptPlayer, RuffleHandle, SocketProxy, RUFFLE_GLOBAL_PANIC};
 use js_sys::Promise;
 use ruffle_core::backend::navigator::OpenURLMode;
 use ruffle_core::backend::ui::FontDefinition;
@@ -307,7 +307,6 @@ impl RuffleInstanceBuilder {
                 // Prevent future players from loading so that they can inform the user about the error.
                 return Err("Ruffle is panicking!".into());
             }
-            set_panic_hook();
 
             let ruffle = RuffleHandle::new_internal(parent, js_player, copy)
                 .await

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -1,3 +1,4 @@
+use crate::navigator::WebNavigatorBackend;
 use crate::{audio, JavascriptPlayer, RuffleHandle, SocketProxy, RUFFLE_GLOBAL_PANIC};
 use js_sys::Promise;
 use ruffle_core::backend::audio::{AudioBackend, NullAudioBackend};
@@ -524,5 +525,21 @@ impl RuffleInstanceBuilder {
             tracing::error!("Unable to create audio backend. No audio will be played.");
             Box::new(NullAudioBackend::new())
         }
+    }
+
+    pub fn create_navigator(
+        &self,
+        log_subscriber: Arc<Layered<WASMLayer, Registry>>,
+    ) -> WebNavigatorBackend {
+        WebNavigatorBackend::new(
+            self.allow_script_access,
+            self.allow_networking,
+            self.upgrade_to_https,
+            self.base_url.clone(),
+            log_subscriber.clone(),
+            self.open_url_mode,
+            self.socket_proxy.clone(),
+            self.credential_allow_list.clone(),
+        )
     }
 }

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -23,7 +23,7 @@ pub struct RuffleInstanceBuilder {
     pub(crate) allow_fullscreen: bool,
     pub(crate) stage_align: StageAlign,
     pub(crate) force_align: bool,
-    pub(crate) quality: Option<StageQuality>,
+    pub(crate) quality: StageQuality,
     pub(crate) scale: StageScaleMode,
     pub(crate) force_scale: bool,
     pub(crate) frame_rate: Option<f64>,
@@ -58,7 +58,7 @@ impl Default for RuffleInstanceBuilder {
             allow_fullscreen: false,
             stage_align: StageAlign::empty(),
             force_align: false,
-            quality: None,
+            quality: StageQuality::High,
             scale: StageScaleMode::ShowAll,
             force_scale: false,
             frame_rate: None,
@@ -159,14 +159,14 @@ impl RuffleInstanceBuilder {
     #[wasm_bindgen(js_name = "setQuality")]
     pub fn set_quality(&mut self, value: &str) {
         self.quality = match value {
-            "low" => Some(StageQuality::Low),
-            "medium" => Some(StageQuality::Medium),
-            "high" => Some(StageQuality::High),
-            "best" => Some(StageQuality::Best),
-            "8x8" => Some(StageQuality::High8x8),
-            "8x8linear" => Some(StageQuality::High8x8Linear),
-            "16x16" => Some(StageQuality::High16x16),
-            "16x16linear" => Some(StageQuality::High16x16Linear),
+            "low" => StageQuality::Low,
+            "medium" => StageQuality::Medium,
+            "high" => StageQuality::High,
+            "best" => StageQuality::Best,
+            "8x8" => StageQuality::High8x8,
+            "8x8linear" => StageQuality::High8x8Linear,
+            "16x16" => StageQuality::High16x16,
+            "16x16linear" => StageQuality::High16x16Linear,
             _ => return,
         };
     }

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -1,5 +1,6 @@
-use crate::{JavascriptPlayer, RuffleHandle, SocketProxy, RUFFLE_GLOBAL_PANIC};
+use crate::{audio, JavascriptPlayer, RuffleHandle, SocketProxy, RUFFLE_GLOBAL_PANIC};
 use js_sys::Promise;
+use ruffle_core::backend::audio::{AudioBackend, NullAudioBackend};
 use ruffle_core::backend::navigator::OpenURLMode;
 use ruffle_core::backend::ui::FontDefinition;
 use ruffle_core::compatibility_rules::CompatibilityRules;
@@ -511,5 +512,17 @@ impl RuffleInstanceBuilder {
             }
         }
         Err("Unable to create renderer".into())
+    }
+
+    pub fn create_audio_backend(
+        &self,
+        log_subscriber: Arc<Layered<WASMLayer, Registry>>,
+    ) -> Box<dyn AudioBackend> {
+        if let Ok(audio) = audio::WebAudioBackend::new(log_subscriber.clone()) {
+            Box::new(audio)
+        } else {
+            tracing::error!("Unable to create audio backend. No audio will be played.");
+            Box::new(NullAudioBackend::new())
+        }
     }
 }

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -304,9 +304,10 @@ impl RuffleInstanceBuilder {
             "sans" => DefaultFont::Sans,
             "serif" => DefaultFont::Serif,
             "typewriter" => DefaultFont::Typewriter,
-            _ => {
-                return;
-            }
+            "japaneseGothic" => DefaultFont::JapaneseGothic,
+            "japaneseGothicMono" => DefaultFont::JapaneseGothicMono,
+            "japaneseMincho" => DefaultFont::JapaneseMincho,
+            _ => return,
         };
         self.default_fonts.insert(
             default,

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -16,7 +16,6 @@ use external_interface::{external_to_js_value, js_to_external_value, JavascriptI
 use input::{web_key_to_codepoint, web_to_ruffle_key_code, web_to_ruffle_text_control};
 use js_sys::{Error as JsError, Uint8Array};
 use ruffle_core::backend::ui::FontDefinition;
-use ruffle_core::compatibility_rules::CompatibilityRules;
 use ruffle_core::config::NetworkingAccessMode;
 use ruffle_core::context::UpdateContext;
 use ruffle_core::events::{MouseButton, MouseWheelDelta, TextControlCode};
@@ -523,11 +522,7 @@ impl RuffleHandle {
             .with_max_execution_duration(config.max_execution_duration)
             .with_player_version(config.player_version)
             .with_player_runtime(config.player_runtime)
-            .with_compatibility_rules(if config.compatibility_rules {
-                CompatibilityRules::default()
-            } else {
-                CompatibilityRules::empty()
-            })
+            .with_compatibility_rules(config.compatibility_rules)
             .with_quality(config.quality.unwrap_or(default_quality))
             .with_align(config.stage_align, config.force_align)
             .with_scale_mode(config.scale.unwrap_or_default(), config.force_scale)

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -398,16 +398,7 @@ impl RuffleHandle {
         let mut builder = PlayerBuilder::new()
             .with_boxed_renderer(renderer)
             .with_boxed_audio(config.create_audio_backend(log_subscriber.clone()))
-            .with_navigator(navigator::WebNavigatorBackend::new(
-                allow_script_access,
-                allow_networking,
-                config.upgrade_to_https,
-                config.base_url.clone(),
-                log_subscriber.clone(),
-                config.open_url_mode,
-                config.socket_proxy.clone(),
-                config.credential_allow_list.clone(),
-            ));
+            .with_navigator(config.create_navigator(log_subscriber.clone()));
 
         match window.local_storage() {
             Ok(Some(s)) => {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -525,7 +525,7 @@ impl RuffleHandle {
             .with_compatibility_rules(config.compatibility_rules)
             .with_quality(config.quality.unwrap_or(default_quality))
             .with_align(config.stage_align, config.force_align)
-            .with_scale_mode(config.scale.unwrap_or_default(), config.force_scale)
+            .with_scale_mode(config.scale, config.force_scale)
             .with_frame_rate(config.frame_rate)
             // FIXME - should this be configurable?
             .with_sandbox_type(SandboxType::Remote)

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -398,16 +398,8 @@ impl RuffleHandle {
         let mut builder = PlayerBuilder::new()
             .with_boxed_renderer(renderer)
             .with_boxed_audio(config.create_audio_backend(log_subscriber.clone()))
-            .with_navigator(config.create_navigator(log_subscriber.clone()));
-
-        match window.local_storage() {
-            Ok(Some(s)) => {
-                builder = builder.with_storage(Box::new(storage::LocalStorageBackend::new(s)));
-            }
-            err => {
-                tracing::warn!("Unable to use localStorage: {:?}\nData will not save.", err);
-            }
-        };
+            .with_navigator(config.create_navigator(log_subscriber.clone()))
+            .with_storage(config.create_storage_backend());
 
         // Create the external interface.
         if allow_script_access && allow_networking == NetworkingAccessMode::All {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -391,27 +391,23 @@ impl RuffleHandle {
         let window = web_sys::window().ok_or("Expected window")?;
 
         let (renderer, canvas) = config.create_renderer().await?;
-        let mut builder = PlayerBuilder::new().with_boxed_renderer(renderer);
-
         parent
             .append_child(&canvas.clone().into())
             .into_js_result()?;
 
-        if let Ok(audio) = audio::WebAudioBackend::new(log_subscriber.clone()) {
-            builder = builder.with_audio(audio);
-        } else {
-            tracing::error!("Unable to create audio backend. No audio will be played.");
-        }
-        builder = builder.with_navigator(navigator::WebNavigatorBackend::new(
-            allow_script_access,
-            allow_networking,
-            config.upgrade_to_https,
-            config.base_url.clone(),
-            log_subscriber.clone(),
-            config.open_url_mode,
-            config.socket_proxy.clone(),
-            config.credential_allow_list.clone(),
-        ));
+        let mut builder = PlayerBuilder::new()
+            .with_boxed_renderer(renderer)
+            .with_boxed_audio(config.create_audio_backend(log_subscriber.clone()))
+            .with_navigator(navigator::WebNavigatorBackend::new(
+                allow_script_access,
+                allow_networking,
+                config.upgrade_to_https,
+                config.base_url.clone(),
+                log_subscriber.clone(),
+                config.open_url_mode,
+                config.socket_proxy.clone(),
+                config.credential_allow_list.clone(),
+            ));
 
         match window.local_storage() {
             Ok(Some(s)) => {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -383,14 +383,7 @@ impl RuffleHandle {
         js_player: JavascriptPlayer,
         config: RuffleInstanceBuilder,
     ) -> Result<Self, Box<dyn Error>> {
-        let log_subscriber = Arc::new(
-            Registry::default().with(WASMLayer::new(
-                WASMLayerConfigBuilder::new()
-                    .set_report_logs_in_timings(cfg!(feature = "profiling"))
-                    .set_max_level(config.log_level)
-                    .build(),
-            )),
-        );
+        let log_subscriber = config.create_log_subscriber();
         let _subscriber = tracing::subscriber::set_default(log_subscriber.clone());
         let allow_script_access = config.allow_script_access;
         let allow_networking = config.allow_networking;


### PR DESCRIPTION
The main motivation here is to get all the parsing of config stuff out from Rust and into TypeScript, for a few reasons:
1. Duck typing is what JS/TS is good at - Rust is really, really bad at it.
2. As we evolve the config, potentially change which values are accepted (eg the duration once went from object to number), we can just translate that in TS and Rust only needs to know the "real", final value
3. We can easily add tests for config parsing, which wasn't quite as simple in Rust
4. We can change what Rust accepts on a whim now, as needed - without changing the actual config interface we expose publicly

Along with this, lots of refactoring to split up `lib.rs` some more. A new `RuffleInstanceBuilder` is responsible for actually constructing the `Player `and `RuffleInstance`.

I've also added a new default log subscriber to capture things that happen outside of a specific ruffle instance, as that's bit us in the butt before.


I feel like I can probably add another 10 more commits and continue the refactor but I'm losing steam, I accomplished what I wanted already :D