### PR TITLE
Managed `AvmStringRepr`s can now point to a `&'static WStr`

### DIFF
--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -1,5 +1,7 @@
 //! Declarative macro for defining AVM1 properties.
 
+use std::borrow::Cow;
+
 use crate::avm1::function::{Executable, FunctionObject, NativeFunction};
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
@@ -67,8 +69,10 @@ impl Declaration {
     ) -> Value<'gc> {
         let mc = context.gc_context;
 
-        let name = ruffle_wstr::from_utf8(self.name);
-        let name = context.interner.intern_wstr(mc, name);
+        let name = match ruffle_wstr::from_utf8(self.name) {
+            Cow::Borrowed(name) => context.interner.intern_static(mc, name),
+            Cow::Owned(name) => context.interner.intern_wstr(mc, name),
+        };
 
         let value = match self.kind {
             DeclKind::Property { getter, setter } => {

--- a/core/src/string/avm_string.rs
+++ b/core/src/string/avm_string.rs
@@ -21,19 +21,19 @@ pub struct AvmString<'gc> {
 
 impl<'gc> AvmString<'gc> {
     /// Turns a string to a fully owned (non-dependent) managed string.
-    pub(super) fn to_fully_owned(self, gc_context: &Mutation<'gc>) -> Gc<'gc, AvmStringRepr<'gc>> {
+    pub(super) fn to_fully_owned(self, mc: &Mutation<'gc>) -> Gc<'gc, AvmStringRepr<'gc>> {
         match self.source {
             Source::Managed(s) => {
                 if s.is_dependent() {
                     let repr = AvmStringRepr::from_raw(WString::from(self.as_wstr()), false);
-                    Gc::new(gc_context, repr)
+                    Gc::new(mc, repr)
                 } else {
                     s
                 }
             }
             Source::Static(s) => {
-                let repr = AvmStringRepr::from_raw(s.into(), false);
-                Gc::new(gc_context, repr)
+                let repr = AvmStringRepr::from_raw_static(s, false);
+                Gc::new(mc, repr)
             }
         }
     }


### PR DESCRIPTION
Allows `&'static WStr`s to be converted into interned `AvmString`s without moving the string data into an heap-allocated buffer.

Slight progress towards getting rid of static `AvmString`s altogether :)