### PR TITLE
avm2: Add AIR classes used by Evoland

### DIFF
--- a/core/src/avm2/globals/flash/desktop/NativeProcess.as
+++ b/core/src/avm2/globals/flash/desktop/NativeProcess.as
@@ -1,0 +1,20 @@
+package flash.desktop {
+    import __ruffle__.stub_method;
+
+    import flash.events.EventDispatcher;
+
+    [API("668")]
+    public class NativeProcess extends EventDispatcher {
+        public function NativeProcess() {
+            super();
+        }
+
+        public static function get isSupported():Boolean {
+            return false;
+        }
+
+        public function start(info:NativeProcessStartupInfo):void {
+            stub_method("flash.desktop.NativeProcess", "start");
+        }
+    }
+}

--- a/core/src/avm2/globals/flash/desktop/NativeProcessStartupInfo.as
+++ b/core/src/avm2/globals/flash/desktop/NativeProcessStartupInfo.as
@@ -1,0 +1,43 @@
+package flash.desktop {
+    import __ruffle__.stub_getter;
+    import __ruffle__.stub_setter;
+
+    import flash.filesystem.File;
+
+    [API("668")]
+    public class NativeProcessStartupInfo {
+        public function NativeProcessStartupInfo() {
+            super();
+        }
+
+        public function get arguments():Vector.<String> {
+            stub_getter("flash.desktop.NativeProcessStartupInfo", "arguments");
+
+            return null;
+        }
+
+        public function set arguments(value:Vector.<String>):void {
+            stub_setter("flash.desktop.NativeProcessStartupInfo", "arguments");
+        }
+
+        public function get executable():File {
+            stub_getter("flash.desktop.NativeProcessStartupInfo", "executable");
+
+            return null;
+        }
+
+        public function set executable(value:File):void {
+            stub_setter("flash.desktop.NativeProcessStartupInfo", "executable");
+        }
+
+        public function get workingDirectory():File {
+            stub_getter("flash.desktop.NativeProcessStartupInfo", "workingDirectory");
+
+            return null;
+        }
+
+        public function set workingDirectory(value:File):void {
+            stub_setter("flash.desktop.NativeProcessStartupInfo", "workingDirectory");
+        }
+    }
+}

--- a/core/src/avm2/globals/flash/filesystem/File.as
+++ b/core/src/avm2/globals/flash/filesystem/File.as
@@ -1,0 +1,36 @@
+package flash.filesystem {
+    import __ruffle__.stub_constructor;
+    import __ruffle__.stub_getter;
+    import __ruffle__.stub_method;
+
+    import flash.net.FileReference;
+
+    [API("661")]
+    public class File extends FileReference {
+        private static var _applicationDirectory:File = null;
+
+        public function File(path:String = null) {
+            stub_constructor("flash.filesystem.File");
+        }
+
+        public static function get applicationDirectory():File {
+            if (_applicationDirectory === null) {
+                _applicationDirectory = new File();
+            }
+
+            return _applicationDirectory;
+        }
+
+        public function resolvePath(path:String):File {
+            stub_method("flash.filesystem.File", "resolvePath");
+
+            return new File();
+        }
+
+        public function get exists():Boolean {
+            stub_getter("flash.filesystem.File", "exists");
+
+            return false;
+        }
+    }
+}

--- a/core/src/avm2/globals/flash/system/ImageDecodingPolicy.as
+++ b/core/src/avm2/globals/flash/system/ImageDecodingPolicy.as
@@ -1,6 +1,7 @@
 package flash.system {
-      public final class ImageDecodingPolicy {
-            public static const ON_DEMAND:String = "onDemand";
-            public static const ON_LOAD:String = "onLoad";
-      }
+    [API("674")]
+    public final class ImageDecodingPolicy {
+        public static const ON_DEMAND:String = "onDemand";
+        public static const ON_LOAD:String = "onLoad";
+    }
 }

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -29,6 +29,9 @@ include "flash/accessibility/AccessibilityProperties.as"
 include "flash/accessibility/ISearchableText.as"
 include "flash/accessibility/ISimpleTextSelection.as"
 
+include "flash/concurrent/Condition.as"
+include "flash/concurrent/Mutex.as"
+
 include "flash/crypto.as"
 
 include "flash/utils/IDataInput.as"
@@ -37,16 +40,15 @@ include "flash/utils/IExternalizable.as"
 include "flash/utils/ByteArray.as"
 include "flash/utils/Dictionary.as"
 
+include "flash/events/IEventDispatcher.as"
+include "flash/events/EventDispatcher.as"
+
 include "flash/desktop/ClipboardFormats.as"
 include "flash/desktop/ClipboardTransferMode.as"
 include "flash/desktop/Clipboard.as"
 include "flash/desktop/IFilePromise.as"
-
-include "flash/events/IEventDispatcher.as"
-include "flash/events/EventDispatcher.as"
-
-include "flash/concurrent/Condition.as"
-include "flash/concurrent/Mutex.as"
+include "flash/desktop/NativeProcess.as"
+include "flash/desktop/NativeProcessStartupInfo.as"
 
 include "flash/display/IBitmapDrawable.as"
 include "flash/display/DisplayObject.as"
@@ -300,6 +302,8 @@ include "flash/net/URLRequestMethod.as"
 include "flash/net/URLStream.as"
 include "flash/net/URLVariables.as"
 include "flash/net/XMLSocket.as"
+
+include "flash/filesystem/File.as" // File extends FileReference
 
 include "flash/net/drm/AuthenticationMethod.as"
 include "flash/net/drm/LoadVoucherSetting.as"

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -28,12 +28,15 @@ include "flash/accessibility/AccessibilityImplementation.as"
 include "flash/accessibility/AccessibilityProperties.as"
 include "flash/accessibility/ISearchableText.as"
 include "flash/accessibility/ISimpleTextSelection.as"
+
 include "flash/crypto.as"
+
 include "flash/utils/IDataInput.as"
 include "flash/utils/IDataOutput.as"
 include "flash/utils/IExternalizable.as"
 include "flash/utils/ByteArray.as"
 include "flash/utils/Dictionary.as"
+
 include "flash/desktop/ClipboardFormats.as"
 include "flash/desktop/ClipboardTransferMode.as"
 include "flash/desktop/Clipboard.as"
@@ -109,6 +112,9 @@ include "flash/display/StageQuality.as"
 include "flash/display/StageScaleMode.as"
 include "flash/display/SWFVersion.as"
 include "flash/display/TriangleCulling.as"
+
+include "flash/display/MovieClip.as"
+
 include "flash/display3D/Context3D.as"
 include "flash/display3D/Context3DBlendFactor.as"
 include "flash/display3D/Context3DBufferUsage.as"
@@ -132,7 +138,13 @@ include "flash/display3D/textures/Texture.as"
 include "flash/display3D/textures/RectangleTexture.as"
 include "flash/display3D/VertexBuffer3D.as"
 
-include "flash/display/MovieClip.as"
+include "flash/errors/IOError.as" // IOError is a superclass of EOFError
+include "flash/errors/EOFError.as"
+include "flash/errors/IllegalOperationError.as"
+include "flash/errors/InvalidSWFError.as"
+include "flash/errors/MemoryError.as"
+include "flash/errors/ScriptTimeoutError.as"
+include "flash/errors/StackOverflowError.as"
 
 // Event needs to come before its subclasses
 include "flash/events/Event.as"
@@ -187,13 +199,7 @@ include "flash/events/UncaughtErrorEvents.as"
 include "flash/events/VideoEvent.as"
 include "flash/events/VideoTextureEvent.as"
 
-include "flash/errors/IOError.as" // IOError is a superclass of EOFError
-include "flash/errors/EOFError.as"
-include "flash/errors/IllegalOperationError.as"
-include "flash/errors/InvalidSWFError.as"
-include "flash/errors/MemoryError.as"
-include "flash/errors/ScriptTimeoutError.as"
-include "flash/errors/StackOverflowError.as"
+include "flash/external/ExternalInterface.as"
 
 include "flash/filters/BitmapFilter.as"
 include "flash/filters/BitmapFilterQuality.as"
@@ -220,6 +226,7 @@ include "flash/geom/Rectangle.as"
 include "flash/geom/Transform.as"
 include "flash/geom/Utils3D.as"
 include "flash/geom/Vector3D.as"
+
 include "flash/globalization/CollatorMode.as"
 include "flash/globalization/CurrencyParseResult.as"
 include "flash/globalization/CurrencyFormatter.as"
@@ -258,8 +265,6 @@ include "flash/media/Video.as"
 include "flash/media/VideoCodec.as"
 include "flash/media/VideoStatus.as"
 include "flash/media/VideoStreamSettings.as"
-
-include "flash/external/ExternalInterface.as"
 
 include "flash/net.as"
 include "flash/net/DatagramSocket.as"


### PR DESCRIPTION
Fixes​ #13436 locking up when getting to the first savepoint.
Also progresses #13437 a tiny bit, it needs `File.exists` to work next.