### PR TITLE
web: Resolve URLs without a protocol in the extension player and improve error messages

### DIFF
--- a/web/packages/core/src/install.ts
+++ b/web/packages/core/src/install.ts
@@ -1,5 +1,6 @@
 import { PublicAPI } from "./public-api";
-import { internalSourceApi } from "./source-api";
+import { getSourceApiImplementation } from "./source-api";
+import { OriginAPI } from "./origin-api";
 
 /**
  * Options to use with this specific installation of Ruffle.
@@ -27,10 +28,12 @@ export interface InstallationOptions {
  * "extension" for browser extensions, and something else for other use cases.
  * Names are unique, and last-installed will replace earlier installations with the same name,
  * regardless of what those installations are or which version they represent.
+ * @param originAPI The OriginAPI of this Ruffle version.
  * @param options Any options used to configure this specific installation of Ruffle.
  */
 export function installRuffle(
     sourceName: string,
+    originAPI: OriginAPI,
     options: InstallationOptions = {},
 ): void {
     let publicAPI: PublicAPI;
@@ -41,8 +44,11 @@ export function installRuffle(
         window.RufflePlayer = publicAPI;
     }
 
-    publicAPI.sources[sourceName] = internalSourceApi;
-    internalSourceApi.options = options;
+    const sourceApiImplementation = getSourceApiImplementation(
+        originAPI,
+        options,
+    );
+    publicAPI.sources[sourceName] = sourceApiImplementation;
 
     // Install the faux plugin detection immediately.
     // This is necessary because scripts such as SWFObject check for the
@@ -51,6 +57,6 @@ export function installRuffle(
     const polyfills =
         "polyfills" in publicAPI.config ? publicAPI.config.polyfills : true;
     if (polyfills !== false) {
-        internalSourceApi.pluginPolyfill();
+        sourceApiImplementation.pluginPolyfill();
     }
 }

--- a/web/packages/core/src/internal/constants.tsx
+++ b/web/packages/core/src/internal/constants.tsx
@@ -1,1 +1,2 @@
 export const RUFFLE_ORIGIN = "https://ruffle.rs";
+export const SUPPORTED_PROTOCOLS = ["https:", "http:"];

--- a/web/packages/core/src/internal/errors.tsx
+++ b/web/packages/core/src/internal/errors.tsx
@@ -1,7 +1,8 @@
 export class LoadSwfError extends Error {
-    constructor(public swfUrl: URL | undefined) {
+    constructor(public swfUrl: URL | undefined, public inExtensionPlayer: boolean) {
         super(`Failed to fetch ${swfUrl}`);
         this.swfUrl = swfUrl;
+        this.inExtensionPlayer = inExtensionPlayer;
     }
 }
 

--- a/web/packages/core/src/internal/errors.tsx
+++ b/web/packages/core/src/internal/errors.tsx
@@ -1,8 +1,7 @@
 export class LoadSwfError extends Error {
-    constructor(public swfUrl: URL | undefined, public inExtensionPlayer: boolean) {
+    constructor(public swfUrl: URL | undefined) {
         super(`Failed to fetch ${swfUrl}`);
         this.swfUrl = swfUrl;
-        this.inExtensionPlayer = inExtensionPlayer;
     }
 }
 

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -14,7 +14,7 @@ import { text, textAsParagraphs } from "../i18n";
 import { swfFileName } from "../../swf-utils";
 import { isExtension } from "../../current-script";
 import { buildInfo } from "../../build-info";
-import { RUFFLE_ORIGIN } from "../constants";
+import { RUFFLE_ORIGIN, SUPPORTED_PROTOCOLS } from "../constants";
 import {
     InvalidOptionsError,
     InvalidSwfError,
@@ -836,6 +836,10 @@ export class InnerPlayer {
             if ("url" in options) {
                 console.log(`Loading SWF file ${options.url}`);
                 this.swfUrl = new URL(options.url, document.baseURI);
+                if (!SUPPORTED_PROTOCOLS.includes(this.swfUrl.protocol)) {
+                    this.displayRootMovieUnsupportedUrlMessage(this.swfUrl.toString());
+                    return;
+                }
 
                 this.instance!.stream_from(
                     this.swfUrl.href,
@@ -1915,6 +1919,11 @@ export class InnerPlayer {
         innerDiv.appendChild(buttonDiv);
         div.appendChild(innerDiv);
         this.container.prepend(div);
+    }
+
+    displayRootMovieUnsupportedUrlMessage(unsupportedUrl: string) {
+        this.swfUrl = new URL(unsupportedUrl, document.baseURI);
+        this.displayRootMovieDownloadFailedMessage(false);
     }
 
     protected displayRootMovieDownloadFailedMessage(invalidSwf: boolean): void {

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -1994,12 +1994,12 @@ export class InnerPlayer {
         }
     }
 
-    private hideSplashScreen(): void {
+    hideSplashScreen(): void {
         this.splashScreen.classList.add("hidden");
         this.container.classList.remove("hidden");
     }
 
-    private showSplashScreen(): void {
+    showSplashScreen(): void {
         this.splashScreen.classList.remove("hidden");
         this.container.classList.add("hidden");
     }

--- a/web/packages/core/src/internal/player/ruffle-embed-element.ts
+++ b/web/packages/core/src/internal/player/ruffle-embed-element.ts
@@ -7,6 +7,7 @@ import {
 } from "./inner";
 import { registerElement } from "../register-element";
 import { isSwf } from "../../swf-utils";
+import { OriginAPI } from "../../origin-api";
 
 /**
  * A polyfill html element.
@@ -134,9 +135,14 @@ export class RuffleEmbedElement extends RufflePlayerElement {
      * Creates a RuffleEmbed that will polyfill and replace the given element.
      *
      * @param elem Element to replace.
+     * @param originAPI The OriginAPI that should be used for the Ruffle version
+     * polyfilling the given Flash element.
      * @returns Created RuffleEmbed.
      */
-    static fromNativeEmbedElement(elem: Element): RuffleEmbedElement {
+    static fromNativeEmbedElement(
+        elem: Element,
+        originAPI: OriginAPI,
+    ): RuffleEmbedElement {
         const externalName = registerElement(
             "ruffle-embed",
             RuffleEmbedElement,
@@ -144,6 +150,7 @@ export class RuffleEmbedElement extends RufflePlayerElement {
         const ruffleObj = document.createElement(
             externalName,
         ) as RuffleEmbedElement;
+        ruffleObj.initialize(originAPI);
         copyElement(elem, ruffleObj);
 
         return ruffleObj;

--- a/web/packages/core/src/internal/player/ruffle-object-element.ts
+++ b/web/packages/core/src/internal/player/ruffle-object-element.ts
@@ -9,6 +9,7 @@ import { FLASH_ACTIVEX_CLASSID } from "../../flash-identifiers";
 import { registerElement } from "../register-element";
 import { RuffleEmbedElement } from "./ruffle-embed-element";
 import { isSwf } from "../../swf-utils";
+import { OriginAPI } from "../../origin-api";
 
 /**
  * Find and return the first value in obj with the given key.
@@ -250,9 +251,14 @@ export class RuffleObjectElement extends RufflePlayerElement {
      * Creates a RuffleObject that will polyfill and replace the given element.
      *
      * @param elem Element to replace.
+     * @param originAPI The OriginAPI that should be used for the Ruffle version
+     * polyfilling the given Flash element.
      * @returns Created RuffleObject.
      */
-    static fromNativeObjectElement(elem: Element): RuffleObjectElement {
+    static fromNativeObjectElement(
+        elem: Element,
+        originAPI: OriginAPI,
+    ): RuffleObjectElement {
         const externalName = registerElement(
             "ruffle-object",
             RuffleObjectElement,
@@ -260,6 +266,7 @@ export class RuffleObjectElement extends RufflePlayerElement {
         const ruffleObj: RuffleObjectElement = document.createElement(
             externalName,
         ) as RuffleObjectElement;
+        ruffleObj.initialize(originAPI);
 
         // Avoid copying embeds-inside-objects to avoid double polyfilling.
         for (const embedElem of Array.from(

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -91,6 +91,10 @@ export class RufflePlayerElement extends HTMLElement implements Player {
         await this.#inner.load(options, isPolyfillElement);
     }
 
+    async loadInExtensionPlayer(options: string | URLLoadOptions | DataLoadOptions) {
+        await this.#inner.load(options, false, true);
+    }
+
     play(): void {
         this.#inner.play();
     }
@@ -101,6 +105,10 @@ export class RufflePlayerElement extends HTMLElement implements Player {
 
     displayRootMovieUnsupportedUrlMessage(unsupportedUrl: string): void {
         this.#inner.displayRootMovieUnsupportedUrlMessage(unsupportedUrl);
+    }
+
+    setInExtensionPlayer(): void {
+        this.#inner.setInExtensionPlayer();
     }
 
     get volume(): number {

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -2,6 +2,7 @@ import type { DataLoadOptions, URLLoadOptions } from "../../load-options";
 import type { MovieMetadata } from "../../movie-metadata";
 import { InnerPlayer, ReadyState } from "./inner";
 import { Player } from "../../public/player";
+import { OriginAPI } from "../../origin-api";
 
 /**
  * The ruffle player element that should be inserted onto the page.
@@ -9,28 +10,40 @@ import { Player } from "../../public/player";
  * This element will represent the rendered and intractable flash movie.
  */
 export class RufflePlayerElement extends HTMLElement implements Player {
-    #inner: InnerPlayer;
+    #inner?: InnerPlayer;
 
     get onFSCommand(): ((command: string, args: string) => boolean) | null {
-        return this.#inner.onFSCommand;
+        return this.#inner!.onFSCommand;
     }
 
     set onFSCommand(
         value: ((command: string, args: string) => boolean) | null,
     ) {
-        this.#inner.onFSCommand = value;
+        this.#inner!.onFSCommand = value;
     }
 
     get readyState(): ReadyState {
-        return this.#inner._readyState;
+        return this.#inner!._readyState;
     }
 
     get metadata(): MovieMetadata | null {
-        return this.#inner.metadata;
+        return this.#inner!.metadata;
     }
 
     constructor() {
         super();
+    }
+
+    /**
+     * Initializes this Ruffle player element.
+     * This *must* always be directly called after creating the element via document#createElement.
+     * @param originAPI The OriginAPI of this Ruffle player element.
+     */
+    initialize(originAPI: OriginAPI) {
+        // The InnerPlayer is set here and not in the constructor to make sure initialize is always
+        // called after the player element is created.
+        // Otherwise, when it's forgotten in a new place, it might not be directly noticed which would
+        // lead to runtime errors.
         this.#inner = new InnerPlayer(
             this,
             () => this.debugPlayerInfo(),
@@ -38,7 +51,7 @@ export class RufflePlayerElement extends HTMLElement implements Player {
                 try {
                     Object.defineProperty(this, name, {
                         value: (...args: unknown[]) => {
-                            return this.#inner.callExternalInterface(
+                            return this.#inner!.callExternalInterface(
                                 name,
                                 args,
                             );
@@ -51,15 +64,16 @@ export class RufflePlayerElement extends HTMLElement implements Player {
                     );
                 }
             },
+            originAPI
         );
     }
 
     get loadedConfig(): URLLoadOptions | DataLoadOptions | null {
-        return this.#inner.loadedConfig ?? null;
+        return this.#inner!.loadedConfig ?? null;
     }
 
     connectedCallback(): void {
-        this.#inner.updateStyles();
+        this.#inner!.updateStyles();
     }
 
     static get observedAttributes(): string[] {
@@ -72,83 +86,79 @@ export class RufflePlayerElement extends HTMLElement implements Player {
         _newValue: string | undefined,
     ): void {
         if (name === "width" || name === "height") {
-            this.#inner.updateStyles();
+            this.#inner!.updateStyles();
         }
     }
 
     disconnectedCallback(): void {
-        this.#inner.destroy();
+        this.#inner!.destroy();
     }
 
     async reload(): Promise<void> {
-        await this.#inner.reload();
+        await this.#inner!.reload();
     }
 
     async load(
         options: string | URLLoadOptions | DataLoadOptions,
         isPolyfillElement: boolean = false,
     ): Promise<void> {
-        await this.#inner.load(options, isPolyfillElement);
-    }
-
-    async loadInExtensionPlayer(options: string | URLLoadOptions | DataLoadOptions) {
-        await this.#inner.load(options, false, true);
+        await this.#inner!.load(options, isPolyfillElement);
     }
 
     play(): void {
-        this.#inner.play();
+        this.#inner!.play();
     }
 
     get isPlaying(): boolean {
-        return this.#inner.isPlaying;
+        return this.#inner!.isPlaying;
     }
 
     displayRootMovieUnsupportedUrlMessage(unsupportedUrl: string): void {
-        this.#inner.displayRootMovieUnsupportedUrlMessage(unsupportedUrl);
+        this.#inner!.displayRootMovieUnsupportedUrlMessage(unsupportedUrl);
     }
 
-    setInExtensionPlayer(): void {
-        this.#inner.setInExtensionPlayer();
+    getOriginAPI(): OriginAPI {
+        return this.#inner!.getOriginAPI();
     }
 
     get volume(): number {
-        return this.#inner.volume;
+        return this.#inner!.volume;
     }
 
     set volume(value: number) {
-        this.#inner.volume = value;
+        this.#inner!.volume = value;
     }
 
     get fullscreenEnabled(): boolean {
-        return this.#inner.fullscreenEnabled;
+        return this.#inner!.fullscreenEnabled;
     }
 
     get isFullscreen(): boolean {
-        return this.#inner.isFullscreen;
+        return this.#inner!.isFullscreen;
     }
 
     setFullscreen(isFull: boolean): void {
-        this.#inner.setFullscreen(isFull);
+        this.#inner!.setFullscreen(isFull);
     }
 
     enterFullscreen(): void {
-        this.#inner.enterFullscreen();
+        this.#inner!.enterFullscreen();
     }
 
     exitFullscreen(): void {
-        this.#inner.exitFullscreen();
+        this.#inner!.exitFullscreen();
     }
 
     async downloadSwf(): Promise<void> {
-        await this.#inner.downloadSwf();
+        await this.#inner!.downloadSwf();
     }
 
     pause(): void {
-        this.#inner.pause();
+        this.#inner!.pause();
     }
 
     set traceObserver(observer: ((message: string) => void) | null) {
-        this.#inner.traceObserver = observer;
+        this.#inner!.traceObserver = observer;
     }
 
     protected debugPlayerInfo(): string {
@@ -165,19 +175,19 @@ export class RufflePlayerElement extends HTMLElement implements Player {
     }
 
     get config(): URLLoadOptions | DataLoadOptions | object {
-        return this.#inner.config;
+        return this.#inner!.config;
     }
 
     set config(value: URLLoadOptions | DataLoadOptions | object) {
-        this.#inner.config = value;
+        this.#inner!.config = value;
     }
 
     hideSplashScreen(): void {
-        this.#inner.hideSplashScreen()
+        this.#inner!.hideSplashScreen()
     }
 
     showSplashScreen(): void {
-        this.#inner.showSplashScreen()
+        this.#inner!.showSplashScreen()
     }
 }
 

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -159,6 +159,14 @@ export class RufflePlayerElement extends HTMLElement implements Player {
     set config(value: URLLoadOptions | DataLoadOptions | object) {
         this.#inner.config = value;
     }
+
+    hideSplashScreen(): void {
+        this.#inner.hideSplashScreen()
+    }
+
+    showSplashScreen(): void {
+        this.#inner.showSplashScreen()
+    }
 }
 
 /**

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -99,6 +99,10 @@ export class RufflePlayerElement extends HTMLElement implements Player {
         return this.#inner.isPlaying;
     }
 
+    displayRootMovieUnsupportedUrlMessage(unsupportedUrl: string): void {
+        this.#inner.displayRootMovieUnsupportedUrlMessage(unsupportedUrl);
+    }
+
     get volume(): number {
         return this.#inner.volume;
     }

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -11,7 +11,7 @@ import {
 } from "wasm-feature-detect";
 import type { RuffleInstanceBuilder, ZipWriter } from "../dist/ruffle_web";
 import { setPolyfillsOnLoad } from "./js-polyfills";
-import { internalSourceApi } from "./source-api";
+import { onFirstLoad } from "./source-api";
 
 type ProgressCallback = (bytesLoaded: number, bytesTotal: number) => void;
 
@@ -50,9 +50,7 @@ async function fetchRuffle(
         );
     }
 
-    // Easy "on first load": just set it to something else after the call.
-    internalSourceApi.options.onFirstLoad?.();
-    internalSourceApi.options.onFirstLoad = () => {};
+    onFirstLoad();
 
     // Note: The argument passed to import() has to be a simple string literal,
     // otherwise some bundler will get confused and won't include the module?

--- a/web/packages/core/src/origin-api.ts
+++ b/web/packages/core/src/origin-api.ts
@@ -1,0 +1,24 @@
+import { PanicAction } from "./internal/ui/panic";
+
+/**
+ * The OriginAPI is used to access behaviour that's specific to the Ruffle origin (selfhosted, demo or extension).
+ */
+export interface OriginAPI {
+    /**
+     * Display a LoadSwfError message for the given URL, customized to the Ruffle origin, if an error message specific
+     * to the origin exists. Returns whether this is the case.
+     * This is used to display error messages that only apply to a specific origin.
+     * If false is returned, a general error message should be displayed instead, otherwise it shouldn't.
+     *
+     * @param swfUrl The URL for which a LoadSwfError message should be displayed.
+     * @returns Whether an error message specific to the Ruffle origin exists.
+     */
+    loadSwfErrorMessage(swfUrl: URL | undefined):
+        | {
+              body: HTMLDivElement;
+              actions: PanicAction[];
+          }
+        | undefined;
+
+    giveTryHttpAdvice(swfUrl: URL | undefined): string;
+}

--- a/web/packages/core/src/public/legacy.ts
+++ b/web/packages/core/src/public/legacy.ts
@@ -73,6 +73,15 @@ export interface LegacyRuffleAPI {
     load(options: string | URLLoadOptions | DataLoadOptions): Promise<void>;
 
     /**
+     * Like {@link RufflePlayer.load}, but only for the extension player.
+     * This is used to make sure error warnings related to the extension player are only shown
+     * in it.
+     * TODO: Remove this after moving inExtensionPlayer into the extension code
+     * @param options See {@link RufflePlayer.load}.
+     */
+    loadInExtensionPlayer(options: string | URLLoadOptions | DataLoadOptions): void;
+
+    /**
      * Plays or resumes the movie.
      */
     play(): void;
@@ -91,6 +100,12 @@ export interface LegacyRuffleAPI {
      * @param unsupportedUrl The given URL that is unsupported.
      */
     displayRootMovieUnsupportedUrlMessage(unsupportedUrl: string): void;
+
+    /**
+     * Sets the information whether the last load command originated from the extension player to true.
+     * TODO: Move this into the extension code and replace its usages with an API call
+     */
+    setInExtensionPlayer(): void;
 
     /**
      * Returns the master volume of the player.

--- a/web/packages/core/src/public/legacy.ts
+++ b/web/packages/core/src/public/legacy.ts
@@ -85,6 +85,14 @@ export interface LegacyRuffleAPI {
     get isPlaying(): boolean;
 
     /**
+     * Displays the panic screen with an error message that the root movie URL is not supported by Ruffle.
+     * If a given URL is unsupported, this should be directly called instead of trying to load the URL, as
+     * it removes the delay before displaying the (same) error message.
+     * @param unsupportedUrl The given URL that is unsupported.
+     */
+    displayRootMovieUnsupportedUrlMessage(unsupportedUrl: string): void;
+
+    /**
      * Returns the master volume of the player.
      *
      * The volume is linear and not adapted for logarithmic hearing.

--- a/web/packages/core/src/public/legacy.ts
+++ b/web/packages/core/src/public/legacy.ts
@@ -1,6 +1,7 @@
 import { DataLoadOptions, URLLoadOptions } from "../load-options";
 import { MovieMetadata } from "../movie-metadata";
 import { ReadyState } from "../internal/player/inner";
+import { OriginAPI } from "../origin-api";
 
 /**
  * Legacy interface to the Ruffle API.
@@ -73,15 +74,6 @@ export interface LegacyRuffleAPI {
     load(options: string | URLLoadOptions | DataLoadOptions): Promise<void>;
 
     /**
-     * Like {@link RufflePlayer.load}, but only for the extension player.
-     * This is used to make sure error warnings related to the extension player are only shown
-     * in it.
-     * TODO: Remove this after moving inExtensionPlayer into the extension code
-     * @param options See {@link RufflePlayer.load}.
-     */
-    loadInExtensionPlayer(options: string | URLLoadOptions | DataLoadOptions): void;
-
-    /**
      * Plays or resumes the movie.
      */
     play(): void;
@@ -97,15 +89,17 @@ export interface LegacyRuffleAPI {
      * Displays the panic screen with an error message that the root movie URL is not supported by Ruffle.
      * If a given URL is unsupported, this should be directly called instead of trying to load the URL, as
      * it removes the delay before displaying the (same) error message.
+     *
      * @param unsupportedUrl The given URL that is unsupported.
      */
     displayRootMovieUnsupportedUrlMessage(unsupportedUrl: string): void;
 
     /**
-     * Sets the information whether the last load command originated from the extension player to true.
-     * TODO: Move this into the extension code and replace its usages with an API call
+     * Returns the OriginAPI of this Ruffle player.
+     *
+     * @returns The OriginAPI of this Ruffle player.
      */
-    setInExtensionPlayer(): void;
+    getOriginAPI(): OriginAPI;
 
     /**
      * Returns the master volume of the player.

--- a/web/packages/core/src/public/legacy.ts
+++ b/web/packages/core/src/public/legacy.ts
@@ -157,4 +157,14 @@ export interface LegacyRuffleAPI {
      * Fetches the loaded SWF and downloads it.
      */
     downloadSwf(): Promise<void>;
+
+    /**
+     * Shows the splash screen.
+     */
+    showSplashScreen(): void;
+
+    /**
+     * Hides the splash screen.
+     */
+    hideSplashScreen(): void;
 }

--- a/web/packages/core/src/source-api.ts
+++ b/web/packages/core/src/source-api.ts
@@ -4,6 +4,7 @@ import { RufflePlayerElement } from "./internal/player/ruffle-player-element";
 import { buildInfo } from "./build-info";
 import { InstallationOptions } from "./install";
 import { Player } from "./public/player";
+import { OriginAPI } from "./origin-api";
 
 /**
  * Represents this particular version of Ruffle.
@@ -18,6 +19,14 @@ export interface SourceAPI {
      * The version of this particular API, as a string in a semver compatible format.
      */
     version: string;
+
+    /**
+     * The OriginAPI of this Ruffle version.
+     * It is used to access behaviour that's specific to the Ruffle origin (selfhosted, demo or extension).
+     * It's given to the (internal) Ruffle player and provides minor helper methods (unlike this SourceAPI,
+     * which manages the whole Ruffle polyfill and player).
+     */
+    originAPI: OriginAPI;
 
     /**
      * Start up the polyfills.
@@ -42,48 +51,75 @@ export interface SourceAPI {
     createPlayer(): Player;
 }
 
+let installationOptions: InstallationOptions = {} as InstallationOptions;
+
 /**
- * The actual source API that describes this installation.
- * This isn't part of the public API and may contain extra details.
+ * Returns the actual source API implementation that describes this installation.
+ * The internal implementation details aren't part of the public API and may contain extra details.
+ *
+ * @param originAPI The OriginAPI of this Ruffle installation.
+ * @param options The InstallationOptions of this Ruffle installation.
+ * @returns The actual source API implementation that describes this installation.
  */
-export const internalSourceApi = {
-    /**
-     * The version of this particular API, as a string in a semver compatible format.
-     */
-    version:
-        buildInfo.versionNumber + "+" + buildInfo.buildDate.substring(0, 10),
+export function getSourceApiImplementation(
+    originAPI: OriginAPI,
+    options: InstallationOptions,
+) {
+    installationOptions = options;
 
-    /**
-     * Start up the polyfills.
-     *
-     * Do not run polyfills for more than one Ruffle source at a time.
-     */
-    polyfill(): void {
-        polyfill();
-    },
+    return {
+        /**
+         * The version of this particular API, as a string in a semver compatible format.
+         */
+        version:
+            buildInfo.versionNumber +
+            "+" +
+            buildInfo.buildDate.substring(0, 10),
 
-    /**
-     * Polyfill the plugin detection.
-     *
-     * This needs to run before any plugin detection script does.
-     */
-    pluginPolyfill(): void {
-        pluginPolyfill();
-    },
+        originAPI: originAPI,
 
-    /**
-     * Create a Ruffle player element using this particular version of Ruffle.
-     *
-     * @returns The player element. This is a DOM element that may be inserted
-     * into the current page as you wish.
-     */
-    createPlayer(): Player {
-        const name = registerElement("ruffle-player", RufflePlayerElement);
-        return document.createElement(name) as RufflePlayerElement;
-    },
+        /**
+         * Start up the polyfills.
+         *
+         * Do not run polyfills for more than one Ruffle source at a time.
+         */
+        polyfill(): void {
+            polyfill(originAPI);
+        },
 
-    /**
-     * Options specified by the user of this library.
-     */
-    options: {} as InstallationOptions,
-};
+        /**
+         * Polyfill the plugin detection.
+         *
+         * This needs to run before any plugin detection script does.
+         */
+        pluginPolyfill(): void {
+            pluginPolyfill();
+        },
+
+        /**
+         * Create a Ruffle player element using this particular version of Ruffle.
+         *
+         * @returns The player element. This is a DOM element that may be inserted
+         * into the current page as you wish.
+         */
+        createPlayer(): Player {
+            const name = registerElement("ruffle-player", RufflePlayerElement);
+            const player = document.createElement(name) as RufflePlayerElement;
+            player.initialize(originAPI);
+            return player;
+        },
+
+        /**
+         * Options specified by the user of this library.
+         */
+        options: installationOptions,
+    };
+}
+
+/**
+ * Executes the onFirstLoad method when called for the first time.
+ */
+export function onFirstLoad() {
+    installationOptions.onFirstLoad?.();
+    installationOptions.onFirstLoad = () => {};
+}

--- a/web/packages/core/texts/en-US/messages.ftl
+++ b/web/packages/core/texts/en-US/messages.ftl
@@ -42,10 +42,13 @@ error-wasm-mime-type =
     If you are the server administrator, please consult the Ruffle wiki for help.
 error-invalid-swf =
     Ruffle cannot parse the requested file.
-    The most likely reason is that the requested file is not a valid SWF.
+    The most likely reason is that the requested file is not a valid SWF file.
 error-swf-fetch =
     Ruffle failed to load the Flash SWF file.
-    The most likely reason is that the file no longer exists, so there is nothing for Ruffle to load.
+    The most likely reason is that the file no longer exists, so there is nothing for Ruffle to load.{$https ->
+        *[true] {"\U00000A"}If the website doesn't support HTTPS, include http:// explicitly.
+        [false] {""}
+    }
     Try contacting the website administrator for help.
 error-swf-cors =
     Ruffle failed to load the Flash SWF file.
@@ -77,6 +80,15 @@ error-csp-conflict =
     Ruffle has encountered a major issue whilst trying to initialize.
     This web server's Content Security Policy does not allow the required ".wasm" component to run.
     If you are the server administrator, please consult the Ruffle wiki for help.
+error-local-root-url =
+    Ruffle can't load a local file URL.
+    To load a local file in the extension player, use the Select File button.
+error-unsupported-root-protocol =
+    Ruffle doesn't support loading a URL with the protocol {$protocol} in the extension player.
+    Please enter a valid web URL (with the protocol https: or http:) or use the Select File button.
+error-no-valid-url =
+    "{$url}" is not a valid URL and can't be resolved.
+    Please enter a valid web URL or use the Select File button.
 error-unknown =
     Ruffle has encountered a major issue whilst trying to display this Flash content.
     {$outdated ->

--- a/web/packages/core/texts/en-US/messages.ftl
+++ b/web/packages/core/texts/en-US/messages.ftl
@@ -89,6 +89,10 @@ error-unsupported-root-protocol =
 error-no-valid-url =
     "{$url}" is not a valid URL and can't be resolved.
     Please enter a valid web URL or use the Select File button.
+error-misconfigured-url =
+    The embedded SWF file is not under a supported URL Ruffle can load.
+    This is most likely due to a website misconfiguration.
+    Try contacting the website administrator for help.
 error-unknown =
     Ruffle has encountered a major issue whilst trying to display this Flash content.
     {$outdated ->

--- a/web/packages/demo/src/demo-origin.ts
+++ b/web/packages/demo/src/demo-origin.ts
@@ -1,0 +1,17 @@
+import { OriginAPI } from "ruffle-core/dist/origin-api";
+import { PanicAction } from "ruffle-core/dist/internal/ui/panic";
+
+export class DemoOrigin implements OriginAPI {
+    loadSwfErrorMessage(_swfUrl: URL | undefined):
+        | {
+              body: HTMLDivElement;
+              actions: PanicAction[];
+          }
+        | undefined {
+        return undefined;
+    }
+
+    giveTryHttpAdvice(_swfUrl: URL | undefined): string {
+        return "false";
+    }
+}

--- a/web/packages/demo/src/main.tsx
+++ b/web/packages/demo/src/main.tsx
@@ -11,8 +11,9 @@ import {
     installRuffle,
     UnmuteOverlay,
 } from "ruffle-core";
+import { DemoOrigin } from "./demo-origin";
 
-installRuffle("local");
+installRuffle("local", new DemoOrigin());
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>

--- a/web/packages/extension/assets/css/common.css
+++ b/web/packages/extension/assets/css/common.css
@@ -79,6 +79,14 @@ button {
     text-shadow: 0 0 0.1px white;
 }
 
+#modal button:hover {
+    background: var(--ruffle-blue);
+}
+
+button:not(#modal button):hover {
+    filter: brightness(1.2);
+}
+
 .options {
     display: flex;
     flex-flow: column;
@@ -156,4 +164,9 @@ button {
     width: 60px;
     height: 20px;
     margin: auto;
+}
+
+#modal {
+    background-color: #ffffffb0;
+    border-radius: 12px;
 }

--- a/web/packages/extension/src/extemsion-origin.ts
+++ b/web/packages/extension/src/extemsion-origin.ts
@@ -1,0 +1,61 @@
+import { OriginAPI } from "ruffle-core/dist/origin-api";
+import { textAsParagraphs } from "ruffle-core/dist/internal/i18n";
+import { SUPPORTED_PROTOCOLS } from "ruffle-core/dist/internal/constants";
+import { CommonActions, PanicAction } from "ruffle-core/dist/internal/ui/panic";
+
+export class ExtensionOrigin implements OriginAPI {
+    private inExtensionPlayer: boolean;
+
+    constructor() {
+        this.inExtensionPlayer = false;
+    }
+
+    setInExtensionPlayer() {
+        this.inExtensionPlayer = true;
+    }
+
+    loadSwfErrorMessage(swfUrl: URL | undefined):
+        | {
+              body: HTMLDivElement;
+              actions: PanicAction[];
+          }
+        | undefined {
+        if (!this.inExtensionPlayer || swfUrl === undefined) {
+            return undefined;
+        }
+
+        const urlExtensionProtocol = document.baseURI.split(":")[0] + ":";
+        if (swfUrl.protocol === urlExtensionProtocol) {
+            // The user entered an invalid URL
+            const urlExtensionPart = document.baseURI.split("player.html")[0]!;
+            return {
+                body: textAsParagraphs("error-no-valid-url", {
+                    url: swfUrl.href.replace(urlExtensionPart, ""),
+                }),
+                actions: [CommonActions.ShowDetails],
+            };
+        } else if (swfUrl.protocol === "file:") {
+            // The user entered a local file URL
+            return {
+                body: textAsParagraphs("error-local-root-url"),
+                actions: [CommonActions.ShowDetails],
+            };
+        } else if (!SUPPORTED_PROTOCOLS.includes(swfUrl.protocol)) {
+            // The user entered a URL with an unsupported protocol
+            return {
+                body: textAsParagraphs("error-unsupported-root-protocol", {
+                    protocol: swfUrl.protocol,
+                }),
+                actions: [CommonActions.ShowDetails],
+            };
+        }
+
+        return undefined;
+    }
+
+    giveTryHttpAdvice(swfUrl: URL | undefined): string {
+        return this.inExtensionPlayer
+            ? (swfUrl?.protocol?.includes("https")?.toString() ?? "true")
+            : "false";
+    }
+}

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -107,6 +107,7 @@ async function load(options: string | DataLoadOptions | URLLoadOptions) {
     player = ruffle.createPlayer();
     player.id = "player";
     playerContainer.append(player);
+    player.showSplashScreen();
     const urlString =
         typeof options === "string"
             ? options
@@ -129,10 +130,17 @@ async function load(options: string | DataLoadOptions | URLLoadOptions) {
     ) {
         const result = await showModal(origin!);
         if (result === "") {
+            player.hideSplashScreen();
+
+            // Hide the splash screen before displaying the alert
             const swfPlayerPermissions = utils.i18n.getMessage(
                 "swf_player_permissions",
             );
-            alert(swfPlayerPermissions);
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    alert(swfPlayerPermissions);
+                });
+            });
             history.pushState("", document.title, window.location.pathname);
             return;
         }
@@ -307,9 +315,12 @@ async function loadSwf(swfUrl: string) {
     const url = await utils.resolveSwfUrl(swfUrl);
     if (url !== null) {
         swfUrl = url.toString();
-        const pathname = url.pathname;
-        document.title = pathname.substring(pathname.lastIndexOf("/") + 1);
     }
+
+    document.title = swfUrl
+        .split("/")
+        .filter((item) => item !== "")
+        .slice(-1)[0]!;
 
     const options = await utils.getExplicitOptions();
     localFileName.textContent = document.title;

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -6,6 +6,7 @@ import type {
     DataLoadOptions,
     URLLoadOptions,
 } from "ruffle-core";
+import { ExtensionOrigin } from "./extemsion-origin";
 
 declare global {
     interface Navigator {
@@ -17,7 +18,7 @@ declare global {
     }
 }
 
-installRuffle("local");
+installRuffle("local", new ExtensionOrigin());
 const ruffle = (window.RufflePlayer as PublicAPI).newest()!;
 let player: Player;
 
@@ -105,6 +106,7 @@ function unload() {
 async function load(options: string | DataLoadOptions | URLLoadOptions) {
     unload();
     player = ruffle.createPlayer();
+    (player.getOriginAPI() as ExtensionOrigin).setInExtensionPlayer();
     player.id = "player";
     playerContainer.append(player);
     player.showSplashScreen();
@@ -125,7 +127,6 @@ async function load(options: string | DataLoadOptions | URLLoadOptions) {
 
     const supportedURL = utils.supportedURL(url);
     if (!supportedURL && urlString) {
-        player.setInExtensionPlayer();
         player.displayRootMovieUnsupportedUrlMessage(urlString);
         return;
     }
@@ -150,7 +151,7 @@ async function load(options: string | DataLoadOptions | URLLoadOptions) {
             return;
         }
     }
-    await player.loadInExtensionPlayer(options);
+    await player.load(options);
     player.addEventListener("loadedmetadata", () => {
         if (player.metadata) {
             for (const [key, value] of Object.entries(player.metadata)) {

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -107,22 +107,27 @@ async function load(options: string | DataLoadOptions | URLLoadOptions) {
     player = ruffle.createPlayer();
     player.id = "player";
     playerContainer.append(player);
-    const url =
+    const urlString =
         typeof options === "string"
             ? options
             : "url" in options
               ? options["url"]
               : undefined;
+    let url;
     let origin;
     try {
-        origin = url ? new URL(url).origin + "/" : url;
+        url = new URL(urlString!);
+        origin = url.origin + "/";
     } catch {
         // Ignore
     }
-    const hostPermissionsForSpecifiedTab =
-        await utils.hasHostPermissionForSpecifiedTab(origin);
-    if (origin && !hostPermissionsForSpecifiedTab) {
-        const result = await showModal(origin);
+
+    const supportedURL = utils.supportedURL(url);
+    if (
+        supportedURL &&
+        !(await utils.hasHostPermissionForSpecifiedTab(origin!))
+    ) {
+        const result = await showModal(origin!);
         if (result === "") {
             const swfPlayerPermissions = utils.i18n.getMessage(
                 "swf_player_permissions",

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -299,11 +299,11 @@ window.addEventListener("load", () => {
 });
 
 async function loadSwf(swfUrl: string) {
-    try {
-        const pathname = new URL(swfUrl).pathname;
+    const url = await utils.resolveSwfUrl(swfUrl);
+    if (url !== null) {
+        swfUrl = url.toString();
+        const pathname = url.pathname;
         document.title = pathname.substring(pathname.lastIndexOf("/") + 1);
-    } catch (_) {
-        // Ignore URL parsing errors.
     }
 
     const options = await utils.getExplicitOptions();

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -124,6 +124,10 @@ async function load(options: string | DataLoadOptions | URLLoadOptions) {
     }
 
     const supportedURL = utils.supportedURL(url);
+    if (!supportedURL && urlString) {
+        player.displayRootMovieUnsupportedUrlMessage(urlString);
+        return;
+    }
     if (
         supportedURL &&
         !(await utils.hasHostPermissionForSpecifiedTab(origin!))

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -125,6 +125,7 @@ async function load(options: string | DataLoadOptions | URLLoadOptions) {
 
     const supportedURL = utils.supportedURL(url);
     if (!supportedURL && urlString) {
+        player.setInExtensionPlayer();
         player.displayRootMovieUnsupportedUrlMessage(urlString);
         return;
     }
@@ -149,7 +150,7 @@ async function load(options: string | DataLoadOptions | URLLoadOptions) {
             return;
         }
     }
-    await player.load(options);
+    await player.loadInExtensionPlayer(options);
     player.addEventListener("loadedmetadata", () => {
         if (player.metadata) {
             for (const [key, value] of Object.entries(player.metadata)) {

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -317,14 +317,15 @@ async function loadSwf(swfUrl: string) {
         swfUrl = url.toString();
     }
 
+    webURL.value = swfUrl;
     document.title = swfUrl
         .split("/")
         .filter((item) => item !== "")
         .slice(-1)[0]!;
-
-    const options = await utils.getExplicitOptions();
     localFileName.textContent = document.title;
     localFileInput.value = "";
+
+    const options = await utils.getExplicitOptions();
     load({
         ...options,
         url: swfUrl,

--- a/web/packages/extension/src/popup.ts
+++ b/web/packages/extension/src/popup.ts
@@ -2,6 +2,7 @@ import * as utils from "./utils";
 import type { Options } from "./common";
 import { bindOptions } from "./common";
 import { buildInfo } from "ruffle-core";
+import { SUPPORTED_PROTOCOLS } from "ruffle-core/dist/internal/constants";
 
 let activeTab: chrome.tabs.Tab | browser.tabs.Tab;
 let savedOptions: Options;
@@ -214,7 +215,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     const url = activeTab?.url ? new URL(activeTab.url) : null;
     if (
         url &&
-        ["https:", "http:"].includes(url.protocol) &&
+        SUPPORTED_PROTOCOLS.includes(url.protocol) &&
         !(await utils.hasHostPermissionForActiveTab())
     ) {
         permissionsButton.classList.remove("hidden");

--- a/web/packages/extension/src/ruffle.ts
+++ b/web/packages/extension/src/ruffle.ts
@@ -1,5 +1,6 @@
 import { installRuffle } from "ruffle-core";
 import { Message } from "./messages";
+import { ExtensionOrigin } from "./extemsion-origin";
 
 function handleMessage(message: Message) {
     switch (message.type) {
@@ -15,7 +16,7 @@ function handleMessage(message: Message) {
                 ...window.RufflePlayer.config,
                 openInNewTab,
             };
-            installRuffle("extension");
+            installRuffle("extension", new ExtensionOrigin());
             return {};
         }
         case "ping":

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -156,8 +156,8 @@ export async function resolveSwfUrl(enteredUrl: string): Promise<URL | null> {
             // Only use http if https doesn't work and http works
             // (Otherwise, error logs for offline websites would always contain http)
             if (
-                (await serverAvailable("https://" + enteredUrl, 200)) ||
-                !(await serverAvailable("http://" + enteredUrl, 100))
+                (await serverAvailable("https://" + enteredUrl, 600)) ||
+                !(await serverAvailable("http://" + enteredUrl, 300))
             ) {
                 return new URL("https://" + enteredUrl);
             } else {

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -1,5 +1,6 @@
 import type { Options } from "./common";
 import { DEFAULT_CONFIG as CORE_DEFAULT_CONFIG } from "ruffle-core";
+import { SUPPORTED_PROTOCOLS } from "ruffle-core/dist/internal/constants";
 
 const DEFAULT_OPTIONS: Required<Options> = {
     ...CORE_DEFAULT_CONFIG,
@@ -106,6 +107,19 @@ export async function getExplicitOptions(): Promise<Options> {
 }
 
 /**
+ * Returns whether the given URL is a URL that Ruffle can open.
+ * @param url The given URL to be tested whether it can be opened.
+ * @return Whether the given URL is a URL that Ruffle can open.
+ */
+export function supportedURL(url: URL | undefined): boolean {
+    if (url) {
+        return SUPPORTED_PROTOCOLS.includes(url.protocol);
+    } else {
+        return false;
+    }
+}
+
+/**
  * Resolves a given string to a URL if possible.
  * If the protocol is missing and the string is otherwise a valid web URL, https:// is inserted if the
  * server supports https, otherwise http.
@@ -192,14 +206,10 @@ export async function hasHostPermissionForSpecifiedTab(
     origin: string | undefined,
 ) {
     try {
-        return origin
-            ? await permissions.contains({
-                  origins: [origin],
-              })
-            : await hasAllUrlsPermission();
+        return await permissions.contains({ origins: [origin!] });
     } catch {
-        // catch error that occurs for special urls like about:
-        return false;
+        // If the URL is invalid, don't ask for permission
+        return true;
     }
 }
 

--- a/web/packages/selfhosted/js/ruffle.js
+++ b/web/packages/selfhosted/js/ruffle.js
@@ -2,6 +2,7 @@
 /* global __webpack_public_path__:writable */
 
 import { installRuffle } from "ruffle-core";
+import { SelfhostedOrigin } from "./selfhosted-origin.js";
 
 let currentScriptURL = null;
 
@@ -46,7 +47,7 @@ function publicPath(config) {
     return path;
 }
 
-installRuffle("local", {
+installRuffle("local", new SelfhostedOrigin(), {
     onFirstLoad: () => {
         __webpack_public_path__ = publicPath(window.RufflePlayer?.config);
     },

--- a/web/packages/selfhosted/js/selfhosted-origin.js
+++ b/web/packages/selfhosted/js/selfhosted-origin.js
@@ -1,0 +1,9 @@
+export class SelfhostedOrigin {
+    loadSwfErrorMessage(_swfUrl) {
+        return undefined;
+    }
+
+    giveTryHttpAdvice(_swfUrl) {
+        return "false";
+    }
+}


### PR DESCRIPTION
Currently, only URLs explicitly including the web protocol (HTTPS or HTTP) in the beginning can be resolved in the extension player. Additionally, if the URL doesn't include the HTTPS or HTTP protocol in the beginning, a wrong error is displayed. It states that the user ran Ruffle on the file: protocol which is wrong and confusing:
<img width="1582" alt="Bildschirmfoto 2024-06-28 um 15 53 04" src="https://github.com/ruffle-rs/ruffle/assets/33464213/b01c70c4-d1bf-4a49-8fc6-e551e0368edb">

This pull request fixes this.
With this pull request, the extension player resolves URLs without a protocol. It adds https:// or http:// if the URL is likely a valid web URL and file:/// if the URL is a valid file URL.
To determine whether HTTPS or HTTP should be used, Ruffle tests whether the server supports HTTPS. HTTP is only used if the server only supports HTTP and not HTTPS. This test happens while the loading screen is displayed.

This means that the user can now enter URLs without a leading https:// like you (usually) do in the browser.

Additionally, this pull request fixes and improves the error behaviour if the URL can't be resolved or used.
Instead of the wrong error, one of four more specific errors will be displayed:
- One new error if the given URL is a local file URL:
  <img width="1582" alt="Bildschirmfoto 2024-06-28 um 15 56 26" src="https://github.com/ruffle-rs/ruffle/assets/33464213/fb0686af-52ee-45f0-abb3-79294ef061d6">
- One new error if the given URL uses a different protocol than https, http or file (e.g. ftp):
  <img width="1582" alt="Bildschirmfoto 2024-06-28 um 15 57 44" src="https://github.com/ruffle-rs/ruffle/assets/33464213/f7ddc81d-87ef-4e1b-87e9-08cf6cf71e8a">
- One new error if the given URL can't be resolved to any valid URL for any protocol
  <img width="1582" alt="Bildschirmfoto 2024-06-28 um 15 58 07" src="https://github.com/ruffle-rs/ruffle/assets/33464213/f7db5285-8101-49c9-a278-ca9ece2b53b9">
- And the usual SWF file not found error if the file under the given web URL couldn't be found.
  That error has also been modified to also include the tip that the HTTP protocol should be (explicitly) used for websites that don't support HTTPS:
  <img width="1582" alt="Bildschirmfoto 2024-06-28 um 15 54 12" src="https://github.com/ruffle-rs/ruffle/assets/33464213/bef18bbf-365c-45c4-9486-bda7b619549d">

Also, a bug that caused the document title to not be set correctly if the SWF URL was the main page of a domain has been fixed. The handling of setting the document title of the extension player has generally been made more consistent.