### PR TITLE
ci: Release and test with Rust 1.78 instead of stable

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -108,7 +108,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          # TODO: Return to latest "stable" once this is released:
+          # https://github.com/gfx-rs/wgpu/pull/5831 (probably in wgpu 0.20.2)
+          toolchain: "1.78"
           targets: ${{ matrix.target }}
 
       - name: Install Linux dependencies

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -38,7 +38,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [stable]
+        # TODO: Return to latest "stable" once this is released:
+        # https://github.com/gfx-rs/wgpu/pull/5831 (probably in wgpu 0.20.2)
+        rust_version: ["1.78"]
         os: [ubuntu-22.04, windows-latest, macos-14]
         include:
           - rust_version: nightly
@@ -180,7 +182,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_version: [stable]
+        # TODO: Return to latest "stable" once this is released:
+        # https://github.com/gfx-rs/wgpu/pull/5831 (probably in wgpu 0.20.2)
+        rust_version: ["1.78"]
         os: [ubuntu-22.04, windows-latest, macos-14]
         include:
           - rust_version: nightly


### PR DESCRIPTION
At least until a release with https://github.com/gfx-rs/wgpu/pull/5831 is out.

Fixes https://github.com/ruffle-rs/ruffle/issues/16715