### PR TITLE
avm2: Remove some dynamic-dispatch TObject logic

### DIFF
--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -69,31 +69,20 @@ pub fn enum_trait_object(args: TokenStream, item: TokenStream) -> TokenStream {
 
                 let mut is_no_dynamic = false;
 
-                let new_attrs = method
-                    .attrs
-                    .iter()
-                    .filter(|attr| match &attr.meta {
-                        Meta::Path(path) => {
-                            if let Some(ident) = path.get_ident() {
-                                if ident == "no_dynamic" {
-                                    is_no_dynamic = true;
+                method.attrs.retain(|attr| match &attr.meta {
+                    Meta::Path(path) => {
+                        if path.is_ident("no_dynamic") {
+                            is_no_dynamic = true;
 
-                                    // Remove the #[no_dynamic] attribute from the
-                                    // list of method attributes.
-                                    false
-                                } else {
-                                    true
-                                }
-                            } else {
-                                true
-                            }
+                            // Remove the #[no_dynamic] attribute from the
+                            // list of method attributes.
+                            false
+                        } else {
+                            true
                         }
-                        _ => true,
-                    })
-                    .map(|o| o.clone())
-                    .collect::<Vec<_>>();
-
-                method.attrs = new_attrs;
+                    }
+                    _ => true,
+                });
 
                 if is_no_dynamic {
                     // Don't create this method as a dynamic-dispatch method

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -23,7 +23,7 @@ use crate::html::TextFormat;
 use crate::streams::NetStream;
 use crate::string::AvmString;
 use gc_arena::{lock::RefLock, Collect, Gc, Mutation};
-use ruffle_macros::{enum_trait_object, no_dynamic};
+use ruffle_macros::enum_trait_object;
 use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -49,7 +49,7 @@ impl fmt::Debug for ArrayObject<'_> {
 
 #[derive(Collect, Clone)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct ArrayObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -59,6 +59,9 @@ pub struct ArrayObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ArrayObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<ArrayObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> ArrayObject<'gc> {
     /// Construct an empty array.

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -54,7 +54,7 @@ impl fmt::Debug for BitmapDataObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct BitmapDataObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -63,6 +63,10 @@ pub struct BitmapDataObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(BitmapDataObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<BitmapDataObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> BitmapDataObject<'gc> {
     // Constructs a BitmapData object from a BitmapDataWrapper.

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -12,7 +12,6 @@ use gc_arena::{
     lock::{Lock, RefLock},
     Collect, Gc, GcWeak, Mutation,
 };
-use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates BitmapData objects.
 pub fn bitmap_data_allocator<'gc>(

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -62,6 +62,8 @@ pub struct BitmapDataObjectData<'gc> {
     bitmap_data: Lock<Option<BitmapDataWrapper<'gc>>>,
 }
 
+const _: () = assert!(std::mem::offset_of!(BitmapDataObjectData, base) == 0);
+
 impl<'gc> BitmapDataObject<'gc> {
     // Constructs a BitmapData object from a BitmapDataWrapper.
     // This is *not* used when explicitly constructing a BitmapData
@@ -103,12 +105,12 @@ impl<'gc> BitmapDataObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), BitmapDataObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -69,7 +69,7 @@ impl fmt::Debug for ByteArrayObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct ByteArrayObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -78,6 +78,10 @@ pub struct ByteArrayObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ByteArrayObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<ByteArrayObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> ByteArrayObject<'gc> {
     pub fn from_storage(

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -38,7 +38,7 @@ pub struct ClassObjectWeak<'gc>(pub GcWeak<'gc, ClassObjectData<'gc>>);
 
 #[derive(Collect, Clone)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct ClassObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -77,6 +77,9 @@ pub struct ClassObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ClassObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<ClassObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> ClassObject<'gc> {
     /// Allocate the prototype for this class.

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -23,7 +23,6 @@ use gc_arena::{
     lock::{Lock, RefLock},
     Collect, Gc, GcWeak, Mutation,
 };
-use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -76,6 +76,8 @@ pub struct ClassObjectData<'gc> {
     instance_vtable: VTable<'gc>,
 }
 
+const _: () = assert!(std::mem::offset_of!(ClassObjectData, base) == 0);
+
 impl<'gc> ClassObject<'gc> {
     /// Allocate the prototype for this class.
     ///
@@ -719,12 +721,12 @@ impl<'gc> ClassObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for ClassObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), ClassObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -493,13 +493,15 @@ pub struct Context3DData<'gc> {
     stage3d: Stage3DObject<'gc>,
 }
 
-impl<'gc> TObject<'gc> for Context3DObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+const _: () = assert!(std::mem::offset_of!(Context3DData, base) == 0);
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), Context3DData, base).borrow_mut()
+impl<'gc> TObject<'gc> for Context3DObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
+
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -8,7 +8,6 @@ use crate::avm2::Error;
 use crate::avm2_stub_method;
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::context::RenderContext;
-use gc_arena::barrier::unlock;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcCell, GcWeak, Mutation};
 use ruffle_render::backend::{
@@ -17,7 +16,7 @@ use ruffle_render::backend::{
     Texture,
 };
 use ruffle_render::commands::CommandHandler;
-use std::cell::{Cell, Ref, RefMut};
+use std::cell::Cell;
 use std::rc::Rc;
 use swf::{Rectangle, Twips};
 

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -482,7 +482,7 @@ impl<'gc> Context3DObject<'gc> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct Context3DData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -494,6 +494,9 @@ pub struct Context3DData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(Context3DData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<Context3DData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for Context3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -82,13 +82,15 @@ pub struct DateObjectData<'gc> {
     date_time: Cell<Option<DateTime<Utc>>>,
 }
 
-impl<'gc> TObject<'gc> for DateObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+const _: () = assert!(std::mem::offset_of!(DateObjectData, base) == 0);
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), DateObjectData, base).borrow_mut()
+impl<'gc> TObject<'gc> for DateObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
+
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -74,7 +74,7 @@ impl<'gc> DateObject<'gc> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct DateObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -83,6 +83,9 @@ pub struct DateObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(DateObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<DateObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for DateObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -5,10 +5,9 @@ use crate::avm2::value::{Hint, Value};
 use crate::avm2::Error;
 use chrono::{DateTime, Utc};
 use core::fmt;
-use gc_arena::barrier::unlock;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
-use std::cell::{Cell, Ref, RefMut};
+use std::cell::Cell;
 
 /// A class instance allocator that allocates Date objects.
 pub fn date_allocator<'gc>(

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -49,13 +49,17 @@ impl fmt::Debug for DictionaryObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct DictionaryObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
 }
 
 const _: () = assert!(std::mem::offset_of!(DictionaryObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<DictionaryObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> DictionaryObject<'gc> {
     /// Retrieve a value in the dictionary's object space.

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -10,7 +10,6 @@ use crate::string::AvmString;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates Dictionary objects.
 pub fn dictionary_allocator<'gc>(

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -55,6 +55,8 @@ pub struct DictionaryObjectData<'gc> {
     base: RefLock<ScriptObjectData<'gc>>,
 }
 
+const _: () = assert!(std::mem::offset_of!(DictionaryObjectData, base) == 0);
+
 impl<'gc> DictionaryObject<'gc> {
     /// Retrieve a value in the dictionary's object space.
     pub fn get_property_by_object(self, name: Object<'gc>) -> Value<'gc> {
@@ -95,12 +97,12 @@ impl<'gc> DictionaryObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for DictionaryObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), DictionaryObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -54,7 +54,7 @@ impl fmt::Debug for DispatchObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct DispatchObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -64,6 +64,9 @@ pub struct DispatchObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(DispatchObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<DispatchObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> DispatchObject<'gc> {
     /// Construct an empty dispatch list.

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -12,7 +12,6 @@ use gc_arena::{
     lock::{Lock, RefLock},
     Collect, Gc, GcWeak, Mutation,
 };
-use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates AppDomain objects.
 pub fn application_domain_allocator<'gc>(

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -59,6 +59,8 @@ pub struct DomainObjectData<'gc> {
     domain: Lock<Domain<'gc>>,
 }
 
+const _: () = assert!(std::mem::offset_of!(DomainObjectData, base) == 0);
+
 impl<'gc> DomainObject<'gc> {
     /// Create a new object for a given domain.
     ///
@@ -91,12 +93,12 @@ impl<'gc> DomainObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for DomainObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), DomainObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -50,7 +50,7 @@ impl fmt::Debug for DomainObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct DomainObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -60,6 +60,9 @@ pub struct DomainObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(DomainObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<DomainObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> DomainObject<'gc> {
     /// Create a new object for a given domain.

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -8,9 +8,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::WString;
 use core::fmt;
-use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 use tracing::{enabled, Level};
 

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -51,7 +51,7 @@ impl fmt::Debug for ErrorObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct ErrorObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -60,6 +60,9 @@ pub struct ErrorObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ErrorObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<ErrorObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> ErrorObject<'gc> {
     pub fn display(&self) -> Result<WString, Error<'gc>> {

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -43,7 +43,7 @@ pub struct EventObjectWeak<'gc>(pub GcWeak<'gc, EventObjectData<'gc>>);
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct EventObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -53,6 +53,9 @@ pub struct EventObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(EventObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<EventObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> EventObject<'gc> {
     /// Create a bare Event instance while skipping the usual `construct()` pipeline.

--- a/core/src/avm2/object/file_reference_object.rs
+++ b/core/src/avm2/object/file_reference_object.rs
@@ -83,7 +83,7 @@ pub enum FileReference {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct FileReferenceObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -94,6 +94,10 @@ pub struct FileReferenceObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(FileReferenceObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<FileReferenceObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl fmt::Debug for FileReferenceObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/avm2/object/file_reference_object.rs
+++ b/core/src/avm2/object/file_reference_object.rs
@@ -3,10 +3,9 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::{Activation, Error};
 use crate::backend::ui::FileDialogResult;
-use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc};
 use gc_arena::{GcWeak, Mutation};
-use std::cell::{Cell, Ref, RefCell, RefMut};
+use std::cell::{Cell, Ref, RefCell};
 use std::fmt;
 
 pub fn file_reference_allocator<'gc>(

--- a/core/src/avm2/object/font_object.rs
+++ b/core/src/avm2/object/font_object.rs
@@ -4,9 +4,7 @@ use crate::avm2::value::Value;
 use crate::avm2::{Activation, ClassObject, Error};
 use crate::character::Character;
 use crate::font::Font;
-use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Ref, RefMut};
 use std::fmt;
 
 /// A class instance allocator that allocates Font objects.

--- a/core/src/avm2/object/font_object.rs
+++ b/core/src/avm2/object/font_object.rs
@@ -88,7 +88,7 @@ impl<'gc> TObject<'gc> for FontObject<'gc> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct FontObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -97,6 +97,9 @@ pub struct FontObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(FontObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<FontObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl fmt::Debug for FontObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/avm2/object/font_object.rs
+++ b/core/src/avm2/object/font_object.rs
@@ -65,12 +65,12 @@ impl<'gc> FontObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for FontObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), FontObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {
@@ -95,6 +95,8 @@ pub struct FontObjectData<'gc> {
 
     font: Option<Font<'gc>>,
 }
+
+const _: () = assert!(std::mem::offset_of!(FontObjectData, base) == 0);
 
 impl fmt::Debug for FontObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -92,6 +92,8 @@ pub struct FunctionObjectData<'gc> {
     prototype: Lock<Option<Object<'gc>>>,
 }
 
+const _: () = assert!(std::mem::offset_of!(FunctionObjectData, base) == 0);
+
 impl<'gc> FunctionObject<'gc> {
     /// Construct a function from an ABC method and the current closure scope.
     ///
@@ -152,12 +154,12 @@ impl<'gc> FunctionObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for FunctionObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), FunctionObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -80,7 +80,7 @@ impl fmt::Debug for FunctionObject<'_> {
 
 #[derive(Collect, Clone)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct FunctionObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -93,6 +93,9 @@ pub struct FunctionObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(FunctionObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<FunctionObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> FunctionObject<'gc> {
     /// Construct a function from an ABC method and the current closure scope.

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -14,7 +14,7 @@ use gc_arena::{
     lock::{Lock, RefLock},
     Collect, Gc, GcCell, GcWeak, Mutation,
 };
-use std::cell::{Ref, RefMut};
+use std::cell::Ref;
 
 /// A class instance allocator that allocates Function objects.
 /// This is only used when ActionScript manually calls 'new Function()',

--- a/core/src/avm2/object/index_buffer_3d_object.rs
+++ b/core/src/avm2/object/index_buffer_3d_object.rs
@@ -77,13 +77,15 @@ pub struct IndexBuffer3DObjectData<'gc> {
     context3d: Context3DObject<'gc>,
 }
 
-impl<'gc> TObject<'gc> for IndexBuffer3DObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+const _: () = assert!(std::mem::offset_of!(IndexBuffer3DObjectData, base) == 0);
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), IndexBuffer3DObjectData, base).borrow_mut()
+impl<'gc> TObject<'gc> for IndexBuffer3DObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
+
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/index_buffer_3d_object.rs
+++ b/core/src/avm2/object/index_buffer_3d_object.rs
@@ -5,11 +5,10 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::barrier::unlock;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::backend::IndexBuffer;
-use std::cell::{Cell, Ref, RefCell, RefMut};
+use std::cell::{Cell, RefCell, RefMut};
 
 use super::Context3DObject;
 

--- a/core/src/avm2/object/index_buffer_3d_object.rs
+++ b/core/src/avm2/object/index_buffer_3d_object.rs
@@ -65,7 +65,7 @@ impl<'gc> IndexBuffer3DObject<'gc> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct IndexBuffer3DObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -78,6 +78,10 @@ pub struct IndexBuffer3DObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(IndexBuffer3DObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<IndexBuffer3DObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for IndexBuffer3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -90,7 +90,7 @@ impl fmt::Debug for LoaderInfoObject<'_> {
 
 #[derive(Collect, Clone)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct LoaderInfoObjectData<'gc> {
     /// All normal script data.
     base: RefLock<ScriptObjectData<'gc>>,
@@ -123,6 +123,10 @@ pub struct LoaderInfoObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(LoaderInfoObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<LoaderInfoObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> LoaderInfoObject<'gc> {
     /// Box a movie into a loader info object.

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -122,6 +122,8 @@ pub struct LoaderInfoObjectData<'gc> {
     errored: Cell<bool>,
 }
 
+const _: () = assert!(std::mem::offset_of!(LoaderInfoObjectData, base) == 0);
+
 impl<'gc> LoaderInfoObject<'gc> {
     /// Box a movie into a loader info object.
     pub fn from_movie(
@@ -390,12 +392,12 @@ impl<'gc> LoaderInfoObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for LoaderInfoObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), LoaderInfoObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -18,7 +18,7 @@ use gc_arena::{
     lock::{Lock, RefLock},
     Collect, Gc, GcWeak, Mutation,
 };
-use std::cell::{Cell, Ref, RefMut};
+use std::cell::{Cell, Ref};
 use std::sync::Arc;
 
 /// ActionScript cannot construct a LoaderInfo. Note that LoaderInfo isn't a final class.

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -9,9 +9,8 @@ use crate::local_connection::{LocalConnectionHandle, LocalConnections};
 use crate::string::AvmString;
 use core::fmt;
 use flash_lso::types::Value as AmfValue;
-use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Ref, RefCell, RefMut};
+use std::cell::RefCell;
 
 /// A class instance allocator that allocates LocalConnection objects.
 pub fn local_connection_allocator<'gc>(

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -48,7 +48,7 @@ impl fmt::Debug for LocalConnectionObject<'_> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct LocalConnectionObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -57,6 +57,10 @@ pub struct LocalConnectionObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(LocalConnectionObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<LocalConnectionObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> LocalConnectionObject<'gc> {
     pub fn is_connected(&self) -> bool {

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -57,7 +57,7 @@ impl fmt::Debug for NamespaceObject<'_> {
 
 #[derive(Collect, Clone)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct NamespaceObjectData<'gc> {
     /// All normal script data.
     base: RefLock<ScriptObjectData<'gc>>,
@@ -70,6 +70,10 @@ pub struct NamespaceObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(NamespaceObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<NamespaceObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> NamespaceObject<'gc> {
     /// Box a namespace into an object.

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -13,7 +13,6 @@ use gc_arena::{
     lock::{Lock, RefLock},
     Collect, Gc, GcWeak, Mutation,
 };
-use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates namespace objects.
 pub fn namespace_allocator<'gc>(

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -40,7 +40,7 @@ pub struct NetConnectionObjectWeak<'gc>(pub GcWeak<'gc, NetConnectionObjectData<
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct NetConnectionObjectData<'gc> {
     base: RefLock<ScriptObjectData<'gc>>,
 
@@ -48,6 +48,10 @@ pub struct NetConnectionObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(NetConnectionObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<NetConnectionObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for NetConnectionObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -6,10 +6,9 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::net_connection::NetConnectionHandle;
-use gc_arena::barrier::unlock;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
-use std::cell::{Cell, Ref, RefMut};
+use std::cell::Cell;
 use std::fmt;
 use std::fmt::Debug;
 

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -41,13 +41,17 @@ pub struct NetStreamObjectWeak<'gc>(pub GcWeak<'gc, NetStreamObjectData<'gc>>);
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct NetStreamObjectData<'gc> {
     base: RefLock<ScriptObjectData<'gc>>,
     ns: NetStream<'gc>,
 }
 
 const _: () = assert!(std::mem::offset_of!(NetStreamObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<NetStreamObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for NetStreamObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -6,9 +6,7 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::streams::NetStream;
-use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 
 pub fn netstream_allocator<'gc>(

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -47,13 +47,15 @@ pub struct NetStreamObjectData<'gc> {
     ns: NetStream<'gc>,
 }
 
-impl<'gc> TObject<'gc> for NetStreamObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+const _: () = assert!(std::mem::offset_of!(NetStreamObjectData, base) == 0);
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), NetStreamObjectData, base).borrow_mut()
+impl<'gc> TObject<'gc> for NetStreamObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
+
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -57,6 +57,8 @@ pub struct PrimitiveObjectData<'gc> {
     primitive: RefLock<Value<'gc>>,
 }
 
+const _: () = assert!(std::mem::offset_of!(PrimitiveObjectData, base) == 0);
+
 impl<'gc> PrimitiveObject<'gc> {
     /// Box a primitive into an object.
     ///
@@ -108,12 +110,12 @@ impl<'gc> PrimitiveObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for PrimitiveObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), PrimitiveObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -48,7 +48,7 @@ impl fmt::Debug for PrimitiveObject<'_> {
 
 #[derive(Collect, Clone)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct PrimitiveObjectData<'gc> {
     /// All normal script data.
     base: RefLock<ScriptObjectData<'gc>>,
@@ -58,6 +58,10 @@ pub struct PrimitiveObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(PrimitiveObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<PrimitiveObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> PrimitiveObject<'gc> {
     /// Box a primitive into an object.

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -67,13 +67,15 @@ pub struct Program3DObjectData<'gc> {
     shader_module_handle: RefCell<Option<Rc<dyn ShaderModule>>>,
 }
 
-impl<'gc> TObject<'gc> for Program3DObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+const _: () = assert!(std::mem::offset_of!(Program3DObjectData, base) == 0);
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), Program3DObjectData, base).borrow_mut()
+impl<'gc> TObject<'gc> for Program3DObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
+
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -5,11 +5,10 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::barrier::unlock;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::backend::ShaderModule;
-use std::cell::{Ref, RefCell, RefMut};
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use super::Context3DObject;

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -57,7 +57,7 @@ impl<'gc> Program3DObject<'gc> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct Program3DObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -68,6 +68,10 @@ pub struct Program3DObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(Program3DObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<Program3DObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for Program3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -44,13 +44,16 @@ impl fmt::Debug for ProxyObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct ProxyObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
 }
 
 const _: () = assert!(std::mem::offset_of!(ProxyObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<ProxyObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for ProxyObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -8,9 +8,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
 use core::fmt;
-use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates Proxy objects.
 pub fn proxy_allocator<'gc>(

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -49,7 +49,7 @@ impl fmt::Debug for QNameObject<'_> {
 
 #[derive(Collect, Clone)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct QNameObjectData<'gc> {
     /// All normal script data.
     base: RefLock<ScriptObjectData<'gc>>,
@@ -59,6 +59,9 @@ pub struct QNameObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(QNameObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<QNameObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> QNameObject<'gc> {
     /// Box a Multiname into an object.

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -58,6 +58,8 @@ pub struct QNameObjectData<'gc> {
     name: RefLock<Multiname<'gc>>,
 }
 
+const _: () = assert!(std::mem::offset_of!(QNameObjectData, base) == 0);
+
 impl<'gc> QNameObject<'gc> {
     /// Box a Multiname into an object.
     pub fn from_name(
@@ -133,12 +135,12 @@ impl<'gc> QNameObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for QNameObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), QNameObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -11,7 +11,7 @@ use crate::avm2::Namespace;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Ref, RefMut};
+use std::cell::Ref;
 
 /// A class instance allocator that allocates QName objects.
 pub fn q_name_allocator<'gc>(

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -47,7 +47,7 @@ impl fmt::Debug for RegExpObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct RegExpObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -56,6 +56,9 @@ pub struct RegExpObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(RegExpObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<RegExpObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> RegExpObject<'gc> {
     pub fn from_regexp(

--- a/core/src/avm2/object/responder_object.rs
+++ b/core/src/avm2/object/responder_object.rs
@@ -104,7 +104,7 @@ impl<'gc> ResponderObject<'gc> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct ResponderObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -117,6 +117,10 @@ pub struct ResponderObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ResponderObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<ResponderObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl fmt::Debug for ResponderObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/avm2/object/responder_object.rs
+++ b/core/src/avm2/object/responder_object.rs
@@ -10,7 +10,6 @@ use gc_arena::{
     lock::{Lock, RefLock},
     Collect, Gc, GcWeak, Mutation,
 };
-use std::cell::{Ref, RefMut};
 use std::fmt;
 
 /// A class instance allocator that allocates Responder objects.

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -11,7 +11,6 @@ use crate::avm2::Multiname;
 use crate::avm2::{Error, QName};
 use crate::string::AvmString;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 
 /// A class instance allocator that allocates `ScriptObject`s.

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -61,12 +61,8 @@ pub struct ScriptObjectData<'gc> {
 }
 
 impl<'gc> TObject<'gc> for ScriptObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.borrow()
-    }
-
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        self.0.borrow_mut(mc)
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        self.0
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -40,6 +40,7 @@ pub struct ScriptObjectWeak<'gc>(pub GcWeak<'gc, RefLock<ScriptObjectData<'gc>>>
 /// struct.
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
+#[repr(align(8))]
 pub struct ScriptObjectData<'gc> {
     /// Values stored on this object.
     pub values: DynamicMap<DynamicKey<'gc>, Value<'gc>>,

--- a/core/src/avm2/object/shader_data_object.rs
+++ b/core/src/avm2/object/shader_data_object.rs
@@ -6,11 +6,10 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use core::fmt;
-use gc_arena::barrier::unlock;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::pixel_bender::PixelBenderShaderHandle;
-use std::cell::{Cell, Ref, RefMut};
+use std::cell::Cell;
 
 /// A class instance allocator that allocates ShaderData objects.
 pub fn shader_data_allocator<'gc>(

--- a/core/src/avm2/object/shader_data_object.rs
+++ b/core/src/avm2/object/shader_data_object.rs
@@ -65,13 +65,15 @@ pub struct ShaderDataObjectData<'gc> {
     shader: Cell<Option<PixelBenderShaderHandle>>,
 }
 
-impl<'gc> TObject<'gc> for ShaderDataObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+const _: () = assert!(std::mem::offset_of!(ShaderDataObjectData, base) == 0);
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), ShaderDataObjectData, base).borrow_mut()
+impl<'gc> TObject<'gc> for ShaderDataObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
+
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/shader_data_object.rs
+++ b/core/src/avm2/object/shader_data_object.rs
@@ -57,7 +57,7 @@ impl<'gc> ShaderDataObject<'gc> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct ShaderDataObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -66,6 +66,10 @@ pub struct ShaderDataObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ShaderDataObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<ShaderDataObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for ShaderDataObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/socket_object.rs
+++ b/core/src/avm2/object/socket_object.rs
@@ -199,7 +199,7 @@ impl_read!(read_float 4; f32, read_double 8; f64, read_int 4; i32, read_unsigned
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct SocketObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -216,6 +216,9 @@ pub struct SocketObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(SocketObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<SocketObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl fmt::Debug for SocketObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/avm2/object/socket_object.rs
+++ b/core/src/avm2/object/socket_object.rs
@@ -4,10 +4,9 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::{Activation, Error};
 use crate::socket::SocketHandle;
-use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc};
 use gc_arena::{GcWeak, Mutation};
-use std::cell::{Cell, Ref, RefCell, RefMut};
+use std::cell::{Cell, RefCell, RefMut};
 use std::fmt;
 
 /// A class instance allocator that allocates ShaderData objects.

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -62,7 +62,7 @@ impl fmt::Debug for SoundObject<'_> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct SoundObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -75,6 +75,9 @@ pub struct SoundObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(SoundObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<SoundObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 #[derive(Collect)]
 #[collect(no_drop)]

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -18,7 +18,6 @@ use gc_arena::{
     Collect, Gc, GcWeak, Mutation,
 };
 use id3::{Tag, TagLike};
-use std::cell::{Ref, RefMut};
 use std::io::Cursor;
 use swf::SoundInfo;
 

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -74,6 +74,8 @@ pub struct SoundObjectData<'gc> {
     id3: Lock<Option<Object<'gc>>>,
 }
 
+const _: () = assert!(std::mem::offset_of!(SoundObjectData, base) == 0);
+
 #[derive(Collect)]
 #[collect(no_drop)]
 pub enum SoundData<'gc> {
@@ -277,12 +279,12 @@ fn play_queued<'gc>(
 }
 
 impl<'gc> TObject<'gc> for SoundObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), SoundObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -64,6 +64,8 @@ pub struct SoundChannelObjectData<'gc> {
     position: Cell<f64>,
 }
 
+const _: () = assert!(std::mem::offset_of!(SoundChannelObjectData, base) == 0);
+
 pub enum SoundChannelData {
     NotLoaded {
         sound_transform: Option<SoundTransform>,
@@ -202,12 +204,12 @@ impl<'gc> SoundChannelObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for SoundChannelObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), SoundChannelObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -9,9 +9,8 @@ use crate::backend::audio::SoundInstanceHandle;
 use crate::context::UpdateContext;
 use crate::display_object::SoundTransform;
 use core::fmt;
-use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Cell, Ref, RefCell, RefMut};
+use std::cell::{Cell, RefCell};
 
 /// A class instance allocator that allocates SoundChannel objects.
 pub fn sound_channel_allocator<'gc>(

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -52,7 +52,7 @@ impl fmt::Debug for SoundChannelObject<'_> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct SoundChannelObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -65,6 +65,10 @@ pub struct SoundChannelObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(SoundChannelObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<SoundChannelObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 pub enum SoundChannelData {
     NotLoaded {

--- a/core/src/avm2/object/stage3d_object.rs
+++ b/core/src/avm2/object/stage3d_object.rs
@@ -9,7 +9,7 @@ use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::lock::{Lock, RefLock};
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
-use std::cell::{Cell, Ref, RefMut};
+use std::cell::Cell;
 
 /// A class instance allocator that allocates Stage3D objects.
 pub fn stage_3d_allocator<'gc>(

--- a/core/src/avm2/object/stage3d_object.rs
+++ b/core/src/avm2/object/stage3d_object.rs
@@ -63,7 +63,7 @@ impl<'gc> Stage3DObject<'gc> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct Stage3DObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -75,6 +75,9 @@ pub struct Stage3DObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(Stage3DObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<Stage3DObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for Stage3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/stage3d_object.rs
+++ b/core/src/avm2/object/stage3d_object.rs
@@ -74,13 +74,15 @@ pub struct Stage3DObjectData<'gc> {
     visible: Cell<bool>,
 }
 
-impl<'gc> TObject<'gc> for Stage3DObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+const _: () = assert!(std::mem::offset_of!(Stage3DObjectData, base) == 0);
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), Stage3DObjectData, base).borrow_mut()
+impl<'gc> TObject<'gc> for Stage3DObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
+
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -30,6 +30,8 @@ pub struct StageObjectData<'gc> {
     display_object: DisplayObject<'gc>,
 }
 
+const _: () = assert!(std::mem::offset_of!(StageObjectData, base) == 0);
+
 impl<'gc> StageObject<'gc> {
     /// Allocate the AVM2 side of a display object intended to be of a given
     /// class's type.
@@ -112,12 +114,12 @@ impl<'gc> StageObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for StageObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), StageObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -21,7 +21,7 @@ pub struct StageObjectWeak<'gc>(pub GcWeak<'gc, StageObjectData<'gc>>);
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct StageObjectData<'gc> {
     /// The base data common to all AVM2 objects.
     base: RefLock<ScriptObjectData<'gc>>,
@@ -31,6 +31,9 @@ pub struct StageObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(StageObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<StageObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> StageObject<'gc> {
     /// Allocate the AVM2 side of a display object intended to be of a given

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -6,9 +6,7 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::DisplayObject;
-use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
-use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 
 #[derive(Clone, Collect, Copy)]

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -56,6 +56,8 @@ pub struct TextFormatObjectData<'gc> {
     text_format: RefCell<TextFormat>,
 }
 
+const _: () = assert!(std::mem::offset_of!(TextFormatObjectData, base) == 0);
+
 impl<'gc> TextFormatObject<'gc> {
     pub fn from_text_format(
         activation: &mut Activation<'_, 'gc>,
@@ -78,12 +80,12 @@ impl<'gc> TextFormatObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for TextFormatObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), TextFormatObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -48,7 +48,7 @@ impl fmt::Debug for TextFormatObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct TextFormatObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -57,6 +57,10 @@ pub struct TextFormatObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(TextFormatObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<TextFormatObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TextFormatObject<'gc> {
     pub fn from_text_format(

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -7,7 +7,6 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::html::{TextDisplay, TextFormat};
 use core::fmt;
-use gc_arena::barrier::unlock;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::cell::{Ref, RefCell, RefMut};

--- a/core/src/avm2/object/texture_object.rs
+++ b/core/src/avm2/object/texture_object.rs
@@ -76,13 +76,15 @@ pub struct TextureObjectData<'gc> {
     handle: Rc<dyn Texture>,
 }
 
-impl<'gc> TObject<'gc> for TextureObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+const _: () = assert!(std::mem::offset_of!(TextureObjectData, base) == 0);
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), TextureObjectData, base).borrow_mut()
+impl<'gc> TObject<'gc> for TextureObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
+
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/texture_object.rs
+++ b/core/src/avm2/object/texture_object.rs
@@ -5,11 +5,9 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::barrier::unlock;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::backend::{Context3DTextureFormat, Texture};
-use std::cell::{Ref, RefMut};
 use std::rc::Rc;
 
 use super::{ClassObject, Context3DObject};

--- a/core/src/avm2/object/texture_object.rs
+++ b/core/src/avm2/object/texture_object.rs
@@ -62,7 +62,7 @@ impl<'gc> TextureObject<'gc> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct TextureObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -77,6 +77,9 @@ pub struct TextureObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(TextureObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<TextureObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for TextureObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -53,7 +53,7 @@ impl fmt::Debug for VectorObject<'_> {
 
 #[derive(Collect, Clone)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct VectorObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -63,6 +63,9 @@ pub struct VectorObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(VectorObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<VectorObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> VectorObject<'gc> {
     /// Wrap an existing vector in an object.

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -5,11 +5,9 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::barrier::unlock;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::backend::VertexBuffer;
-use std::cell::{Ref, RefMut};
 use std::rc::Rc;
 
 use super::Context3DObject;

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -79,13 +79,15 @@ pub struct VertexBuffer3DObjectData<'gc> {
     data32_per_vertex: u8,
 }
 
-impl<'gc> TObject<'gc> for VertexBuffer3DObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+const _: () = assert!(std::mem::offset_of!(VertexBuffer3DObjectData, base) == 0);
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), VertexBuffer3DObjectData, base).borrow_mut()
+impl<'gc> TObject<'gc> for VertexBuffer3DObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
+
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -63,7 +63,7 @@ impl<'gc> VertexBuffer3DObject<'gc> {
 
 #[derive(Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct VertexBuffer3DObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -80,6 +80,10 @@ pub struct VertexBuffer3DObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(VertexBuffer3DObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<VertexBuffer3DObjectData>()
+        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> TObject<'gc> for VertexBuffer3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -345,7 +345,7 @@ impl<'gc> XmlListObject<'gc> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct XmlListObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -364,6 +364,9 @@ pub struct XmlListObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(XmlListObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<XmlListObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 /// Holds either an `E4XNode` or an `XmlObject`. This can be converted
 /// in-place to an `XmlObject` via `get_or_create_xml`.

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -363,6 +363,8 @@ pub struct XmlListObjectData<'gc> {
     target_dirty: Cell<bool>,
 }
 
+const _: () = assert!(std::mem::offset_of!(XmlListObjectData, base) == 0);
+
 /// Holds either an `E4XNode` or an `XmlObject`. This can be converted
 /// in-place to an `XmlObject` via `get_or_create_xml`.
 /// This deliberately does not implement `Copy`, since `get_or_create_xml`
@@ -468,12 +470,12 @@ impl<'gc> From<XmlObject<'gc>> for XmlOrXmlListObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for XmlListObject<'gc> {
-    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        self.0.base.borrow()
-    }
+    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+        // SAFETY: Object data is repr(C), and a compile-time assert ensures
+        // that the ScriptObjectData stays at offset 0 of the struct- so the
+        // layouts are compatible
 
-    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        unlock!(Gc::write(mc, self.0), XmlListObjectData, base).borrow_mut()
+        unsafe { Gc::cast(self.0) }
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -18,7 +18,6 @@ use gc_arena::{
     Collect, Gc, GcWeak, Mutation,
 };
 use ruffle_wstr::WString;
-use std::cell::{Ref, RefMut};
 
 use super::xml_list_object::{E4XOrXml, XmlOrXmlListObject};
 use super::PrimitiveObject;

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -58,7 +58,7 @@ impl fmt::Debug for XmlObject<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct XmlObjectData<'gc> {
     /// Base script object
     base: RefLock<ScriptObjectData<'gc>>,
@@ -67,6 +67,9 @@ pub struct XmlObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(XmlObjectData, base) == 0);
+const _: () = assert!(
+    std::mem::align_of::<XmlObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
+);
 
 impl<'gc> XmlObject<'gc> {
     pub fn new(node: E4XNode<'gc>, activation: &mut Activation<'_, 'gc>) -> Self {


### PR DESCRIPTION
All Object variants must now implement a method `gc_base`, which returns a `Gc` around `RefLock<ScriptObjectData>` (which will later be changed to just `ScriptObjectData`). Additionally, `TObject` methods that aren't overriden by the object variants are marked as `#[no_dynamic]`, which prevents them getting duplicated by `enum_trait_object`.