### PR TITLE
web: Use CSS scale attribute instead of non-existent scale property

### DIFF
--- a/web/packages/core/src/internal/ui/container.tsx
+++ b/web/packages/core/src/internal/ui/container.tsx
@@ -21,7 +21,7 @@ export function MainContainer() {
             <div id="unmute-overlay">
                 <div class="background"></div>
                 <div class="icon">
-                    <svg id="unmute-overlay-svg" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid" viewBox="0 0 512 584" width="100%" height="100%" scale="0.8">
+                    <svg id="unmute-overlay-svg" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid" viewBox="0 0 512 584" width="100%" height="100%">
                         <path xmlns="http://www.w3.org/2000/svg" fill="#FFF" stroke="#FFF" d="m457.941 256 47.029-47.029c9.372-9.373 9.372-24.568 0-33.941-9.373-9.373-24.568-9.373-33.941 0l-47.029 47.029-47.029-47.029c-9.373-9.373-24.568-9.373-33.941 0-9.372 9.373-9.372 24.568 0 33.941l47.029 47.029-47.029 47.029c-9.372 9.373-9.372 24.568 0 33.941 4.686 4.687 10.827 7.03 16.97 7.03s12.284-2.343 16.971-7.029l47.029-47.03 47.029 47.029c4.687 4.687 10.828 7.03 16.971 7.03s12.284-2.343 16.971-7.029c9.372-9.373 9.372-24.568 0-33.941z"></path>
                         <path xmlns="http://www.w3.org/2000/svg" fill="#FFF" stroke="#FFF" d="m99 160h-55c-24.301 0-44 19.699-44 44v104c0 24.301 19.699 44 44 44h55c2.761 0 5-2.239 5-5v-182c0-2.761-2.239-5-5-5z"></path>
                         <path xmlns="http://www.w3.org/2000/svg" fill="#FFF" stroke="#FFF" d="m280 56h-24c-5.269 0-10.392 1.734-14.578 4.935l-103.459 79.116c-1.237.946-1.963 2.414-1.963 3.972v223.955c0 1.557.726 3.026 1.963 3.972l103.459 79.115c4.186 3.201 9.309 4.936 14.579 4.936h23.999c13.255 0 24-10.745 24-24v-352.001c0-13.255-10.745-24-24-24z"></path>

--- a/web/packages/core/src/internal/ui/static-styles.css
+++ b/web/packages/core/src/internal/ui/static-styles.css
@@ -81,6 +81,10 @@
     opacity: 1;
 }
 
+#unmute-overlay-svg {
+    scale: 0.8;
+}
+
 /* Includes inverted colors from play button! */
 #panic {
     font-size: 20px;


### PR DESCRIPTION
This has been incorrect since https://github.com/ruffle-rs/ruffle/pull/6843. The SVG `scale` attribute only exists on \<feDisplacementMap>: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/scale