### PR TITLE
core: Use layout lines in `screen_position_to_index`

### DIFF
--- a/core/src/html.rs
+++ b/core/src/html.rs
@@ -6,7 +6,9 @@ mod layout;
 mod text_format;
 
 pub use dimensions::Position;
-pub use layout::{lower_from_text_spans, Layout, LayoutBox, LayoutContent, LayoutMetrics};
+pub use layout::{
+    lower_from_text_spans, Layout, LayoutBox, LayoutContent, LayoutLine, LayoutMetrics,
+};
 pub use stylesheet::{transform_dashes_to_camel_case, CssStream};
 pub use text_format::{FormatSpans, TextDisplay, TextFormat, TextSpan};
 


### PR DESCRIPTION
This refactor makes it possible for layout boxes in the same line to have different extents, and it does not change the method's behavior.

Currently Ruffle ensures that all layout boxes within the same line have the same extent, which is wrong, as they should be aligned by their respective baselines, not their extents. This refactor makes it possible to fix that misalignment.

This is the first step of a bigger layout refactor, which in turn will make it possible to implement `screen_position_to_index` in a simpler way.