### PR TITLE
web: Use browser focus events for focus management, improve virtual keyboard support

### DIFF
--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -91,8 +91,9 @@ pub trait UiBackend: Downcast {
     // Unused, but kept in case we need it later.
     fn message(&self, message: &str);
 
-    // Only used on web.
     fn open_virtual_keyboard(&self);
+
+    fn close_virtual_keyboard(&self);
 
     fn language(&self) -> LanguageIdentifier;
 
@@ -359,6 +360,8 @@ impl UiBackend for NullUiBackend {
     }
 
     fn open_virtual_keyboard(&self) {}
+
+    fn close_virtual_keyboard(&self) {}
 
     fn language(&self) -> LanguageIdentifier {
         US_ENGLISH.clone()

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -197,12 +197,18 @@ impl<'gc> FocusTracker<'gc> {
         if let Some(text_field) = self.get_as_edit_text() {
             if text_field.is_editable() {
                 if !text_field.movie().is_action_script_3() {
+                    // TODO This logic is inaccurate and addresses
+                    //   only setting the focus programmatically.
                     let length = text_field.text_length();
                     text_field
                         .set_selection(Some(TextSelection::for_range(0, length)), context.gc());
                 }
                 context.ui.open_virtual_keyboard();
+            } else {
+                context.ui.close_virtual_keyboard();
             }
+        } else {
+            context.ui.close_virtual_keyboard();
         }
     }
 

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -310,6 +310,8 @@ impl UiBackend for DesktopUiBackend {
     // Unused on desktop
     fn open_virtual_keyboard(&self) {}
 
+    fn close_virtual_keyboard(&self) {}
+
     fn language(&self) -> LanguageIdentifier {
         self.preferences.language().clone()
     }

--- a/tests/framework/src/backends/ui.rs
+++ b/tests/framework/src/backends/ui.rs
@@ -117,6 +117,8 @@ impl UiBackend for TestUiBackend {
 
     fn open_virtual_keyboard(&self) {}
 
+    fn close_virtual_keyboard(&self) {}
+
     fn language(&self) -> LanguageIdentifier {
         US_ENGLISH.clone()
     }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -74,7 +74,7 @@ features = [
     "EventTarget", "GainNode", "Headers", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement",
     "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent",
     "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "ReadableStream", "RequestCredentials",
-    "Url", "Clipboard",
+    "Url", "Clipboard", "FocusEvent"
 ]
 
 [package.metadata.cargo-machete]

--- a/web/packages/core/src/internal/ui/static-styles.css
+++ b/web/packages/core/src/internal/ui/static-styles.css
@@ -45,6 +45,7 @@
 
 #container {
     overflow: hidden;
+    outline: none;
 
     canvas {
         width: 100%;

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -175,6 +175,9 @@ extern "C" {
     #[wasm_bindgen(method, js_name = "openVirtualKeyboard")]
     fn open_virtual_keyboard(this: &JavascriptPlayer);
 
+    #[wasm_bindgen(method, js_name = "closeVirtualKeyboard")]
+    fn close_virtual_keyboard(this: &JavascriptPlayer);
+
     #[wasm_bindgen(method, js_name = "isVirtualKeyboardFocused")]
     fn is_virtual_keyboard_focused(this: &JavascriptPlayer) -> bool;
 
@@ -287,6 +290,11 @@ impl RuffleHandle {
 
     pub fn is_playing(&self) -> bool {
         self.with_core(|core| core.is_playing()).unwrap_or_default()
+    }
+
+    pub fn has_focus(&self) -> bool {
+        self.with_instance(|instance| instance.has_focus)
+            .unwrap_or_default()
     }
 
     pub fn volume(&self) -> f32 {

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -292,6 +292,8 @@ impl UiBackend for WebUiBackend {
         self.js_player.open_virtual_keyboard()
     }
 
+    fn close_virtual_keyboard(&self) {}
+
     fn language(&self) -> LanguageIdentifier {
         self.language.clone()
     }

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -292,7 +292,9 @@ impl UiBackend for WebUiBackend {
         self.js_player.open_virtual_keyboard()
     }
 
-    fn close_virtual_keyboard(&self) {}
+    fn close_virtual_keyboard(&self) {
+        self.js_player.close_virtual_keyboard()
+    }
 
     fn language(&self) -> LanguageIdentifier {
         self.language.clone()


### PR DESCRIPTION
Reapplication of reverted https://github.com/ruffle-rs/ruffle/pull/17165, with fixed virtual keyboard.

Virtual keyboard on web is represented as an input inside the container. In order to preserve player focus when virtual keyboard is open, this PR moves the focus management to the container from the canvas. This way, when the input is focused, the container does not lose its focus.

This PR also integrates the virtual keyboard with the newly added focus management and removes Android-specific code, instead using generic logic which takes advantage of improved focus support in SWFs. It also fixes some issues related to the keyboard flickering when selecting text.
