### PR TITLE
avm2: Use small string cache when stringifying ints < 10

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1969,6 +1969,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let coerced = match value {
             Value::Undefined | Value::Null => Value::Null,
+            Value::String(_) => value,
             _ => value.coerce_to_string(self)?.into(),
         };
 

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -852,7 +852,16 @@ impl<'gc> Value<'gc> {
                     AvmString::new_utf8(activation.context.gc_context, n.to_string())
                 }
             }
-            Value::Integer(i) => AvmString::new_utf8(activation.context.gc_context, i.to_string()),
+            Value::Integer(i) => {
+                if *i >= 0 && *i < 10 {
+                    activation
+                        .context
+                        .interner
+                        .get_char(activation.context.gc_context, '0' as u16 + *i as u16)
+                } else {
+                    AvmString::new_utf8(activation.context.gc_context, i.to_string())
+                }
+            }
             Value::String(s) => *s,
             Value::Object(_) => self
                 .coerce_to_primitive(Some(Hint::String), activation)?


### PR DESCRIPTION
I checked that it speeds up a `vector[0] = 0; ...up to 10` microbenchmark by ~2x; will also reduce GC work, significantly if a movie relies on these kinds of accesses a lot.
This will become irrelevant for this benchmark when we optimize `setproperty` and `nextvalue` to not create strings at all, but it's a useful optimization anyway.

Created as draft as I still wanna play with it later today.