### PR TITLE
core: Reduce serde dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,7 +39,7 @@ chrono = { workspace = true, features = ["clock"] }
 web-time = "1.1.0"
 encoding_rs = "0.8.34"
 rand = { version = "0.8.5", features = ["std", "small_rng"], default-features = false }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "754b1184037aa9952a907107284fb73897e26adc", optional = true }
 regress = "0.10"
@@ -83,12 +83,13 @@ timeline_debug = []
 mp3 = ["symphonia"]
 nellymoser = ["nellymoser-rs"]
 audio = ["dasp"]
-known_stubs = ["linkme"]
+known_stubs = ["linkme", "serde"]
 default_compatibility_rules = []
 egui = ["dep:egui", "dep:egui_extras", "png"]
 jpegxr = ["dep:jpegxr", "lzma"]
 default_font = []
 test_only_as3 = []
+serde = ["serde/derive"]
 
 [build-dependencies]
 build_playerglobal = { path = "build_playerglobal" }

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -5,7 +5,6 @@ use crate::socket::{ConnectionState, SocketAction, SocketHandle};
 use crate::string::WStr;
 use async_channel::{Receiver, Sender};
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Display;
@@ -57,18 +56,19 @@ pub enum SocketMode {
 
 /// The handling mode of links opening a new website.
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum OpenURLMode {
     /// Allow all links to open a new website.
-    #[serde(rename = "allow")]
+    #[cfg_attr(feature = "serde", serde(rename = "allow"))]
     Allow,
 
     /// A confirmation dialog opens with every link trying to open a new website.
-    #[serde(rename = "confirm")]
+    #[cfg_attr(feature = "serde", serde(rename = "confirm"))]
     Confirm,
 
     /// Deny all links to open a new website.
-    #[serde(rename = "deny")]
+    #[cfg_attr(feature = "serde", serde(rename = "deny"))]
     Deny,
 }
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 /// Controls whether the content is letterboxed or pillarboxed when the
@@ -7,19 +6,23 @@ use std::str::FromStr;
 /// When letterboxed, black bars will be rendered around the exterior
 /// margins of the content.
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename = "letterbox")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename = "letterbox")
+)]
 pub enum Letterbox {
     /// The content will never be letterboxed.
-    #[serde(rename = "off")]
+    #[cfg_attr(feature = "serde", serde(rename = "off"))]
     Off,
 
     /// The content will only be letterboxed if the content is running fullscreen.
-    #[serde(rename = "fullscreen")]
+    #[cfg_attr(feature = "serde", serde(rename = "fullscreen"))]
     Fullscreen,
 
     /// The content will always be letterboxed.
-    #[serde(rename = "on")]
+    #[cfg_attr(feature = "serde", serde(rename = "on"))]
     On,
 }
 
@@ -41,17 +44,18 @@ impl FromStr for Letterbox {
 
 /// The networking API access mode of the Ruffle player.
 /// This setting is only used on web.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NetworkingAccessMode {
     /// All networking APIs are permitted in the SWF file.
-    #[serde(rename = "all")]
+    #[cfg_attr(feature = "serde", serde(rename = "all"))]
     All,
 
     /// The SWF file may not call browser navigation or browser interaction APIs.
     ///
     /// The APIs getURL(), navigateToURL(), fscommand() and ExternalInterface.call()
     /// are prevented in this mode.
-    #[serde(rename = "internal")]
+    #[cfg_attr(feature = "serde", serde(rename = "internal"))]
     Internal,
 
     /// The SWF file may not call browser navigation or browser interaction APIs
@@ -65,6 +69,6 @@ pub enum NetworkingAccessMode {
     /// URLStream.load() and XMLSocket.connect() are prevented in this mode.
     ///
     /// This mode is not implemented yet.
-    #[serde(rename = "none")]
+    #[cfg_attr(feature = "serde", serde(rename = "none"))]
     None,
 }

--- a/core/src/context_menu.rs
+++ b/core/src/context_menu.rs
@@ -13,7 +13,6 @@ use crate::events::TextControlCode;
 use crate::i18n::core_text;
 use gc_arena::Collect;
 use ruffle_render::quality::StageQuality;
-use serde::Serialize;
 
 #[derive(Collect, Default)]
 #[collect(no_drop)]
@@ -203,10 +202,11 @@ impl<'gc> ContextMenuState<'gc> {
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct ContextMenuItem {
     pub enabled: bool,
-    #[serde(rename = "separatorBefore")]
+    #[cfg_attr(feature = "serde", serde(rename = "separatorBefore"))]
     pub separator_before: bool,
     pub checked: bool,
     pub caption: String,

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,5 +1,4 @@
 use crate::display_object::InteractiveObject;
-use serde::Deserialize;
 use swf::ClipEventFlag;
 
 #[derive(Debug, Clone, Copy)]
@@ -341,7 +340,8 @@ impl<'gc> ClipEvent<'gc> {
 }
 
 /// Control inputs to a text field
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub enum TextControlCode {
     MoveLeft,
     MoveLeftWord,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -56,7 +56,6 @@ use ruffle_render::commands::CommandList;
 use ruffle_render::quality::StageQuality;
 use ruffle_render::transform::TransformStack;
 use ruffle_video::backend::VideoBackend;
-use serde::Deserialize;
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::ops::DerefMut;
@@ -2795,7 +2794,8 @@ fn run_mouse_pick<'gc>(
 }
 
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Default, Clone, Copy, Debug, Eq, PartialEq, Deserialize)]
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub enum PlayerRuntime {
     #[default]
     FlashPlayer,

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -24,7 +24,7 @@ lyon_geom = "1.0.5"
 thiserror = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
 enum-map = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"], optional = true }
 clap = { workspace = true, optional = true }
 h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "f0fa94c366a1d0383df99aa835add175658d6bad"}
 num-traits = { workspace = true }
@@ -50,3 +50,4 @@ default = []
 tessellator = ["lyon"]
 web = ["wasm-bindgen"]
 wgpu = ["dep:wgpu"]
+serde = ["dep:serde"]

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -9,7 +9,6 @@ use crate::quality::StageQuality;
 use crate::shape_utils::DistilledShape;
 use downcast_rs::{impl_downcast, Downcast};
 use ruffle_wstr::WStr;
-use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt::Debug;
@@ -533,8 +532,9 @@ pub struct ShapeHandle(pub Arc<dyn ShapeHandleImpl>);
 pub trait ShapeHandleImpl: Downcast + Debug {}
 impl_downcast!(ShapeHandleImpl);
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct ViewportDimensions {
     /// The dimensions of the stage's containing viewport.
     pub width: u32,

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-ruffle_core = { path = "../../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "default_font"] }
+ruffle_core = { path = "../../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "default_font", "serde"] }
 ruffle_render = { path = "../../render", features = ["serde"] }
 ruffle_input_format = { path = "../input-format" }
 ruffle_socket_format = { path = "../socket-format" }

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 ruffle_core = { path = "../../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "default_font"] }
-ruffle_render = { path = "../../render" }
+ruffle_render = { path = "../../render", features = ["serde"] }
 ruffle_input_format = { path = "../input-format" }
 ruffle_socket_format = { path = "../socket-format" }
 ruffle_video_software = { path = "../../video/software", optional = true }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -63,7 +63,7 @@ zip = { version = "2.1.2", default-features = false}
 
 [dependencies.ruffle_core]
 path = "../core"
-features = ["audio", "mp3", "nellymoser", "default_compatibility_rules", "default_font"]
+features = ["audio", "mp3", "nellymoser", "default_compatibility_rules", "default_font", "serde"]
 
 [dependencies.web-sys]
 version = "0.3.69"

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -21,7 +21,7 @@ use ruffle_core::events::{MouseButton, MouseWheelDelta, TextControlCode};
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::{Player, PlayerEvent, StaticCallstack, ViewportDimensions};
 use ruffle_web_common::JsResult;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use slotmap::{new_key_type, SlotMap};
 use std::rc::Rc;
 use std::str::FromStr;
@@ -180,8 +180,7 @@ extern "C" {
     fn display_unsupported_video(this: &JavascriptPlayer, url: &str);
 }
 
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
 pub struct SocketProxy {
     host: String,
     port: u16,


### PR DESCRIPTION
We still need the dependency because of `serde_json` - but this removes the `derive` feature at least, which should increase compile times a bit (for desktop at least; web still uses serde a little)

Sadly it's still being built on desktop anyway because of https://github.com/emilk/egui/pull/4641 but... eventually!