### PR TITLE
web: Update ws manually until new webdriverio major update

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11097,17 +11097,16 @@
             }
         },
         "node_modules/puppeteer-core/node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=8.3.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
+                "utf-8-validate": "^5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -14021,6 +14020,27 @@
             },
             "engines": {
                 "node": "^16.13 || >=18"
+            }
+        },
+        "node_modules/webdriver/node_modules/ws": {
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webdriverio": {

--- a/web/package.json
+++ b/web/package.json
@@ -54,5 +54,8 @@
         "lint": "npm run checkTypes --workspaces --if-present && eslint . && stylelint **.css",
         "format": "eslint . --fix && stylelint --fix **.css",
         "version-seal": "cross-env ENABLE_VERSION_SEAL=true tsx packages/core/tools/set_version.ts"
+    },
+    "overrides": {
+        "ws": "^7.0.0"
     }
 }


### PR DESCRIPTION
Removes our security alert (not that it actually affected us)

(https://github.com/webdriverio/webdriverio/issues/13056)