### PR TITLE
extension: Don't register 4399 content script if Ruffle is disabled

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -26,12 +26,6 @@
             "all_frames": true,
             "run_at": "document_start",
         },
-        {
-            "matches": ["https://www.4399.com/flash/*"],
-            "js": ["dist/siteContentScript4399.js"],
-            "world": "MAIN",
-            "run_at": "document_start",
-        }
     ],
 
     "content_security_policy": {

--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -34,6 +34,13 @@ async function enable() {
                 runAt: "document_start",
                 world: "MAIN",
             },
+            {
+                id: "4399",
+                matches: ["https://www.4399.com/flash/*"],
+                js: ["dist/siteContentScript4399.js"],
+                world: "MAIN",
+                runAt: "document_start",
+            },
         ]);
     }
 }
@@ -47,7 +54,7 @@ async function disable() {
     }
     if (await contentScriptRegistered()) {
         await utils.scripting.unregisterContentScripts({
-            ids: ["plugin-polyfill"],
+            ids: ["plugin-polyfill", "4399"],
         });
     }
 }


### PR DESCRIPTION
Dual-purpose:
1) Don't register the 4399 content script if Ruffle is installed but disabled.
2) Don't show a separate permission for 4399 to avoid confusing people (see https://github.com/ruffle-rs/ruffle/discussions/16990). I tested on Firefox and it doesn't show after this PR.

Also has another benefit, which is that there's no manifest warning on Firefox versions without MAIN world support.

Ideally, the 4399 specific code could be toggled off in the extension settings, but between this and the declarativeNetRequestWithHostAccess change, at least its code doesn't generate additional permissions anymore, so I'll leave that for now. I could change the `contentScriptRegistered` function but since they're both registered at once it seems unnecessary.

Edit: Important note: this has not actually been tested on 4399.com