### PR TITLE
wgpu: Do not use 'packed' as variable name in WGSL shaders

### DIFF
--- a/render/wgpu/shaders/filter/displacement_map.wgsl
+++ b/render/wgpu/shaders/filter/displacement_map.wgsl
@@ -40,8 +40,8 @@ fn main_vertex(in: VertexInput) -> VertexOutput {
     return VertexOutput(pos, in.uv);
 }
 
-fn unpack_components(packed: u32) -> vec2<u32> {
-    return vec2<u32>(packed >> 8u, packed & 15u);
+fn unpack_components(packed_components: u32) -> vec2<u32> {
+    return vec2<u32>(packed_components >> 8u, packed_components & 15u);
 }
 
 fn get_component(map: vec4<f32>, component: u32) -> f32 {


### PR DESCRIPTION
Fixes https://github.com/ruffle-rs/ruffle/issues/12844, fixes https://github.com/ruffle-rs/ruffle/issues/16642.

Turns out that 'packed' is a keyword in some GLSL shaders, and naga currently preserves it, producing a syntax error.

As a workaround, this patch renames the variable to something else.
 