### PR TITLE
desktop: Update screenshot URLs to point to a commit

### DIFF
--- a/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
@@ -54,18 +54,17 @@
     <url type="vcs-browser">https://github.com/ruffle-rs/ruffle</url>
     <url type="contribute">https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md</url>
     <screenshots>
-        <!-- TODO Update URLs to point to a commit -->
         <screenshot environment="gnome:dark" type="default">
-            <image>https://raw.githubusercontent.com/ruffle-rs/ruffle/master/desktop/packages/linux/screenshots/dark-launcher.png</image>
+            <image>https://raw.githubusercontent.com/ruffle-rs/ruffle/efe754cdcc57f0e1f2820e66983f6a5a91e5d2c8/desktop/packages/linux/screenshots/dark-launcher.png</image>
         </screenshot>
         <screenshot environment="gnome:dark">
-            <image>https://raw.githubusercontent.com/ruffle-rs/ruffle/master/desktop/packages/linux/screenshots/dark-bloonstd.png</image>
+            <image>https://raw.githubusercontent.com/ruffle-rs/ruffle/efe754cdcc57f0e1f2820e66983f6a5a91e5d2c8/desktop/packages/linux/screenshots/dark-bloonstd.png</image>
         </screenshot>
         <screenshot environment="gnome:dark">
-            <image>https://raw.githubusercontent.com/ruffle-rs/ruffle/master/desktop/packages/linux/screenshots/dark-learntofly.png</image>
+            <image>https://raw.githubusercontent.com/ruffle-rs/ruffle/efe754cdcc57f0e1f2820e66983f6a5a91e5d2c8/desktop/packages/linux/screenshots/dark-learntofly.png</image>
         </screenshot>
         <screenshot environment="gnome">
-            <image>https://raw.githubusercontent.com/ruffle-rs/ruffle/master/desktop/packages/linux/screenshots/light-launcher.png</image>
+            <image>https://raw.githubusercontent.com/ruffle-rs/ruffle/efe754cdcc57f0e1f2820e66983f6a5a91e5d2c8/desktop/packages/linux/screenshots/light-launcher.png</image>
         </screenshot>
     </screenshots>
     <provides>


### PR DESCRIPTION
Makes URLs more stable after merging https://github.com/ruffle-rs/ruffle/pull/11227