### PR TITLE
core: Log an error when a URLLoader load fails

### DIFF
--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1656,6 +1656,12 @@ impl<'gc> Loader<'gc> {
                         Avm2::dispatch_event(uc, complete_evt, target);
                     }
                     Err(response) => {
+                        tracing::error!(
+                            "Error during URLLoader load of {:?}: {:?}",
+                            response.url,
+                            response.error
+                        );
+
                         // Testing with Flash shoes that the 'data' property is cleared
                         // when an error occurs
 


### PR DESCRIPTION
This would have been helpful when debugging Dungeon Blitz