### PR TITLE
extension: Fix zip tool by adding import.meta.url back

### DIFF
--- a/web/packages/extension/tools/tsconfig.json
+++ b/web/packages/extension/tools/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "@tsconfig/strictest/tsconfig.json",
     "compilerOptions": {
         "composite": true,
-        "module": "commonjs",
+        "module": "nodenext",
         "target": "ES2021",
         "rootDir": "."
     },

--- a/web/packages/extension/tools/zip.ts
+++ b/web/packages/extension/tools/zip.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
+import url from "url";
 import archiver from "archiver";
 
 async function zip(source: string, destination: string) {
@@ -31,5 +32,5 @@ async function zip(source: string, destination: string) {
 
     await archive.finalize();
 }
-
-zip("../assets/", process.argv[2] ?? "").catch(console.error);
+const assets = url.fileURLToPath(new URL("../assets/", import.meta.url));
+zip(assets, process.argv[2] ?? "").catch(console.error);


### PR DESCRIPTION
Will hopefully fix last night's errors: https://github.com/ruffle-rs/ruffle/actions/runs/9491395142