### PR TITLE
swf: Bump version to 0.2.1 in preparation for new package publication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5280,7 +5280,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "swf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags 2.5.0",
  "bitstream-io",

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf"
-version = "0.2.0"
+version = "0.2.1"
 description = "Read and write the Adobe Flash SWF file format."
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
I published a new version of `swf` after like two years and needed to bump the version.