### PR TITLE
debug_ui: Add option to draw layout boxes for EditText

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -460,6 +460,16 @@ impl DisplayObjectWindow {
                     ui.weak("None");
                 }
                 ui.end_row();
+
+                ui.label("Draw Layout Boxes");
+                ui.horizontal(|ui| {
+                    let mut draw_layout_boxes = object.draw_layout_boxes();
+                    ui.checkbox(&mut draw_layout_boxes, "Enabled");
+                    if draw_layout_boxes != object.draw_layout_boxes() {
+                        object.set_draw_layout_boxes(context, draw_layout_boxes);
+                    }
+                });
+                ui.end_row();
             });
 
         CollapsingHeader::new("Span List")

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -659,6 +659,20 @@ impl<'gc> EditText<'gc> {
         self.0.write(gc_context).is_tlf = is_tlf;
     }
 
+    pub fn draw_layout_boxes(self) -> bool {
+        self.0
+            .read()
+            .flags
+            .contains(EditTextFlag::DRAW_LAYOUT_BOXES)
+    }
+
+    pub fn set_draw_layout_boxes(self, context: &mut UpdateContext<'_, 'gc>, value: bool) {
+        self.0
+            .write(context.gc())
+            .flags
+            .set(EditTextFlag::DRAW_LAYOUT_BOXES, value);
+    }
+
     pub fn replace_text(
         self,
         from: usize,
@@ -2275,7 +2289,20 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
                 }
             }
         } else {
+            let draw_boxes = edit_text.flags.contains(EditTextFlag::DRAW_LAYOUT_BOXES);
+            if draw_boxes {
+                context.draw_rect_outline(
+                    Color::GREEN,
+                    edit_text.intrinsic_bounds.into(),
+                    Twips::ONE,
+                );
+            }
+
             for layout_box in edit_text.layout.iter() {
+                if draw_boxes {
+                    context.draw_rect_outline(Color::RED, layout_box.bounds().into(), Twips::ONE);
+                }
+
                 self.render_layout_box(context, layout_box);
             }
         }
@@ -2525,6 +2552,7 @@ bitflags::bitflags! {
     struct EditTextFlag: u16 {
         const FIRING_VARIABLE_BINDING = 1 << 0;
         const HAS_BACKGROUND = 1 << 1;
+        const DRAW_LAYOUT_BOXES = 1 << 2;
 
         // The following bits need to match `swf::EditTextFlag`.
         const READ_ONLY = 1 << 3;


### PR DESCRIPTION
It's useful when debugging issues related to EditText's layout.

| Disabled | Enabled |
| -------- | ------- |
| <image src="https://github.com/ruffle-rs/ruffle/assets/1507072/50331a04-6a85-4cb2-ab98-023728f44102" width="300"/> | <image src="https://github.com/ruffle-rs/ruffle/assets/1507072/5666d71f-3830-43ba-87e0-4e3a30d2989a" width="300"/> |
