### PR TITLE
text: Fix calculating line bounds

### DIFF
--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -364,6 +364,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
         let start = first_box.start();
         let bounds = boxes
             .iter()
+            .filter(|b| b.is_text_box())
             .fold(first_box.bounds, |bounds, b| bounds + b.bounds);
 
         // Update last line's end position to take into account the delimiter.
@@ -859,6 +860,8 @@ impl<'gc> LayoutLine<'gc> {
 #[collect(no_drop)]
 pub struct LayoutBox<'gc> {
     /// The rectangle corresponding to the outer boundaries of the content box.
+    ///
+    /// TODO Currently, only text boxes have meaningful bounds.
     #[collect(require_static)]
     bounds: BoxBounds<Twips>,
 


### PR DESCRIPTION
This fixes a small regression introduced by https://github.com/ruffle-rs/ruffle/pull/17312. In some cases, having bullets or underlines in the text will negatively influence `screen_position_to_index` calculations due to their dummy bounds, and cause the result to be more off than before.

Unfortunately writing a test for that is currently very difficult, as this method (and generally laying out multiline text) is inaccurate.