### PR TITLE
ci: Get `wasm-opt` directly from GitHub using `sigoden/install-binary@v1` ...

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -315,16 +315,14 @@ jobs:
       - name: Install wasm-bindgen
         run: cargo install wasm-bindgen-cli --version 0.2.92
 
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v3
+      # Keep the version number in sync in all workflows,
+      # and in the extension builder Dockerfile!
+      - name: Install wasm-opt
+        uses: sigoden/install-binary@v1
         with:
-          activate-environment: binaryen
-
-      # conda is available only with "shell: bash -l {0}".
-      # See https://github.com/marketplace/actions/setup-miniconda.
-      - name: Install binaryen
-        shell: bash -l {0}
-        run: conda install -c conda-forge binaryen
+          repo: WebAssembly/binaryen
+          tag: version_118
+          name: wasm-opt
 
       - name: Install node packages
         working-directory: web

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Install wasm-bindgen
         run: cargo install wasm-bindgen-cli --version 0.2.92
 
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v3
+      # Keep the version number in sync in all workflows,
+      # and in the extension builder Dockerfile!
+      - name: Install wasm-opt
+        uses: sigoden/install-binary@v1
         with:
-          activate-environment: binaryen
-
-      - name: Install binaryen
-        shell: bash -l {0}
-        run: conda install -c conda-forge binaryen
+          repo: WebAssembly/binaryen
+          tag: version_118
+          name: wasm-opt
 
       - name: Install fclones
         run: cargo install fclones

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -63,16 +63,14 @@ jobs:
       - name: Install wasm-bindgen
         run: cargo install wasm-bindgen-cli --version 0.2.92
 
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v3
+      # Keep the version number in sync in all workflows,
+      # and in the extension builder Dockerfile!
+      - name: Install wasm-opt
+        uses: sigoden/install-binary@v1
         with:
-          activate-environment: binaryen
-
-      # conda is available only with "shell: bash -l {0}".
-      # See https://github.com/marketplace/actions/setup-miniconda.
-      - name: Install binaryen
-        shell: bash -l {0}
-        run: conda install -c conda-forge binaryen
+          repo: WebAssembly/binaryen
+          tag: version_118
+          name: wasm-opt
 
       - name: Build
         env:

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -4,11 +4,11 @@
 # docker cp $(docker create ruffle-web-docker:latest):/ruffle/web/packages web/docker/docker_builds/packages
 FROM node:20
 
-# Getting Miniconda from their website:
-RUN wget 'https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh'
-RUN bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda
-ENV PATH="/miniconda/bin:$PATH"
-RUN conda install -y -c conda-forge binaryen
+# Installing wasm-opt from GitHub:
+# Keep the version number in sync with the ones in the Actions workflows!
+RUN wget --progress=:giga https://github.com/WebAssembly/binaryen/releases/download/version_118/binaryen-version_118-x86_64-linux.tar.gz
+RUN tar xzf binaryen-version_118-x86_64-linux.tar.gz binaryen-version_118/bin/wasm-opt
+RUN mv binaryen-version_118/bin/wasm-opt /usr/local/bin
 
 # Installing Rust using rustup:
 RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown


### PR DESCRIPTION
... instead of from `conda-forge` using `miniconda`.

See: https://github.com/sigoden/install-binary?tab=readme-ov-file#installing-a-binary-with-a-specific-tag-and-name
We've been getting notes about this: https://github.com/conda-incubator/setup-miniconda/issues/354

Also, using wget + tar in the extension builder Dockerfile.
There were concerns with conda and "corporate" use (for the store reviewers).