### PR TITLE
web,video: Add H264 decoding using the WebCodecs API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4519,7 +4519,7 @@ dependencies = [
  "ruffle_render_canvas",
  "ruffle_render_webgl",
  "ruffle_render_wgpu",
- "ruffle_video_software",
+ "ruffle_video_external",
  "ruffle_web_common",
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4464,6 +4464,7 @@ version = "0.1.0"
 dependencies = [
  "bzip2",
  "hex",
+ "js-sys",
  "libloading",
  "reqwest",
  "ruffle_render",
@@ -4475,6 +4476,10 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
+ "tracing-subscriber",
+ "tracing-wasm",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/video/external/Cargo.toml
+++ b/video/external/Cargo.toml
@@ -24,5 +24,21 @@ bzip2 = { version = "0.5.2", features = ["static"], optional = true }
 tempfile = { version = "3.15.0", optional = true }
 sha2 = { version = "0.10.8", optional = true }
 
+# Needed for WebCodecs:
+js-sys = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["registry"], optional = true }
+tracing-wasm = { version = "0.2.1", optional = true }
+
+[dependencies.web-sys]
+workspace = true
+optional = true
+features = [
+    "CodecState", "DomException", "DomRectReadOnly", "EncodedVideoChunk",
+    "EncodedVideoChunkInit", "EncodedVideoChunkType", "VideoDecoder",
+    "VideoDecoderConfig", "VideoDecoderInit", "VideoFrame", "VideoPixelFormat",
+]
+
 [features]
 openh264 = ["libloading", "reqwest", "hex", "bzip2", "tempfile", "sha2"]
+webcodecs = ["web-sys", "js-sys", "wasm-bindgen", "tracing-subscriber", "tracing-wasm"]

--- a/video/external/src/backend.rs
+++ b/video/external/src/backend.rs
@@ -13,6 +13,12 @@ use slotmap::SlotMap;
 
 use swf::{VideoCodec, VideoDeblocking};
 
+// Just to avoid the several conditional imports.
+#[cfg(feature = "webcodecs")]
+type LogSubscriberArc = std::sync::Arc<
+    tracing_subscriber::layer::Layered<tracing_wasm::WASMLayer, tracing_subscriber::Registry>,
+>;
+
 enum ProxyOrStream {
     /// These streams are passed through to the wrapped software
     /// backend, accessed using the stored ("inner") handle,
@@ -29,6 +35,9 @@ pub struct ExternalVideoBackend {
     streams: SlotMap<VideoStreamHandle, ProxyOrStream>,
     #[cfg(feature = "openh264")]
     openh264_codec: Option<OpenH264Codec>,
+    // Needed for the callbacks in the `webcodecs` backend.
+    #[cfg(feature = "webcodecs")]
+    log_subscriber: Option<LogSubscriberArc>,
     software: SoftwareVideoBackend,
 }
 
@@ -46,14 +55,28 @@ impl ExternalVideoBackend {
             return Ok(decoder);
         }
 
-        Err(Error::DecoderError("No OpenH264".into()))
+        #[cfg(feature = "webcodecs")]
+        {
+            let log_subscriber = self
+                .log_subscriber
+                .clone()
+                .ok_or(Error::DecoderError("log subscriber not set".into()))?;
+            let decoder = crate::decoder::webcodecs::H264Decoder::new(log_subscriber);
+            return decoder.map(|decoder| Box::new(decoder) as Box<dyn VideoDecoder>);
+        }
+
+        #[allow(unreachable_code)]
+        Err(Error::DecoderError("No H.264 decoder available".into()))
     }
 
+    // Neither the `openh264` nor the `webcodecs` backend will be available.
     pub fn new() -> Self {
         Self {
             streams: SlotMap::with_key(),
             #[cfg(feature = "openh264")]
             openh264_codec: None,
+            #[cfg(feature = "webcodecs")]
+            log_subscriber: None,
             software: SoftwareVideoBackend::new(),
         }
     }
@@ -63,6 +86,19 @@ impl ExternalVideoBackend {
         Self {
             streams: SlotMap::with_key(),
             openh264_codec: Some(openh264_codec),
+            #[cfg(feature = "webcodecs")]
+            log_subscriber: None,
+            software: SoftwareVideoBackend::new(),
+        }
+    }
+
+    #[cfg(feature = "webcodecs")]
+    pub fn new_with_webcodecs(log_subscriber: LogSubscriberArc) -> Self {
+        Self {
+            streams: SlotMap::with_key(),
+            #[cfg(feature = "openh264")]
+            openh264_codec: None,
+            log_subscriber: Some(log_subscriber),
             software: SoftwareVideoBackend::new(),
         }
     }

--- a/video/external/src/decoder.rs
+++ b/video/external/src/decoder.rs
@@ -10,4 +10,7 @@ mod openh264_sys;
 #[cfg(feature = "openh264")]
 pub mod openh264;
 
+#[cfg(feature = "webcodecs")]
+pub mod webcodecs;
+
 pub use ruffle_video_software::decoder::VideoDecoder;

--- a/video/external/src/decoder/webcodecs.rs
+++ b/video/external/src/decoder/webcodecs.rs
@@ -1,0 +1,287 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::decoder::VideoDecoder;
+
+use ruffle_render::bitmap::BitmapFormat;
+use ruffle_video::error::Error;
+use ruffle_video::frame::{DecodedFrame, EncodedFrame, FrameDependency};
+
+use js_sys::Uint8Array;
+use tracing::{debug, trace, warn};
+use tracing_subscriber::{layer::Layered, Registry};
+use tracing_wasm::WASMLayer;
+use wasm_bindgen::prelude::*;
+use web_sys::{
+    DomException, EncodedVideoChunk, EncodedVideoChunkInit, EncodedVideoChunkType,
+    VideoDecoder as WebVideoDecoder, VideoDecoderConfig, VideoDecoderInit, VideoFrame,
+    VideoPixelFormat,
+};
+
+// Abbreviations used:
+//  - NAL: Network Abstraction Layer
+//  - NALU: NAL unit
+//  - VCL: Video Coding Layer
+//  - SPS: Sequence Parameter Set
+//  - PPS: Picture Parameter Set
+//  - IDR: Instantaneous Decoding Refresh
+//  - SEI: Supplemental enhancement information
+
+// NALU type 5 means IDR frame - basically a keyframe.
+const NALU_TYPE_IDR: u8 = 5;
+
+fn js_error_to_decoder_error(js_error: JsValue) -> Error {
+    Error::DecoderError(
+        js_error
+            .dyn_ref::<js_sys::Error>()
+            .unwrap()
+            .message()
+            .as_string()
+            .unwrap()
+            .into(),
+    )
+}
+
+pub struct H264Decoder {
+    /// How many bytes are used to store the length of the NALU (1, 2, 3, or 4).
+    length_size: u8,
+
+    /// The WebCodecs decoder object.
+    decoder: WebVideoDecoder,
+
+    /// The decoder output callback writes this, and the decode_frame method reads it.
+    ///
+    /// This in itself results in one frame of delay (because we can't block decode_frame
+    /// until the callback is invoked), but it shouldn't matter in practice.
+    last_frame: Rc<RefCell<Option<DecodedFrame>>>,
+
+    // Simply keeping these objects alive, as they are used by the JS side.
+    // See: https://rustwasm.github.io/wasm-bindgen/examples/closures.html
+    #[allow(dead_code)]
+    output_callback: Closure<dyn Fn(VideoFrame)>,
+    #[allow(dead_code)]
+    error_callback: Closure<dyn Fn(DomException)>,
+}
+
+impl H264Decoder {
+    /// `extradata` should hold "AVCC (MP4) format" decoder configuration, including PPS and SPS.
+    /// Make sure it has any start code emulation prevention "three bytes" removed.
+    ///
+    /// The log_subscriber is needed so that we have proper logging from within the callbacks.
+    pub fn new(log_subscriber: Arc<Layered<WASMLayer, Registry>>) -> Result<Self, Error> {
+        let last_frame = Rc::new(RefCell::new(None));
+        let lf = last_frame.clone();
+
+        let log_subscriber_for_output = log_subscriber.clone();
+        let output = move |output: &VideoFrame| {
+            let _subscriber = tracing::subscriber::set_default(log_subscriber_for_output.clone());
+            let visible_rect = output.visible_rect().unwrap();
+
+            match output.format().unwrap() {
+                VideoPixelFormat::I420 => {
+                    let mut data: Vec<u8> =
+                        vec![
+                            0;
+                            visible_rect.width() as usize * visible_rect.height() as usize * 3 / 2
+                        ];
+                    let _ = output.copy_to_with_u8_slice(&mut data);
+                    last_frame.replace(Some(DecodedFrame::new(
+                        visible_rect.width() as u32,
+                        visible_rect.height() as u32,
+                        BitmapFormat::Yuv420p,
+                        data,
+                    )));
+                }
+                VideoPixelFormat::Bgrx => {
+                    let mut data: Vec<u8> =
+                        vec![0; visible_rect.width() as usize * visible_rect.height() as usize * 4];
+                    let _ = output.copy_to_with_u8_slice(&mut data);
+                    for pixel in data.chunks_mut(4) {
+                        pixel.swap(0, 2);
+                        pixel[3] = 0xff;
+                    }
+                    last_frame.replace(Some(DecodedFrame::new(
+                        visible_rect.width() as u32,
+                        visible_rect.height() as u32,
+                        BitmapFormat::Rgba,
+                        data,
+                    )));
+                }
+                other_format => {
+                    tracing::error!("Unsupported pixel format: {:?}", other_format);
+                }
+            };
+        };
+
+        let log_subscriber_for_error = log_subscriber.clone();
+        let error = move |error: &DomException| {
+            let _subscriber = tracing::subscriber::set_default(log_subscriber_for_error.clone());
+            tracing::error!("WebCodecs error: {:}", error.message());
+        };
+
+        let output_callback = Closure::new(move |frame| output(&frame));
+        let error_callback = Closure::new(move |exception| error(&exception));
+
+        let decoder = WebVideoDecoder::new(&VideoDecoderInit::new(
+            error_callback.as_ref().unchecked_ref(),
+            output_callback.as_ref().unchecked_ref(),
+        ))
+        .map_err(js_error_to_decoder_error)?;
+
+        Ok(Self {
+            length_size: 0,
+            decoder,
+            output_callback,
+            error_callback,
+            last_frame: lf,
+        })
+    }
+}
+
+/// Provides an iterator for individual consecutive NALUs in a byte stream,
+/// also providing the type of each NALU for easier usage.
+fn iter_nalus(data: &[u8], length_size: usize) -> impl Iterator<Item = (u8, &[u8])> {
+    trace!(
+        "iter_nalus on a {} long chunk with length_size {}",
+        data.len(),
+        length_size
+    );
+
+    let mut rest = data;
+    std::iter::from_fn(move || {
+        if rest.is_empty() {
+            return None;
+        }
+
+        if rest.len() < length_size {
+            warn!("Not enough data to read NALU length");
+            return None;
+        }
+
+        // Extracting and skipping over the NALU length.
+        let mut encoded_len = 0;
+        for b in rest.iter().take(length_size) {
+            encoded_len = (encoded_len << 8) | *b as usize;
+        }
+        trace!("encoded_len: {}", encoded_len);
+
+        if rest.len() < length_size + encoded_len {
+            warn!("Not enough data to read NALU");
+            return None;
+        }
+
+        // Extracting and skipping over the NALU type and data.
+        let nalu_type = rest[length_size] & 0b0001_1111;
+        let nalu;
+        (nalu, rest) = rest.split_at(length_size + encoded_len);
+
+        trace!("nalu_type: {}", nalu_type);
+        trace!("rest len: {}", rest.len());
+        Some((nalu_type, nalu))
+    })
+}
+
+impl VideoDecoder for H264Decoder {
+    fn configure_decoder(&mut self, configuration_data: &[u8]) -> Result<(), Error> {
+        // extradata[0]: configuration version, always 1
+        // extradata[1]: profile
+        // extradata[2]: compatibility
+        // extradata[3]: level
+        // extradata[4]: 6 reserved bits | NALU length size - 1
+
+        // The codec string is the profile, compatibility, and level bytes as hex.
+
+        if configuration_data.len() < 5 {
+            return Err(Error::DecoderError(
+                "Invalid configuration data for H264 decoder".into(),
+            ));
+        }
+        if configuration_data[0] != 1 {
+            return Err(Error::DecoderError(
+                "Invalid configuration version for H264 decoder".into(),
+            ));
+        }
+
+        self.length_size = (configuration_data[4] & 0b0000_0011) + 1;
+
+        trace!("length_size: {}", self.length_size);
+
+        let codec_string = format!(
+            "avc1.{:02x}{:02x}{:02x}",
+            configuration_data[1], configuration_data[2], configuration_data[3]
+        );
+        let config = VideoDecoderConfig::new(&codec_string);
+        trace!("decoder state: {:?}", self.decoder.state());
+        trace!("configuring decoder with: {:?}", &configuration_data[1..4]);
+
+        let data = Uint8Array::from(configuration_data);
+        config.set_description(&data);
+        config.set_optimize_for_latency(true);
+        self.decoder
+            .configure(&config)
+            .map_err(js_error_to_decoder_error)?;
+
+        trace!("decoder state: {:?}", self.decoder.state());
+        Ok(())
+    }
+
+    fn preload_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<FrameDependency, Error> {
+        debug!("preloading frame {}", encoded_frame.frame_id);
+
+        for (nalu_type, _nalu) in iter_nalus(encoded_frame.data, self.length_size as usize) {
+            // "After the decoding of an IDR picture all following coded pictures in decoding order can
+            // be decoded without inter prediction from any picture decoded prior to the IDR picture."
+            if nalu_type == NALU_TYPE_IDR {
+                tracing::trace!("is key");
+                return Ok(FrameDependency::None);
+            }
+        }
+
+        tracing::trace!("is not key");
+        Ok(FrameDependency::Past)
+    }
+
+    fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error> {
+        debug!("decoding frame {}", encoded_frame.frame_id);
+        trace!("decoder state: {:?}", self.decoder.state());
+        trace!("queue size: {}", self.decoder.decode_queue_size());
+
+        for (nalu_type, nalu) in iter_nalus(encoded_frame.data, self.length_size as usize) {
+            let frame_type = match nalu_type {
+                0 => {
+                    trace!("skipping NALU of unspecified type");
+                    continue;
+                }
+                // 1 is "Coded slice of a non-IDR picture"
+                // 2, 3, and 4 are "Coded slice data partition ..." A, B, and C
+                1..NALU_TYPE_IDR => EncodedVideoChunkType::Delta,
+                // This is 5.
+                NALU_TYPE_IDR => EncodedVideoChunkType::Key,
+                // Skipping any NALUs that are not for the VCL, such as SEI (6), SPS (7), PPS (8), etc.
+                // TODO: Maybe handle the SPS and PPS NALUs by reconfiguring the decoder?
+                _ => {
+                    trace!("skipping NALU of type {}", nalu_type);
+                    continue;
+                }
+            };
+            trace!("frame type: {:?}", frame_type);
+
+            // The timestamp doesn't matter for us.
+            let init = EncodedVideoChunkInit::new(&Uint8Array::from(nalu), 0.0, frame_type);
+            let chunk = EncodedVideoChunk::new(&init).unwrap();
+
+            self.decoder
+                .decode(&chunk)
+                .map_err(js_error_to_decoder_error)?;
+            trace!("decoder state: {:?}", self.decoder.state());
+        }
+
+        match self.last_frame.borrow_mut().take() {
+            Some(frame) => Ok(frame),
+            None => Err(Error::DecoderError(
+                "No output frame produced by the decoder".into(),
+            )),
+        }
+    }
+}

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -43,7 +43,7 @@ ruffle_web_common = { path = "common" }
 ruffle_render = { path = "../render" }
 ruffle_render_webgl = { path = "../render/webgl", optional = true }
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
-ruffle_video_software = { path = "../video/software" }
+ruffle_video_external = { path = "../video/external", features = ["webcodecs"] }
 url = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = "0.4.50"

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -17,7 +17,7 @@ use ruffle_core::{
 };
 use ruffle_render::backend::RenderBackend;
 use ruffle_render::quality::StageQuality;
-use ruffle_video_software::backend::SoftwareVideoBackend;
+use ruffle_video_external::backend::ExternalVideoBackend;
 use ruffle_web_common::JsResult;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -665,7 +665,10 @@ impl RuffleInstanceBuilder {
         let core = builder
             .with_log(log_adapter::WebLogBackend::new(trace_observer.clone()))
             .with_ui(ui::WebUiBackend::new(js_player.clone(), &canvas))
-            .with_video(SoftwareVideoBackend::new())
+            // `ExternalVideoBackend` has an internal `SoftwareVideoBackend` that it uses for any non-H.264 video.
+            .with_video(ExternalVideoBackend::new_with_webcodecs(
+                log_subscriber.clone(),
+            ))
             .with_letterbox(self.letterbox)
             .with_max_execution_duration(self.max_execution_duration)
             .with_player_version(self.player_version)


### PR DESCRIPTION
A continuation of https://github.com/ruffle-rs/ruffle/pull/14654.

Not really done yet, just pushing for visibility, and so that it doesn't get forgotten.
~_(Just look at the commit history lol.)_~

Due to this API being based on callbacks, this currently adds at least one additional (video) frame of delay as compared to a synchronous decoder, such as OpenH264 on desktop. I think this should be acceptable.
It would be possible to wire the callback straight from the browser through the video backend to the renderer backend, to update the texture immediately (off the regular frame pacing schedule), but I think that would be a bit too complicated, and could potentially result in less smooth playback.

Mostly works, in Chrome and in Firefox 129+.

I don't think this could be problematic at all from a patents/licensing/royalty standpoint.

Advances #8891.