### PR TITLE
web: Don't use direct eval, use indirect new Function(...) instead

### DIFF
--- a/web/packages/core/src/ruffle-imports.ts
+++ b/web/packages/core/src/ruffle-imports.ts
@@ -65,14 +65,13 @@ export function copyToAudioBufferInterleaved(
  *
  * @internal
  */
-// @ts-expect-error defined but not used
-// eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function callExternalInterface(name: string, args: any[]): any {
-    // [NA] Yes, this is direct eval. Yes, this is a Bad Thing when it comes to security.
+    // [NA] Yes, this is indirect eval. Yes, this is a Bad Thing when it comes to security.
     // In fact, yes this is vulnerable to an XSS attack!
     // But plot twist: Flash allowed for this and many games *rely on it*. :(
     // Flash content can do `call("eval", "....")` regardless, this doesn't enable anything that wasn't already permitted.
     // It just goes against what the documentation says, and *looks* really suspicious.
     // Content can only run this if the website has enabled `allowScriptAccess`, so it has to be enabled by the website too.
-    return eval(`(${name})(...args)`);
+    return new Function(`return (${name})(...arguments);`)(...args);
 }

--- a/web/packages/selfhosted/test/integration_tests/external_interface/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/external_interface/test.ts
@@ -275,4 +275,26 @@ log called with 1 argument
 `,
         );
     });
+
+    it("doesn't enforce Strict Mode", async () => {
+        const player = await browser.$("<ruffle-object>");
+        await browser.execute((player) => {
+            player.callMethodWithDelay(
+                "function(){return aPropertyThatDoesntExist = 'success!'}",
+            );
+        }, player);
+
+        // [NA] Because of the delay, if we fetch immediately we *may* just get part of the log.
+        await browser.pause(200);
+
+        const actualOutput = await getTraceOutput(browser, player);
+        expect(actualOutput).to.eql(
+            `callMethodWithDelay called with 1 argument
+  [
+    "function(){return aPropertyThatDoesntExist = 'success!'}"
+  ]
+  call(function(){return aPropertyThatDoesntExist = 'success!'}, ...) = "success!"
+`,
+        );
+    });
 });


### PR DESCRIPTION
This fixes #8330 (club penguin / newcp.net). It works surprisingly well, minor issues so far - mostly audio and text. Decent performance too!

It looks like my earlier PR to make LocalConnection likely would have fixed Club Penguin in general, but this specific site uses some javascript that doesn't work in strict mode. This change (thanks @evilpie for the recommendation to use Function!) makes it work!

The site needs a proxy to get working, which I'll leave as an exercise to the site owners.

![image](https://github.com/ruffle-rs/ruffle/assets/317625/50a41fa9-4312-488a-a925-d320a95d552a)
