### PR TITLE
core,desktop: Update `wgpu` to `v0.20.1`, bump `egui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,16 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
-name = "accesskit"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a4b14f3d99c1255dcba8f45621ab1a2e7540a0009652d33989005a4d0bfc6b"
-dependencies = [
- "enumn",
- "serde",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,7 +48,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
@@ -1452,31 +1441,30 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "ecolor"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
+source = "git+https://github.com/emilk/egui.git?rev=413843dd7ca7c177aaac233cd24b547d2b904d19#413843dd7ca7c177aaac233cd24b547d2b904d19"
 dependencies = [
  "bytemuck",
- "serde",
+ "emath",
 ]
 
 [[package]]
 name = "egui"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
+source = "git+https://github.com/emilk/egui.git?rev=413843dd7ca7c177aaac233cd24b547d2b904d19#413843dd7ca7c177aaac233cd24b547d2b904d19"
 dependencies = [
- "accesskit",
  "ahash",
  "emath",
  "epaint",
  "log",
  "nohash-hasher",
- "serde",
 ]
 
 [[package]]
 name = "egui-wgpu"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
+source = "git+https://github.com/emilk/egui.git?rev=413843dd7ca7c177aaac233cd24b547d2b904d19#413843dd7ca7c177aaac233cd24b547d2b904d19"
 dependencies = [
+ "ahash",
  "bytemuck",
  "document-features",
  "egui",
@@ -1492,8 +1480,9 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
+source = "git+https://github.com/emilk/egui.git?rev=413843dd7ca7c177aaac233cd24b547d2b904d19#413843dd7ca7c177aaac233cd24b547d2b904d19"
 dependencies = [
+ "ahash",
  "arboard",
  "egui",
  "log",
@@ -1507,14 +1496,14 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
+source = "git+https://github.com/emilk/egui.git?rev=413843dd7ca7c177aaac233cd24b547d2b904d19#413843dd7ca7c177aaac233cd24b547d2b904d19"
 dependencies = [
+ "ahash",
  "egui",
  "enum-map",
  "image",
  "log",
  "mime_guess2",
- "serde",
 ]
 
 [[package]]
@@ -1526,10 +1515,9 @@ checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 [[package]]
 name = "emath"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
+source = "git+https://github.com/emilk/egui.git?rev=413843dd7ca7c177aaac233cd24b547d2b904d19#413843dd7ca7c177aaac233cd24b547d2b904d19"
 dependencies = [
  "bytemuck",
- "serde",
 ]
 
 [[package]]
@@ -1610,17 +1598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enumn"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "enumset"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,7 +1644,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
+source = "git+https://github.com/emilk/egui.git?rev=413843dd7ca7c177aaac233cd24b547d2b904d19#413843dd7ca7c177aaac233cd24b547d2b904d19"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1677,7 +1654,6 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
- "serde",
 ]
 
 [[package]]
@@ -6408,9 +6384,9 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ff1bfee408e1028e2e3acbf6d32d98b08a5a059ccbf5f33305534453ba5d3e"
+checksum = "90e37c7b9921b75dfd26dd973fdcbce36f13dfa6e2dc82aece584e0ed48c355c"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -6435,9 +6411,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6a86eaa5e763e59c73cf9e97d55fffd4dfda69fd8bda19589fcf851ddfef1f"
+checksum = "d59e0d5fc509601c69e4e1fa06c1eb3c4c9f12956a5e30c79b61ef1c1be7daf0"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -6464,9 +6440,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d71c8ae05170583049b65ee562fd839fdc0b3e9ddb84f4e40c9d5f8ea0d4c8c"
+checksum = "6aa24c3889f885a3fb9133b454c8418bfcfaadcfe4ed3be96ac80e76703b863b"
 dependencies = [
  "android_system_properties",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ version = "0.1.0"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 naga = { version = "0.20.0", features = ["wgsl-out"] }
-wgpu = "0.20.0"
-egui = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b" }
+wgpu = "0.20.1"
+egui = { git = "https://github.com/emilk/egui.git", rev = "413843dd7ca7c177aaac233cd24b547d2b904d19" }
 clap = { version = "4.5.7", features = ["derive"] }
 anyhow = "1.0"
 slotmap = "1.0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.9.4"
 egui = { workspace = true, optional = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b", optional = true }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "413843dd7ca7c177aaac233cd24b547d2b904d19", optional = true }
 png = { version = "0.17.13", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 clap = { workspace = true }
 cpal = "0.15.3"
 egui = { workspace = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b", features = ["image"] }
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b", features = ["winit"] }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "413843dd7ca7c177aaac233cd24b547d2b904d19", features = ["image"] }
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "413843dd7ca7c177aaac233cd24b547d2b904d19", features = ["winit"] }
 image = { workspace = true, features = ["png"] }
-egui-winit = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b" }
+egui-winit = { git = "https://github.com/emilk/egui.git", rev = "413843dd7ca7c177aaac233cd24b547d2b904d19" }
 fontdb = "0.18"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }

--- a/desktop/src/gui/context_menu.rs
+++ b/desktop/src/gui/context_menu.rs
@@ -44,7 +44,8 @@ impl ContextMenu {
                             let clicked = if item.checked {
                                 Checkbox::new(&mut true, &item.caption).ui(ui).clicked()
                             } else {
-                                let button = Button::new(&item.caption).wrap(false);
+                                let button = Button::new(&item.caption)
+                                    .wrap_mode(egui::TextWrapMode::Extend);
 
                                 ui.add_enabled(item.enabled, button).clicked()
                             };

--- a/desktop/src/gui/dialogs/bookmarks_dialog.rs
+++ b/desktop/src/gui/dialogs/bookmarks_dialog.rs
@@ -175,13 +175,17 @@ impl BookmarksDialog {
                             }
 
                             row.col(|ui| {
-                                ui.add(Label::new(&bookmark.name).selectable(false).wrap(false));
+                                ui.add(
+                                    Label::new(&bookmark.name)
+                                        .selectable(false)
+                                        .wrap_mode(egui::TextWrapMode::Extend),
+                                );
                             });
                             row.col(|ui| {
                                 ui.add(
                                     Label::new(bookmark.url.as_str())
                                         .selectable(false)
-                                        .wrap(false),
+                                        .wrap_mode(egui::TextWrapMode::Extend),
                                 );
                             });
 


### PR DESCRIPTION
`egui` actually reverted to `wgpu` `0.19` for a while (https://github.com/emilk/egui/pull/4559), but now that https://github.com/gfx-rs/wgpu/pull/5681 fixed the reasons for the downgrade, they have updated again: https://github.com/emilk/egui/pull/4560

The little `egui` API change was: https://github.com/emilk/egui/pull/4556