### PR TITLE
swf: Remove 'libflate' feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,12 +34,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,15 +1011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "core_maths"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,12 +1210,6 @@ dependencies = [
  "quote",
  "syn 2.0.70",
 ]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "dasp"
@@ -2871,30 +2850,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libflate"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
-dependencies = [
- "core2",
- "hashbrown",
- "rle-decode-fast",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4307,12 +4262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5195,7 +5144,6 @@ dependencies = [
  "encoding_rs",
  "enum-map",
  "flate2",
- "libflate",
  "log",
  "lzma-rs",
  "num-derive",

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -401,8 +401,6 @@ Ruffle depends on third-party libraries with compatible licenses.
 | [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2010 The Rust Project Developers  | 
 | [lazycell](https://github.com/indiv0/lazycell) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) Alex Crichton <alex@alexcrichton.com>, Nikita Pekin <contact@nikitapek.in> | 
 | [libc](https://github.com/rust-lang/libc) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014-2020 The Rust Project Developers  | 
-| [libflate](https://github.com/sile/libflate) | [MIT](#MIT) | Copyright (c) 2016 Takeru Ohta <phjgt308@gmail.com>  | 
-| [libflate_lz77](https://github.com/sile/libflate) | [MIT](#MIT) | Copyright (c) 2016 Takeru Ohta <phjgt308@gmail.com>  | 
 | [libloading](https://github.com/nagisa/rust_libloading/) | [ISC](#ISC) | Copyright © 2015, Simonas Kazlauskas  | 
 | [libnghttp2-sys](https://github.com/alexcrichton/nghttp2-rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Alex Crichton  | 
 | [libz-sys](https://github.com/rust-lang/libz-sys) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Alex Crichton Copyright (c) 2020 Josh Triplett  | 

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -18,7 +18,6 @@ byteorder = "1.5"
 encoding_rs = "0.8.34"
 num-derive = { workspace = true }
 num-traits = { workspace = true }
-libflate = {version = "2.1", optional = true}
 log = { workspace = true }
 flate2 = { workspace = true, optional = true}
 lzma-rs = {version = "0.3.0", optional = true }

--- a/swf/src/lib.rs
+++ b/swf/src/lib.rs
@@ -9,8 +9,6 @@
 
 #[cfg(feature = "flate2")]
 extern crate flate2;
-#[cfg(feature = "libflate")]
-extern crate libflate;
 #[macro_use]
 extern crate num_derive;
 extern crate num_traits;

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -179,14 +179,7 @@ fn make_zlib_reader<'a, R: Read + 'a>(input: R) -> Result<Box<dyn Read + 'a>> {
     Ok(Box::new(ZlibDecoder::new(input)))
 }
 
-#[cfg(all(feature = "libflate", not(feature = "flate2")))]
-fn make_zlib_reader<'a, R: Read + 'a>(input: R) -> Result<Box<dyn Read + 'a>> {
-    use libflate::zlib::Decoder;
-    let decoder = Decoder::new(input)?;
-    Ok(Box::new(decoder))
-}
-
-#[cfg(not(any(feature = "flate2", feature = "libflate")))]
+#[cfg(not(feature = "flate2"))]
 fn make_zlib_reader<'a, R: Read + 'a>(_input: R) -> Result<Box<dyn Read + 'a>> {
     Err(Error::unsupported(
         "Support for Zlib compressed SWFs is not enabled.",

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -91,16 +91,7 @@ fn write_zlib_swf<W: Write>(mut output: W, swf_body: &[u8]) -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "libflate", not(feature = "flate2")))]
-fn write_zlib_swf<W: Write>(mut output: W, swf_body: &[u8]) -> Result<()> {
-    use libflate::zlib::Encoder;
-    let mut encoder = Encoder::new(&mut output)?;
-    encoder.write_all(&swf_body)?;
-    encoder.finish().into_result()?;
-    Ok(())
-}
-
-#[cfg(not(any(feature = "flate2", feature = "libflate")))]
+#[cfg(not(feature = "flate2"))]
 fn write_zlib_swf<W: Write>(_output: W, _swf_body: &[u8]) -> Result<()> {
     Err(Error::unsupported(
         "Support for Zlib compressed SWFs is not enabled.",

--- a/web/LICENSE.md
+++ b/web/LICENSE.md
@@ -401,8 +401,6 @@ Ruffle depends on third-party libraries with compatible licenses.
 | [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2010 The Rust Project Developers  | 
 | [lazycell](https://github.com/indiv0/lazycell) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) Alex Crichton <alex@alexcrichton.com>, Nikita Pekin <contact@nikitapek.in> | 
 | [libc](https://github.com/rust-lang/libc) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014-2020 The Rust Project Developers  | 
-| [libflate](https://github.com/sile/libflate) | [MIT](#MIT) | Copyright (c) 2016 Takeru Ohta <phjgt308@gmail.com>  | 
-| [libflate_lz77](https://github.com/sile/libflate) | [MIT](#MIT) | Copyright (c) 2016 Takeru Ohta <phjgt308@gmail.com>  | 
 | [libloading](https://github.com/nagisa/rust_libloading/) | [ISC](#ISC) | Copyright © 2015, Simonas Kazlauskas  | 
 | [libnghttp2-sys](https://github.com/alexcrichton/nghttp2-rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Alex Crichton  | 
 | [libz-sys](https://github.com/rust-lang/libz-sys) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Alex Crichton Copyright (c) 2020 Josh Triplett  | 


### PR DESCRIPTION
The 'flate2' crate already supports both C and pure Rust backends, so we don't gain anything by supporting libflate