### PR TITLE
render,desktop: Update to `wgpu` `v22.1.0` and `egui` from `git`, remove `exclude_warp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,11 +238,11 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ash"
-version = "0.37.3+1.3.251"
+version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading 0.7.4",
+ "libloading",
 ]
 
 [[package]]
@@ -476,18 +476,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bitflags"
@@ -786,7 +786,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.5",
+ "libloading",
 ]
 
 [[package]]
@@ -1168,12 +1168,12 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "d3d12"
-version = "0.20.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
+checksum = "bdbd1f579714e3c809ebd822c81ef148b1ceaeb3d535352afc73fd0c4c6a0017"
 dependencies = [
  "bitflags 2.6.0",
- "libloading 0.8.5",
+ "libloading",
  "winapi",
 ]
 
@@ -1410,14 +1410,14 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.5",
+ "libloading",
 ]
 
 [[package]]
 name = "document-features"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
 dependencies = [
  "litrs",
 ]
@@ -1431,8 +1431,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "ecolor"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6b451ff1143f6de0f33fc7f1b68fecfd2c7de06e104de96c4514de3f5396f8"
+source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1441,8 +1440,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c97e70a2768de630f161bb5392cbd3874fcf72868f14df0e002e82e06cb798"
+source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
 dependencies = [
  "ahash",
  "emath",
@@ -1454,8 +1452,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c7a7c707877c3362a321ebb4f32be811c0b91f7aebf345fb162405c0218b4c"
+source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1473,8 +1470,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4e066af341bf92559f60dbdf2020b2a03c963415349af5f3f8d79ff7a4926"
+source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
 dependencies = [
  "ahash",
  "arboard",
@@ -1490,8 +1486,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb783d9fa348f69ed5c340aa25af78b5472043090e8b809040e30960cc2a746"
+source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
 dependencies = [
  "ahash",
  "egui",
@@ -1509,8 +1504,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
+source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
 dependencies = [
  "bytemuck",
 ]
@@ -1639,8 +1633,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0dcc0a0771e7500e94cd1cb797bd13c9f23b9409bdc3c824e2cbc562b7fa01"
+source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2247,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "glutin_wgl_sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+checksum = "0a4e1951bbd9434a81aa496fe59ccc2235af3820d27b85f9314e279609211e2c"
 dependencies = [
  "gl_generator",
 ]
@@ -2275,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
+checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
 dependencies = [
  "log",
  "presser",
@@ -2373,7 +2366,7 @@ dependencies = [
  "bitflags 2.6.0",
  "com",
  "libc",
- "libloading 0.8.5",
+ "libloading",
  "thiserror",
  "widestring",
  "winapi",
@@ -2809,7 +2802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.8.5",
+ "libloading",
  "pkg-config",
 ]
 
@@ -2836,16 +2829,6 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
 
 [[package]]
 name = "libloading"
@@ -3129,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
  "bitflags 2.6.0",
  "block",
@@ -3189,18 +3172,18 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.20.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
+checksum = "8bd5a652b6faf21496f2cfd88fc49989c8db0825d1f6746b1a71a6ede24a63ad"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.6.0",
+ "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
  "log",
- "num-traits",
  "rustc-hash",
  "spirv",
  "termcolor",
@@ -4162,7 +4145,7 @@ checksum = "ac633a08f39bf3268714799bd8c4a1a19c19c203d817d3448bb8b91c97817cf0"
 dependencies = [
  "bitflags 2.6.0",
  "float-cmp",
- "libloading 0.8.5",
+ "libloading",
  "once_cell",
  "renderdoc-sys",
  "winapi",
@@ -4574,7 +4557,7 @@ version = "0.1.0"
 dependencies = [
  "bzip2",
  "hex",
- "libloading 0.8.5",
+ "libloading",
  "md-5",
  "reqwest",
  "ruffle_render",
@@ -6235,12 +6218,11 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "0.20.1"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e37c7b9921b75dfd26dd973fdcbce36f13dfa6e2dc82aece584e0ed48c355c"
+checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
 dependencies = [
  "arrayvec",
- "cfg-if",
  "cfg_aliases 0.1.1",
  "document-features",
  "js-sys",
@@ -6261,15 +6243,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.21.1"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
+checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
- "codespan-reporting",
  "document-features",
  "indexmap",
  "log",
@@ -6281,16 +6262,15 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "thiserror",
- "web-sys",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "0.21.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
+checksum = "f6bbf4b4de8b2a83c0401d9e5ae0080a2792055f25859a02bf9be97952bbed4f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6310,7 +6290,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.5",
+ "libloading",
  "log",
  "metal",
  "naga",
@@ -6333,9 +6313,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.20.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
+checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",
@@ -6759,7 +6739,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading 0.8.5",
+ "libloading",
  "once_cell",
  "rustix",
  "x11rb-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,6 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -450,12 +447,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -509,9 +500,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitstream-io"
@@ -2636,7 +2624,6 @@ checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -3215,7 +3202,6 @@ dependencies = [
  "log",
  "num-traits",
  "rustc-hash",
- "serde",
  "spirv",
  "termcolor",
  "thiserror",
@@ -4195,7 +4181,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "cookie",
  "cookie_store",
@@ -4273,18 +4259,6 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "ron"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
-dependencies = [
- "base64 0.21.7",
- "bitflags 2.6.0",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -4634,7 +4608,7 @@ name = "ruffle_web"
 version = "0.1.0"
 dependencies = [
  "async-channel",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "console_error_panic_hook",
  "futures",
@@ -4763,7 +4737,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -6275,7 +6249,6 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle",
- "serde",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -6305,9 +6278,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle",
- "ron",
  "rustc-hash",
- "serde",
  "smallvec",
  "thiserror",
  "web-sys",
@@ -6368,7 +6339,6 @@ checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",
- "serde",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ version = "0.1.0"
 [workspace.dependencies]
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-naga = { version = "0.20.0", features = ["wgsl-out"] }
-wgpu = "0.20.1"
-egui = "0.28.1"
+naga = { version = "22.1.0", features = ["wgsl-out"] }
+wgpu = "22.1.0"
+egui = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf" }
 clap = { version = "4.5.13", features = ["derive"] }
 anyhow = "1.0"
 slotmap = "1.0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.9.4"
 egui = { workspace = true, optional = true }
-egui_extras = { version = "0.28.1", default-features = false, optional = true }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf", default-features = false, optional = true }
 png = { version = "0.17.13", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,8 @@ unknown-git = "deny"
 #  github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
+    # TODO: Remove once a release with https://github.com/emilk/egui/pull/4847 in it is out.
+    "emilk",
 ]
 
 [advisories]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -74,7 +74,6 @@ tracy = ["tracing-tracy", "ruffle_render_wgpu/profile-with-tracy"]
 
 # wgpu features
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]
-render_trace = ["ruffle_render_wgpu/render_trace"]
 
 # sandboxing
 sandbox = []

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 clap = { workspace = true }
 cpal = "0.15.3"
 egui = { workspace = true }
-egui_extras = { version = "0.28.1", default-features = false, features = ["image"] }
-egui-wgpu = { version = "0.28.1", features = ["winit"] }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf", default-features = false, features = ["image"] }
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf", features = ["winit"] }
 image = { workspace = true, features = ["png"] }
-egui-winit = "0.28.1"
+egui-winit = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf" }
 fontdb = "0.20"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -103,11 +103,6 @@ pub struct Opt {
     #[clap(long, action)]
     pub force_scale: bool,
 
-    /// Location to store a wgpu trace output
-    #[clap(long)]
-    #[cfg(feature = "render_trace")]
-    trace_path: Option<std::path::PathBuf>,
-
     /// Location to store save data for games.
     ///
     /// This option has no effect if `storage` is not `disk`.
@@ -271,17 +266,6 @@ fn parse_gamepad_button(mapping: &str) -> Result<(GamepadButton, KeyCode), Error
 }
 
 impl Opt {
-    #[cfg(feature = "render_trace")]
-    pub fn trace_path(&self) -> Option<&Path> {
-        if let Some(path) = &self.trace_path {
-            let _ = std::fs::create_dir_all(path);
-            Some(path)
-        } else {
-            None
-        }
-    }
-
-    #[cfg(not(feature = "render_trace"))]
     pub fn trace_path(&self) -> Option<&Path> {
         None
     }

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -108,7 +108,8 @@ impl GuiController {
             size.height,
             window.scale_factor(),
         ));
-        let egui_renderer = egui_wgpu::Renderer::new(&descriptors.device, surface_format, None, 1);
+        let egui_renderer =
+            egui_wgpu::Renderer::new(&descriptors.device, surface_format, None, 1, true);
         let descriptors = Arc::new(descriptors);
         let gui = RuffleGui::new(
             event_loop,

--- a/desktop/src/gui/movie.rs
+++ b/desktop/src/gui/movie.rs
@@ -120,6 +120,7 @@ impl MovieViewRenderer {
                 compilation_options: Default::default(),
             }),
             multiview: None,
+            cache: None,
         });
         let vertices = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: None,

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -24,5 +24,4 @@ anyhow = { workspace = true }
 [features]
 avm_debug = ["ruffle_core/avm_debug"]
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]
-render_trace = ["ruffle_render_wgpu/render_trace"]
 lzma = ["ruffle_core/lzma"]

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -73,11 +73,6 @@ struct Opt {
     #[clap(long, short, default_value = "high")]
     power: PowerPreference,
 
-    /// Location to store a wgpu trace output
-    #[clap(long)]
-    #[cfg(feature = "render_trace")]
-    trace_path: Option<PathBuf>,
-
     /// Skip unsupported movie types (currently AVM 2)
     #[clap(long, action)]
     skip_unsupported: bool,
@@ -382,17 +377,6 @@ fn capture_multiple_swfs(descriptors: Arc<Descriptors>, opt: &Opt) -> Result<()>
     Ok(())
 }
 
-#[cfg(feature = "render_trace")]
-fn trace_path(opt: &Opt) -> Option<&Path> {
-    if let Some(path) = &opt.trace_path {
-        let _ = std::fs::create_dir_all(path);
-        Some(path)
-    } else {
-        None
-    }
-}
-
-#[cfg(not(feature = "render_trace"))]
 fn trace_path(_opt: &Opt) -> Option<&Path> {
     None
 }

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -38,7 +38,6 @@ features = ["HtmlCanvasElement"]
 
 [features]
 render_debug_labels = []
-render_trace = ["wgpu/trace"]
 webgl = ["wgpu/webgl"]
 profile-with-tracy = ["profiling", "profiling/profile-with-tracy"]
 

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -1134,7 +1134,6 @@ async fn request_device(
 
     let try_features = [
         wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
-        wgpu::Features::SHADER_UNUSED_VERTEX_OUTPUT,
         wgpu::Features::TEXTURE_COMPRESSION_BC,
         wgpu::Features::FLOAT32_FILTERABLE,
     ];
@@ -1151,6 +1150,7 @@ async fn request_device(
                 label: None,
                 required_features: features,
                 required_limits: limits,
+                memory_hints: Default::default(),
             },
             trace_path,
         )

--- a/render/wgpu/src/context3d/current_pipeline.rs
+++ b/render/wgpu/src/context3d/current_pipeline.rs
@@ -521,6 +521,7 @@ impl CurrentPipeline {
                     alpha_to_coverage_enabled: false,
                 },
                 multiview: Default::default(),
+                cache: None,
             });
         Some((compiled, bind_group))
     }

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -130,6 +130,7 @@ impl Descriptors {
                                 alpha_to_coverage_enabled: false,
                             },
                             multiview: None,
+                            cache: None,
                         }),
                 )
             })
@@ -199,6 +200,7 @@ impl Descriptors {
                                 alpha_to_coverage_enabled: false,
                             },
                             multiview: None,
+                            cache: None,
                         }),
                 )
             })

--- a/render/wgpu/src/filters/bevel.rs
+++ b/render/wgpu/src/filters/bevel.rs
@@ -146,6 +146,7 @@ impl BevelFilter {
                         compilation_options: Default::default(),
                     }),
                     multiview: None,
+                    cache: None,
                 })
         })
     }

--- a/render/wgpu/src/filters/blur.rs
+++ b/render/wgpu/src/filters/blur.rs
@@ -141,6 +141,7 @@ impl BlurFilter {
                         compilation_options: Default::default(),
                     }),
                     multiview: None,
+                    cache: None,
                 })
         })
     }

--- a/render/wgpu/src/filters/color_matrix.rs
+++ b/render/wgpu/src/filters/color_matrix.rs
@@ -122,6 +122,7 @@ impl ColorMatrixFilter {
                         compilation_options: Default::default(),
                     }),
                     multiview: None,
+                    cache: None,
                 })
         })
     }

--- a/render/wgpu/src/filters/displacement_map.rs
+++ b/render/wgpu/src/filters/displacement_map.rs
@@ -159,6 +159,7 @@ impl DisplacementMapFilter {
                         compilation_options: Default::default(),
                     }),
                     multiview: None,
+                    cache: None,
                 })
         })
     }

--- a/render/wgpu/src/filters/glow.rs
+++ b/render/wgpu/src/filters/glow.rs
@@ -145,6 +145,7 @@ impl GlowFilter {
                         compilation_options: Default::default(),
                     }),
                     multiview: None,
+                    cache: None,
                 })
         })
     }

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -296,6 +296,7 @@ fn create_pipeline_descriptor<'a>(
             alpha_to_coverage_enabled: false,
         },
         multiview: None,
+        cache: None,
     }
 }
 

--- a/render/wgpu/src/pixel_bender.rs
+++ b/render/wgpu/src/pixel_bender.rs
@@ -89,6 +89,7 @@ impl PixelBenderWgpuShader {
                                 alpha_to_coverage_enabled: false,
                             },
                             multiview: Default::default(),
+                            cache: None,
                         }),
                 )
             })

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,7 @@ max_relative = 0.0 # The default relative tolerance for testing values that are 
 [player_options]
 max_execution_duration = { secs = 15, nanos = 0} # How long can actionscript execute for before being forcefully stopped
 viewport_dimensions = { width = 100, height = 100, scale_factor = 1 } # The size of the player. Defaults to the swfs stage size
-with_renderer = { optional = false, sample_count = 4, exclude_warp = false } # If this test requires a renderer to run. Optional will enable the renderer where available.
+with_renderer = { optional = false, sample_count = 4 } # If this test requires a renderer to run. Optional will enable the renderer where available.
 with_audio = false # If this test requires an audio backend to run.
 with_video = false # If this test requires a video decoder backend to run.
 runtime = "AIR" # The runtime to emulate ("FlashPlayer" or "AIR"). Defaults to "FlashPlayer"

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -388,7 +388,6 @@ impl ImageComparison {
 pub struct RenderOptions {
     optional: bool,
     pub sample_count: u32,
-    pub exclude_warp: bool,
 }
 
 impl Default for RenderOptions {
@@ -396,7 +395,6 @@ impl Default for RenderOptions {
         Self {
             optional: false,
             sample_count: 1,
-            exclude_warp: false,
         }
     }
 }

--- a/tests/tests/environment.rs
+++ b/tests/tests/environment.rs
@@ -76,16 +76,8 @@ mod renderer {
         }
     }
 
-    pub fn is_supported(requirements: &RenderOptions) -> bool {
-        if let Some(descriptors) = descriptors() {
-            let adapter_info = descriptors.adapter.get_info();
-            let is_warp =
-                cfg!(windows) && adapter_info.vendor == 5140 && adapter_info.device == 140;
-
-            !requirements.exclude_warp || !is_warp
-        } else {
-            false
-        }
+    pub fn is_supported(_requirements: &RenderOptions) -> bool {
+        descriptors().is_some()
     }
 
     static WGPU: OnceLock<Option<Arc<Descriptors>>> = OnceLock::new();

--- a/tests/tests/swfs/avm2/stage3d_raytrace/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_raytrace/test.toml
@@ -12,5 +12,4 @@ max_outliers = 10
 # This test runs very slowly on unoptimized `test` builds,
 # so give it plenty of time.
 max_execution_duration = { secs = 1000, nanos = 0 }
-# Exclude WARP due to https://github.com/gfx-rs/wgpu/issues/3193
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_sampler_partial_upload/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_sampler_partial_upload/test.toml
@@ -5,4 +5,4 @@ tolerance = 1
 max_outliers = 782
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }


### PR DESCRIPTION
Deduplicates the `base64` dependency (by dropping `ron`) and `libloading` (by updating `ash`).

I don't know how important is it to wait for the `trace` feature to be added back.

Also see the commit messages for a bit more info.