### PR TITLE
desktop: Add theme preference

### DIFF
--- a/desktop/assets/texts/en-US/preferences_dialog.ftl
+++ b/desktop/assets/texts/en-US/preferences_dialog.ftl
@@ -28,3 +28,8 @@ storage-backend-memory = Memory
 
 recent-limit = Recent Limit
 recent-clear = Clear
+
+theme = Theme
+theme-system = System Default
+theme-light = Light
+theme-dark = Dark

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -539,10 +539,6 @@ impl App {
                     return;
                 }
 
-                winit::event::Event::UserEvent(RuffleEvent::ThemeChanged(theme)) => {
-                    self.gui.borrow().set_theme(theme);
-                }
-
                 _ => (),
             }
 

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -12,6 +12,7 @@ use ruffle_core::{PlayerEvent, StageDisplayState};
 use ruffle_render::backend::ViewportDimensions;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use url::Url;
 use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Size};
@@ -22,7 +23,7 @@ use winit::window::{Fullscreen, Icon, Window, WindowBuilder};
 
 pub struct App {
     preferences: GlobalPreferences,
-    window: Rc<Window>,
+    window: Arc<Window>,
     event_loop: Option<EventLoop<RuffleEvent>>,
     gui: Rc<RefCell<GuiController>>,
     player: PlayerController,
@@ -58,7 +59,7 @@ impl App {
             .with_min_inner_size(min_window_size)
             .with_max_inner_size(max_window_size)
             .build(&event_loop)?;
-        let window = Rc::new(window);
+        let window = Arc::new(window);
 
         let mut font_database = fontdb::Database::default();
         font_database.load_system_fonts();

--- a/desktop/src/backends/fscommand.rs
+++ b/desktop/src/backends/fscommand.rs
@@ -1,13 +1,13 @@
 use crate::custom_event::RuffleEvent;
 
 use ruffle_core::external::FsCommandProvider;
-use std::rc::Rc;
+use std::sync::Arc;
 use winit::event_loop::EventLoopProxy;
 use winit::window::{Fullscreen, Window};
 
 pub struct DesktopFSCommandProvider {
     pub event_loop: EventLoopProxy<RuffleEvent>,
-    pub window: Rc<Window>,
+    pub window: Arc<Window>,
 }
 
 impl FsCommandProvider for DesktopFSCommandProvider {

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -12,6 +12,7 @@ use ruffle_core::backend::ui::{
     FullscreenError, LanguageIdentifier, MouseCursor, UiBackend,
 };
 use std::rc::Rc;
+use std::sync::Arc;
 use tracing::error;
 use url::Url;
 use winit::raw_window_handle::HasDisplayHandle;
@@ -112,7 +113,7 @@ impl FileDialogResult for DesktopFileDialogResult {
 }
 
 pub struct DesktopUiBackend {
-    window: Rc<Window>,
+    window: Arc<Window>,
     cursor_visible: bool,
     clipboard: Clipboard,
     preferences: GlobalPreferences,
@@ -125,7 +126,7 @@ pub struct DesktopUiBackend {
 
 impl DesktopUiBackend {
     pub fn new(
-        window: Rc<Window>,
+        window: Arc<Window>,
         open_url_mode: OpenURLMode,
         font_database: Rc<fontdb::Database>,
         preferences: GlobalPreferences,

--- a/desktop/src/custom_event.rs
+++ b/desktop/src/custom_event.rs
@@ -1,7 +1,6 @@
 //! Custom event type for desktop ruffle
 
 use crate::player::LaunchOptions;
-use winit::window::Theme;
 
 /// User-defined events.
 pub enum RuffleEvent {
@@ -25,7 +24,4 @@ pub enum RuffleEvent {
 
     /// The user selected an item in the right-click context menu.
     ContextMenuItemClicked(usize),
-
-    /// System theme has changed.
-    ThemeChanged(Theme),
 }

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -9,6 +9,7 @@ mod widgets;
 pub use controller::GuiController;
 pub use movie::MovieView;
 use std::borrow::Cow;
+pub use theme::ThemePreference;
 use url::Url;
 
 use crate::custom_event::RuffleEvent;

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -3,6 +3,7 @@ mod controller;
 mod dialogs;
 mod menu_bar;
 mod movie;
+mod theme;
 mod widgets;
 
 pub use controller::GuiController;

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -13,7 +13,6 @@ use ruffle_render_wgpu::backend::{request_adapter_and_device, WgpuRenderBackend}
 use ruffle_render_wgpu::descriptors::Descriptors;
 use ruffle_render_wgpu::utils::{format_list, get_backend_names};
 use std::error::Error;
-use std::rc::Rc;
 use std::sync::{Arc, MutexGuard};
 use std::time::{Duration, Instant};
 use unic_langid::LanguageIdentifier;
@@ -31,7 +30,7 @@ pub struct GuiController {
     egui_winit: egui_winit::State,
     egui_renderer: egui_wgpu::Renderer,
     gui: RuffleGui,
-    window: Rc<Window>,
+    window: Arc<Window>,
     last_update: Instant,
     repaint_after: Duration,
     surface: wgpu::Surface<'static>,
@@ -46,7 +45,7 @@ pub struct GuiController {
 
 impl GuiController {
     pub async fn new(
-        window: Rc<Window>,
+        window: Arc<Window>,
         event_loop: &EventLoop<RuffleEvent>,
         preferences: GlobalPreferences,
         font_database: &Database,

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -95,7 +95,8 @@ impl GuiController {
         let descriptors = Descriptors::new(instance, adapter, device, queue);
         let egui_ctx = Context::default();
 
-        let theme_controller = ThemeController::new(window.clone(), egui_ctx.clone()).await;
+        let theme_controller =
+            ThemeController::new(window.clone(), preferences.clone(), egui_ctx.clone()).await;
         let mut egui_winit =
             egui_winit::State::new(egui_ctx, ViewportId::ROOT, window.as_ref(), None, None);
         egui_winit.set_max_texture_side(descriptors.limits.max_texture_dimension_2d as usize);

--- a/desktop/src/gui/theme.rs
+++ b/desktop/src/gui/theme.rs
@@ -1,0 +1,130 @@
+#[cfg(target_os = "linux")]
+use crate::dbus::{ColorScheme, FreedesktopSettings};
+use egui::Context;
+use futures::StreamExt;
+use std::error::Error;
+use std::sync::{Arc, Weak};
+use tokio::sync::{Mutex, MutexGuard};
+use winit::window::{Theme, Window};
+
+struct ThemeControllerData {
+    window: Weak<Window>,
+    egui_ctx: Context,
+
+    #[cfg(target_os = "linux")]
+    zbus_connection: Option<zbus::Connection>,
+}
+
+#[derive(Clone)]
+pub struct ThemeController(Arc<Mutex<ThemeControllerData>>);
+
+impl ThemeController {
+    pub async fn new(window: Arc<Window>, egui_ctx: Context) -> Self {
+        let this = Self(Arc::new(Mutex::new(ThemeControllerData {
+            window: Arc::downgrade(&window),
+            egui_ctx,
+            #[cfg(target_os = "linux")]
+            zbus_connection: zbus::Connection::session()
+                .await
+                .inspect_err(|err| tracing::warn!("Failed to connect to D-Bus: {err}"))
+                .ok(),
+        })));
+
+        #[cfg(target_os = "linux")]
+        this.start_dbus_theme_watcher_linux().await;
+
+        if let Ok(theme) = this.get_system_theme().await {
+            this.set_theme(theme);
+        }
+
+        this
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn start_dbus_theme_watcher_linux(&self) {
+        async fn start_inner(this: &ThemeController) -> Result<(), Box<dyn Error>> {
+            let Some(ref connection) = this.data().zbus_connection else {
+                return Ok(());
+            };
+
+            let settings = FreedesktopSettings::new(connection).await?;
+
+            let mut stream = Box::pin(settings.watch_color_scheme().await?);
+
+            let this2 = this.clone();
+            tokio::spawn(Box::pin(async move {
+                while let Some(scheme) = stream.next().await {
+                    match scheme {
+                        Ok(scheme) => {
+                            this2.set_theme(scheme_to_theme(scheme));
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                "Error while watching for color scheme changes: {}",
+                                err
+                            );
+                        }
+                    }
+                }
+            }));
+
+            Ok(())
+        }
+
+        if let Err(err) = start_inner(self).await {
+            tracing::warn!("Error registering theme watcher: {}", err);
+        }
+    }
+
+    fn data(&self) -> MutexGuard<'_, ThemeControllerData> {
+        self.0.try_lock().expect("Non-reentrant data mutex")
+    }
+
+    pub fn set_theme(&self, theme: Theme) {
+        let data = self.data();
+        self.set_theme_internal(data, theme);
+    }
+
+    fn set_theme_internal(&self, data: MutexGuard<'_, ThemeControllerData>, theme: Theme) {
+        data.egui_ctx.set_visuals(match theme {
+            Theme::Light => egui::Visuals::light(),
+            Theme::Dark => egui::Visuals::dark(),
+        });
+        if let Some(window) = data.window.upgrade() {
+            window.request_redraw();
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn get_system_theme(&self) -> Result<Theme, Box<dyn Error>> {
+        let Some(ref connection) = self.data().zbus_connection else {
+            return Ok(Theme::Dark);
+        };
+        let settings = FreedesktopSettings::new(connection).await?;
+        let scheme = settings.color_scheme().await?;
+
+        Ok(scheme_to_theme(scheme))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub async fn get_system_theme(&self) -> Result<Theme, Box<dyn Error>> {
+        #[derive(thiserror::Error, Debug)]
+        #[error("Unsupported operation")]
+        struct UnsupportedOperationError;
+        self.data()
+            .window
+            .upgrade()
+            .and_then(|w| w.theme())
+            .ok_or(Box::new(UnsupportedOperationError))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn scheme_to_theme(color_scheme: ColorScheme) -> Theme {
+    use crate::dbus::ColorScheme;
+    match color_scheme {
+        ColorScheme::Default => Theme::Light,
+        ColorScheme::PreferLight => Theme::Light,
+        ColorScheme::PreferDark => Theme::Dark,
+    }
+}

--- a/desktop/src/gui/theme.rs
+++ b/desktop/src/gui/theme.rs
@@ -22,7 +22,11 @@ struct ThemeControllerData {
 pub struct ThemeController(Arc<Mutex<ThemeControllerData>>);
 
 impl ThemeController {
-    pub async fn new(window: Arc<Window>, egui_ctx: Context) -> Self {
+    pub async fn new(
+        window: Arc<Window>,
+        preferences: GlobalPreferences,
+        egui_ctx: Context,
+    ) -> Self {
         let this = Self(Arc::new(Mutex::new(ThemeControllerData {
             window: Arc::downgrade(&window),
             egui_ctx,
@@ -37,9 +41,8 @@ impl ThemeController {
         #[cfg(target_os = "linux")]
         this.start_dbus_theme_watcher_linux().await;
 
-        if let Ok(theme) = this.get_system_theme().await {
-            this.set_theme(theme);
-        }
+        this.set_theme_preference(preferences.theme_preference())
+            .await;
 
         this
     }

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -123,7 +123,7 @@ impl ActivePlayer {
         opt: &LaunchOptions,
         event_loop: EventLoopProxy<RuffleEvent>,
         movie_url: &Url,
-        window: Rc<Window>,
+        window: Arc<Window>,
         descriptors: Arc<Descriptors>,
         movie_view: MovieView,
         font_database: Rc<fontdb::Database>,
@@ -381,7 +381,7 @@ impl ActivePlayer {
 pub struct PlayerController {
     player: Option<ActivePlayer>,
     event_loop: EventLoopProxy<RuffleEvent>,
-    window: Rc<Window>,
+    window: Arc<Window>,
     descriptors: Arc<Descriptors>,
     font_database: Rc<fontdb::Database>,
     preferences: GlobalPreferences,
@@ -390,7 +390,7 @@ pub struct PlayerController {
 impl PlayerController {
     pub fn new(
         event_loop: EventLoopProxy<RuffleEvent>,
-        window: Rc<Window>,
+        window: Arc<Window>,
         descriptors: Arc<Descriptors>,
         font_database: fontdb::Database,
         preferences: GlobalPreferences,

--- a/desktop/src/preferences.rs
+++ b/desktop/src/preferences.rs
@@ -4,6 +4,7 @@ mod write;
 pub mod storage;
 
 use crate::cli::Opt;
+use crate::gui::ThemePreference;
 use crate::log::FilenamePattern;
 use crate::preferences::read::read_preferences;
 use crate::preferences::write::PreferencesWriter;
@@ -187,6 +188,13 @@ impl GlobalPreferences {
             .recent_limit
     }
 
+    pub fn theme_preference(&self) -> ThemePreference {
+        self.preferences
+            .lock()
+            .expect("Non-poisoned preferences")
+            .theme_preference
+    }
+
     pub fn recents<R>(&self, fun: impl FnOnce(&Recents) -> R) -> R {
         fun(&self.recents.lock().expect("Recents is not reentrant"))
     }
@@ -240,6 +248,7 @@ pub struct SavedGlobalPreferences {
     pub recent_limit: usize,
     pub log: LogPreferences,
     pub storage: StoragePreferences,
+    pub theme_preference: ThemePreference,
 }
 
 impl Default for SavedGlobalPreferences {
@@ -259,6 +268,7 @@ impl Default for SavedGlobalPreferences {
             recent_limit: 10,
             log: Default::default(),
             storage: Default::default(),
+            theme_preference: Default::default(),
         }
     }
 }

--- a/desktop/src/preferences/write.rs
+++ b/desktop/src/preferences/write.rs
@@ -1,3 +1,4 @@
+use crate::gui::ThemePreference;
 use crate::log::FilenamePattern;
 use crate::preferences::storage::StorageBackend;
 use crate::preferences::SavedGlobalPreferences;
@@ -85,6 +86,17 @@ impl<'a> PreferencesWriter<'a> {
             toml_document["recent_limit"] = value(limit as i64);
             values.recent_limit = limit;
         })
+    }
+
+    pub fn set_theme_preference(&mut self, theme_preference: ThemePreference) {
+        self.0.edit(|values, toml_document| {
+            if let Some(theme_preference) = theme_preference.as_str() {
+                toml_document["theme"] = value(theme_preference);
+            } else {
+                toml_document.remove("theme");
+            }
+            values.theme_preference = theme_preference;
+        });
     }
 }
 
@@ -238,6 +250,20 @@ mod tests {
             "recent_limit = 5",
             |writer| writer.set_recent_limit(15),
             "recent_limit = 15\n",
+        );
+    }
+
+    #[test]
+    fn set_theme() {
+        test(
+            "theme = 6\n",
+            |writer| writer.set_theme_preference(ThemePreference::Dark),
+            "theme = \"dark\"\n",
+        );
+        test(
+            "theme = \"dark\"",
+            |writer| writer.set_theme_preference(ThemePreference::System),
+            "",
         );
     }
 }


### PR DESCRIPTION
Related to https://github.com/ruffle-rs/ruffle/issues/17288.

This PR adds a setting for GUI theme. The default value is `System`, which matches the theme with system's theme and watches for theme changes.

The theme-related code became somewhat complicated, so I added `ThemeController` to make the code more readable.
