### PR TITLE
avm2: Port registerClassAlias logic to Rust

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -178,6 +178,9 @@ pub struct Avm2<'gc> {
     /// strong references around (this matches Flash's behavior).
     orphan_objects: Rc<Vec<DisplayObjectWeak<'gc>>>,
 
+    alias_to_class_map: FnvHashMap<AvmString<'gc>, ClassObject<'gc>>,
+    class_to_alias_map: FnvHashMap<ClassObject<'gc>, AvmString<'gc>>,
+
     /// The api version of our root movie clip. Note - this is used as the
     /// api version for swfs loaded via `Loader`, overriding the api version
     /// specified in the loaded SWF. This is only used for API versioning (hiding
@@ -254,6 +257,9 @@ impl<'gc> Avm2<'gc> {
 
             orphan_objects: Default::default(),
 
+            alias_to_class_map: Default::default(),
+            class_to_alias_map: Default::default(),
+
             // Set the lowest version for now - this will be overridden when we set our movie
             root_api_version: ApiVersion::AllVersions,
 
@@ -283,6 +289,19 @@ impl<'gc> Avm2<'gc> {
 
     pub fn toplevel_global_object(&self) -> Option<Object<'gc>> {
         self.toplevel_global_object
+    }
+
+    pub fn register_class_alias(&mut self, name: AvmString<'gc>, class_object: ClassObject<'gc>) {
+        self.alias_to_class_map.insert(name, class_object);
+        self.class_to_alias_map.insert(class_object, name);
+    }
+
+    pub fn get_class_by_alias(&self, name: AvmString<'gc>) -> Option<ClassObject<'gc>> {
+        self.alias_to_class_map.get(&name).copied()
+    }
+
+    pub fn get_alias_by_class(&self, cls: ClassObject<'gc>) -> Option<AvmString<'gc>> {
+        self.class_to_alias_map.get(&cls).copied()
     }
 
     /// Run a script's initializer method.

--- a/core/src/avm2/globals/flash/net.as
+++ b/core/src/avm2/globals/flash/net.as
@@ -1,49 +1,12 @@
 package flash.net {
 
     import flash.net.URLRequest;
-    import flash.utils.Dictionary;
     import __ruffle__.stub_method;
-
-    internal var _aliasToClass: Object = {};
-    internal var _classToAlias: Dictionary = new Dictionary();
 
     public native function navigateToURL(request:URLRequest, window:String = null):void;
 
-    public function registerClassAlias(name:String, object:Class):void {
-        if (name == null) {
-            throw new TypeError("Error #2007: Parameter aliasName must be non-null.", 2007);
-        }
-        if (object == null) {
-            throw new TypeError("Error #2007: Parameter classObject must be non-null.", 2007);
-        }
-
-        this._aliasToClass[name] = object;
-        this._classToAlias[object] = name;
-    }
-
-    internal function _getClassByAlias(name:String):Class {
-        if (!this._aliasToClass.hasOwnProperty(name)) {
-            return null;
-        }
-
-        return this._aliasToClass[name];
-    }
-
-    public function getClassByAlias(name:String):Class {
-        var klass: Class = this._getClassByAlias(name);
-        if (klass == null) {
-            throw new ReferenceError("Error #1014: Class " + name + " could not be found.", 1014);
-        }
-        return klass;
-    }
-
-    internal function _getAliasByClass(object:Class):String {
-        if (this._classToAlias[object]) {
-            return this._classToAlias[object];
-        } else {
-            return null;
-        }
-    }
+    public native function registerClassAlias(name:String, object:Class):void;
+    public native function getClassByAlias(name:String):Class;
 
     public function sendToURL(request:URLRequest):void {
         stub_method("flash.net", "sendToURL");


### PR DESCRIPTION
No functional changes intended.

Prerequisite for future refactor to make `class_to_alias_map` use a `Class` instead of `ClassObject` key.