### PR TITLE
web: Make ruffle-core actually work when not being used as a selfhosted zip

### DIFF
--- a/web/packages/core/src/index.ts
+++ b/web/packages/core/src/index.ts
@@ -28,6 +28,8 @@ import { SourceAPI } from "./source-api";
  * @param sourceName The name of this particular
  * Ruffle source. Common convention is "local" for websites that bundle their own Ruffle,
  * "extension" for browser extensions, and something else for other use cases.
+ * Names are unique, and last-installed will replace earlier installations with the same name,
+ * regardless of what those installations are or which version they represent.
  */
 export function installRuffle(sourceName: string): void {
     let publicAPI: PublicAPI;
@@ -38,7 +40,7 @@ export function installRuffle(sourceName: string): void {
         window.RufflePlayer = publicAPI;
     }
 
-    publicAPI.registerSource(sourceName);
+    publicAPI.sources[sourceName] = SourceAPI;
 
     // Install the faux plugin detection immediately.
     // This is necessary because scripts such as SWFObject check for the

--- a/web/packages/core/src/index.ts
+++ b/web/packages/core/src/index.ts
@@ -29,7 +29,7 @@ import { SourceAPI } from "./source-api";
  * Ruffle source. Common convention is "local" for websites that bundle their own Ruffle,
  * "extension" for browser extensions, and something else for other use cases.
  */
-export function installRuffle(sourceName?: string): void {
+export function installRuffle(sourceName: string): void {
     let publicAPI: PublicAPI;
     if (window.RufflePlayer instanceof PublicAPI) {
         publicAPI = window.RufflePlayer;
@@ -38,17 +38,15 @@ export function installRuffle(sourceName?: string): void {
         window.RufflePlayer = publicAPI;
     }
 
-    if (sourceName !== undefined) {
-        publicAPI.registerSource(sourceName);
+    publicAPI.registerSource(sourceName);
 
-        // Install the faux plugin detection immediately.
-        // This is necessary because scripts such as SWFObject check for the
-        // Flash Player immediately when they load.
-        // TODO: Maybe there's a better place for this.
-        const polyfills =
-            "polyfills" in publicAPI.config ? publicAPI.config.polyfills : true;
-        if (polyfills !== false) {
-            SourceAPI.pluginPolyfill();
-        }
+    // Install the faux plugin detection immediately.
+    // This is necessary because scripts such as SWFObject check for the
+    // Flash Player immediately when they load.
+    // TODO: Maybe there's a better place for this.
+    const polyfills =
+        "polyfills" in publicAPI.config ? publicAPI.config.polyfills : true;
+    if (polyfills !== false) {
+        SourceAPI.pluginPolyfill();
     }
 }

--- a/web/packages/core/src/index.ts
+++ b/web/packages/core/src/index.ts
@@ -14,3 +14,55 @@ export * from "./load-options";
 export * from "./build-info";
 export * from "./swf-utils";
 export * from "./movie-metadata";
+
+import { PublicAPI, PublicAPILike } from "./public-api";
+import { SourceAPI } from "./source-api";
+
+/**
+ * Join a source into the public API, if it doesn't already exist.
+ *
+ * @param prevRuffle The previous iteration of the Ruffle API.
+ *
+ * The `prevRuffle` param lists the previous object in the RufflePlayer
+ * slot. We perform some checks to see if this is a Ruffle public API or a
+ * conflicting object. If this is conflicting, then a new public API will
+ * be constructed (see the constructor information for what happens to
+ * `prevRuffle`).
+ *
+ * Note that Public API upgrades are deliberately not enabled in this
+ * version of Ruffle, since there is no Public API to upgrade from.
+ * @param sourceName The name of this particular
+ * Ruffle source. Common convention is "local" for websites that bundle their own Ruffle,
+ * "extension" for browser extensions, and something else for other use cases.
+ *
+ * If both parameters are provided they will be used to define a new Ruffle
+ * source to register with the public API.
+ * @returns The Ruffle Public API.
+ */
+export function installRuffle(
+    prevRuffle?: PublicAPILike | null,
+    sourceName?: string,
+): PublicAPI {
+    let publicAPI: PublicAPI;
+    if (prevRuffle instanceof PublicAPI) {
+        publicAPI = prevRuffle;
+    } else {
+        publicAPI = new PublicAPI(prevRuffle);
+    }
+
+    if (sourceName !== undefined) {
+        publicAPI.registerSource(sourceName);
+
+        // Install the faux plugin detection immediately.
+        // This is necessary because scripts such as SWFObject check for the
+        // Flash Player immediately when they load.
+        // TODO: Maybe there's a better place for this.
+        const polyfills =
+            "polyfills" in publicAPI.config ? publicAPI.config.polyfills : true;
+        if (polyfills !== false) {
+            SourceAPI.pluginPolyfill();
+        }
+    }
+
+    return publicAPI;
+}

--- a/web/packages/core/src/index.ts
+++ b/web/packages/core/src/index.ts
@@ -14,41 +14,4 @@ export * from "./load-options";
 export * from "./build-info";
 export * from "./swf-utils";
 export * from "./movie-metadata";
-
-import { PublicAPI } from "./public-api";
-import { SourceAPI } from "./source-api";
-
-/**
- * Install this version of Ruffle into the current page.
- *
- * Multiple (or zero) versions of Ruffle may be installed at the same time,
- * and you should use `window.RufflePlayer.newest()` or similar to access the appropriate
- * installation at time of use.
- *
- * @param sourceName The name of this particular
- * Ruffle source. Common convention is "local" for websites that bundle their own Ruffle,
- * "extension" for browser extensions, and something else for other use cases.
- * Names are unique, and last-installed will replace earlier installations with the same name,
- * regardless of what those installations are or which version they represent.
- */
-export function installRuffle(sourceName: string): void {
-    let publicAPI: PublicAPI;
-    if (window.RufflePlayer instanceof PublicAPI) {
-        publicAPI = window.RufflePlayer;
-    } else {
-        publicAPI = new PublicAPI(window.RufflePlayer);
-        window.RufflePlayer = publicAPI;
-    }
-
-    publicAPI.sources[sourceName] = SourceAPI;
-
-    // Install the faux plugin detection immediately.
-    // This is necessary because scripts such as SWFObject check for the
-    // Flash Player immediately when they load.
-    // TODO: Maybe there's a better place for this.
-    const polyfills =
-        "polyfills" in publicAPI.config ? publicAPI.config.polyfills : true;
-    if (polyfills !== false) {
-        SourceAPI.pluginPolyfill();
-    }
-}
+export * from "./install";

--- a/web/packages/core/src/index.ts
+++ b/web/packages/core/src/index.ts
@@ -15,39 +15,27 @@ export * from "./build-info";
 export * from "./swf-utils";
 export * from "./movie-metadata";
 
-import { PublicAPI, PublicAPILike } from "./public-api";
+import { PublicAPI } from "./public-api";
 import { SourceAPI } from "./source-api";
 
 /**
- * Join a source into the public API, if it doesn't already exist.
+ * Install this version of Ruffle into the current page.
  *
- * @param prevRuffle The previous iteration of the Ruffle API.
+ * Multiple (or zero) versions of Ruffle may be installed at the same time,
+ * and you should use `window.RufflePlayer.newest()` or similar to access the appropriate
+ * installation at time of use.
  *
- * The `prevRuffle` param lists the previous object in the RufflePlayer
- * slot. We perform some checks to see if this is a Ruffle public API or a
- * conflicting object. If this is conflicting, then a new public API will
- * be constructed (see the constructor information for what happens to
- * `prevRuffle`).
- *
- * Note that Public API upgrades are deliberately not enabled in this
- * version of Ruffle, since there is no Public API to upgrade from.
  * @param sourceName The name of this particular
  * Ruffle source. Common convention is "local" for websites that bundle their own Ruffle,
  * "extension" for browser extensions, and something else for other use cases.
- *
- * If both parameters are provided they will be used to define a new Ruffle
- * source to register with the public API.
- * @returns The Ruffle Public API.
  */
-export function installRuffle(
-    prevRuffle?: PublicAPILike | null,
-    sourceName?: string,
-): PublicAPI {
+export function installRuffle(sourceName?: string): void {
     let publicAPI: PublicAPI;
-    if (prevRuffle instanceof PublicAPI) {
-        publicAPI = prevRuffle;
+    if (window.RufflePlayer instanceof PublicAPI) {
+        publicAPI = window.RufflePlayer;
     } else {
-        publicAPI = new PublicAPI(prevRuffle);
+        publicAPI = new PublicAPI(window.RufflePlayer);
+        window.RufflePlayer = publicAPI;
     }
 
     if (sourceName !== undefined) {
@@ -63,6 +51,4 @@ export function installRuffle(
             SourceAPI.pluginPolyfill();
         }
     }
-
-    return publicAPI;
 }

--- a/web/packages/core/src/install.ts
+++ b/web/packages/core/src/install.ts
@@ -1,0 +1,50 @@
+import { PublicAPI } from "./public-api";
+import { internalSourceApi } from "./source-api";
+
+/**
+ * Options to use with this specific installation of Ruffle.
+ *
+ * This is mostly to provide a way to configure environmental settings, like using
+ * `onFirstLoad` to potentially configure webpack prior to loading wasm files.
+ */
+export interface InstallationOptions {}
+
+/**
+ * Install this version of Ruffle into the current page.
+ *
+ * Multiple (or zero) versions of Ruffle may be installed at the same time,
+ * and you should use `window.RufflePlayer.newest()` or similar to access the appropriate
+ * installation at time of use.
+ *
+ * @param sourceName The name of this particular
+ * Ruffle source. Common convention is "local" for websites that bundle their own Ruffle,
+ * "extension" for browser extensions, and something else for other use cases.
+ * Names are unique, and last-installed will replace earlier installations with the same name,
+ * regardless of what those installations are or which version they represent.
+ * @param options Any options used to configure this specific installation of Ruffle.
+ */
+export function installRuffle(
+    sourceName: string,
+    options: InstallationOptions = {},
+): void {
+    let publicAPI: PublicAPI;
+    if (window.RufflePlayer instanceof PublicAPI) {
+        publicAPI = window.RufflePlayer;
+    } else {
+        publicAPI = new PublicAPI(window.RufflePlayer);
+        window.RufflePlayer = publicAPI;
+    }
+
+    publicAPI.sources[sourceName] = internalSourceApi;
+    internalSourceApi.options = options;
+
+    // Install the faux plugin detection immediately.
+    // This is necessary because scripts such as SWFObject check for the
+    // Flash Player immediately when they load.
+    // TODO: Maybe there's a better place for this.
+    const polyfills =
+        "polyfills" in publicAPI.config ? publicAPI.config.polyfills : true;
+    if (polyfills !== false) {
+        internalSourceApi.pluginPolyfill();
+    }
+}

--- a/web/packages/core/src/install.ts
+++ b/web/packages/core/src/install.ts
@@ -7,7 +7,13 @@ import { internalSourceApi } from "./source-api";
  * This is mostly to provide a way to configure environmental settings, like using
  * `onFirstLoad` to potentially configure webpack prior to loading wasm files.
  */
-export interface InstallationOptions {}
+export interface InstallationOptions {
+    /**
+     * A callback to be run before the very first time Ruffle is loaded.
+     * This may be used to configure a bundler prior to asset loading.
+     */
+    onFirstLoad?: () => void;
+}
 
 /**
  * Install this version of Ruffle into the current page.

--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -8,7 +8,7 @@ declare global {
         /**
          * The public API for generating a ruffle player.
          * This may be a config holder, which will be converted to a
-         * [[PublicAPI]] via [[PublicAPI.negotiate]], or an actual
+         * [[PublicAPI]] via [[installRuffle]], or an actual
          * [[PublicAPI]] instance itself.
          */
         RufflePlayer?: PublicAPILike | PublicAPI;
@@ -21,7 +21,7 @@ declare global {
  * Unlike [[PublicAPI]], this may come from any source, past or future.
  * It needs to be forwards compatible and convertible into a modern day [[PublicAPI]].
  */
-interface PublicAPILike {
+export interface PublicAPILike {
     config?: DataLoadOptions | URLLoadOptions | object;
     sources?: Record<string, typeof SourceAPI>;
     invoked?: boolean;
@@ -65,7 +65,7 @@ export class PublicAPI implements PublicAPILike {
      * This is used to upgrade from a prior version of the public API, or from
      * a user-defined configuration object placed in the public API slot.
      */
-    protected constructor(prev?: PublicAPILike | null) {
+    public constructor(prev?: PublicAPILike | null) {
         this.sources = prev?.sources || {};
         this.config = prev?.config || {};
         this.invoked = prev?.invoked || false;
@@ -233,55 +233,5 @@ export class PublicAPI implements PublicAPILike {
      */
     superseded(): void {
         this.invoked = true;
-    }
-
-    /**
-     * Join a source into the public API, if it doesn't already exist.
-     *
-     * @param prevRuffle The previous iteration of the Ruffle API.
-     *
-     * The `prevRuffle` param lists the previous object in the RufflePlayer
-     * slot. We perform some checks to see if this is a Ruffle public API or a
-     * conflicting object. If this is conflicting, then a new public API will
-     * be constructed (see the constructor information for what happens to
-     * `prevRuffle`).
-     *
-     * Note that Public API upgrades are deliberately not enabled in this
-     * version of Ruffle, since there is no Public API to upgrade from.
-     * @param sourceName The name of this particular
-     * Ruffle source.
-     *
-     * If both parameters are provided they will be used to define a new Ruffle
-     * source to register with the public API.
-     * @returns The Ruffle Public API.
-     */
-    static negotiate(
-        prevRuffle?: PublicAPILike | null,
-        sourceName?: string,
-    ): PublicAPI {
-        let publicAPI: PublicAPI;
-        if (prevRuffle instanceof PublicAPI) {
-            publicAPI = prevRuffle;
-        } else {
-            publicAPI = new PublicAPI(prevRuffle);
-        }
-
-        if (sourceName !== undefined) {
-            publicAPI.registerSource(sourceName);
-
-            // Install the faux plugin detection immediately.
-            // This is necessary because scripts such as SWFObject check for the
-            // Flash Player immediately when they load.
-            // TODO: Maybe there's a better place for this.
-            const polyfills =
-                "polyfills" in publicAPI.config
-                    ? publicAPI.config.polyfills
-                    : true;
-            if (polyfills !== false) {
-                SourceAPI.pluginPolyfill();
-            }
-        }
-
-        return publicAPI;
     }
 }

--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -33,7 +33,7 @@ export interface PublicAPILike {
 /**
  * Represents the Ruffle public API.
  *
- * The public API exists primarily to allow multiple installs of Ruffle on a
+ * The public API exists primarily to allow multiple installations of Ruffle on a
  * page (e.g. an extension install and a local one) to cooperate. In an ideal
  * situation, all Ruffle sources on the page install themselves into a single
  * public API, and then the public API picks the newest version by default.
@@ -96,15 +96,6 @@ export class PublicAPI implements PublicAPILike {
      */
     get version(): string {
         return "0.1.0";
-    }
-
-    /**
-     * Register a given source with the Ruffle Public API.
-     *
-     * @param name The name of the source.
-     */
-    registerSource(name: string): void {
-        this.sources[name] = SourceAPI;
     }
 
     /**

--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -23,7 +23,7 @@ declare global {
  */
 export interface PublicAPILike {
     config?: DataLoadOptions | URLLoadOptions | object;
-    sources?: Record<string, typeof SourceAPI>;
+    sources?: Record<string, SourceAPI>;
     invoked?: boolean;
     newestName?: string | null;
 
@@ -46,7 +46,7 @@ export class PublicAPI implements PublicAPILike {
      * The configuration object used when Ruffle is instantiated.
      */
     config: DataLoadOptions | URLLoadOptions | object;
-    sources: Record<string, typeof SourceAPI>;
+    sources: Record<string, SourceAPI>;
     invoked: boolean;
     newestName: string | null;
 
@@ -151,7 +151,7 @@ export class PublicAPI implements PublicAPILike {
      *
      * @returns An instance of the Source API.
      */
-    newest(): typeof SourceAPI | null {
+    newest(): SourceAPI | null {
         const name = this.newestSourceName();
         return name !== null ? this.sources[name]! : null;
     }
@@ -165,7 +165,7 @@ export class PublicAPI implements PublicAPILike {
      * @returns An instance of the Source API, if one or more
      * sources satisfied the requirement.
      */
-    satisfying(requirementString: string): typeof SourceAPI | null {
+    satisfying(requirementString: string): SourceAPI | null {
         const requirement =
             VersionRange.fromRequirementString(requirementString);
         let valid = null;
@@ -189,7 +189,7 @@ export class PublicAPI implements PublicAPILike {
      *
      * @returns An instance of the Source API
      */
-    localCompatible(): typeof SourceAPI | null {
+    localCompatible(): SourceAPI | null {
         if (this.sources["local"] !== undefined) {
             return this.satisfying("^" + this.sources["local"].version);
         } else {
@@ -203,7 +203,7 @@ export class PublicAPI implements PublicAPILike {
      *
      * @returns An instance of the Source API
      */
-    local(): typeof SourceAPI | null {
+    local(): SourceAPI | null {
         if (this.sources["local"] !== undefined) {
             return this.satisfying("=" + this.sources["local"].version);
         } else {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -681,7 +681,6 @@ export class RufflePlayer extends HTMLElement {
         }
 
         const [builder, zipWriterClass] = await createRuffleBuilder(
-            this.loadedConfig || {},
             this.onRuffleDownloadProgress.bind(this),
         ).catch((e) => {
             console.error(`Serious error loading Ruffle: ${e}`);

--- a/web/packages/core/src/source-api.ts
+++ b/web/packages/core/src/source-api.ts
@@ -2,6 +2,7 @@ import { pluginPolyfill, polyfill } from "./polyfills";
 import { registerElement } from "./register-element";
 import { RufflePlayer } from "./ruffle-player";
 import { buildInfo } from "./build-info";
+import { InstallationOptions } from "./install";
 
 /**
  * Represents this particular version of Ruffle.
@@ -11,7 +12,40 @@ import { buildInfo } from "./build-info";
  * negotiator (see [[PublicAPI]]) what this particular version of Ruffle is and
  * how to control it.
  */
-export const SourceAPI = {
+export interface SourceAPI {
+    /**
+     * The version of this particular API, as a string in a semver compatible format.
+     */
+    version: string;
+
+    /**
+     * Start up the polyfills.
+     *
+     * Do not run polyfills for more than one Ruffle source at a time.
+     */
+    polyfill(): void;
+
+    /**
+     * Polyfill the plugin detection.
+     *
+     * This needs to run before any plugin detection script does.
+     */
+    pluginPolyfill(): void;
+
+    /**
+     * Create a Ruffle player element using this particular version of Ruffle.
+     *
+     * @returns The player element. This is a DOM element that may be inserted
+     * into the current page as you wish.
+     */
+    createPlayer(): RufflePlayer;
+}
+
+/**
+ * The actual source API that describes this installation.
+ * This isn't part of the public API and may contain extra details.
+ */
+export const internalSourceApi = {
     /**
      * The version of this particular API, as a string in a semver compatible format.
      */
@@ -46,4 +80,9 @@ export const SourceAPI = {
         const name = registerElement("ruffle-player", RufflePlayer);
         return <RufflePlayer>document.createElement(name);
     },
+
+    /**
+     * Options specified by the user of this library.
+     */
+    options: {} as InstallationOptions,
 };

--- a/web/packages/demo/src/main.tsx
+++ b/web/packages/demo/src/main.tsx
@@ -12,7 +12,7 @@ import {
     UnmuteOverlay,
 } from "ruffle-core";
 
-window.RufflePlayer = installRuffle(window.RufflePlayer, "local");
+installRuffle("local");
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>

--- a/web/packages/demo/src/main.tsx
+++ b/web/packages/demo/src/main.tsx
@@ -8,11 +8,11 @@ import {
     AutoPlay,
     Letterbox,
     LogLevel,
-    PublicAPI,
+    installRuffle,
     UnmuteOverlay,
 } from "ruffle-core";
 
-window.RufflePlayer = PublicAPI.negotiate(window.RufflePlayer, "local");
+window.RufflePlayer = installRuffle(window.RufflePlayer, "local");
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -1,5 +1,5 @@
 import * as utils from "./utils";
-import { PublicAPI } from "ruffle-core";
+import { installRuffle } from "ruffle-core";
 import type {
     Letterbox,
     RufflePlayer,
@@ -17,7 +17,7 @@ declare global {
     }
 }
 
-const api = PublicAPI.negotiate(window.RufflePlayer!, "local");
+const api = installRuffle(window.RufflePlayer!, "local");
 window.RufflePlayer = api;
 const ruffle = api.newest()!;
 let player: RufflePlayer;

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -1,5 +1,5 @@
 import * as utils from "./utils";
-import { installRuffle } from "ruffle-core";
+import { installRuffle, PublicAPI } from "ruffle-core";
 import type {
     Letterbox,
     RufflePlayer,
@@ -17,9 +17,8 @@ declare global {
     }
 }
 
-const api = installRuffle(window.RufflePlayer!, "local");
-window.RufflePlayer = api;
-const ruffle = api.newest()!;
+installRuffle("local");
+const ruffle = (window.RufflePlayer as PublicAPI).newest()!;
 let player: RufflePlayer;
 
 const playerContainer = document.getElementById("player-container")!;

--- a/web/packages/extension/src/ruffle.ts
+++ b/web/packages/extension/src/ruffle.ts
@@ -4,13 +4,18 @@ import { Message } from "./messages";
 function handleMessage(message: Message) {
     switch (message.type) {
         case "load": {
-            const api = window.RufflePlayer ?? {};
-            api.config = {
+            if (window.RufflePlayer === undefined) {
+                window.RufflePlayer = {};
+            }
+            if (window.RufflePlayer.config === undefined) {
+                window.RufflePlayer.config = {};
+            }
+            window.RufflePlayer.config = {
                 ...message.config,
-                ...api.config,
+                ...window.RufflePlayer.config,
                 openInNewTab,
             };
-            window.RufflePlayer = installRuffle(api, "extension");
+            installRuffle("extension");
             return {};
         }
         case "ping":

--- a/web/packages/extension/src/ruffle.ts
+++ b/web/packages/extension/src/ruffle.ts
@@ -1,4 +1,4 @@
-import { PublicAPI } from "ruffle-core";
+import { installRuffle } from "ruffle-core";
 import { Message } from "./messages";
 
 function handleMessage(message: Message) {
@@ -10,7 +10,7 @@ function handleMessage(message: Message) {
                 ...api.config,
                 openInNewTab,
             };
-            window.RufflePlayer = PublicAPI.negotiate(api, "extension");
+            window.RufflePlayer = installRuffle(api, "extension");
             return {};
         }
         case "ping":

--- a/web/packages/selfhosted/js/ruffle.js
+++ b/web/packages/selfhosted/js/ruffle.js
@@ -1,3 +1,3 @@
-import { PublicAPI } from "ruffle-core";
+import { installRuffle } from "ruffle-core";
 
-window.RufflePlayer = PublicAPI.negotiate(window.RufflePlayer, "local");
+window.RufflePlayer = installRuffle(window.RufflePlayer, "local");

--- a/web/packages/selfhosted/js/ruffle.js
+++ b/web/packages/selfhosted/js/ruffle.js
@@ -1,3 +1,3 @@
 import { installRuffle } from "ruffle-core";
 
-window.RufflePlayer = installRuffle(window.RufflePlayer, "local");
+installRuffle("local");

--- a/web/packages/selfhosted/js/ruffle.js
+++ b/web/packages/selfhosted/js/ruffle.js
@@ -1,3 +1,52 @@
+// eslint-disable-next-line no-unused-vars
+/* global __webpack_public_path__:writable */
+
 import { installRuffle } from "ruffle-core";
 
-installRuffle("local");
+let currentScriptURL = null;
+
+try {
+    if (
+        document.currentScript !== undefined &&
+        document.currentScript !== null &&
+        "src" in document.currentScript &&
+        document.currentScript.src !== ""
+    ) {
+        let src = document.currentScript.src;
+
+        // CDNs allow omitting the filename. If it's omitted, append a slash to
+        // prevent the last component from being dropped.
+        if (!src.endsWith(".js") && !src.endsWith("/")) {
+            src += "/";
+        }
+
+        currentScriptURL = new URL(".", src);
+    }
+} catch (e) {
+    console.warn("Unable to get currentScript URL");
+}
+
+function publicPath(config) {
+    // Default to the directory where this script resides.
+    let path = currentScriptURL?.href ?? "";
+    if (
+        "publicPath" in config &&
+        config.publicPath !== null &&
+        config.publicPath !== undefined
+    ) {
+        path = config.publicPath;
+    }
+
+    // Webpack expects the paths to end with a slash.
+    if (path !== "" && !path.endsWith("/")) {
+        path += "/";
+    }
+
+    return path;
+}
+
+installRuffle("local", {
+    onFirstLoad: () => {
+        __webpack_public_path__ = publicPath(window.RufflePlayer?.config);
+    },
+});


### PR DESCRIPTION
Now things like ruffle website can *actually* depend on ruffle-core as a library, rather than only as an already built zip of assets and js files.

This does **not** include releasing ruffle-core to npm, I'll look at that later after reviewing the API.


API of selfhosted does not change. API of ruffle-core changes... but nobody can use it yet anyway, so it's all fine.