### PR TITLE
chore: Bump `httparse` to `v1.9.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.2"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3935c160d00ac752e09787e6e6bfc26494c2183cc922f1bc678a60d4733bc2"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "humantime"


### PR DESCRIPTION
The version we're currently locking to got yankificated: https://crates.io/crates/httparse/versions