### PR TITLE
tests: Fix some image tests failing locally

### DIFF
--- a/tests/tests/swfs/avm2/netstream_seek_flv/test.toml
+++ b/tests/tests/swfs/avm2/netstream_seek_flv/test.toml
@@ -1,7 +1,7 @@
 num_ticks=60
 
 [image_comparisons.output]
-tolerance = 4
+tolerance = 30
 max_outliers = 271
 
 [player_options]

--- a/tests/tests/swfs/avm2/stage3d_blend/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_blend/test.toml
@@ -1,7 +1,7 @@
 num_frames = 1
 
 [image_comparisons.output]
-tolerance = 2
+tolerance = 3
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_raytrace/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_raytrace/test.toml
@@ -6,7 +6,7 @@ num_frames = 80
 
 [image_comparisons.output]
 tolerance = 1
-max_outliers = 6
+max_outliers = 10
 
 [player_options]
 # This test runs very slowly on unoptimized `test` builds,

--- a/tests/tests/swfs/from_shumway/flash_geom_ColorTransform/test.toml
+++ b/tests/tests/swfs/from_shumway/flash_geom_ColorTransform/test.toml
@@ -1,7 +1,7 @@
 num_frames = 1
 
 [image_comparisons.output]
-tolerance = 0
+tolerance = 1
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }


### PR DESCRIPTION
Some tests were failing on my system despite producing valid results. This PR updates tolerance for their output comparison.

~~... and replaces image output of `netstream_seek_flv` with FP's original output (lets see how it performs on other platforms)~~ — that did not help, I increased tolerance instead.