### PR TITLE
avm2: Fix performance regression

### DIFF
--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -607,7 +607,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                 class,
                 arguments,
                 activation,
-                ScriptObject::custom_object(activation.context.gc_context, None, None), // Callee deliberately invalid.
+                self.into(), // Callee deliberately invalid.
             );
         }
 


### PR DESCRIPTION
A `ScriptObject` was being allocated on every `call_method` call