### PR TITLE
chore: Fix subject-verb agreement

### DIFF
--- a/web/packages/core/src/ruffle-imports.ts
+++ b/web/packages/core/src/ruffle-imports.ts
@@ -70,7 +70,7 @@ export function copyToAudioBufferInterleaved(
 export function callExternalInterface(name: string, args: any[]): any {
     // [NA] Yes, this is direct eval. Yes, this is a Bad Thing when it comes to security.
     // In fact, yes this is vulnerable to an XSS attack!
-    // But plot twist: Flash allowed for this and many games *relies on it*. :(
+    // But plot twist: Flash allowed for this and many games *rely on it*. :(
     // Flash content can do `call("eval", "....")` regardless, this doesn't enable anything that wasn't already permitted.
     // It just goes against what the documentation says, and *looks* really suspicious.
     // Content can only run this if the website has enabled `allowScriptAccess`, so it has to be enabled by the website too.


### PR DESCRIPTION
Following a last minute change due to a review comment on #16505, the word "content" was changed to "games", which changed a singular noun to a plural noun. However, the singular verb form was kept.