### PR TITLE
Small `AvmString` cleanup

### DIFF
--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -677,7 +677,7 @@ fn is_dependent<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(prim) = this.as_primitive() {
         if let Value::String(s) = *prim {
-            return Ok(s.owner().is_some().into());
+            return Ok(s.is_dependent().into());
         }
     }
     panic!();

--- a/core/src/string/interner.rs
+++ b/core/src/string/interner.rs
@@ -157,7 +157,7 @@ impl<'gc> AvmStringInterner<'gc> {
                 }
             }
         }
-        AvmString::new_dependent(mc, s, start_index, end_index)
+        AvmString::substring(mc, s, start_index, end_index)
     }
 }
 

--- a/core/src/string/repr.rs
+++ b/core/src/string/repr.rs
@@ -1,10 +1,8 @@
 use std::cell::Cell;
 use std::ops::Deref;
 
-use gc_arena::Collect;
+use gc_arena::{Collect, Gc};
 use ruffle_wstr::{panic_on_invalid_length, ptr as wptr, wstr_impl_traits, WStr, WString};
-
-use crate::string::avm_string::AvmString;
 
 /// Internal representation of `AvmAtom`s and (owned) `AvmString`.
 ///
@@ -22,7 +20,6 @@ pub struct AvmStringRepr<'gc> {
 
     // We abuse WStrMetadata to store capacity and is_interned bit.
     // If a string is Dependent, the capacity should always be 0.
-    #[collect(require_static)]
     capacity: Cell<wptr::WStrMetadata>,
 
     // If a string is Dependent, this should always be 0.
@@ -30,11 +27,10 @@ pub struct AvmStringRepr<'gc> {
     // Example: assume a string a="abc" has 10 bytes of capacity (chars_used=3).
     // Then, with a+"d", we produce a dependent string and owner's chars_used becomes 4.
     // len <= chars_used <= capacity.
-    #[collect(require_static)]
     chars_used: Cell<u32>,
 
     // If Some, the string is dependent. The owner is assumed to be non-dynamic.
-    owner: Option<AvmString<'gc>>,
+    owner: Option<Gc<'gc, Self>>,
 }
 
 impl<'gc> AvmStringRepr<'gc> {
@@ -50,128 +46,105 @@ impl<'gc> AvmStringRepr<'gc> {
         }
     }
 
-    pub fn new_dependent(s: AvmString<'gc>, start: usize, end: usize) -> Self {
+    pub fn new_dependent(s: Gc<'gc, Self>, start: usize, end: usize) -> Self {
         let wstr = &s[start..end];
         let wstr_ptr = wstr as *const WStr;
 
-        let meta = unsafe { wptr::WStrMetadata::of(wstr_ptr) };
-        // Dependent strings are never interned
-        let capacity = Cell::new(wptr::WStrMetadata::new32(0, false));
-        let ptr = wstr_ptr as *mut WStr as *mut ();
-
-        let owner = if let Some(owner) = s.owner() {
-            owner
-        } else {
-            s
-        };
-
         Self {
-            owner: Some(owner),
-            ptr,
-            meta,
+            owner: Some(s.owner().unwrap_or(s)),
+            ptr: wstr_ptr as *mut WStr as *mut (),
+            meta: unsafe { wptr::WStrMetadata::of(wstr_ptr) },
             chars_used: Cell::new(0),
-            capacity,
+            // Dependent strings are never interned
+            capacity: Cell::new(wptr::WStrMetadata::new32(0, false)),
         }
     }
 
     unsafe fn new_dependent_raw(
-        owner: AvmString<'gc>,
+        owner: Gc<'gc, Self>,
         ptr: *const u8,
         length: u32,
         is_wide: bool,
     ) -> Self {
-        let meta = wptr::WStrMetadata::new32(length, is_wide);
-        // Dependent strings are never interned
-        let capacity = Cell::new(wptr::WStrMetadata::new32(0, false));
-        let ptr = ptr as *mut ();
-
         Self {
             owner: Some(owner),
-            ptr,
-            meta,
+            ptr: ptr as *mut (),
+            meta: wptr::WStrMetadata::new32(length, is_wide),
             chars_used: Cell::new(0),
-            capacity,
+            // Dependent strings are never interned
+            capacity: Cell::new(wptr::WStrMetadata::new32(0, false)),
         }
     }
 
-    pub fn try_append_inline(left: AvmString<'gc>, right: &WStr) -> Option<Self> {
+    pub fn try_append_inline(left: Gc<'gc, Self>, right: &WStr) -> Option<Self> {
         // note: we could also in-place append a byte string to a wide string
         // But it was skipped for now.
         if left.is_wide() != right.is_wide() {
             return None;
         }
 
-        let left_origin_s = left.owner().unwrap_or(left);
-        if let (Some(left), Some(left_origin)) = (left.as_managed(), left_origin_s.as_managed()) {
-            let char_size = if left.is_wide() { 2 } else { 1 };
+        let left_origin = left.owner().unwrap_or(left);
+        let char_size = if left.is_wide() { 2 } else { 1 };
+        /*
+            assumptions:
+            - left.len <= left.chars_used <= left.capacity
+            - left_ptr is inside left_origin_ptr .. left_origin_ptr + left.chars_used
+
+            note: it's possible that left == left_origin.
+        */
+        unsafe {
+            let left_origin_ptr = left_origin.ptr as *const u8;
+            let left_ptr = left.ptr as *const u8;
+
             /*
-                assumptions:
-                - left.len <= left.chars_used <= left.capacity
-                - left_ptr is inside left_origin_ptr .. left_origin_ptr + left.chars_used
+            Assume a="abc", b=a+"d", c=a.substr(1), we're running d=c+"e"
 
-                note: it's possible that left == left_origin.
+            a          ->  abc
+            b          ->  abcd
+            c          ->   bc        v left_capacity_end
+            a's memory ->  abcd_______
+                                ^ first_requested
+                                ^ first_available
+
+            We can only append in-place if first_requested and first_available match
+            And we have enough spare capacity.
             */
-            unsafe {
-                let left_origin_ptr = left_origin.ptr as *const u8;
-                let left_ptr = left.ptr as *const u8;
 
-                /*
-                Assume a="abc", b=a+"d", c=a.substr(1), we're running d=c+"e"
+            let first_available =
+                left_origin_ptr.add(char_size * left_origin.chars_used.get() as usize);
+            let first_requested = left_ptr.add(char_size * left.len());
 
-                a          ->  abc
-                b          ->  abcd
-                c          ->   bc        v left_capacity_end
-                a's memory ->  abcd_______
-                                  ^ first_requested
-                                   ^ first_available
+            let mut chars_available = 0;
+            if first_available == first_requested {
+                let left_capacity_end =
+                    left_origin_ptr.add(char_size * left_origin.capacity.get().len());
+                chars_available =
+                    ((left_capacity_end as usize) - (first_available as usize)) / char_size;
+            }
+            if chars_available >= right.len() {
+                let first_available = first_available as *mut u8;
+                let right_ptr = right as *const WStr as *const () as *const u8;
+                std::ptr::copy_nonoverlapping(right_ptr, first_available, char_size * right.len());
 
-                We can only append in-place if first_requested and first_available match
-                And we have enough spare capacity.
-                */
-
-                let first_available =
-                    left_origin_ptr.add(char_size * left_origin.chars_used.get() as usize);
-                let first_requested = left_ptr.add(char_size * left.len());
-
-                let mut chars_available = 0;
-                if first_available == first_requested {
-                    let left_capacity_end =
-                        left_origin_ptr.add(char_size * left_origin.capacity.get().len());
-                    chars_available =
-                        ((left_capacity_end as usize) - (first_available as usize)) / char_size;
+                let new_chars_used: usize = left_origin.chars_used.get() as usize + right.len();
+                if new_chars_used >= u32::MAX as usize {
+                    // This isn't really about the string length,
+                    // but it's close enough?
+                    panic_on_invalid_length(new_chars_used);
                 }
-                if chars_available >= right.len() {
-                    let first_available = first_available as *mut u8;
-                    let right_ptr = right as *const WStr as *const () as *const u8;
-                    std::ptr::copy_nonoverlapping(
-                        right_ptr,
-                        first_available,
-                        char_size * right.len(),
-                    );
+                left_origin.chars_used.set(new_chars_used as u32);
 
-                    let new_chars_used: usize = left_origin.chars_used.get() as usize + right.len();
-                    if new_chars_used >= u32::MAX as usize {
-                        // This isn't really about the string length,
-                        // but it's close enough?
-                        panic_on_invalid_length(new_chars_used);
-                    }
-                    left_origin.chars_used.set(new_chars_used as u32);
-
-                    let new_len = left.len() + right.len();
-                    if new_len > WStr::MAX_LEN {
-                        panic_on_invalid_length(new_len);
-                    }
-
-                    let ret = Self::new_dependent_raw(
-                        left_origin_s,
-                        left_ptr,
-                        new_len as u32,
-                        left.is_wide(),
-                    );
-                    return Some(ret);
+                let new_len = left.len() + right.len();
+                if new_len > WStr::MAX_LEN {
+                    panic_on_invalid_length(new_len);
                 }
+
+                let ret =
+                    Self::new_dependent_raw(left_origin, left_ptr, new_len as u32, left.is_wide());
+                return Some(ret);
             }
         }
+
         None
     }
 
@@ -181,7 +154,7 @@ impl<'gc> AvmStringRepr<'gc> {
     }
 
     #[inline]
-    pub fn owner(&self) -> Option<AvmString<'gc>> {
+    pub fn owner(&self) -> Option<Gc<'gc, Self>> {
         self.owner
     }
 


### PR DESCRIPTION
Small `AvmString`-related cleanups and optimisations:

- Rename `Source::Owned` to `Source::Managed`, to avoid confusion with the owned/depending distinction in `AvmStringRepr`
- Store a raw `Gc<AvmStringRepr>` instead of an `AvmString` in `AvmStringRepr`'s `owner` field; there's no reason to ever make a dependant string pointing to a static `AvmString`.