### PR TITLE
web: Use automatic publicPath in extension

### DIFF
--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -101,7 +101,7 @@ export default function (/** @type {Record<string, any>} */ env, _argv) {
         },
         output: {
             path: url.fileURLToPath(new URL("assets/dist/", import.meta.url)),
-            publicPath: "dist/",
+            publicPath: "auto",
             clean: true,
             assetModuleFilename: "assets/[name][ext][query]",
         },


### PR DESCRIPTION
Fixes #16939 for realsies

"auto" uses the scripts current path and derives it from there.