### PR TITLE
core: Stop searching after finding the first default font

### DIFF
--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -485,6 +485,7 @@ impl<'gc> Library<'gc> {
                 .get_or_load_exact_device_font(&name, is_bold, is_italic, ui, renderer, gc_context)
             {
                 result.push(font);
+                break; // TODO: Return multiple fonts when it's needed.
             }
         }
 
@@ -496,6 +497,7 @@ impl<'gc> Library<'gc> {
                         .find(&name, FontType::Device, is_bold, is_italic)
                 {
                     result.push(font);
+                    break; // TODO: Return multiple fonts when it's needed.
                 }
             }
         }


### PR DESCRIPTION
We only support one default font implementation anyway and currently this generates annoying warnings about unknown device fonts.