### PR TITLE
avm2: More work on the class refactor

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -72,6 +72,7 @@ mod vtable;
 pub use crate::avm2::activation::Activation;
 pub use crate::avm2::array::ArrayStorage;
 pub use crate::avm2::call_stack::{CallNode, CallStack};
+pub use crate::avm2::class::Class;
 #[allow(unused)] // For debug_ui
 pub use crate::avm2::domain::{Domain, DomainPtr};
 pub use crate::avm2::error::Error;
@@ -179,7 +180,7 @@ pub struct Avm2<'gc> {
     orphan_objects: Rc<Vec<DisplayObjectWeak<'gc>>>,
 
     alias_to_class_map: FnvHashMap<AvmString<'gc>, ClassObject<'gc>>,
-    class_to_alias_map: FnvHashMap<ClassObject<'gc>, AvmString<'gc>>,
+    class_to_alias_map: FnvHashMap<Class<'gc>, AvmString<'gc>>,
 
     /// The api version of our root movie clip. Note - this is used as the
     /// api version for swfs loaded via `Loader`, overriding the api version
@@ -293,14 +294,15 @@ impl<'gc> Avm2<'gc> {
 
     pub fn register_class_alias(&mut self, name: AvmString<'gc>, class_object: ClassObject<'gc>) {
         self.alias_to_class_map.insert(name, class_object);
-        self.class_to_alias_map.insert(class_object, name);
+        self.class_to_alias_map
+            .insert(class_object.inner_class_definition(), name);
     }
 
     pub fn get_class_by_alias(&self, name: AvmString<'gc>) -> Option<ClassObject<'gc>> {
         self.alias_to_class_map.get(&name).copied()
     }
 
-    pub fn get_alias_by_class(&self, cls: ClassObject<'gc>) -> Option<AvmString<'gc>> {
+    pub fn get_alias_by_class(&self, cls: Class<'gc>) -> Option<AvmString<'gc>> {
         self.class_to_alias_map.get(&cls).copied()
     }
 

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1632,6 +1632,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn op_get_outer_scope(&mut self, index: u32) -> Result<FrameControl<'gc>, Error<'gc>> {
         // Verifier ensures that this points to a valid outer scope
+
         let scope = self.outer.get_unchecked(index as usize);
 
         self.push_stack(scope.values());
@@ -1730,10 +1731,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         } else {
             // Even if it's an object with the "descendants" property, we won't support it.
             let class_name = object
-                .instance_of()
+                .instance_class()
                 .map(|cls| {
-                    cls.inner_class_definition()
-                        .name()
+                    cls.name()
                         .to_qualified_name_err_message(self.context.gc_context)
                 })
                 .unwrap_or_else(|| AvmString::from("<UNKNOWN>"));

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -104,7 +104,10 @@ pub struct ClassData<'gc> {
     /// superinterfaces, nor interfaces implemented by the superclass.
     direct_interfaces: Vec<Class<'gc>>,
 
-    /// The list of all interfaces implemented by this class.
+    /// Interfaces implemented by this class, including interfaces
+    /// from parent classes and superinterfaces (recursively).
+    /// TODO - avoid cloning this when a subclass implements the
+    /// same interface as its superclass.
     all_interfaces: Vec<Class<'gc>>,
 
     /// The instance allocator for this class.
@@ -633,7 +636,7 @@ impl<'gc> Class<'gc> {
                     .into());
                 }
 
-                if dedup.insert(ClassHashWrapper(*interface)) {
+                if dedup.insert(*interface) {
                     queue.push(*interface);
                     interfaces.push(*interface);
                 }
@@ -1147,20 +1150,5 @@ impl<'gc> Class<'gc> {
     /// Determine if this class is generic (can be specialized)
     pub fn is_generic(self) -> bool {
         self.0.read().attributes.contains(ClassAttributes::GENERIC)
-    }
-}
-
-pub struct ClassHashWrapper<'gc>(pub Class<'gc>);
-
-impl<'gc> PartialEq for ClassHashWrapper<'gc> {
-    fn eq(&self, other: &Self) -> bool {
-        GcCell::ptr_eq(self.0 .0, other.0 .0)
-    }
-}
-impl<'gc> Eq for ClassHashWrapper<'gc> {}
-
-impl<'gc> Hash for ClassHashWrapper<'gc> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0 .0.as_ptr().hash(state);
     }
 }

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -604,8 +604,8 @@ impl<'gc> Class<'gc> {
         }
 
         read.instance_vtable.init_vtable(
+            self,
             None,
-            self.protected_namespace(),
             &read.instance_traits,
             None,
             read.super_class.map(|c| c.instance_vtable()),

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -104,6 +104,9 @@ pub struct ClassData<'gc> {
     /// superinterfaces, nor interfaces implemented by the superclass.
     direct_interfaces: Vec<Class<'gc>>,
 
+    /// The list of all interfaces implemented by this class.
+    all_interfaces: Vec<Class<'gc>>,
+
     /// The instance allocator for this class.
     ///
     /// If `None`, then instances of this object will be allocated the same way
@@ -163,7 +166,7 @@ pub struct ClassData<'gc> {
     /// Maps a type parameter to the application of this class with that parameter.
     ///
     /// Only applicable if this class is generic.
-    applications: FnvHashMap<Option<ClassKey<'gc>>, Class<'gc>>,
+    applications: FnvHashMap<Option<Class<'gc>>, Class<'gc>>,
 
     /// Whether or not this is a system-defined class.
     ///
@@ -184,29 +187,17 @@ impl PartialEq for Class<'_> {
     }
 }
 
+impl Eq for Class<'_> {}
+
+impl Hash for Class<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_ptr().hash(state);
+    }
+}
+
 impl<'gc> core::fmt::Debug for Class<'gc> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("Class").field("name", &self.name()).finish()
-    }
-}
-
-/// Allows using a `Class<'gc>` as a HashMap key,
-/// using the pointer address for hashing/equality.
-#[derive(Collect, Copy, Clone)]
-#[collect(no_drop)]
-struct ClassKey<'gc>(Class<'gc>);
-
-impl PartialEq for ClassKey<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl Eq for ClassKey<'_> {}
-
-impl Hash for ClassKey<'_> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0 .0.as_ptr().hash(state);
     }
 }
 
@@ -237,6 +228,7 @@ impl<'gc> Class<'gc> {
                 attributes: ClassAttributes::empty(),
                 protected_namespace: None,
                 direct_interfaces: Vec::new(),
+                all_interfaces: Vec::new(),
                 instance_allocator: None,
                 instance_init,
                 native_instance_init,
@@ -255,8 +247,7 @@ impl<'gc> Class<'gc> {
     }
 
     pub fn add_application(self, mc: &Mutation<'gc>, param: Option<Class<'gc>>, cls: Class<'gc>) {
-        let key = param.map(ClassKey);
-        self.0.write(mc).applications.insert(key, cls);
+        self.0.write(mc).applications.insert(param, cls);
     }
 
     /// Apply type parameters to an existing class.
@@ -271,9 +262,7 @@ impl<'gc> Class<'gc> {
         let mc = context.gc_context;
         let this_read = this.0.read();
 
-        let key = param.map(ClassKey);
-
-        if let Some(application) = this_read.applications.get(&key) {
+        if let Some(application) = this_read.applications.get(&param) {
             return *application;
         }
 
@@ -312,7 +301,7 @@ impl<'gc> Class<'gc> {
 
         drop(this_read);
 
-        this.0.write(mc).applications.insert(key, new_class);
+        this.0.write(mc).applications.insert(Some(param), new_class);
         new_class
     }
 
@@ -464,6 +453,7 @@ impl<'gc> Class<'gc> {
                 attributes,
                 protected_namespace,
                 direct_interfaces: interfaces,
+                all_interfaces: Vec::new(),
                 instance_allocator,
                 instance_init,
                 native_instance_init,
@@ -658,7 +648,7 @@ impl<'gc> Class<'gc> {
         // interfaces (i.e. those that were not already implemented by the superclass)
         // Otherwise, our behavior diverges from Flash Player in certain cases.
         // See the ignored test 'tests/tests/swfs/avm2/weird_superinterface_properties/'
-        for interface in interfaces {
+        for interface in &interfaces {
             for interface_trait in &*interface.instance_traits() {
                 if !interface_trait.name().namespace().is_public() {
                     let public_name = QName::new(
@@ -673,6 +663,8 @@ impl<'gc> Class<'gc> {
                 }
             }
         }
+
+        self.0.write(context.gc_context).all_interfaces = interfaces;
 
         Ok(())
     }
@@ -704,6 +696,7 @@ impl<'gc> Class<'gc> {
                 attributes: ClassAttributes::empty(),
                 protected_namespace: None,
                 direct_interfaces: Vec::new(),
+                all_interfaces: Vec::new(),
                 instance_allocator: None,
                 instance_init: Method::from_builtin(
                     |_, _, _| Ok(Value::Undefined),
@@ -737,6 +730,36 @@ impl<'gc> Class<'gc> {
         Ok(class)
     }
 
+    /// Determine if this class has a given type in its superclass chain.
+    ///
+    /// The given class `test_class` should be either a superclass or
+    /// interface we are checking against this class.
+    ///
+    /// To test if a class *instance* is of a given type, see `Object::is_of_type`.
+    pub fn has_class_in_chain(self, test_class: Class<'gc>) -> bool {
+        let mut my_class = Some(self);
+
+        while let Some(class) = my_class {
+            if class == test_class {
+                return true;
+            }
+
+            my_class = class.super_class()
+        }
+
+        // A `Class` stores all of the interfaces it implements, including
+        // those from superinterfaces and superclasses (recursively).
+        if test_class.is_interface() {
+            for interface in &*self.all_interfaces() {
+                if *interface == test_class {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
     pub fn instance_vtable(self) -> VTable<'gc> {
         self.0.read().instance_vtable
     }
@@ -747,6 +770,26 @@ impl<'gc> Class<'gc> {
 
     pub fn try_name(self) -> Result<QName<'gc>, std::cell::BorrowError> {
         self.0.try_read().map(|r| r.name)
+    }
+
+    /// Attempts to obtain the name of this class.
+    /// If we are unable to read from the necessary `GcCell`,
+    /// the returned value will be some kind of error message.
+    ///
+    /// This should only be used in a debug context, where
+    /// we need infallible access to *something* to print
+    /// out.
+    pub fn debug_name(self) -> Box<dyn fmt::Debug + 'gc> {
+        let class_name = self.try_name();
+
+        match class_name {
+            Ok(class_name) => Box::new(class_name),
+            Err(err) => Box::new(err),
+        }
+    }
+
+    pub fn param(self) -> Option<Option<Class<'gc>>> {
+        self.0.read().param
     }
 
     pub fn set_param(self, mc: &Mutation<'gc>, param: Option<Option<Class<'gc>>>) {
@@ -1077,6 +1120,10 @@ impl<'gc> Class<'gc> {
 
     pub fn direct_interfaces(&self) -> Ref<Vec<Class<'gc>>> {
         Ref::map(self.0.read(), |c| &c.direct_interfaces)
+    }
+
+    pub fn all_interfaces(&self) -> Ref<Vec<Class<'gc>>> {
+        Ref::map(self.0.read(), |c| &c.all_interfaces)
     }
 
     /// Determine if this class is sealed (no dynamic properties)

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -1,10 +1,7 @@
 use ruffle_wstr::WString;
 
 use crate::avm2::object::TObject;
-use crate::avm2::Activation;
-use crate::avm2::AvmString;
-use crate::avm2::Multiname;
-use crate::avm2::Value;
+use crate::avm2::{Activation, AvmString, Class, Multiname, Value};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::mem::size_of;
@@ -94,13 +91,12 @@ pub fn make_reference_error<'gc>(
     activation: &mut Activation<'_, 'gc>,
     code: ReferenceErrorCode,
     multiname: &Multiname<'gc>,
-    object_class: Option<ClassObject<'gc>>,
+    object_class: Option<Class<'gc>>,
 ) -> Error<'gc> {
     let qualified_name = multiname.as_uri(activation.context.gc_context);
     let class_name = object_class
         .map(|cls| {
-            cls.inner_class_definition()
-                .name()
+            cls.name()
                 .to_qualified_name_err_message(activation.context.gc_context)
         })
         .unwrap_or_else(|| AvmString::from("<UNKNOWN>"));

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -419,18 +419,17 @@ fn vector_class<'gc>(
     let mc = activation.context.gc_context;
     let (_, global, mut domain) = script.init();
 
-    let cls = param_class.map(|c| c.inner_class_definition());
+    let param_class = param_class.map(|c| c.inner_class_definition());
     let vector_cls = class(
-        vector::create_builtin_class(activation, cls),
+        vector::create_builtin_class(activation, param_class),
         script,
         activation,
     )?;
-    vector_cls.set_param(mc, Some(param_class));
 
     let generic_vector = activation.avm2().classes().generic_vector;
     generic_vector.add_application(mc, param_class, vector_cls);
     let generic_cls = generic_vector.inner_class_definition();
-    generic_cls.add_application(mc, cls, vector_cls.inner_class_definition());
+    generic_cls.add_application(mc, param_class, vector_cls.inner_class_definition());
 
     let legacy_name = QName::new(activation.avm2().vector_internal_namespace, legacy_name);
     global.install_const_late(

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -279,7 +279,7 @@ fn describe_internal_body<'gc>(
     };
 
     if flags.contains(DescribeTypeFlags::INCLUDE_INTERFACES) && use_instance_traits {
-        for interface in class_obj.interfaces() {
+        for interface in &*class_obj.inner_class_definition().all_interfaces() {
             let interface_name = interface
                 .name()
                 .to_qualified_name(activation.context.gc_context);

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -383,14 +383,12 @@ fn describe_internal_body<'gc>(
                 let declared_by = method.class;
 
                 if flags.contains(DescribeTypeFlags::HIDE_OBJECT)
-                    && declared_by == Some(activation.avm2().classes().object)
+                    && declared_by == activation.avm2().classes().object.inner_class_definition()
                 {
                     continue;
                 }
 
                 let declared_by_name = declared_by
-                    .unwrap()
-                    .inner_class_definition()
                     .name()
                     .to_qualified_name(activation.context.gc_context);
 
@@ -477,8 +475,6 @@ fn describe_internal_body<'gc>(
                 let accessor_type =
                     method_type.to_qualified_name_or_star(activation.context.gc_context);
                 let declared_by = defining_class
-                    .unwrap()
-                    .inner_class_definition()
                     .name()
                     .to_qualified_name(activation.context.gc_context);
 

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -275,7 +275,7 @@ fn describe_internal_body<'gc>(
     let super_vtable = if use_instance_traits {
         class_obj.superclass_object().map(|c| c.instance_vtable())
     } else {
-        class_obj.instance_of().map(|c| c.instance_vtable())
+        class_obj.instance_class().map(|c| c.instance_vtable())
     };
 
     if flags.contains(DescribeTypeFlags::INCLUDE_INTERFACES) && use_instance_traits {

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -92,7 +92,7 @@ pub fn init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     // We set the underlying BitmapData instance - we start out with a dummy BitmapDataWrapper,
     // which makes custom classes see a disposed BitmapData before they call super()
-    let name = this.instance_of_class_definition().map(|c| c.name());
+    let name = this.instance_class().map(|c| c.name());
     let character = this
         .instance_of()
         .and_then(|t| {
@@ -374,7 +374,7 @@ pub fn get_vector<'gc>(
             height,
         );
 
-        let value_type = activation.avm2().classes().uint;
+        let value_type = activation.avm2().classes().uint.inner_class_definition();
         let new_storage = VectorStorage::from_values(pixels, false, Some(value_type));
 
         return Ok(VectorObject::from_vector(new_storage, activation)?.into());

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -1166,7 +1166,11 @@ pub fn read_graphics_data<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.display.Graphics", "readGraphicsData");
-    let value_type = activation.avm2().classes().igraphicsdata;
+    let value_type = activation
+        .avm2()
+        .classes()
+        .igraphicsdata
+        .inner_class_definition();
     let new_storage = VectorStorage::new(0, false, Some(value_type), activation);
     Ok(VectorObject::from_vector(new_storage, activation)?.into())
 }
@@ -1298,17 +1302,41 @@ fn handle_igraphics_data<'gc>(
     drawing: &mut Drawing,
     obj: &Object<'gc>,
 ) -> Result<(), Error<'gc>> {
-    let class = obj.instance_of().expect("No class");
+    let class = obj.instance_class().expect("No class");
 
-    if class == activation.avm2().classes().graphicsbitmapfill {
+    if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicsbitmapfill
+            .inner_class_definition()
+    {
         let style = handle_bitmap_fill(activation, drawing, obj)?;
         drawing.set_fill_style(Some(style));
-    } else if class == activation.avm2().classes().graphicsendfill {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicsendfill
+            .inner_class_definition()
+    {
         drawing.set_fill_style(None);
-    } else if class == activation.avm2().classes().graphicsgradientfill {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicsgradientfill
+            .inner_class_definition()
+    {
         let style = handle_gradient_fill(activation, obj)?;
         drawing.set_fill_style(Some(style));
-    } else if class == activation.avm2().classes().graphicspath {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicspath
+            .inner_class_definition()
+    {
         let commands = obj
             .get_public_property("commands", activation)?
             .coerce_to_object(activation)?;
@@ -1330,13 +1358,31 @@ fn handle_igraphics_data<'gc>(
                 .expect("commands is not a Vector"),
             &data.as_vector_storage().expect("data is not a Vector"),
         )?;
-    } else if class == activation.avm2().classes().graphicssolidfill {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicssolidfill
+            .inner_class_definition()
+    {
         let style = handle_solid_fill(activation, obj)?;
         drawing.set_fill_style(Some(style));
-    } else if class == activation.avm2().classes().graphicsshaderfill {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicsshaderfill
+            .inner_class_definition()
+    {
         tracing::warn!("Graphics shader fill unimplemented {:?}", class);
         drawing.set_fill_style(None);
-    } else if class == activation.avm2().classes().graphicsstroke {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicsstroke
+            .inner_class_definition()
+    {
         let thickness = obj
             .get_public_property("thickness", activation)?
             .coerce_to_number(activation)?;
@@ -1392,7 +1438,13 @@ fn handle_igraphics_data<'gc>(
 
             drawing.set_line_style(Some(line_style));
         }
-    } else if class == activation.avm2().classes().graphicstrianglepath {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicstrianglepath
+            .inner_class_definition()
+    {
         handle_graphics_triangle_path(activation, drawing, obj)?;
     } else {
         panic!("Unknown graphics data class {:?}", class);
@@ -1528,20 +1580,50 @@ fn handle_igraphics_fill<'gc>(
     drawing: &mut Drawing,
     obj: &Object<'gc>,
 ) -> Result<Option<FillStyle>, Error<'gc>> {
-    let class = obj.instance_of().expect("No class");
+    let class = obj.instance_class().expect("No class");
 
-    if class == activation.avm2().classes().graphicsbitmapfill {
+    if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicsbitmapfill
+            .inner_class_definition()
+    {
         let style = handle_bitmap_fill(activation, drawing, obj)?;
         Ok(Some(style))
-    } else if class == activation.avm2().classes().graphicsendfill {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicsendfill
+            .inner_class_definition()
+    {
         Ok(None)
-    } else if class == activation.avm2().classes().graphicsgradientfill {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicsgradientfill
+            .inner_class_definition()
+    {
         let style = handle_gradient_fill(activation, obj)?;
         Ok(Some(style))
-    } else if class == activation.avm2().classes().graphicssolidfill {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicssolidfill
+            .inner_class_definition()
+    {
         let style = handle_solid_fill(activation, obj)?;
         Ok(Some(style))
-    } else if class == activation.avm2().classes().graphicsshaderfill {
+    } else if class
+        == activation
+            .avm2()
+            .classes()
+            .graphicsshaderfill
+            .inner_class_definition()
+    {
         tracing::warn!("Graphics shader fill unimplemented {:?}", class);
         Ok(None)
     } else {

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -423,7 +423,7 @@ pub fn get_stage3ds<'gc>(
                 .map(|obj| Value::Object(*obj))
                 .collect(),
             false,
-            Some(activation.avm2().classes().stage3d),
+            Some(activation.avm2().classes().stage3d.inner_class_definition()),
         );
         let stage3ds = VectorObject::from_vector(storage, activation)?;
         return Ok(stage3ds.into());

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -68,7 +68,7 @@ pub fn attach_net_stream<'gc>(
             return Err(format!(
                 "Cannot use value of type {:?} as video source",
                 source
-                    .and_then(|o| o.instance_of_class_definition())
+                    .and_then(|o| o.instance_class())
                     .map(|c| c.name().local_name())
                     .unwrap_or_else(|| "Object".into())
             )

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -123,7 +123,7 @@ pub fn get_qualified_definition_names<'gc>(
                 .map(|name| Value::String(name.to_qualified_name(activation.context.gc_context)))
                 .collect(),
             false,
-            Some(activation.avm2().classes().string),
+            Some(activation.avm2().classes().string.inner_class_definition()),
         );
 
         let name_vector = VectorObject::from_vector(storage, activation)?;

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -199,15 +199,14 @@ pub fn get_qualified_class_name<'gc>(
     let obj = val.coerce_to_object(activation)?;
 
     let class = match obj.as_class_object() {
-        Some(class) => class,
-        None => match obj.instance_of() {
+        Some(class) => class.inner_class_definition(),
+        None => match obj.instance_class() {
             Some(cls) => cls,
             None => return Ok(Value::Null),
         },
     };
 
     Ok(class
-        .inner_class_definition()
         .name()
         .to_qualified_name(activation.context.gc_context)
         .into())
@@ -225,16 +224,15 @@ pub fn get_qualified_superclass_name<'gc>(
         .coerce_to_object(activation)?;
 
     let class = match obj.as_class_object() {
-        Some(class) => class,
-        None => match obj.instance_of() {
+        Some(class) => class.inner_class_definition(),
+        None => match obj.instance_class() {
             Some(cls) => cls,
             None => return Ok(Value::Null),
         },
     };
 
-    if let Some(super_class) = class.superclass_object() {
+    if let Some(super_class) = class.super_class() {
         Ok(super_class
-            .inner_class_definition()
             .name()
             .to_qualified_name(activation.context.gc_context)
             .into())

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -597,14 +597,15 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             let ClassBoundMethod {
                 method,
                 scope,
-                class,
+                class_obj,
+                ..
             } = full_method;
 
             return exec(
                 method,
                 scope.expect("Scope should exist here"),
                 self.into(),
-                class,
+                class_obj,
                 arguments,
                 activation,
                 self.into(), // Callee deliberately invalid.

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -268,7 +268,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     activation,
                     error::ReferenceErrorCode::ReadFromWriteOnly,
                     multiname,
-                    self.instance_of(),
+                    self.instance_class(),
                 ));
             }
             None => self.get_property_local(multiname, activation),
@@ -359,7 +359,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     activation,
                     error::ReferenceErrorCode::AssignToMethod,
                     multiname,
-                    self.instance_of(),
+                    self.instance_class(),
                 ));
             }
             Some(Property::Virtual { set: Some(set), .. }) => {
@@ -370,7 +370,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     activation,
                     error::ReferenceErrorCode::WriteToReadOnly,
                     multiname,
-                    self.instance_of(),
+                    self.instance_class(),
                 ));
             }
             None => self.set_property_local(multiname, value, activation),
@@ -437,7 +437,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     activation,
                     error::ReferenceErrorCode::AssignToMethod,
                     multiname,
-                    self.instance_of(),
+                    self.instance_class(),
                 ));
             }
             Some(Property::Virtual { set: Some(set), .. }) => {
@@ -448,7 +448,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     activation,
                     error::ReferenceErrorCode::WriteToReadOnly,
                     multiname,
-                    self.instance_of(),
+                    self.instance_class(),
                 ));
             }
             None => self.init_property_local(multiname, value, activation),
@@ -518,7 +518,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     activation,
                     error::ReferenceErrorCode::ReadFromWriteOnly,
                     multiname,
-                    self.instance_of(),
+                    self.instance_class(),
                 ));
             }
             None => self.call_property_local(multiname, arguments, activation),
@@ -705,14 +705,14 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                 activation,
                 error::ReferenceErrorCode::InvalidDelete,
                 multiname,
-                self.instance_of(),
+                self.instance_class(),
             ));
         }
 
         match self.vtable().and_then(|vtable| vtable.get_trait(multiname)) {
             None => {
                 if self
-                    .instance_of_class_definition()
+                    .instance_class()
                     .map(|c| c.is_sealed())
                     .unwrap_or(false)
                 {
@@ -968,7 +968,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// coercions.
     fn to_string(&self, activation: &mut Activation<'_, 'gc>) -> Result<Value<'gc>, Error<'gc>> {
         let class_name = self
-            .instance_of_class_definition()
+            .instance_class()
             .map(|c| c.name().local_name())
             .unwrap_or_else(|| "Object".into());
 
@@ -988,7 +988,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let class_name = self
-            .instance_of_class_definition()
+            .instance_class()
             .map(|c| c.name().local_name())
             .unwrap_or_else(|| "Object".into());
 
@@ -1086,7 +1086,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// The given object should be the class object for the given type we are
     /// checking against this object.
     fn is_of_type(&self, test_class: Class<'gc>, context: &mut UpdateContext<'_, 'gc>) -> bool {
-        let my_class = self.instance_of();
+        let my_class = self.instance_class();
 
         // ES3 objects are not class instances but are still treated as
         // instances of Object, which is an ES4 class.
@@ -1123,13 +1123,13 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     }
 
     /// Get this object's class's `Class`, if it has one.
-    fn instance_of_class_definition(&self) -> Option<Class<'gc>> {
+    fn instance_class(&self) -> Option<Class<'gc>> {
         self.instance_of().map(|cls| cls.inner_class_definition())
     }
 
     /// Get this object's class's name, formatted for debug output.
     fn instance_of_class_name(&self, mc: &Mutation<'gc>) -> AvmString<'gc> {
-        self.instance_of_class_definition()
+        self.instance_class()
             .map(|r| r.name().to_qualified_name(mc))
             .unwrap_or_else(|| "<Unknown type>".into())
     }

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -224,7 +224,7 @@ impl<'gc> ClassObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
         let class = self.inner_class_definition();
-        self.instance_of().ok_or(
+        self.instance_class().ok_or(
             "Cannot finish initialization of core class without it being linked to a type!",
         )?;
 

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -239,8 +239,8 @@ impl<'gc> ClassObject<'gc> {
         class.validate_class(self.superclass_object())?;
 
         self.instance_vtable().init_vtable(
+            class,
             Some(self),
-            class.protected_namespace(),
             &class.instance_traits(),
             Some(self.instance_scope()),
             self.superclass_object().map(|cls| cls.instance_vtable()),
@@ -275,8 +275,8 @@ impl<'gc> ClassObject<'gc> {
 
         // class vtable == class traits + Class instance traits
         self.class_vtable().init_vtable(
+            class,
             Some(self),
-            class.protected_namespace(),
             &class.class_traits(),
             Some(self.class_scope()),
             Some(self.instance_of().unwrap().instance_vtable()),
@@ -516,16 +516,17 @@ impl<'gc> ClassObject<'gc> {
         if let Some(Property::Method { disp_id, .. }) = property {
             // todo: handle errors
             let ClassBoundMethod {
-                class,
+                class_obj,
                 scope,
                 method,
+                ..
             } = self.instance_vtable().get_full_method(disp_id).unwrap();
             let callee = FunctionObject::from_method(
                 activation,
                 method,
                 scope.expect("Scope should exist here"),
                 Some(receiver),
-                class,
+                class_obj,
             );
 
             callee.call(receiver.into(), arguments, activation)
@@ -575,16 +576,17 @@ impl<'gc> ClassObject<'gc> {
             ) => {
                 // todo: handle errors
                 let ClassBoundMethod {
-                    class,
+                    class_obj,
                     scope,
                     method,
+                    ..
                 } = self.instance_vtable().get_full_method(disp_id).unwrap();
                 let callee = FunctionObject::from_method(
                     activation,
                     method,
                     scope.expect("Scope should exist here"),
                     Some(receiver),
-                    class,
+                    class_obj,
                 );
 
                 // We call getters, but return the actual function object for normal methods
@@ -657,12 +659,13 @@ impl<'gc> ClassObject<'gc> {
             }) => {
                 // todo: handle errors
                 let ClassBoundMethod {
-                    class,
+                    class_obj,
                     scope,
                     method,
+                    ..
                 } = self.instance_vtable().get_full_method(disp_id).unwrap();
                 let callee =
-                    FunctionObject::from_method(activation, method, scope.expect("Scope should exist here"), Some(receiver), class);
+                    FunctionObject::from_method(activation, method, scope.expect("Scope should exist here"), Some(receiver), class_obj);
 
                 callee.call(receiver.into(), &[value], activation)?;
                 Ok(())

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -113,8 +113,8 @@ impl<'gc> ErrorObject<'gc> {
             .try_read()
             .map(|obj| {
                 obj.base
-                    .instance_of()
-                    .map(|cls| cls.debug_class_name())
+                    .instance_class()
+                    .map(|cls| cls.debug_name())
                     .unwrap_or_else(|| Box::new("None"))
             })
             .unwrap_or_else(|err| Box::new(err))

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -123,7 +123,7 @@ impl<'gc> TObject<'gc> for PrimitiveObject<'gc> {
             val @ Value::Integer(_) => Ok(val),
             _ => {
                 let class_name = self
-                    .instance_of_class_definition()
+                    .instance_class()
                     .map(|c| c.name().local_name())
                     .unwrap_or_else(|| "Object".into());
 

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -2,7 +2,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
 use crate::avm2::method::{BytecodeMethod, ResolvedParamConfig};
 use crate::avm2::multiname::Multiname;
-use crate::avm2::object::{ClassObject, TObject};
+use crate::avm2::object::TObject;
 use crate::avm2::op::Op;
 use crate::avm2::property::Property;
 use crate::avm2::verify::JumpSources;
@@ -145,11 +145,6 @@ struct Stack<'gc>(Vec<OptValue<'gc>>);
 impl<'gc> Stack<'gc> {
     fn new() -> Self {
         Self(Vec::new())
-    }
-
-    fn push_class_object(&mut self, class: ClassObject<'gc>) {
-        self.0
-            .push(OptValue::of_type(class.inner_class_definition()));
     }
 
     fn push_class(&mut self, class: Class<'gc>) {
@@ -867,7 +862,7 @@ pub fn optimize<'gc>(
 
                                 stack_push_done = true;
                                 if let Some(class) = class {
-                                    stack.push_class_object(class);
+                                    stack.push_class(class);
                                 } else {
                                     stack.push_any();
                                 }
@@ -1292,8 +1287,8 @@ pub fn optimize<'gc>(
                     let global_scope = outer_scope.get_unchecked(0);
 
                     stack_push_done = true;
-                    if let Some(class) = global_scope.values().instance_of() {
-                        stack.push_class_object(class);
+                    if let Some(class) = global_scope.values().instance_class() {
+                        stack.push_class(class);
                     } else {
                         stack.push_any();
                     }
@@ -1310,7 +1305,7 @@ pub fn optimize<'gc>(
                 if !outer_scope.is_empty() {
                     let global_scope = outer_scope.get_unchecked(0);
 
-                    if let Some(class) = global_scope.values().instance_of() {
+                    if let Some(class) = global_scope.values().instance_class() {
                         let mut value_class =
                             class.instance_vtable().slot_classes()[*slot_id as usize];
                         let resolved_value_class = value_class.get_class(activation);

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -1,8 +1,9 @@
 //! Represents AVM2 scope chain resolution.
 
 use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
 use crate::avm2::domain::Domain;
-use crate::avm2::object::{ClassObject, Object, TObject};
+use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::{Multiname, Namespace};
@@ -237,7 +238,7 @@ impl<'gc> ScopeChain<'gc> {
     pub fn get_entry_for_multiname(
         &self,
         multiname: &Multiname<'gc>,
-    ) -> Option<Option<(Option<ClassObject<'gc>>, u32)>> {
+    ) -> Option<Option<(Option<Class<'gc>>, u32)>> {
         if let Some(container) = self.container {
             for (index, scope) in container.scopes.iter().enumerate().skip(1).rev() {
                 if scope.with() {
@@ -248,7 +249,7 @@ impl<'gc> ScopeChain<'gc> {
 
                 let values = scope.values();
                 if values.has_trait(multiname) {
-                    return Some(Some((values.instance_of(), index as u32)));
+                    return Some(Some((values.instance_class(), index as u32)));
                 }
             }
         }

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -620,11 +620,7 @@ impl<'gc> Script<'gc> {
 
             globals.vtable().unwrap().init_vtable(
                 globals.instance_of(),
-                globals
-                    .instance_of()
-                    .unwrap()
-                    .inner_class_definition()
-                    .protected_namespace(),
+                globals.instance_class().unwrap().protected_namespace(),
                 &self.traits()?,
                 Some(scope),
                 None,

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -619,8 +619,8 @@ impl<'gc> Script<'gc> {
             let scope = ScopeChain::new(domain);
 
             globals.vtable().unwrap().init_vtable(
+                globals.instance_class().unwrap(),
                 globals.instance_of(),
-                globals.instance_class().unwrap().protected_namespace(),
                 &self.traits()?,
                 Some(scope),
                 None,

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -438,7 +438,7 @@ fn object_name<'gc>(mc: &Mutation<'gc>, object: Object<'gc>) -> String {
             .to_string()
     } else {
         let name = object
-            .instance_of_class_definition()
+            .instance_class()
             .map(|r| Cow::Owned(r.name().local_name().to_string()))
             .unwrap_or(Cow::Borrowed("Object"));
         format!("{} {:p}", name, object.as_ptr())

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -213,7 +213,7 @@ impl Avm2ObjectWindow {
 
                 ui.label("Interfaces");
                 ui.vertical(|ui| {
-                    for interface in class.interfaces() {
+                    for interface in &*class.inner_class_definition().all_interfaces() {
                         ui.text_edit_singleline(
                             &mut interface
                                 .name()

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -64,9 +64,12 @@ impl<'gc> BitmapClass<'gc> {
         class: Avm2ClassObject<'gc>,
         context: &mut UpdateContext<'_, 'gc>,
     ) -> Option<Self> {
-        if class.has_class_in_chain(context.avm2.classes().bitmap.inner_class_definition()) {
+        let class_definition = class.inner_class_definition();
+        if class_definition
+            .has_class_in_chain(context.avm2.classes().bitmap.inner_class_definition())
+        {
             Some(BitmapClass::Bitmap(class))
-        } else if class
+        } else if class_definition
             .has_class_in_chain(context.avm2.classes().bitmapdata.inner_class_definition())
         {
             Some(BitmapClass::BitmapData(class))


### PR DESCRIPTION
This is work on storing a `Class` instead of a `ClassObject` as an Object's `instance_of`, which is necessary for the refactor.

Notable changes:
- `ClassObject` no longer stores its interfaces
- `ClassObject` no longer stores its type parameter, and the `applications` map is now a `Option<Class>` -> `ClassObject` map instead of an `Option<ClassObject>` -> `ClassObject`
- `has_class_in_chain` has been moved to `Class`
- `Class` now stores a list of all its interfaces (`all_interfaces`)
- `ClassKey` and `ClassHashWrapper` have been removed as they were no longer necessary after #16128
- `VectorStorage` now stores the value type as a `Class` instead of a `ClassObject`
- Logic for applying a type parameter to a `ClassObject` has been moved into its own function, `ClassObject::parametrize`