### PR TITLE
chore: Suppress a `clippy::doc_lazy_continuation` beta lint false positive

### DIFF
--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -1,5 +1,8 @@
 //! `flash.display.Graphics` builtin/prototype
 
+// See: https://github.com/rust-lang/rust-clippy/issues/12917
+#![allow(clippy::doc_lazy_continuation)]
+
 use crate::avm2::activation::Activation;
 use crate::avm2::error::{argument_error, make_error_2008};
 use crate::avm2::globals::flash::geom::transform::object_to_matrix;


### PR DESCRIPTION
Split out from https://github.com/ruffle-rs/ruffle/pull/16679.
Referencing https://github.com/rust-lang/rust-clippy/issues/12917 again.