### PR TITLE
web: Check for locked 'Player' mutex and reschedule with setTimeout

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -4,6 +4,7 @@ use crate::loader::Error;
 use crate::socket::{ConnectionState, SocketAction, SocketHandle};
 use crate::string::WStr;
 use async_channel::{Receiver, Sender};
+use downcast_rs::Downcast;
 use encoding_rs::Encoding;
 use indexmap::IndexMap;
 use std::borrow::Cow;
@@ -244,7 +245,7 @@ pub struct ErrorResponse {
 pub type OwnedFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + 'static>>;
 
 /// A backend interacting with a browser environment.
-pub trait NavigatorBackend {
+pub trait NavigatorBackend: Downcast {
     /// Cause a browser navigation to a given URL.
     ///
     /// The URL given may be any URL scheme a browser can support. This may not
@@ -319,6 +320,7 @@ pub trait NavigatorBackend {
         sender: Sender<SocketAction>,
     );
 }
+impl_downcast!(NavigatorBackend);
 
 #[cfg(not(target_family = "wasm"))]
 pub struct NullExecutor(futures::executor::LocalPool);

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -122,7 +122,7 @@ pub struct UpdateContext<'a, 'gc> {
     pub audio_manager: &'a mut AudioManager<'gc>,
 
     /// The navigator backend, used by the AVM to make HTTP requests and visit webpages.
-    pub navigator: &'a mut (dyn NavigatorBackend + 'a),
+    pub navigator: &'a mut dyn NavigatorBackend,
 
     /// The renderer, used by the display objects to draw themselves.
     pub renderer: &'a mut dyn RenderBackend,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1941,6 +1941,10 @@ impl Player {
         &self.navigator
     }
 
+    pub fn navigator_mut(&mut self) -> &mut Navigator {
+        &mut self.navigator
+    }
+
     // The frame rate of the current movie in FPS.
     pub fn frame_rate(&self) -> f64 {
         self.frame_rate

--- a/frontend-utils/src/backends/navigator.rs
+++ b/frontend-utils/src/backends/navigator.rs
@@ -134,7 +134,9 @@ impl<F: FutureSpawner, I: NavigatorInterface> ExternalNavigatorBackend<F, I> {
     }
 }
 
-impl<F: FutureSpawner, I: NavigatorInterface> NavigatorBackend for ExternalNavigatorBackend<F, I> {
+impl<F: FutureSpawner + 'static, I: NavigatorInterface> NavigatorBackend
+    for ExternalNavigatorBackend<F, I>
+{
     fn navigate_to_url(
         &self,
         url: &str,

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -609,7 +609,16 @@ impl RuffleInstanceBuilder {
             .with_page_url(window.location().href().ok())
             .build();
 
-        if let Ok(mut core) = core.try_lock() {
+        let player_weak = Arc::downgrade(&core);
+
+        {
+            let mut core = core
+                .lock()
+                .expect("Failed to lock player after construction");
+            core.navigator_mut()
+                .downcast_mut::<WebNavigatorBackend>()
+                .expect("Expected WebNavigatorBackend")
+                .set_player(player_weak);
             // Set config parameters.
             core.set_volume(self.volume);
             core.set_background_color(self.background_color);


### PR DESCRIPTION
We use 'wasm-bindgen-futures' as our futures executor on web, which in turn uses 'queueMicroTask'. This can result in the browser executing one of our futures while we're still inside our `requestAnimationFrame` callback (in particular, while we still have the `Player` mutex locked).

We now detect this condition by attempting the lock the Player mutex inside of our `spawn_local` future. If this fails, we `await` a `setTimeout`-based promise, which ensures that our code runs in a new top-level `setTimeout` javascript 'task' (outside of our `requestAnimationFrame` callback).

Fixes #8427