### PR TITLE
web: Implement pasting text using Clipboard API

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,11 @@
+[target.'cfg(all())']
+# NOTE that the web build overrides this setting in package.json via the RUSTFLAGS environment variable
+rustflags = [
+    # We need to specify this flag for all targets because Clippy checks all of our code against all targets
+    # and our web code does not compile without this flag
+    "--cfg=web_sys_unstable_apis",
+]
+
 [target.x86_64-pc-windows-msvc]
 # Use the LLD linker, it should be faster than the default.
 # See: https://github.com/rust-lang/rust/issues/71520

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Disable linker start-stop-gc
         # Note: We also use `rust-lld` on Windows, see `config.toml`.
         if: runner.os != 'macOS'
-        run: echo RUSTFLAGS=${RUSTFLAGS}\ -Clink-args=-znostart-stop-gc >> $GITHUB_ENV
+        run: echo RUSTFLAGS=${RUSTFLAGS}\ --cfg=web_sys_unstable_apis\ -Clink-args=-znostart-stop-gc >> $GITHUB_ENV
 
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -74,7 +74,7 @@ features = [
     "EventTarget", "GainNode", "Headers", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement",
     "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent",
     "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "ReadableStream", "RequestCredentials",
-    "Url",
+    "Url", "Clipboard",
 ]
 
 [package.metadata.cargo-machete]

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -146,6 +146,7 @@ export class RufflePlayer extends HTMLElement {
     private readonly volumeControls: HTMLDivElement;
     private readonly videoModal: HTMLDivElement;
     private readonly hardwareAccelerationModal: HTMLDivElement;
+    private readonly clipboardModal: HTMLDivElement;
 
     private readonly contextMenuOverlay: HTMLElement;
     // Firefox has a read-only "contextMenu" property,
@@ -271,10 +272,14 @@ export class RufflePlayer extends HTMLElement {
         this.volumeControls = <HTMLDivElement>(
             this.shadow.getElementById("volume-controls-modal")
         );
+        this.clipboardModal = <HTMLDivElement>(
+            this.shadow.getElementById("clipboard-modal")
+        );
         this.addModalJavaScript(this.saveManager);
         this.addModalJavaScript(this.volumeControls);
         this.addModalJavaScript(this.videoModal);
         this.addModalJavaScript(this.hardwareAccelerationModal);
+        this.addModalJavaScript(this.clipboardModal);
 
         this.volumeSettings = new VolumeControls(false, 100);
         this.addVolumeControlsJavaScript(this.volumeControls);
@@ -2363,6 +2368,18 @@ export class RufflePlayer extends HTMLElement {
             videoHolder.textContent = "";
             videoHolder.appendChild(video);
             this.videoModal.classList.remove("hidden");
+        }
+    }
+
+    protected displayClipboardModal(accessDenied: boolean): void {
+        const description = this.clipboardModal.querySelector(
+            "#clipboard-modal-description",
+        );
+        if (description) {
+            description.textContent = text("clipboard-message-description", {
+                variant: accessDenied ? "access-denied" : "unsupported",
+            });
+            this.clipboardModal.classList.remove("hidden");
         }
     }
 

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -815,6 +815,36 @@ hardwareModalLink.target = "_blank";
 hardwareModalLink.className = "acceleration-link";
 hardwareModalLink.textContent = text("enable-hardware-acceleration");
 
+// Clipboard message
+const clipboardModal = createElement("div", "clipboard-modal", "modal hidden");
+const clipboardModalArea = createElement("div", undefined, "modal-area");
+const clipboardModalClose = createElement("span", undefined, "close-modal");
+clipboardModalClose.textContent = "\u00D7";
+const clipboardModalHeading = createElement("h2", undefined);
+clipboardModalHeading.textContent = text("clipboard-message-title");
+const clipboardModalTextDescription = createElement(
+    "p",
+    "clipboard-modal-description",
+);
+const shortcutModifier = navigator.userAgent.includes("Mac OS X")
+    ? "Command"
+    : "Ctrl";
+const clipboardModalTextCopy = createElement("p", undefined);
+const clipboardModalTextCopyShortcut = createElement("b", undefined);
+clipboardModalTextCopyShortcut.textContent = `${shortcutModifier}+C`;
+const clipboardModalTextCopyText = createElement("span", undefined);
+clipboardModalTextCopyText.textContent = text("clipboard-message-copy");
+const clipboardModalTextCut = createElement("p", undefined);
+const clipboardModalTextCutShortcut = createElement("b", undefined);
+clipboardModalTextCutShortcut.textContent = `${shortcutModifier}+X`;
+const clipboardModalTextCutText = createElement("span", undefined);
+clipboardModalTextCutText.textContent = text("clipboard-message-cut");
+const clipboardModalTextPaste = createElement("p", undefined);
+const clipboardModalTextPasteShortcut = createElement("b", undefined);
+clipboardModalTextPasteShortcut.textContent = `${shortcutModifier}+V`;
+const clipboardModalTextPasteText = createElement("span", undefined);
+clipboardModalTextPasteText.textContent = text("clipboard-message-paste");
+
 // Context menu overlay elements
 const contextMenuOverlay = createElement(
     "div",
@@ -888,6 +918,21 @@ appendElement(ruffleShadowTemplate.content, hardwareModal);
 appendElement(hardwareModal, hardwareModalArea);
 appendElement(hardwareModalArea, hardwareModalClose);
 appendElement(hardwareModalArea, hardwareModalLink);
+// Clipboard modal append
+appendElement(ruffleShadowTemplate.content, clipboardModal);
+appendElement(clipboardModal, clipboardModalArea);
+appendElement(clipboardModalArea, clipboardModalClose);
+appendElement(clipboardModalArea, clipboardModalHeading);
+appendElement(clipboardModalArea, clipboardModalTextDescription);
+appendElement(clipboardModalArea, clipboardModalTextCopy);
+appendElement(clipboardModalTextCopy, clipboardModalTextCopyShortcut);
+appendElement(clipboardModalTextCopy, clipboardModalTextCopyText);
+appendElement(clipboardModalArea, clipboardModalTextCut);
+appendElement(clipboardModalTextCut, clipboardModalTextCutShortcut);
+appendElement(clipboardModalTextCut, clipboardModalTextCutText);
+appendElement(clipboardModalArea, clipboardModalTextPaste);
+appendElement(clipboardModalTextPaste, clipboardModalTextPasteShortcut);
+appendElement(clipboardModalTextPaste, clipboardModalTextPasteText);
 // Context menu overlay append
 appendElement(ruffleShadowTemplate.content, contextMenuOverlay);
 appendElement(contextMenuOverlay, contextMenu);

--- a/web/packages/core/texts/en-US/messages.ftl
+++ b/web/packages/core/texts/en-US/messages.ftl
@@ -14,6 +14,15 @@ enable-hardware-acceleration = It looks like hardware acceleration is not enable
 view-error-details = View Error Details
 open-in-new-tab = Open in a new tab
 click-to-unmute = Click to unmute
+clipboard-message-title = Copying and pasting in Ruffle
+clipboard-message-description =
+    { $variant ->
+        *[unsupported] Your browser does not support full clipboard access,
+        [access-denied] Access to the clipboard has been denied,
+    } but you can always use these shortcuts instead:
+clipboard-message-copy = { " " } for copy
+clipboard-message-cut = { " " } for cut
+clipboard-message-paste = { " " } for paste
 error-file-protocol =
     It appears you are running Ruffle on the "file:" protocol.
     This doesn't work as browsers block many features from working for security reasons.

--- a/web/packages/core/tools/build_wasm.ts
+++ b/web/packages/core/tools/build_wasm.ts
@@ -84,7 +84,7 @@ function buildWasm(
     extensions: boolean,
     wasmSource: string,
 ) {
-    const rustFlags = ["-Aunknown_lints"];
+    const rustFlags = ["--cfg=web_sys_unstable_apis", "-Aunknown_lints"];
     const wasmBindgenFlags = [];
     const wasmOptFlags = [];
     const flavor = extensions ? "extensions" : "vanilla";

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -178,6 +178,9 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = "displayUnsupportedVideo")]
     fn display_unsupported_video(this: &JavascriptPlayer, url: &str);
+
+    #[wasm_bindgen(method, js_name = "displayClipboardModal")]
+    fn display_clipboard_modal(this: &JavascriptPlayer, access_denied: bool);
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Fixes https://github.com/ruffle-rs/ruffle/issues/16678.

Ruffle does not have direct clipboard access on web, so the current paste implementation from the context menu does not work. This patch intercepts the paste context menu callback, and uses the Clipboard API to ask the browser for the clipboard and update it before calling the callback. When the Clipboard API is not available, a modal informing the user about cut, copy, paste shortcuts is displayed.

| Firefox | Chromium |
| ------- | -------- |
| <image src="https://github.com/ruffle-rs/ruffle/assets/1507072/dd3d576f-7ecc-4140-aa8b-ffba7e14ef8a" width="400"/> | <image src="https://github.com/ruffle-rs/ruffle/assets/1507072/7a5aeb40-3dab-4a0c-9d59-8598aff05d4c" width="400"/> |

| Clipboard modal |
| --------------- |
| <image src="https://github.com/ruffle-rs/ruffle/assets/1507072/3991ee24-29e5-4ea1-a7c6-d33a2b1a99b9" width="500"/> |
| A modal is displayed when the Clipboard API is not supported |

