### PR TITLE
avm2: More optimizations

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -1012,15 +1012,11 @@ impl<'gc> Class<'gc> {
         self,
         activation: &mut Activation<'_, 'gc>,
         name: QName<'gc>,
-        value: Value<'gc>,
+        class_object: ClassObject<'gc>,
     ) {
         self.define_instance_trait(
             activation.context.gc_context,
-            Trait::from_const(
-                name,
-                Multiname::new(activation.avm2().public_namespace_base_version, "Class"),
-                Some(value),
-            ),
+            Trait::from_class(name, class_object.inner_class_definition()),
         );
     }
 

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -365,11 +365,9 @@ fn dynamic_class<'gc>(
         class_object.into(),
         class_class,
     );
-    script.global_class().define_constant_class_instance_trait(
-        activation,
-        name,
-        class_object.into(),
-    );
+    script
+        .global_class()
+        .define_constant_class_instance_trait(activation, name, class_object);
     domain.export_definition(name, script, activation.context.gc_context)
 }
 
@@ -407,7 +405,7 @@ fn class<'gc>(
     script.global_class().define_constant_class_instance_trait(
         activation,
         class_name,
-        class_object.into(),
+        class_object,
     );
     domain.export_definition(class_name, script, mc);
     domain.export_class(class_name, class_def, mc);
@@ -442,11 +440,9 @@ fn vector_class<'gc>(
         vector_cls.into(),
         activation.avm2().classes().class,
     );
-    script.global_class().define_constant_class_instance_trait(
-        activation,
-        legacy_name,
-        vector_cls.into(),
-    );
+    script
+        .global_class()
+        .define_constant_class_instance_trait(activation, legacy_name, vector_cls);
     domain.export_definition(legacy_name, script, mc);
     Ok(vector_cls)
 }

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -234,7 +234,7 @@ pub fn create_class<'gc>(
     );
 
     let function_c_class = Class::custom_new(
-        QName::new(activation.avm2().public_namespace_base_version, "Function"),
+        QName::new(activation.avm2().public_namespace_base_version, "Function$"),
         Some(class_i_class),
         Method::from_builtin(class_init, "<Function class initializer>", gc_context),
         gc_context,

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -69,13 +69,19 @@ pub enum Op<'gc> {
     Coerce {
         class: Class<'gc>,
     },
+    CoerceSwapPop {
+        class: Class<'gc>,
+    },
     CoerceA,
     CoerceB,
     CoerceD,
+    CoerceDSwapPop,
     CoerceI,
+    CoerceISwapPop,
     CoerceO,
     CoerceS,
     CoerceU,
+    CoerceUSwapPop,
     Construct {
         num_args: u32,
     },

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -1316,6 +1316,9 @@ pub fn optimize<'gc>(
 
                 // Receiver
                 stack.pop();
+
+                // Avoid checking return value for now
+                stack.push_any();
             }
             Op::SetSuper { multiname } => {
                 stack.pop();

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -107,9 +107,7 @@ pub enum TraitKind<'gc> {
 }
 
 impl<'gc> Trait<'gc> {
-    pub fn from_class(class: Class<'gc>) -> Self {
-        let name = class.name();
-
+    pub fn from_class(name: QName<'gc>, class: Class<'gc>) -> Self {
         Trait {
             name,
             attributes: TraitAttributes::empty(),


### PR DESCRIPTION
These depend on the class refactor. We now propagate the resulting type from `astypelate`, and convert the case of
```
findpropstrict "int"
...
callproperty "int"
```
to
```
getscriptglobals ...
...
coerceiswappop
```
(and the same applies for Number and uint). Surprisingly, calls like that made up a large portion of `callproperty`s in the box2d SWF that I use for testing:
```
FindPropStrict -> GetScriptGlobals : 62.18%
FindPropStrict -> GetOuterScope : 7.76%
FindPropStrict -> GetScopeObject : 8.24%

FindProperty -> GetOuterScope : 2.83%
FindProperty -> GetScopeObject : 94.34%

InitProperty -> SetSlot : 17.31% (-21.43%)
InitProperty -> SetSlotNoCoerce : 68.13% (+21.43%)

SetProperty -> SetSlot : 20.28% (-3.67%)
SetProperty -> SetSlotNoCoerce : 48.6% (+3.84%)
SetProperty -> CallMethod : 1.57%

GetProperty -> GetSlot : 74.31% (+0.62%)
GetProperty -> CallMethod : 0.34%

CallProperty -> CallMethod : 70.97%
CallProperty -> CoerceUSwapPop : 5.24% (+5.24%)
CallProperty -> CoerceISwapPop : 9.68% (+9.68%)

CallPropVoid -> CallMethod : 75.76% (+0.38%)

Coerce -> Nop : 59.14% (+7.43%)

CoerceD -> Nop : 82.84% (+1.50%)

CoerceB -> Nop : 10.81%

CoerceU -> Nop : 50%

CoerceI -> Nop : 33%

ReturnValue -> ReturnValueNoCoerce : 75.23% (+3.67%)
```

Also, the builtin classes' slots are now properly typed to `T$` instead of `Class`, and we handle the return type of `constructprop`.