### PR TITLE
chore: Make dependabot increase version requirements for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/web/"
+    versioning-strategy: increase
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
It's completely ignoring things like new major versions, because it thinks we're a library and the default strategy for libraries is to stay semver compatible

However; the only library that we will actually publish is `ruffle-core` - which has no publicly accessible dependencies, so it's fine

Documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy