### PR TITLE
avm2: Add `error_backtrace` feature to capture RustError backtrace

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -93,6 +93,7 @@ jpegxr = ["dep:jpegxr", "lzma"]
 default_font = []
 test_only_as3 = []
 serde = ["serde/derive"]
+error_backtrace = []
 
 [build-dependencies]
 build_playerglobal = { path = "build_playerglobal" }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -67,6 +67,7 @@ jpegxr = ["ruffle_core/jpegxr"]
 
 # core features
 avm_debug = ["ruffle_core/avm_debug"]
+error_backtrace = ["ruffle_core/error_backtrace"]
 lzma = ["ruffle_core/lzma"]
 software_video = ["ruffle_video_software"]
 external_video = ["ruffle_video_external"]


### PR DESCRIPTION
This off-by-default feature is useful when debugging a RustError (e.g. `TypeError: null is not an Object`) that wasn't handled by a caller like `coerce_to_type`