### PR TITLE
tests: Remove an obsolete comment from edittext_html_swf8

### DIFF
--- a/tests/tests/swfs/avm1/edittext_html_swf8/test.as
+++ b/tests/tests/swfs/avm1/edittext_html_swf8/test.as
@@ -1,5 +1,3 @@
-// Newlines are OS-dependent, we do not
-// want to deal with this in this test.
 function escapeNewlines(text) {
     return text
         .split("\r").join("\\r")


### PR DESCRIPTION
That comment is obsolete after https://github.com/ruffle-rs/ruffle/pull/17056.