### PR TITLE
extension: Use scripting permission for Flash spoofing on Firefox too

### DIFF
--- a/web/packages/extension/manifest_firefox.json5
+++ b/web/packages/extension/manifest_firefox.json5
@@ -49,6 +49,7 @@
     },
     "permissions": [
         "<all_urls>", // // To allow script injecting + the internal player to bypass CORS
+        "scripting",
         "storage"
     ],
     "web_accessible_resources": ["*"],

--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -10,8 +10,8 @@ async function contentScriptRegistered() {
 
 async function enable() {
     if (
-        utils.scripting.ExecutionWorld &&
-        !utils.scripting.ExecutionWorld.MAIN
+        !utils.scripting ||
+        (utils.scripting.ExecutionWorld && !utils.scripting.ExecutionWorld.MAIN)
     ) {
         return;
     }
@@ -40,8 +40,8 @@ async function enable() {
 
 async function disable() {
     if (
-        utils.scripting.ExecutionWorld &&
-        !utils.scripting.ExecutionWorld.MAIN
+        !utils.scripting ||
+        (utils.scripting.ExecutionWorld && !utils.scripting.ExecutionWorld.MAIN)
     ) {
         return;
     }

--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -2,15 +2,21 @@ import * as utils from "./utils";
 import { isMessage } from "./messages";
 
 async function contentScriptRegistered() {
-    const matchingScripts = await chrome.scripting.getRegisteredContentScripts({
+    const matchingScripts = await utils.scripting.getRegisteredContentScripts({
         ids: ["plugin-polyfill"],
     });
     return matchingScripts?.length > 0;
 }
 
 async function enable() {
-    if (chrome?.scripting && !(await contentScriptRegistered())) {
-        await chrome.scripting.registerContentScripts([
+    if (
+        utils.scripting.ExecutionWorld &&
+        !utils.scripting.ExecutionWorld.MAIN
+    ) {
+        return;
+    }
+    if (!(await contentScriptRegistered())) {
+        await utils.scripting.registerContentScripts([
             {
                 id: "plugin-polyfill",
                 js: ["dist/pluginPolyfill.js"],
@@ -33,8 +39,14 @@ async function enable() {
 }
 
 async function disable() {
-    if (chrome?.scripting && (await contentScriptRegistered())) {
-        await chrome.scripting.unregisterContentScripts({
+    if (
+        utils.scripting.ExecutionWorld &&
+        !utils.scripting.ExecutionWorld.MAIN
+    ) {
+        return;
+    }
+    if (await contentScriptRegistered()) {
+        await utils.scripting.unregisterContentScripts({
             ids: ["plugin-polyfill"],
         });
     }

--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -5,7 +5,7 @@ async function contentScriptRegistered() {
     const matchingScripts = await chrome.scripting.getRegisteredContentScripts({
         ids: ["plugin-polyfill"],
     });
-    return matchingScripts.length > 0;
+    return matchingScripts?.length > 0;
 }
 
 async function enable() {

--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -46,17 +46,6 @@ function sendMessageToPage(data: unknown): Promise<unknown> {
 }
 
 /**
- * Inject a raw script to the main world.
- * @param {string} src - Script to inject.
- */
-function injectScriptRaw(src: string) {
-    const script = document.createElement("script");
-    script.textContent = src;
-    (document.head || document.documentElement).append(script);
-    script.remove();
-}
-
-/**
  * Inject a script by URL to the main world.
  * @param {string} url - Script URL to inject.
  */
@@ -144,18 +133,6 @@ function isXMLDocument(): boolean {
 
     if (!shouldLoad) {
         return;
-    }
-
-    // We must run the plugin polyfill before any flash detection scripts.
-    // Unfortunately, this might still be too late for some websites (issue #969).
-    // NOTE: The script code injected here is the compiled form of
-    // plugin-polyfill.ts. It is injected by tools/inject_plugin_polyfill.js
-    // which just search-and-replaces for this particular string.
-    const permissions = (chrome || browser).runtime.getManifest().permissions;
-    if (!permissions?.includes("scripting")) {
-        // Chrome does this differently, by injecting it straight into the main world.
-        // This isn't as fast, oh well.
-        injectScriptRaw("%PLUGIN_POLYFILL_SOURCE%");
     }
 
     await injectScriptURL(utils.runtime.getURL(`dist/ruffle.js?id=${ID}`));

--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -23,6 +23,7 @@ import { isMessage } from "./messages";
 
 declare global {
     interface Navigator {
+        // Only supported in Firefox, see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts#accessing_page_script_objects_from_content_scripts
         wrappedJSObject?: Navigator;
     }
 }

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -19,6 +19,15 @@ interface StorageArea {
     set: (items: Record<string, unknown>) => Promise<void>;
 }
 
+type ScriptingType = (typeof browser.scripting | typeof chrome.scripting) & {
+    ExecutionWorld: {
+        MAIN: string | undefined;
+        ISOLATED: string;
+    };
+};
+
+export let scripting: ScriptingType;
+
 export let storage: {
     local: StorageArea;
     sync: StorageArea;
@@ -95,6 +104,7 @@ function promisifyStorageArea(
 
 if (typeof chrome !== "undefined") {
     i18n = chrome.i18n;
+    scripting = chrome.scripting as ScriptingType;
 
     storage = {
         local: promisifyStorageArea(chrome.storage.local),
@@ -136,6 +146,7 @@ if (typeof chrome !== "undefined") {
         );
 } else if (typeof browser !== "undefined") {
     i18n = browser.i18n;
+    scripting = browser.scripting as ScriptingType;
     storage = browser.storage;
     tabs = browser.tabs;
     runtime = browser.runtime;

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -53,7 +53,6 @@ function transformManifest(content, env) {
         manifest.browser_specific_settings = {
             gecko: {
                 id: firefoxExtensionId,
-                strict_min_version: "128.0a1",
             },
         };
     } else {

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -53,6 +53,7 @@ function transformManifest(content, env) {
         manifest.browser_specific_settings = {
             gecko: {
                 id: firefoxExtensionId,
+                strict_min_version: "128.0a1",
             },
         };
     } else {


### PR DESCRIPTION
Currently works on Firefox Nightly and Beta. Will reach stable on July 9th. ~~This will stay a draft until we deem adaptation levels for Firefox 128 acceptable to merge it. Any version of Firefox below Firefox 128 has the following error due to the code in background.ts: `Error: Type error for parameter scripts (Error processing 0: Unexpected property "world") for scripting.registerContentScripts.` We probably could avoid the `strict_min_version` and I'm guessing the only issue on older browsers would be a failure to spoof the Flash plugin, but I thought it better that the spoofing always works.~~

Edit: Now works on all Firefox versions.