### PR TITLE
core: Use DisplayObject.movie() instead of context.swf where applicable

### DIFF
--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -495,7 +495,8 @@ pub trait TDisplayObjectContainer<'gc>:
     /// According to the AS2 documentation, it should affect only automatic tab ordering.
     /// However, that does not seem to be the case, as it also affects custom ordering.
     fn is_tab_children(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
-        if context.swf.is_action_script_3() {
+        let this: DisplayObject<'_> = (*self).into();
+        if this.movie().is_action_script_3() {
             self.raw_container().tab_children
         } else {
             self.is_tab_children_avm1(context)
@@ -503,11 +504,11 @@ pub trait TDisplayObjectContainer<'gc>:
     }
 
     fn set_tab_children(&self, context: &mut UpdateContext<'_, 'gc>, value: bool) {
-        if context.swf.is_action_script_3() {
+        let this: DisplayObject<'_> = (*self).into();
+        if this.movie().is_action_script_3() {
             self.raw_container_mut(context.gc()).tab_children = value;
         } else {
-            let self_do: DisplayObject<'gc> = (*self).into();
-            self_do.set_avm1_property(context, "tabChildren", value.into());
+            this.set_avm1_property(context, "tabChildren", value.into());
         }
     }
 

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -615,7 +615,7 @@ pub trait TInteractiveObject<'gc>:
     /// Note: This value does not mean that a highlight should actually be rendered,
     /// for that see [`Self::is_highlightable()`].
     fn is_highlight_enabled(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
-        if context.swf.version() >= 6 {
+        if self.as_displayobject().movie().version() >= 6 {
             self.focus_rect()
                 .unwrap_or_else(|| context.stage.stage_focus_rect())
         } else {
@@ -638,7 +638,7 @@ pub trait TInteractiveObject<'gc>:
     /// Some objects may be excluded from tab ordering
     /// even if it's enabled, see [`Self::is_tabbable()`].
     fn tab_enabled(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
-        if context.swf.is_action_script_3() {
+        if self.as_displayobject().movie().is_action_script_3() {
             self.raw_interactive()
                 .tab_enabled
                 .unwrap_or_else(|| self.tab_enabled_default(context))
@@ -655,7 +655,7 @@ pub trait TInteractiveObject<'gc>:
     }
 
     fn set_tab_enabled(&self, context: &mut UpdateContext<'_, 'gc>, value: bool) {
-        if context.swf.is_action_script_3() {
+        if self.as_displayobject().movie().is_action_script_3() {
             self.raw_interactive_mut(context.gc()).tab_enabled = Some(value)
         } else {
             self.as_displayobject()
@@ -687,7 +687,7 @@ pub trait TInteractiveObject<'gc>:
         event: ClipEvent,
     ) -> bool {
         // Event handlers are supported only by SWF6+.
-        if context.swf.version() < 6 {
+        if self.as_displayobject().movie().version() < 6 {
             return false;
         }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3378,7 +3378,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
             return true;
         }
 
-        let is_avm1 = !context.swf.is_action_script_3();
+        let is_avm1 = !self.movie().is_action_script_3();
         if is_avm1 && self.tab_index().is_some() {
             return true;
         }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1582,17 +1582,22 @@ impl Player {
     }
 
     fn update_focus_on_mouse_press(context: &mut UpdateContext, pressed_object: DisplayObject) {
-        let is_avm2 = context.swf.is_action_script_3();
+        let tracker = context.focus_tracker;
+        let Some(focus) = tracker.get() else {
+            return;
+        };
+        let focus_do = focus.as_displayobject();
+
+        let is_avm2 = focus_do.movie().is_action_script_3();
 
         // Update AVM1 focus
         if !is_avm2 {
-            let tracker = context.focus_tracker;
             // In AVM1 text fields are somewhat special when handling focus.
             // When a text field is clicked, it gains focus,
             // when something else is clicked, it loses the focus.
             // However, this logic only applies to text fields, other objects
             // (buttons, movie clips) neither gain focus nor lose it upon press.
-            if tracker.get_as_edit_text().is_some() && pressed_object.as_edit_text().is_none() {
+            if focus_do.as_edit_text().is_some() && pressed_object.as_edit_text().is_none() {
                 tracker.set(None, context);
             }
         }


### PR DESCRIPTION
This prevents problems in case of mixed-AVM content.

cc @Lord-McSweeney 