### PR TITLE
desktop: Add View menu

### DIFF
--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -113,7 +113,7 @@ fn set_scale_mode<'gc>(
     activation
         .context
         .stage
-        .set_scale_mode(&mut activation.context, scale_mode);
+        .set_scale_mode(&mut activation.context, scale_mode, true);
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -279,7 +279,7 @@ pub fn set_scale_mode<'gc>(
         activation
             .context
             .stage
-            .set_scale_mode(&mut activation.context, scale_mode);
+            .set_scale_mode(&mut activation.context, scale_mode, true);
     } else {
         return Err(make_error_2008(activation, "scaleMode"));
     }

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -314,11 +314,18 @@ impl<'gc> Stage<'gc> {
     }
 
     /// Set the stage scale mode.
-    pub fn set_scale_mode(self, context: &mut UpdateContext<'_, 'gc>, scale_mode: StageScaleMode) {
-        if !self.forced_scale_mode() {
-            self.0.write(context.gc_context).scale_mode = scale_mode;
-            self.build_matrices(context);
+    pub fn set_scale_mode(
+        self,
+        context: &mut UpdateContext<'_, 'gc>,
+        scale_mode: StageScaleMode,
+        respect_forced: bool,
+    ) {
+        if respect_forced && self.forced_scale_mode() {
+            return;
         }
+
+        self.0.write(context.gc_context).scale_mode = scale_mode;
+        self.build_matrices(context);
     }
 
     /// Get whether movies are prevented from changing the stage scale mode.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2855,7 +2855,7 @@ impl PlayerBuilder {
             let stage = context.stage;
             stage.set_align(context, self.align);
             stage.set_forced_align(context, self.forced_align);
-            stage.set_scale_mode(context, self.scale_mode);
+            stage.set_scale_mode(context, self.scale_mode, false);
             stage.set_forced_scale_mode(context, self.forced_scale_mode);
             stage.set_allow_fullscreen(context, self.allow_fullscreen);
             stage.post_instantiation(context, None, Instantiator::Movie, false);

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -854,6 +854,10 @@ impl Player {
         })
     }
 
+    pub fn quality(&mut self) -> StageQuality {
+        self.mutate_with_update_context(|context| context.stage.quality())
+    }
+
     pub fn set_quality(&mut self, quality: StageQuality) {
         self.mutate_with_update_context(|context| {
             context.stage.set_quality(context, quality);
@@ -866,6 +870,26 @@ impl Player {
             if let Ok(window_mode) = WindowMode::from_str(window_mode) {
                 stage.set_window_mode(context, window_mode);
             }
+        })
+    }
+
+    pub fn scale_mode(&mut self) -> StageScaleMode {
+        self.mutate_with_update_context(|context| context.stage.scale_mode())
+    }
+
+    pub fn set_scale_mode(&mut self, scale_mode: StageScaleMode) {
+        self.mutate_with_update_context(|context| {
+            context.stage.set_scale_mode(context, scale_mode, false);
+        })
+    }
+
+    pub fn forced_scale_mode(&mut self) -> bool {
+        self.mutate_with_update_context(|context| context.stage.forced_scale_mode())
+    }
+
+    pub fn set_forced_scale_mode(&mut self, force: bool) {
+        self.mutate_with_update_context(|context| {
+            context.stage.set_forced_scale_mode(context, force);
         })
     }
 

--- a/desktop/assets/texts/en-US/main_menu.ftl
+++ b/desktop/assets/texts/en-US/main_menu.ftl
@@ -40,3 +40,5 @@ debug-menu-open-movie-list = Show Known Movies
 debug-menu-open-domain-list = Show Domains
 debug-menu-search-display-objects = Search Display Objects...
 
+view-menu = View
+view-menu-fullscreen = Full Screen

--- a/desktop/assets/texts/en-US/settings.ftl
+++ b/desktop/assets/texts/en-US/settings.ftl
@@ -58,10 +58,10 @@ align-bottom-right = Bottom-Right
 align-force = Force
 
 scale-mode = Scale Mode
-scale-mode-exactfit = Exact Fit
-scale-mode-noborder = No Border
-scale-mode-noscale = No Scale
-scale-mode-showall = Show All
+scale-mode-noscale = Unscaled (100%)
+scale-mode-showall = Zoom to Fit
+scale-mode-exactfit = Stretch to Fit
+scale-mode-noborder = Crop to Fit
 scale-mode-force = Force
 
 player-version = Player Version

--- a/desktop/assets/texts/en-US/settings.ftl
+++ b/desktop/assets/texts/en-US/settings.ftl
@@ -59,10 +59,28 @@ align-force = Force
 
 scale-mode = Scale Mode
 scale-mode-noscale = Unscaled (100%)
+scale-mode-noscale-tooltip =
+    Displays the movie at its original size, without any zoom.
+
+    Corresponds to StageScaleMode.NO_SCALE
 scale-mode-showall = Zoom to Fit
+scale-mode-showall-tooltip =
+    Zooms the movie to fill the window as much as possible without cropping, maintaining aspect ratio.
+
+    Corresponds to StageScaleMode.SHOW_ALL
 scale-mode-exactfit = Stretch to Fit
+scale-mode-exactfit-tooltip =
+    Ensures the movie fills the entire window, disregarding aspect ratio.
+
+    Corresponds to StageScaleMode.EXACT_FIT
 scale-mode-noborder = Crop to Fit
+scale-mode-noborder-tooltip =
+    Fills the entire window while maintaining aspect ratio, cropping the movie if necessary.
+
+    Corresponds to StageScaleMode.NO_BORDER
 scale-mode-force = Force
+scale-mode-force-tooltip =
+    Prevents the movie from changing the scale mode, locking it to the selected setting.
 
 player-version = Player Version
 


### PR DESCRIPTION
This PR adds the "View" menu, which is responsible for controlling the view:
1. options "100% (Unscaled)" and "Zoom to Fit" are analogous to FP's "100%" and "Show All",
2. options "Stretch to Fit" and "Crop to Fit" allow setting other scale modes which are not in FP,
3. option "Letterbox" controls letterbox rendering when "Zoom to Fit" is selected,
4. option "Full Screen" enter the full screen (as in FP),
5. option "Quality" selects the quality (as in FP, context menu does not have to be always shown).

![image](https://github.com/user-attachments/assets/2aae75e9-ce8d-4daf-94d1-6a7b6696fef2)
![image](https://github.com/user-attachments/assets/1fd84292-13d1-44e9-9be7-3391f86051c7)
