### PR TITLE
core: Add missing At sign key codes for Android Apps

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -505,6 +505,7 @@ pub enum KeyCode {
     Key7 = 55,
     Key8 = 56,
     Key9 = 57,
+    At = 64,
     A = 65,
     B = 66,
     C = 67,


### PR DESCRIPTION
@ sign for swf files that require a mail account for the Android app

https://github.com/ruffle-rs/ruffle-android/pull/220