### PR TITLE
debug_ui: Improve debug rect bounds calculation & draw bounds on hover

### DIFF
--- a/core/src/debug_ui.rs
+++ b/core/src/debug_ui.rs
@@ -171,7 +171,12 @@ impl DebugUi {
                 let object = object.fetch(dynamic_root_set);
                 let bounds = world_matrix * object.debug_rect_bounds();
 
-                draw_debug_rect(context, swf::Color::RED, bounds, 5.0);
+                draw_debug_rect(context, Color::RED, bounds, 5.0);
+            }
+
+            if let Some(bounds) = window.hovered_bounds() {
+                let bounds = world_matrix * bounds;
+                draw_debug_rect(context, Color::RED, bounds, 5.0);
             }
         }
 
@@ -189,7 +194,7 @@ impl DebugUi {
                 let object = object.fetch(dynamic_root_set);
                 let bounds = world_matrix * object.debug_rect_bounds();
 
-                draw_debug_rect(context, swf::Color::RED, bounds, 5.0);
+                draw_debug_rect(context, Color::RED, bounds, 5.0);
             }
         }
 
@@ -198,7 +203,7 @@ impl DebugUi {
                 let object = object.fetch(dynamic_root_set);
                 let bounds = world_matrix * object.debug_rect_bounds();
 
-                draw_debug_rect(context, swf::Color::RED, bounds, 5.0);
+                draw_debug_rect(context, Color::RED, bounds, 5.0);
             }
         }
     }

--- a/core/src/debug_ui.rs
+++ b/core/src/debug_ui.rs
@@ -162,14 +162,14 @@ impl DebugUi {
         for (object, window) in self.display_objects.iter() {
             if let Some(color) = window.debug_rect_color() {
                 let object = object.fetch(dynamic_root_set);
-                let bounds = world_matrix * object.world_bounds();
+                let bounds = world_matrix * object.debug_rect_bounds();
 
                 draw_debug_rect(context, color, bounds, 3.0);
             }
 
             if let Some(object) = window.hovered_debug_rect() {
                 let object = object.fetch(dynamic_root_set);
-                let bounds = world_matrix * object.world_bounds();
+                let bounds = world_matrix * object.debug_rect_bounds();
 
                 draw_debug_rect(context, swf::Color::RED, bounds, 5.0);
             }
@@ -178,7 +178,7 @@ impl DebugUi {
         if let Some(window) = &self.display_object_search {
             for (color, object) in window.hovered_debug_rects() {
                 let object = object.fetch(dynamic_root_set);
-                let bounds = world_matrix * object.world_bounds();
+                let bounds = world_matrix * object.debug_rect_bounds();
 
                 draw_debug_rect(context, color, bounds, 5.0);
             }
@@ -187,7 +187,7 @@ impl DebugUi {
         for (_object, window) in self.avm1_objects.iter() {
             if let Some(object) = window.hovered_debug_rect() {
                 let object = object.fetch(dynamic_root_set);
-                let bounds = world_matrix * object.world_bounds();
+                let bounds = world_matrix * object.debug_rect_bounds();
 
                 draw_debug_rect(context, swf::Color::RED, bounds, 5.0);
             }
@@ -196,7 +196,7 @@ impl DebugUi {
         for (_object, window) in self.avm2_objects.iter() {
             if let Some(object) = window.hovered_debug_rect() {
                 let object = object.fetch(dynamic_root_set);
-                let bounds = world_matrix * object.world_bounds();
+                let bounds = world_matrix * object.debug_rect_bounds();
 
                 draw_debug_rect(context, swf::Color::RED, bounds, 5.0);
             }

--- a/core/src/debug_ui/display_object/search.rs
+++ b/core/src/debug_ui/display_object/search.rs
@@ -118,7 +118,7 @@ impl DisplayObjectSearchWindow {
         {
             return false;
         }
-        object.world_bounds().contains(cursor)
+        object.debug_rect_bounds().contains(cursor)
     }
 
     fn create_result_tree<'gc>(

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1149,6 +1149,17 @@ pub trait TDisplayObject<'gc>:
         self.bounds_with_transform(&self.local_to_global_matrix())
     }
 
+    /// Bounds used for drawing debug rects and picking objects.
+    fn debug_rect_bounds(&self) -> Rectangle<Twips> {
+        // Make the rect at least as big as highlight bounds to ensure that anything
+        // interactive is also highlighted even if not included in world bounds.
+        let highlight_bounds = self
+            .as_interactive()
+            .map(|int| int.highlight_bounds())
+            .unwrap_or_default();
+        self.world_bounds().union(&highlight_bounds)
+    }
+
     /// Gets the bounds of this object and all children, transformed by a given matrix.
     /// This function recurses down and transforms the AABB each child before adding
     /// it to the bounding box. This gives a tighter AABB then if we simply transformed


### PR DESCRIPTION
Before this patch, it was possible that some objects did not have a debug rect despite existing on the stage and interacting with the user. That was the case for instance for buttons with hit bounds and no up state (see for instance https://github.com/ruffle-rs/ruffle/issues/16921).

This patch ensures that debug rect is at least as big as highlight bounds, which are used to highlight focused objects on the stage.

Additionally, when the user hovers on world bounds and highlight bounds, debug rects signifying their positions are automatically drawn in order to visualize their positions on the stage.