### PR TITLE
ci: Temporarily pin to Node 22.4

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["20", "22"]
+        node_version: ["20", "22.4"]
         os: [ubuntu-22.04, windows-latest]
 
     steps:


### PR DESCRIPTION
See https://github.com/nodejs/node/issues/53902