### PR TITLE
core: Use existing methods for rounding twips

### DIFF
--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -8,7 +8,6 @@ use crate::context::GcContext;
 use crate::display_object::{
     AutoSizeMode, EditText, TDisplayObject, TInteractiveObject, TextSelection,
 };
-use crate::font::round_down_to_pixel;
 use crate::html::TextFormat;
 use crate::string::{AvmString, WStr};
 use gc_arena::Gc;
@@ -490,7 +489,7 @@ pub fn text_width<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let metrics = this.measure_text(&mut activation.context);
-    Ok(round_down_to_pixel(metrics.0).to_pixels().into())
+    Ok(metrics.0.trunc_to_pixel().to_pixels().into())
 }
 
 pub fn text_height<'gc>(
@@ -498,7 +497,7 @@ pub fn text_height<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let metrics = this.measure_text(&mut activation.context);
-    Ok(round_down_to_pixel(metrics.1).to_pixels().into())
+    Ok(metrics.1.trunc_to_pixel().to_pixels().into())
 }
 
 pub fn mouse_wheel_enabled<'gc>(

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -19,7 +19,7 @@ use crate::display_object::interactive::{
 };
 use crate::display_object::{DisplayObjectBase, DisplayObjectPtr};
 use crate::events::{ClipEvent, ClipEventResult, TextControlCode};
-use crate::font::{round_down_to_pixel, FontType, Glyph, TextRenderSettings};
+use crate::font::{FontType, Glyph, TextRenderSettings};
 use crate::html;
 use crate::html::{
     FormatSpans, Layout, LayoutBox, LayoutContent, LayoutMetrics, Position, TextFormat,
@@ -809,11 +809,10 @@ impl<'gc> EditText<'gc> {
             return 0.0;
         }
 
-        let base = round_down_to_pixel(
-            edit_text.layout.exterior_bounds().width() - edit_text.bounds.width(),
-        )
-        .to_pixels()
-        .max(0.0);
+        let base = (edit_text.layout.exterior_bounds().width() - edit_text.bounds.width())
+            .trunc_to_pixel()
+            .to_pixels()
+            .max(0.0);
 
         // input text boxes get extra space at the end
         if !edit_text.flags.contains(EditTextFlag::READ_ONLY) {


### PR DESCRIPTION
Replace `round_to_pixel_half_even` and `round_down_to_pixel` with existing methods used for rounding twips to pixels.