### PR TITLE
web: Remove now unused `copyToAudioBuffer` and `getAudioOutputTimestamp`

### DIFF
--- a/web/packages/core/src/ruffle-imports.ts
+++ b/web/packages/core/src/ruffle-imports.ts
@@ -6,17 +6,6 @@
  */
 
 /**
- * Returns the estimated output timestamp for the audio context.
- * This is necessary because web-sys does not export `AudioContext.baseLatency`.
- *
- * @internal
- */
-export function getAudioOutputTimestamp(context: AudioContext): number {
-    // TODO: Ideally we'd use `context.getOutputTimestamp`, but this is broken as of Safari 15.4.
-    return context.currentTime - context.baseLatency;
-}
-
-/**
  * Copies interleaved stereo audio data into an `AudioBuffer`.
  *
  * @internal

--- a/web/packages/core/src/ruffle-imports.ts
+++ b/web/packages/core/src/ruffle-imports.ts
@@ -6,28 +6,6 @@
  */
 
 /**
- * Copies data into the given audio channel.
- * This is necessary because Safari does not support `AudioBuffer.copyToChannel`.
- *
- * @internal
- */
-export function copyToAudioBuffer(
-    audioBuffer: AudioBuffer,
-    leftData: ArrayLike<number>,
-    rightData: ArrayLike<number>,
-): void {
-    if (leftData) {
-        const dstBuffer = audioBuffer.getChannelData(0);
-        dstBuffer.set(leftData);
-    }
-
-    if (rightData) {
-        const dstBuffer = audioBuffer.getChannelData(1);
-        dstBuffer.set(rightData);
-    }
-}
-
-/**
  * Returns the estimated output timestamp for the audio context.
  * This is necessary because web-sys does not export `AudioContext.baseLatency`.
  *


### PR DESCRIPTION
I couldn't find any references to them anymore, they're probably leftovers from before a refactor (~probably~ _definitely_ #4273).

An actual test in Safari would be nice - I don't really have access to it.