### PR TITLE
chore: Update quick-xml to 0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3977,6 +3977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e446ed58cef1bbfe847bc2fda0e2e4ea9f0e57b90c507d4781292590d72a4e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4366,7 +4375,7 @@ dependencies = [
  "num-traits",
  "percent-encoding",
  "png",
- "quick-xml",
+ "quick-xml 0.35.0",
  "rand",
  "realfft",
  "regress",
@@ -6211,7 +6220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67da50b9f80159dec0ea4c11c13e24ef9e7574bd6ce24b01860a175010cea565"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.31.0",
  "quote",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,7 @@ bitflags = { workspace = true }
 smallvec = { version = "1.13.2", features = ["union"] }
 num-traits = { workspace = true }
 num-derive = { workspace = true }
-quick-xml = "0.31.0"
+quick-xml = "0.35.0"
 downcast-rs = "1.2.1"
 url = { workspace = true }
 weak-table = "0.3.2"

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -5,6 +5,7 @@ use std::{
 
 use gc_arena::{Collect, GcCell, Mutation};
 use quick_xml::{
+    errors::SyntaxError as XmlSyntaxError,
     events::{attributes::AttrError as XmlAttrError, BytesStart, Event},
     name::ResolveResult,
     Error as XmlError, NsReader,
@@ -59,23 +60,24 @@ fn make_xml_error<'gc>(activation: &mut Activation<'_, 'gc>, err: XmlError) -> E
             "Error #1104: Attribute was already specified for element.",
             1104,
         ),
-        XmlError::UnexpectedEof(currently_parsing) => match currently_parsing.as_str() {
-            "CData" => type_error(
+
+        XmlError::Syntax(syntax_error) => match syntax_error {
+            XmlSyntaxError::UnclosedCData => type_error(
                 activation,
                 "Error #1091: XML parser failure: Unterminated CDATA section.",
                 1091,
             ),
-            "DOCTYPE" => type_error(
+            XmlSyntaxError::UnclosedDoctype => type_error(
                 activation,
                 "Error #1093: XML parser failure: Unterminated DOCTYPE declaration.",
                 1093,
             ),
-            "Comment" => type_error(
+            XmlSyntaxError::UnclosedComment => type_error(
                 activation,
                 "Error #1094: XML parser failure: Unterminated comment.",
                 1094,
             ),
-            "XmlDecl" => type_error(
+            XmlSyntaxError::UnclosedPIOrXmlDecl => type_error(
                 activation,
                 "Error #1097: XML parser failure: Unterminated processing instruction.",
                 1097,

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -671,8 +671,11 @@ impl FormatSpans {
         let mut last_closed_font: Option<TextSpanFont> = None;
 
         let mut reader = Reader::from_reader(&raw_bytes[..]);
-        reader.expand_empty_elements(true);
-        reader.check_end_names(false);
+        let reader_config = reader.config_mut();
+        reader_config.expand_empty_elements = true;
+        reader_config.check_end_names = false;
+        reader_config.allow_unmatched_ends = true;
+
         loop {
             match reader.read_event() {
                 Ok(Event::Start(ref e)) => {

--- a/tests/tests/swfs/from_avmplus/as3/RuntimeErrors/Error1090XmlElementMalformed/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/RuntimeErrors/Error1090XmlElementMalformed/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Split from https://github.com/ruffle-rs/ruffle/pull/16769 / https://github.com/ruffle-rs/ruffle/pull/16870 / https://github.com/ruffle-rs/ruffle/pull/16871.
Changelog:
 https://github.com/tafia/quick-xml/releases/tag/v0.32.0
 https://github.com/tafia/quick-xml/releases/tag/v0.33.0
 https://github.com/tafia/quick-xml/releases/tag/v0.34.0
 https://github.com/tafia/quick-xml/releases/tag/v0.35.0
I'm not 100% sure I did all the `UnexpectedEof` replacements correctly.