### PR TITLE
chore: Update `wgpu-core` and `wgpu-hal` to `v0.21.1`

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -108,9 +108,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          # TODO: Return to latest "stable" once this is released:
-          # https://github.com/gfx-rs/wgpu/pull/5831 (probably in wgpu 0.20.2)
-          toolchain: "1.78"
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Install Linux dependencies

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -38,9 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Return to latest "stable" once this is released:
-        # https://github.com/gfx-rs/wgpu/pull/5831 (probably in wgpu 0.20.2)
-        rust_version: ["1.78"]
+        rust_version: [stable]
         os: [ubuntu-22.04, windows-latest, macos-14]
         include:
           - rust_version: nightly
@@ -182,9 +180,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # TODO: Return to latest "stable" once this is released:
-        # https://github.com/gfx-rs/wgpu/pull/5831 (probably in wgpu 0.20.2)
-        rust_version: ["1.78"]
+        rust_version: [stable]
         os: [ubuntu-22.04, windows-latest, macos-14]
         include:
           - rust_version: nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
  "bitflags 2.5.0",
- "libloading 0.7.4",
+ "libloading 0.8.4",
  "winapi",
 ]
 
@@ -1431,7 +1431,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.4",
 ]
 
 [[package]]
@@ -2389,7 +2389,7 @@ dependencies = [
  "bitflags 2.5.0",
  "com",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.4",
  "thiserror",
  "widestring",
  "winapi",
@@ -6325,9 +6325,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59e0d5fc509601c69e4e1fa06c1eb3c4c9f12956a5e30c79b61ef1c1be7daf0"
+checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -6354,9 +6354,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa24c3889f885a3fb9133b454c8418bfcfaadcfe4ed3be96ac80e76703b863b"
+checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6376,7 +6376,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.4",
  "log",
  "metal",
  "naga",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "bitstream-io"
-version = "2.3.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c12d1856e42f0d817a835fe55853957c85c8c8a470114029143d3f12671446e"
+checksum = "415f8399438eb5e4b2f73ed3152a3448b98149dda642a957ee704e1daa5cf1d8"
 
 [[package]]
 name = "block"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 linkme = { version = "0.3", optional = true }
 byteorder = "1.5"
-bitstream-io = "2.3.0"
+bitstream-io = "2.4.2"
 flate2 = { workspace = true }
 fnv = "1.0.7"
 gc-arena = { package = "ruffle_gc_arena", path = "../ruffle_gc_arena" }

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 bitflags = { workspace = true }
-bitstream-io = "2.3.0"
+bitstream-io = "2.4.2"
 byteorder = "1.5"
 encoding_rs = "0.8.34"
 num-derive = { workspace = true }


### PR DESCRIPTION
Now that https://github.com/gfx-rs/wgpu/pull/5831 is merged, let's revert https://github.com/ruffle-rs/ruffle/pull/16764, go forward to the ~~yet un~~released `wgpu` version, and finish up https://github.com/ruffle-rs/ruffle/pull/16770.