### PR TITLE
web: Specify the correct path of assets for webpack in extension

### DIFF
--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -101,7 +101,7 @@ export default function (/** @type {Record<string, any>} */ env, _argv) {
         },
         output: {
             path: url.fileURLToPath(new URL("assets/dist/", import.meta.url)),
-            publicPath: "",
+            publicPath: "dist/",
             clean: true,
             assetModuleFilename: "assets/[name][ext][query]",
         },


### PR DESCRIPTION
This fixes #16939

Turns out we've always specified this wrong, but accidentally worked around it at runtime before