### PR TITLE
[AVM1 debug ui] Make some object properties editable

### DIFF
--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -12,6 +12,8 @@ pub struct Avm1ObjectWindow {
     key_filter_string: String,
     edited_key: Option<String>,
     value_edit_buf: String,
+    /// True if the active text edit should be focused (after clicking 'edit', etc.)
+    focus_text_edit: bool,
 }
 
 impl Avm1ObjectWindow {
@@ -139,7 +141,12 @@ impl Avm1ObjectWindow {
             .is_some_and(|edit_key| *edit_key == key.to_utf8_lossy())
         {
             ui.horizontal(|ui| {
-                ui.add(egui::TextEdit::singleline(&mut self.value_edit_buf).desired_width(96.0));
+                let re = ui
+                    .add(egui::TextEdit::singleline(&mut self.value_edit_buf).desired_width(96.0));
+                if self.focus_text_edit {
+                    re.request_focus();
+                    self.focus_text_edit = false;
+                }
                 match self.value_edit_buf.parse::<f64>() {
                     Ok(num) => {
                         if ui.input(|inp| inp.key_pressed(egui::Key::Enter))
@@ -165,6 +172,7 @@ impl Avm1ObjectWindow {
                 if ui.button("✏").on_hover_text("Edit").clicked() {
                     self.edited_key = Some(key.to_utf8_lossy().into_owned());
                     self.value_edit_buf = num_str;
+                    self.focus_text_edit = true;
                 }
             });
         }

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -3,12 +3,17 @@ use crate::context::UpdateContext;
 use crate::debug_ui::display_object::open_display_object_button;
 use crate::debug_ui::handle::{AVM1ObjectHandle, DisplayObjectHandle};
 use crate::debug_ui::Message;
+use crate::string::AvmString;
 use egui::{Grid, Id, TextEdit, Ui, Window};
+use std::collections::HashMap;
+
+type ValueEditBuffers = HashMap<usize, String>;
 
 #[derive(Debug, Default)]
 pub struct Avm1ObjectWindow {
     hovered_debug_rect: Option<DisplayObjectHandle>,
     key_filter_string: String,
+    value_edit_buffers: ValueEditBuffers,
 }
 
 impl Avm1ObjectWindow {
@@ -57,6 +62,8 @@ impl Avm1ObjectWindow {
                             if let Some(new) = show_avm1_value(
                                 ui,
                                 &mut activation,
+                                &mut self.value_edit_buffers,
+                                &key,
                                 value,
                                 messages,
                                 &mut self.hovered_debug_rect,
@@ -85,12 +92,56 @@ fn object_name(object: Object) -> String {
     }
 }
 
+fn num_edit_ui(
+    ui: &mut Ui,
+    value_edit_buffers: &mut ValueEditBuffers,
+    key: &AvmString,
+    num: f64,
+) -> Option<f64> {
+    let mut new_val = None;
+    let ptr = key.as_wstr() as *const _ as *const () as usize;
+    match value_edit_buffers.get_mut(&ptr) {
+        Some(buf) => {
+            let mut remove = false;
+            ui.horizontal(|ui| {
+                ui.add(egui::TextEdit::singleline(buf).desired_width(96.0));
+                match buf.parse::<f64>() {
+                    Ok(num) => {
+                        if ui.button("set").clicked() {
+                            new_val = Some(num);
+                            remove = true;
+                        }
+                    }
+                    Err(e) => {
+                        ui.add_enabled(false, egui::Button::new("set"))
+                            .on_disabled_hover_text(e.to_string());
+                    }
+                }
+            });
+            if remove {
+                value_edit_buffers.remove(&ptr);
+            }
+        }
+        None => {
+            ui.horizontal(|ui| {
+                ui.label(num.to_string());
+                if ui.button("edit").clicked() {
+                    value_edit_buffers.insert(ptr, num.to_string());
+                }
+            });
+        }
+    }
+    new_val
+}
+
 /// Shows an egui widget to inspect and (for certain value types) edit an AVM1 value.
 ///
 /// Optionally returns the updated value, if the user edited it.
 pub fn show_avm1_value<'gc>(
     ui: &mut Ui,
     activation: &mut Activation<'_, 'gc>,
+    value_edit_buffers: &mut ValueEditBuffers,
+    key: &AvmString,
     value: Result<Value<'gc>, Error<'gc>>,
     messages: &mut Vec<Message>,
     hover: &mut Option<DisplayObjectHandle>,
@@ -107,10 +158,9 @@ pub fn show_avm1_value<'gc>(
                 return Some(Value::Bool(value));
             }
         }
-        Ok(Value::Number(mut value)) => {
-            if ui.add(egui::DragValue::new(&mut value)).changed() {
-                return Some(Value::Number(value));
-            }
+        Ok(Value::Number(value)) => {
+            return num_edit_ui(ui, value_edit_buffers, key, value)
+                .map(|float| Value::Number(float));
         }
         Ok(Value::String(value)) => {
             TextEdit::singleline(&mut value.to_string()).show(ui);

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -168,22 +168,27 @@ fn num_edit_ui(
             ui.add(egui::TextEdit::singleline(edit_buf).desired_width(96.0));
             match edit_buf.parse::<f64>() {
                 Ok(num) => {
-                    if ui.button("set").clicked() {
+                    if ui.input(|inp| inp.key_pressed(egui::Key::Enter))
+                        || ui.button("✔").on_hover_text("Set").clicked()
+                    {
                         new_val = Some(num);
                         *edited_key = None;
                     }
                 }
                 Err(e) => {
-                    ui.add_enabled(false, egui::Button::new("set"))
+                    ui.add_enabled(false, egui::Button::new("✔"))
                         .on_disabled_hover_text(e.to_string());
                 }
+            }
+            if ui.button("🗙").on_hover_text("Cancel").clicked() {
+                *edited_key = None;
             }
         });
     } else {
         ui.horizontal(|ui| {
             let num_str = num.to_string();
             ui.label(&num_str);
-            if ui.button("edit").clicked() {
+            if ui.button("✏").on_hover_text("Edit").clicked() {
                 *edited_key = Some(key.to_utf8_lossy().into_owned());
                 *edit_buf = num_str;
             }

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -52,9 +52,9 @@ impl Avm1ObjectWindow {
                         keys.retain(|key| {
                             self.key_filter_string.is_empty()
                                 || key
-                                .to_string()
-                                .to_ascii_lowercase()
-                                .contains(&self.key_filter_string.to_ascii_lowercase())
+                                    .to_string()
+                                    .to_ascii_lowercase()
+                                    .contains(&self.key_filter_string.to_ascii_lowercase())
                         });
 
                         for key in keys {

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -85,6 +85,9 @@ fn object_name(object: Object) -> String {
     }
 }
 
+/// Shows an egui widget to inspect and (for certain value types) edit an AVM1 value.
+///
+/// Optionally returns the updated value, if the user edited it.
 pub fn show_avm1_value<'gc>(
     ui: &mut Ui,
     activation: &mut Activation<'_, 'gc>,

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -52,9 +52,9 @@ impl Avm1ObjectWindow {
                         keys.retain(|key| {
                             self.key_filter_string.is_empty()
                                 || key
-                                    .to_string()
-                                    .to_ascii_lowercase()
-                                    .contains(&self.key_filter_string.to_ascii_lowercase())
+                                .to_string()
+                                .to_ascii_lowercase()
+                                .contains(&self.key_filter_string.to_ascii_lowercase())
                         });
 
                         for key in keys {
@@ -111,7 +111,7 @@ impl Avm1ObjectWindow {
                             ui.label("Function");
                         } else if ui.button(object_name(value)).clicked() {
                             messages.push(Message::TrackAVM1Object(AVM1ObjectHandle::new(
-                                &mut activation.context,
+                                activation.context,
                                 value,
                             )));
                         }
@@ -120,7 +120,7 @@ impl Avm1ObjectWindow {
                         if let Some((_, _, object)) = value.resolve_reference(activation) {
                             open_display_object_button(
                                 ui,
-                                &mut activation.context,
+                                activation.context,
                                 messages,
                                 object,
                                 &mut self.hovered_debug_rect,

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -4,7 +4,7 @@ use crate::debug_ui::display_object::open_display_object_button;
 use crate::debug_ui::handle::{AVM1ObjectHandle, DisplayObjectHandle};
 use crate::debug_ui::Message;
 use crate::string::AvmString;
-use egui::{Grid, Id, TextEdit, Ui, Window};
+use egui::{Grid, Id, TextBuffer, TextEdit, Ui, Window};
 
 #[derive(Debug, Default)]
 pub struct Avm1ObjectWindow {
@@ -99,7 +99,9 @@ impl Avm1ObjectWindow {
                 return self.num_edit_ui(ui, key, value).map(Value::Number);
             }
             Ok(Value::String(value)) => {
-                TextEdit::singleline(&mut value.to_string()).show(ui);
+                return self
+                    .string_edit_ui(ui, key, value)
+                    .map(|string| Value::String(AvmString::new_utf8(activation.gc(), string)));
             }
             Ok(Value::Object(value)) => {
                 if value.as_executable().is_some() {
@@ -150,18 +152,18 @@ impl Avm1ObjectWindow {
                 match self.value_edit_buf.parse::<f64>() {
                     Ok(num) => {
                         if ui.input(|inp| inp.key_pressed(egui::Key::Enter))
-                            || ui.button("✔").on_hover_text("Set").clicked()
+                            || ui.set_button().clicked()
                         {
                             new_val = Some(num);
                             self.edited_key = None;
                         }
                     }
                     Err(e) => {
-                        ui.add_enabled(false, egui::Button::new("✔"))
+                        ui.add_enabled(false, egui::Button::new(CHECKMARK_ICON))
                             .on_disabled_hover_text(e.to_string());
                     }
                 }
-                if ui.button("🗙").on_hover_text("Cancel").clicked() {
+                if ui.cancel_button().clicked() {
                     self.edited_key = None;
                 }
             });
@@ -169,7 +171,7 @@ impl Avm1ObjectWindow {
             ui.horizontal(|ui| {
                 let num_str = num.to_string();
                 ui.label(&num_str);
-                if ui.button("✏").on_hover_text("Edit").clicked() {
+                if ui.edit_button().clicked() {
                     self.edited_key = Some(key.to_utf8_lossy().into_owned());
                     self.value_edit_buf = num_str;
                     self.focus_text_edit = true;
@@ -177,6 +179,64 @@ impl Avm1ObjectWindow {
             });
         }
         new_val
+    }
+    fn string_edit_ui(
+        &mut self,
+        ui: &mut Ui,
+        key: &AvmString,
+        string: AvmString,
+    ) -> Option<String> {
+        let mut new_val = None;
+        ui.horizontal(|ui| {
+            if self
+                .edited_key
+                .as_ref()
+                .is_some_and(|edit_key| *edit_key == key.to_utf8_lossy())
+            {
+                let re = ui.add(TextEdit::singleline(&mut self.value_edit_buf).desired_width(96.0));
+                if self.focus_text_edit {
+                    re.request_focus();
+                    self.focus_text_edit = false;
+                }
+                if ui.set_button().clicked() {
+                    new_val = Some(self.value_edit_buf.take());
+                    self.edited_key = None;
+                }
+                if ui.cancel_button().clicked() {
+                    self.edited_key = None;
+                }
+            } else {
+                ui.label(string.to_utf8_lossy());
+                if ui.edit_button().clicked() {
+                    self.value_edit_buf = string.to_string();
+                    self.edited_key = Some(key.to_string());
+                    self.focus_text_edit = true;
+                }
+            }
+        });
+        new_val
+    }
+}
+
+const PENCIL_ICON: &str = "✏";
+const CHECKMARK_ICON: &str = "✔";
+const CANCEL_ICON: &str = "🗙";
+
+trait UiExt {
+    fn edit_button(&mut self) -> egui::Response;
+    fn set_button(&mut self) -> egui::Response;
+    fn cancel_button(&mut self) -> egui::Response;
+}
+
+impl UiExt for egui::Ui {
+    fn edit_button(&mut self) -> egui::Response {
+        self.button(PENCIL_ICON).on_hover_text("Edit")
+    }
+    fn set_button(&mut self) -> egui::Response {
+        self.button(CHECKMARK_ICON).on_hover_text("Set")
+    }
+    fn cancel_button(&mut self) -> egui::Response {
+        self.button(CANCEL_ICON).on_hover_text("Cancel")
     }
 }
 

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -5,12 +5,13 @@ use crate::debug_ui::handle::{AVM1ObjectHandle, DisplayObjectHandle};
 use crate::debug_ui::Message;
 use crate::string::AvmString;
 use egui::{Grid, Id, TextBuffer, TextEdit, Ui, Window};
+use ruffle_wstr::WString;
 
 #[derive(Debug, Default)]
 pub struct Avm1ObjectWindow {
     hovered_debug_rect: Option<DisplayObjectHandle>,
     key_filter_string: String,
-    edited_key: Option<String>,
+    edited_key: Option<WString>,
     value_edit_buf: String,
     /// True if the active text edit should be focused (after clicking 'edit', etc.)
     focus_text_edit: bool,
@@ -140,7 +141,7 @@ impl Avm1ObjectWindow {
         if self
             .edited_key
             .as_ref()
-            .is_some_and(|edit_key| *edit_key == key.to_utf8_lossy())
+            .is_some_and(|edit_key| *edit_key == key.as_wstr())
         {
             ui.horizontal(|ui| {
                 let re = ui
@@ -172,7 +173,7 @@ impl Avm1ObjectWindow {
                 let num_str = num.to_string();
                 ui.label(&num_str);
                 if ui.edit_button().clicked() {
-                    self.edited_key = Some(key.to_utf8_lossy().into_owned());
+                    self.edited_key = Some(key.as_wstr().to_owned());
                     self.value_edit_buf = num_str;
                     self.focus_text_edit = true;
                 }
@@ -191,7 +192,7 @@ impl Avm1ObjectWindow {
             if self
                 .edited_key
                 .as_ref()
-                .is_some_and(|edit_key| *edit_key == key.to_utf8_lossy())
+                .is_some_and(|edit_key| *edit_key == key.as_wstr())
             {
                 let re = ui.add(TextEdit::singleline(&mut self.value_edit_buf).desired_width(96.0));
                 if self.focus_text_edit {
@@ -209,7 +210,7 @@ impl Avm1ObjectWindow {
                 ui.label(string.to_utf8_lossy());
                 if ui.edit_button().clicked() {
                     self.value_edit_buf = string.to_string();
-                    self.edited_key = Some(key.to_string());
+                    self.edited_key = Some(key.as_wstr().to_owned());
                     self.focus_text_edit = true;
                 }
             }


### PR DESCRIPTION
Changing object properties can be useful for helping debugging games, or just cheating/general messing around.

Also adds a filter to quickly find fields of interest.

Todo
- [ ] ~~Attempt to add AVM2 support~~
   AVM2 debug ui code would require significant changes to add editing support, and I want to keep this pull request fairly simple. Perhaps a followup/intermediate step would be some refactoring and unification work on the AVM1 and AVM2 debug UI code.
- [x] Optionally try to add support to change type of a value
- [x] Try using `WString` as key instead of `String`

Screenshot of what it looks like:
![image](https://github.com/user-attachments/assets/d41196a1-2e37-4faf-96a7-c5a574896acb)

