### PR TITLE
avm2: Add 'avm_caught' trace target to log caught exceptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,17 @@ This will also enable printing `trace()` statements.
 
 Additionally, if you build Ruffle with `--features avm_debug` then you will activate a few more built-in debugging utilities inside Ruffle, listed below.
 
+### Logging caught exceptions
+
+Some SWFs may catch and suppress exceptions, which can hide the fact that the SWF is trying to use an unimplemented definition. To log call caught exceptions:
+
+1. Add `avm_caught=info` to your `RUST_LOG` environment variable (e.g. `RUST_LOG=warn,avm_caught=debug`)
+2. Build ruffle with `--features avm_debug`
+
+Caught exceptions will be logged as "Caught exception: <exception object>"
+Note that some SWFs throw and catch exceptions as part of their normal control flow, so a caught exception
+does not necessarily indicate a bug in Ruffle.
+
 ### Warnings and Errors
 
 All AVM errors and warnings will print their stack trace so that you can view where they are in relation to the

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -808,6 +808,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 }
 
                 if matches {
+                    #[cfg(feature = "avm_debug")]
+                    tracing::info!(target: "avm_caught", "Caught exception: {:?}", Error::AvmError(error));
+
                     self.clear_stack();
                     self.push_stack(error);
 


### PR DESCRIPTION
When the `avm_debug` feature is enabled, we log all caught exceptions under the `avm_caught` target at INFO level. This is useful for debugging SWFs that catch and suppress exceptions, which can end up hiding errors from unimplemented flash APIs.