### PR TITLE
avm2: Make 'Loader.unloadAndStop' call 'Loader.unload'

### DIFF
--- a/core/src/avm2/globals/flash/display/Loader.as
+++ b/core/src/avm2/globals/flash/display/Loader.as
@@ -29,6 +29,7 @@ package flash.display {
 
 		public function unloadAndStop(gc:Boolean = true):void {
 			stub_method("flash.display.Loader", "unloadAndStop");
+			this.unload();
 		}
 		
 		public function close():void {


### PR DESCRIPTION
We still need to implement the 'stop' behavior, but this should bring us closer to matching Flash Player.