### PR TITLE
extension: Use source-map devtool for debug build (close #15064)

### DIFF
--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -125,6 +125,7 @@ export default function (/** @type {Record<string, any>} */ env, _argv) {
         optimization: {
             minimize: false,
         },
+        devtool: mode === "development" ? "source-map" : false,
         plugins: [
             new CopyPlugin({
                 patterns: [


### PR DESCRIPTION
Fixes #15064 

The default value for Webpack `devtool` under development mode is `eval`, however, CSP `script-src: unsafe-eval` is banned from Chrome manifest v3. The PR fixes the issue by changing `devtool` to `source-map`.