### PR TITLE
core: Fix double caret rendering in justified text

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -902,10 +902,11 @@ impl<'gc> EditText<'gc> {
 
         let caret = if let LayoutContent::Text { start, end, .. } = &lbox.content() {
             if let Some(visible_selection) = visible_selection {
+                let text_len = edit_text.text_spans.text().len();
                 if visible_selection.is_caret()
                     && !edit_text.flags.contains(EditTextFlag::READ_ONLY)
                     && visible_selection.start() >= *start
-                    && visible_selection.end() <= *end
+                    && (visible_selection.end() < *end || *end == text_len)
                     && !visible_selection.blinks_now()
                 {
                     Some(visible_selection.start() - start)


### PR DESCRIPTION
Progresses https://github.com/ruffle-rs/ruffle/issues/1891.

| Before | After |
| ------ | ----- |
| <img src="https://github.com/ruffle-rs/ruffle/assets/1507072/e11fee24-cd94-44ae-abec-09c23472d521" width="200"/> | <img src="https://github.com/ruffle-rs/ruffle/assets/1507072/23a9bf33-67d4-4dee-96aa-b762f1bcbac8" width="200"/> |
| <img src="https://github.com/ruffle-rs/ruffle/assets/1507072/845cc2fc-b030-479b-b7be-d7ae1bfa34a2" width="200"/> | <img src="https://github.com/ruffle-rs/ruffle/assets/1507072/96068edb-8235-44ad-8bae-cc4dc8c8adb1" width="200"/> |
