### PR TITLE
avm2: Fix a bunch of API mismatches (versions/base class/accessors)

### DIFF
--- a/core/src/avm2/globals/flash/display/FrameLabel.as
+++ b/core/src/avm2/globals/flash/display/FrameLabel.as
@@ -1,5 +1,7 @@
 package flash.display {
-    public final class FrameLabel {
+    import flash.events.EventDispatcher;
+
+    public final class FrameLabel extends EventDispatcher {
         private var _name: String;
         private var _frame: int;
 

--- a/core/src/avm2/globals/flash/display/Stage.as
+++ b/core/src/avm2/globals/flash/display/Stage.as
@@ -75,10 +75,6 @@ package flash.display {
             throw new IllegalOperationError("Error #2071: The Stage class does not implement this property or method.", 2071);
         }
 
-        public function set loaderInfo(value:LoaderInfo):void {
-            throw new IllegalOperationError("Error #2071: The Stage class does not implement this property or method.", 2071);
-        }
-
         override public function set mask(value:DisplayObject):void {
             throw new IllegalOperationError("Error #2071: The Stage class does not implement this property or method.", 2071);
         }

--- a/core/src/avm2/globals/flash/events/Event.as
+++ b/core/src/avm2/globals/flash/events/Event.as
@@ -79,6 +79,7 @@ package flash.events {
 
 		public static const VIDEO_FRAME:String = "videoFrame";
 
+		[API("681")]
 		public static const SUSPEND:String = "suspend";
 
 		public static const CHANNEL_MESSAGE:String = "channelMessage";

--- a/core/src/avm2/globals/flash/events/FocusEvent.as
+++ b/core/src/avm2/globals/flash/events/FocusEvent.as
@@ -31,6 +31,7 @@ package flash.events
         public var keyCode: uint;
 
         // Specifies direction of focus for a focusIn event.
+        [API("661")]
         public var direction: String;
 
         // If true, the relatedObject property is set to null for reasons related to security sandboxes.

--- a/core/src/avm2/globals/flash/events/HTTPStatusEvent.as
+++ b/core/src/avm2/globals/flash/events/HTTPStatusEvent.as
@@ -7,12 +7,16 @@ package flash.events
     
     public class HTTPStatusEvent extends Event
     {
+        [API("661")]
         public static const HTTP_RESPONSE_STATUS:String = "httpResponseStatus"; // Unlike the httpStatus event, the httpResponseStatus event is delivered before any response data.
         public static const HTTP_STATUS:String = "httpStatus"; // The HTTPStatusEvent.HTTP_STATUS constant defines the value of the type property of a httpStatus event object.
 
         private var _status: int; // The HTTP status code returned by the server.
         public var redirected: Boolean; // Indicates whether the request was redirected.
+
+        [API("661")]
         public var responseHeaders: Array; // The response headers that the response returned, as an array of URLRequestHeader objects.
+        [API("661")]
         public var responseURL: String; // The URL that the response was returned from.
 
         public function HTTPStatusEvent(type:String, bubbles:Boolean = false, cancelable:Boolean = false, status:int = 0, redirected:Boolean = false)

--- a/core/src/avm2/globals/flash/events/TouchEvent.as
+++ b/core/src/avm2/globals/flash/events/TouchEvent.as
@@ -68,12 +68,14 @@ public class TouchEvent extends Event {
     }
 
     // Updates the specified ByteArray object with the high-frequency data points for a multi-point touch event.
+    [API("675")]
     public function getSamples(buffer: ByteArray, append: Boolean = false): uint {
         stub_method("flash.events.TouchEvent", "getSamples");
         return 0;
     }
 
     // Reports that the hardware button at the specified index is pressed.
+    [API("675")]
     public function isToolButtonDown(index: int): Boolean {
         stub_method("flash.events.TouchEvent", "isToolButtonDown");
         return false;

--- a/core/src/avm2/globals/flash/net/FileReference.as
+++ b/core/src/avm2/globals/flash/net/FileReference.as
@@ -47,6 +47,7 @@ package flash.net
 
         public native function load():void;
 
+        [API("681")]
         public function requestPermission():void {
             stub_method("flash.net.FileReference", "requestPermission");
         }
@@ -57,6 +58,7 @@ package flash.net
             stub_method("flash.net.FileReference", "upload");
         }
 
+        [API("681")]
         public function uploadUnencoded(request:URLRequest):void {
             stub_method("flash.net.FileReference", "uploadUnencoded");
         }

--- a/core/src/avm2/globals/flash/net/NetStream.as
+++ b/core/src/avm2/globals/flash/net/NetStream.as
@@ -57,6 +57,7 @@ package flash.net {
             stub_method("flash.net.NetStream", "play2");
         }
 
+        [API("663")]
         public function preloadEmbeddedData(param:NetStreamPlayOptions) {
             stub_method("flash.net.NetStream", "preloadEmbeddedData");
         }
@@ -89,6 +90,7 @@ package flash.net {
             stub_method("flash.net.NetStream", "send");
         }
 
+        [API("661")]
         public function setDRMAuthenticationCredentials(userName:String, password:String, type:String) {
             stub_method("flash.net.NetStream", "setDRMAuthenticationCredentials");
         }

--- a/core/src/avm2/globals/flash/net/URLRequestDefaults.as
+++ b/core/src/avm2/globals/flash/net/URLRequestDefaults.as
@@ -9,6 +9,7 @@ package flash.net
     import __ruffle__.stub_getter;
     import __ruffle__.stub_setter;
 
+    [API("661")]
     public class URLRequestDefaults
     {
         // The default setting for the authenticate property of URLRequest objects.

--- a/core/src/avm2/globals/flash/system/IME.as
+++ b/core/src/avm2/globals/flash/system/IME.as
@@ -13,10 +13,10 @@ package flash.system
     public final class IME extends EventDispatcher
     {
         // The conversion mode of the current IME.
-        public static var _conversionMode: String = "ALPHANUMERIC_HALF";
+        private static var _conversionMode: String = "ALPHANUMERIC_HALF";
 
         // Indicates whether the system IME is enabled (true) or disabled (false).
-        public static var _enabled: Boolean;
+        private static var _enabled: Boolean;
 
         // The isSupported property is set to true if the IME class is available on the current platform, otherwise it is set to false.
         private static var _isSupported: Boolean;

--- a/core/src/avm2/globals/flash/system/LoaderContext.as
+++ b/core/src/avm2/globals/flash/system/LoaderContext.as
@@ -3,7 +3,6 @@ package flash.system {
 
     public class LoaderContext {
         public var allowCodeImport : Boolean;
-        public var allowLoadBytesCodeExecution : Boolean;
         public var applicationDomain : ApplicationDomain;
         public var checkPolicyFile : Boolean;
         public var imageDecodingPolicy : String;
@@ -13,12 +12,21 @@ package flash.system {
 
         public function LoaderContext(checkPolicyFile:Boolean = false, applicationDomain:ApplicationDomain = null, securityDomain:SecurityDomain = null) {
             this.allowCodeImport = true;
-            this.allowLoadBytesCodeExecution = true;
             this.applicationDomain = applicationDomain;
             this.checkPolicyFile = checkPolicyFile;
             // This should be `ImageDecodingPolicy.ON_DEMAND;`, but that's an AIR only class.
             this.imageDecodingPolicy = "onDemand";
             this.securityDomain = securityDomain;
+        }
+
+        [API("661")]
+        public function get allowLoadBytesCodeExecution(): Boolean {
+            return this.allowCodeImport;
+        }
+
+        [API("661")]
+        public function set allowLoadBytesCodeExecution(value:Boolean): void {
+            this.allowCodeImport = value;
         }
     }
 }

--- a/core/src/avm2/globals/flash/system/Security.as
+++ b/core/src/avm2/globals/flash/system/Security.as
@@ -8,6 +8,7 @@ package flash.system {
 		public static native function loadPolicyFile(url: String):void;
 		public static native function showSettings(panel: String = "default"):void;
 
+		[API("661")]
 		public static const APPLICATION:String = "application";
 		public static const LOCAL_TRUSTED:String = "localTrusted";
 		public static const LOCAL_WITH_FILE:String = "localWithFile";

--- a/core/src/avm2/globals/flash/system/Worker.as
+++ b/core/src/avm2/globals/flash/system/Worker.as
@@ -1,5 +1,7 @@
 package flash.system {
-    public final class Worker {
+    import flash.events.EventDispatcher;
+
+    public final class Worker extends EventDispatcher {
         public function Worker() {
             throw new ArgumentError("Error #2012: Worker$ class cannot be instantiated.", 2012);
         }

--- a/core/src/avm2/globals/flash/text/TextRenderer.as
+++ b/core/src/avm2/globals/flash/text/TextRenderer.as
@@ -12,10 +12,10 @@ package flash.text
     public final class TextRenderer
     {
         // Controls the rendering of advanced anti-aliased text.
-        public static var _displayMode: String = "default";
+        private static var _displayMode: String = "default";
 
         // The adaptively sampled distance fields (ADFs) quality level for advanced anti-aliasing.
-        public static var _maxLevel: int = 4;
+        private static var _maxLevel: int = 4;
 
         // Sets a custom continuous stroke modulation (CSM) lookup table for a font.
         public static function setAdvancedAntiAliasingTable(fontName:String, fontStyle:String, colorType:String, advancedAntiAliasingTable:Array):void

--- a/core/src/avm2/globals/flash/text/engine/TextLine.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLine.as
@@ -95,7 +95,7 @@ package flash.text.engine {
             return 0.0;
         }
 
-        public function hasTabs():Boolean {
+        public function get hasTabs():Boolean {
             stub_getter("flash.text.engine.TextLine", "hasTabs");
             return false;
         }

--- a/core/src/avm2/globals/flash/ui/GameInputControl.as
+++ b/core/src/avm2/globals/flash/ui/GameInputControl.as
@@ -1,6 +1,8 @@
 package flash.ui {
+    import flash.events.EventDispatcher;
+
     [API("688")]
-    public dynamic class GameInputControl {
+    public dynamic class GameInputControl extends EventDispatcher {
         public function GameInputControl() {
             throw new ArgumentError("Error #2012: GameInputControl$ class cannot be instantiated.", 2012)
         }

--- a/core/src/avm2/globals/flash/ui/Keyboard.as
+++ b/core/src/avm2/globals/flash/ui/Keyboard.as
@@ -105,38 +105,72 @@ package flash.ui {
         public static const BACKSLASH: uint = 220;
         public static const RIGHTBRACKET: uint = 221;
         public static const QUOTE: uint = 222;
+
+        [API("669")]
         public static const SETUP: uint = 0x0100001C;
+        [API("669")]
         public static const NEXT: uint = 0x0100000E;
+        [API("669")]
         public static const MENU: uint = 0x01000012;
+        [API("669")]
         public static const CHANNEL_UP: uint = 0x01000004;
+        [API("669")]
         public static const EXIT: uint = 0x01000015;
+        [API("669")]
         public static const BLUE: uint = 0x01000003;
+        [API("669")]
         public static const CHANNEL_DOWN: uint = 0x01000005;
+        [API("669")]
         public static const INPUT: uint = 0x0100001B;
+        [API("669")]
         public static const DVR: uint = 0x01000019;
+        [API("669")]
         public static const SEARCH: uint = 0x0100001F;
+        [API("669")]
         public static const MASTER_SHELL: uint = 0x0100001E;
+        [API("669")]
         public static const SKIP_BACKWARD: uint = 0x0100000D;
+        [API("669")] // [NA] This should be 719, but it's not supported at time of writing
         public static const PLAY_PAUSE: uint = 0x01000020;
+        [API("669")]
         public static const HELP: uint = 0x0100001D;
+        [API("669")]
         public static const VOD: uint = 0x0100001A;
+        [API("669")]
         public static const LIVE: uint = 0x01000010;
+        [API("669")]
         public static const RED: uint = 0x01000000;
+        [API("669")]
         public static const PREVIOUS: uint = 0x0100000F;
+        [API("669")]
         public static const RECORD: uint = 0x01000006;
+        [API("669")]
         public static const STOP: uint = 0x01000009;
+        [API("669")]
         public static const SUBTITLE: uint = 0x01000018;
+        [API("669")]
         public static const PLAY: uint = 0x01000007;
+        [API("669")]
         public static const GUIDE: uint = 0x01000014;
+        [API("669")]
         public static const YELLOW: uint = 0x01000002;
+        [API("669")]
         public static const REWIND: uint = 0x0100000B;
+        [API("669")]
         public static const INFO: uint = 0x01000013;
+        [API("669")]
         public static const LAST: uint = 0x01000011;
+        [API("669")]
         public static const PAUSE: uint = 0x01000008;
+        [API("669")]
         public static const AUDIO: uint = 0x01000017;
+        [API("669")]
         public static const GREEN: uint = 0x01000001;
+        [API("669")]
         public static const FAST_FORWARD: uint = 0x0100000A;
+        [API("669")]
         public static const SKIP_FORWARD: uint = 0x0100000C;
+        [API("669")]
         public static const BACK: uint = 0x01000016;
 
         public static const STRING_BEGIN: String = "\uf72a";

--- a/core/src/avm2/globals/flash/ui/MouseCursorData.as
+++ b/core/src/avm2/globals/flash/ui/MouseCursorData.as
@@ -13,13 +13,13 @@ package flash.ui
     public final class MouseCursorData
     {
         // A Vector of BitmapData objects containing the cursor image or images.
-        public var _data: Vector.<BitmapData>;
+        private var _data: Vector.<BitmapData>;
 
         // The frame rate for animating the cursor.
-        public var _frameRate: Number;
+        private var _frameRate: Number;
 
         // The hot spot of the cursor in pixels.
-        public var _hotSpot: Point = new Point(0,0);
+        private var _hotSpot: Point = new Point(0,0);
 
         public function get data():Vector.<BitmapData>
         {

--- a/core/src/avm2/globals/flash/utils/ByteArray.as
+++ b/core/src/avm2/globals/flash/utils/ByteArray.as
@@ -1,6 +1,6 @@
 package flash.utils {
 	[Ruffle(InstanceAllocator)]
-	public class ByteArray implements IDataInput, IDataOutput {
+	public class ByteArray implements IDataInput2, IDataOutput2 {
 		private static var _defaultObjectEncoding:uint = 3;
 		public static function get defaultObjectEncoding():uint {
 			return _defaultObjectEncoding;

--- a/core/src/avm2/globals/flash/utils/IDataInput2.as
+++ b/core/src/avm2/globals/flash/utils/IDataInput2.as
@@ -1,0 +1,4 @@
+package flash.utils {
+    internal interface IDataInput2 extends IDataInput {
+    }
+}

--- a/core/src/avm2/globals/flash/utils/IDataOutput2.as
+++ b/core/src/avm2/globals/flash/utils/IDataOutput2.as
@@ -1,0 +1,4 @@
+package flash.utils {
+    internal interface IDataOutput2 extends IDataOutput {
+    }
+}

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -36,6 +36,8 @@ include "flash/crypto.as"
 
 include "flash/utils/IDataInput.as"
 include "flash/utils/IDataOutput.as"
+include "flash/utils/IDataInput2.as"
+include "flash/utils/IDataOutput2.as"
 include "flash/utils/IExternalizable.as"
 include "flash/utils/ByteArray.as"
 include "flash/utils/Dictionary.as"


### PR DESCRIPTION
It's not *everything*, we have some issues remaining, but it's a pretty good chunk


-----


Remaining issues if anyone else wants to tackle those:

```
String static has extra method "fromCharCode"
```
This is *technically correct*, the worst kind of correct. Flash doesn't define it on the class, somehow. I didn't care enough to figure out why.

-----

```
flash.accessibility.AccessibilityImplementation has extra method "get_selectionActiveIndex"
flash.accessibility.AccessibilityImplementation has extra method "get_selectionAnchorIndex"
```
Should be gated behind API 736 which ruffle doesn't support 

-----

```
flash.display3D.Context3D variable "maxBackBufferWidth"'s access should be "readwrite", actually "readonly"
flash.display3D.Context3D variable "maxBackBufferHeight"'s access should be "readwrite", actually "readonly"
```
Didn't really feel like touching context3d stuff :D

-----
 
```
flash.events.GestureEvent has extra variable "controlKey"
 
flash.events.KeyboardEvent has extra variable "controlKey"
flash.events.KeyboardEvent has extra variable "commandKey"
 
flash.events.PressAndTapGestureEvent has extra variable "controlKey"
 
flash.events.TransformGestureEvent has extra variable "controlKey"
```
I couldn't find a consistent answer on what these should be gated behind, the docs and playerglobals seem inconsistent.

-----
 
```
flash.net.SharedObject variable "data"'s access should be "readonly", actually "readwrite"
flash.net.SharedObject has extra variable "_ruffleName" (uri "__ruffle__")
```
Looked too scary

-----
 
```
flash.net.URLLoader variable "bytesTotal"'s access should be "readwrite", actually "readonly"
flash.net.URLLoader variable "bytesLoaded"'s access should be "readwrite", actually "readonly"
```
Also scary

-----
 
```
flash.system.IME has extra variable "isSupported"
```
Docs were inconsistent with playerglobals
