### PR TITLE
Revert "ci: Don't test on Edge as the latest release is missing for Linux"

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -96,7 +96,7 @@ jobs:
         # Don't run browser tests on Windows because it's flaky for unknown reasons. :-(
         if: runner.os == 'Linux'
         working-directory: web
-        run: npm run wdio -- --headless --chrome --firefox
+        run: npm run wdio -- --headless --chrome --firefox --edge
 
   check-required:
     needs: changes


### PR DESCRIPTION
Reverts ruffle-rs/ruffle#17253
To be merged once https://github.com/MicrosoftEdge/EdgeWebDriver/issues/156 is fixed.