### PR TITLE
Always build LZMA support and remove the feature flag

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -84,7 +84,7 @@ jobs:
         if: runner.os != 'macOS'
         # TODO: Disallow retries in general once we can allow only after SIGABRT.
         # See: https://github.com/nextest-rs/nextest/issues/1172
-        run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast --retries 2 -j 4 --features imgtests,lzma,jpegxr
+        run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast --retries 2 -j 4 --features imgtests,jpegxr
         env:
           # This is to counteract the disabling by rust-cache.
           # See: https://github.com/Swatinem/rust-cache/issues/43
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run tests without image tests
         if: runner.os == 'macOS'
-        run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features lzma,jpegxr
+        run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features jpegxr
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "754b1184037aa9952a907107284fb73897e26adc", optional = true }
 regress = "0.10"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "f9e3de59a86df1c954fecba6b4b752df61cad73a" }
-lzma-rs = {version = "0.3.0", optional = true }
+lzma-rs = {version = "0.3.0" }
 dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.4", default-features = false, features = ["mp3"], optional = true }
 enumset = "1.1.5"
@@ -77,7 +77,6 @@ version = "0.4.42"
 
 [features]
 default = []
-lzma = ["lzma-rs", "swf/lzma"]
 avm_debug = []
 deterministic = []
 timeline_debug = []
@@ -87,7 +86,7 @@ audio = ["dasp"]
 known_stubs = ["linkme", "serde"]
 default_compatibility_rules = []
 egui = ["dep:egui", "dep:egui_extras", "png"]
-jpegxr = ["dep:jpegxr", "lzma"]
+jpegxr = ["dep:jpegxr"]
 default_font = []
 test_only_as3 = []
 serde = ["serde/derive"]

--- a/core/src/avm2/bytearray.rs
+++ b/core/src/avm2/bytearray.rs
@@ -236,12 +236,9 @@ impl ByteArrayStorage {
                 let mut encoder = DeflateEncoder::new(&*self.bytes, Compression::fast());
                 encoder.read_to_end(&mut buffer).err().map(|e| e.into())
             }
-            #[cfg(feature = "lzma")]
             CompressionAlgorithm::Lzma => lzma_rs::lzma_compress(&mut &*self.bytes, &mut buffer)
                 .err()
                 .map(|e| e.into()),
-            #[cfg(not(feature = "lzma"))]
-            CompressionAlgorithm::Lzma => Some("Ruffle was not compiled with LZMA support".into()),
         };
         if let Some(error) = error {
             // On error, just return an empty buffer.
@@ -263,12 +260,9 @@ impl ByteArrayStorage {
                 let mut decoder = DeflateDecoder::new(&*self.bytes);
                 decoder.read_to_end(&mut buffer).err().map(|e| e.into())
             }
-            #[cfg(feature = "lzma")]
             CompressionAlgorithm::Lzma => lzma_rs::lzma_decompress(&mut &*self.bytes, &mut buffer)
                 .err()
                 .map(|e| e.into()),
-            #[cfg(not(feature = "lzma"))]
-            CompressionAlgorithm::Lzma => Some("Ruffle was not compiled with LZMA support".into()),
         };
         if let Some(error) = error {
             tracing::warn!("ByteArray.decompress: {}", error);

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -67,7 +67,6 @@ jpegxr = ["ruffle_core/jpegxr"]
 
 # core features
 avm_debug = ["ruffle_core/avm_debug"]
-lzma = ["ruffle_core/lzma"]
 software_video = ["ruffle_video_software"]
 external_video = ["ruffle_video_external"]
 tracy = ["tracing-tracy", "ruffle_render_wgpu/profile-with-tracy"]

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -25,4 +25,3 @@ anyhow = { workspace = true }
 avm_debug = ["ruffle_core/avm_debug"]
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]
 render_trace = ["ruffle_render_wgpu/render_trace"]
-lzma = ["ruffle_core/lzma"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,7 +20,6 @@ imgtests = [
     "ruffle_test_framework/ruffle_video_external",
 ]
 jpegxr = ["ruffle_test_framework/jpegxr"]
-lzma = ["ruffle_test_framework/lzma"]
 
 [dependencies]
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -32,4 +32,3 @@ percent-encoding = "2.3.1"
 
 [features]
 jpegxr = ["ruffle_core/jpegxr"]
-lzma = ["ruffle_core/lzma"]

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -131,13 +131,12 @@ impl Approximations {
 #[derive(Clone, Deserialize, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct RequiredFeatures {
-    lzma: bool,
     jpegxr: bool,
 }
 
 impl RequiredFeatures {
     pub fn can_run(&self) -> bool {
-        (!self.lzma || cfg!(feature = "lzma")) && (!self.jpegxr || cfg!(feature = "jpegxr"))
+        !self.jpegxr || cfg!(feature = "jpegxr")
     }
 }
 

--- a/tests/tests/swfs/from_avmplus/as3/ByteArray/ByteArrayLzma/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/ByteArray/ByteArrayLzma/test.toml
@@ -1,4 +1,1 @@
 num_ticks = 1
-
-[required_features]
-lzma = true

--- a/tests/tests/swfs/from_avmplus/as3/ByteArray/ByteArrayLzmaThirdParty/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/ByteArray/ByteArrayLzmaThirdParty/test.toml
@@ -1,4 +1,2 @@
 num_ticks = 1
 
-[required_features]
-lzma = true

--- a/tests/tests/swfs/from_shumway/lzma/test.toml
+++ b/tests/tests/swfs/from_shumway/lzma/test.toml
@@ -1,4 +1,2 @@
 num_frames = 1
 
-[required_features]
-lzma = true

--- a/tests/tests/swfs/from_shumway/lzma_bytes/test.toml
+++ b/tests/tests/swfs/from_shumway/lzma_bytes/test.toml
@@ -1,4 +1,2 @@
 num_frames = 1
 
-[required_features]
-lzma = true

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -20,7 +20,6 @@ default = ["canvas", "console_error_panic_hook", "webgl", "wgpu-webgl", "webgpu"
 
 # core features
 avm_debug = ["ruffle_core/avm_debug"]
-lzma = ["ruffle_core/lzma"]
 jpegxr = ["ruffle_core/jpegxr"]
 
 # web features


### PR DESCRIPTION
From what I've heard LZMA support was not enabled by default because it used to require building C/C++ code.