### PR TITLE
wgpu: Directly copy BitmapData gpu buffer to Stage3D texture

### DIFF
--- a/core/src/avm2/globals/flash/display3D/textures/cube_texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/cube_texture.rs
@@ -88,10 +88,11 @@ pub fn upload_from_bitmap_data<'gc>(
             let mip_level = args[2].coerce_to_u32(activation)?;
             if mip_level == 0 {
                 texture.context3d().copy_bitmapdata_to_texture(
-                    source.sync(activation.context.renderer),
+                    source,
                     texture.handle(),
                     // FIXME - is this right?
                     side,
+                    &mut activation.context,
                 );
             } else {
                 avm2_stub_method!(

--- a/core/src/avm2/globals/flash/display3D/textures/rectangle_texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/rectangle_texture.rs
@@ -27,9 +27,10 @@ pub fn upload_from_bitmap_data<'gc>(
     if let Some(texture) = this.as_texture() {
         if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
             texture.context3d().copy_bitmapdata_to_texture(
-                source.sync(activation.context.renderer),
+                source,
                 texture.handle(),
                 0,
+                &mut activation.context,
             );
         } else {
             panic!("Invalid source: {:?}", args[0]);

--- a/core/src/avm2/globals/flash/display3D/textures/texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/texture.rs
@@ -63,9 +63,10 @@ pub fn do_copy<'gc>(
         }
     };
     texture.context3d().copy_bitmapdata_to_texture(
-        bitmap_data.sync(activation.context.renderer),
+        bitmap_data,
         texture.handle(),
         side,
+        &mut activation.context,
     );
     Ok(())
 }
@@ -121,9 +122,10 @@ pub fn upload_from_bitmap_data<'gc>(
             let mip_level = args[1].coerce_to_u32(activation)?;
             if mip_level == 0 {
                 texture.context3d().copy_bitmapdata_to_texture(
-                    source.sync(activation.context.renderer),
+                    source,
                     texture.handle(),
                     0,
+                    &mut activation.context,
                 );
             } else {
                 avm2_stub_method!(

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -491,6 +491,11 @@ pub enum Context3DCommand<'a> {
         face: Context3DTriangleFace,
     },
     CopyBitmapToTexture {
+        source: BitmapHandle,
+        dest: Rc<dyn Texture>,
+        layer: u32,
+    },
+    CopyBytesToTexture {
         source: Vec<u8>,
         source_width: u32,
         source_height: u32,


### PR DESCRIPTION
We now immediately flush our in-progress buffer CommandEncoder after executing a `CopyBitmapToTexture` command, to ensure that we don't pick up any future avm2-side changes to the BitmapData gpu texture.

The Vec -> gpu buffer copy implementation is moved to a new `CopyBytesToTexture` command, which we use for copying AGAL textures.