### PR TITLE
avm2: Use interior mutability in `ScriptObjectData`

### DIFF
--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -59,9 +59,8 @@ pub struct ArrayObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ArrayObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<ArrayObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<ArrayObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> ArrayObject<'gc> {
     /// Construct an empty array.

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -18,7 +18,7 @@ pub fn array_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(ArrayObject(Gc::new(
         activation.context.gc_context,
@@ -52,7 +52,7 @@ impl fmt::Debug for ArrayObject<'_> {
 #[repr(C, align(8))]
 pub struct ArrayObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// Array-structured properties
     array: RefLock<ArrayStorage<'gc>>,
@@ -77,7 +77,7 @@ impl<'gc> ArrayObject<'gc> {
         array: ArrayStorage<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().array;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
 
         let instance: Object<'gc> = ArrayObject(Gc::new(
             activation.context.gc_context,
@@ -96,7 +96,7 @@ impl<'gc> ArrayObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for ArrayObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible
@@ -123,7 +123,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
             }
         }
 
-        self.0.base.borrow().get_property_local(name, activation)
+        self.base().get_property_local(name, activation)
     }
 
     fn get_index_property(self, index: usize) -> Option<Value<'gc>> {
@@ -150,9 +150,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
             }
         }
 
-        unlock!(Gc::write(mc, self.0), ArrayObjectData, base)
-            .borrow_mut()
-            .set_property_local(name, value, activation)
+        self.base().set_property_local(name, value, activation)
     }
 
     fn init_property_local(
@@ -175,9 +173,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
             }
         }
 
-        unlock!(Gc::write(mc, self.0), ArrayObjectData, base)
-            .borrow_mut()
-            .init_property_local(name, value, activation)
+        self.base().init_property_local(name, value, activation)
     }
 
     fn delete_property_local(
@@ -199,9 +195,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
             }
         }
 
-        Ok(unlock!(Gc::write(mc, self.0), ArrayObjectData, base)
-            .borrow_mut()
-            .delete_property_local(name))
+        Ok(self.base().delete_property_local(mc, name))
     }
 
     fn has_own_property(self, name: &Multiname<'gc>) -> bool {
@@ -213,7 +207,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
             }
         }
 
-        self.0.base.borrow().has_own_property(name)
+        self.base().has_own_property(name)
     }
 
     fn get_next_enumerant(
@@ -237,12 +231,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         // After enumerating all of the 'normal' array entries,
         // we enumerate all of the local properties stored on the
         // ScriptObject.
-        if let Some(index) = self
-            .0
-            .base
-            .borrow()
-            .get_next_enumerant(last_index - array_length)
-        {
+        if let Some(index) = self.base().get_next_enumerant(last_index - array_length) {
             return Ok(Some(index + array_length));
         }
         Ok(None)
@@ -261,9 +250,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
                 .unwrap_or(Value::Undefined))
         } else {
             Ok(self
-                .0
-                .base
-                .borrow()
+                .base()
                 .get_enumerant_name(index - arr_len)
                 .unwrap_or(Value::Undefined))
         }
@@ -273,7 +260,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         name.parse::<u32>()
             .map(|index| index < self.0.array.borrow().length() as u32)
             .unwrap_or(false)
-            || self.0.base.borrow().property_is_enumerable(name)
+            || self.base().property_is_enumerable(name)
     }
 
     fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -8,17 +8,14 @@ use crate::avm2::Error;
 use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use core::fmt;
 use gc_arena::barrier::unlock;
-use gc_arena::{
-    lock::{Lock, RefLock},
-    Collect, Gc, GcWeak, Mutation,
-};
+use gc_arena::{lock::Lock, Collect, Gc, GcWeak, Mutation};
 
 /// A class instance allocator that allocates BitmapData objects.
 pub fn bitmap_data_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(BitmapDataObject(Gc::new(
         activation.context.gc_context,
@@ -56,7 +53,7 @@ impl fmt::Debug for BitmapDataObject<'_> {
 #[repr(C, align(8))]
 pub struct BitmapDataObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     bitmap_data: Lock<Option<BitmapDataWrapper<'gc>>>,
 }
@@ -108,7 +105,7 @@ impl<'gc> BitmapDataObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -60,8 +60,7 @@ pub struct BitmapDataObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(BitmapDataObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<BitmapDataObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<BitmapDataObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> BitmapDataObject<'gc> {
@@ -82,7 +81,7 @@ impl<'gc> BitmapDataObject<'gc> {
         let instance: Object<'gc> = Self(Gc::new(
             activation.context.gc_context,
             BitmapDataObjectData {
-                base: ScriptObjectData::new(class).into(),
+                base: ScriptObjectData::new(class),
                 bitmap_data: Lock::new(Some(bitmap_data)),
             },
         ))

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -7,8 +7,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::character::Character;
 use core::fmt;
-use gc_arena::barrier::unlock;
-use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::cell::{Ref, RefCell, RefMut};
 
 /// A class instance allocator that allocates ByteArray objects.
@@ -39,7 +38,7 @@ pub fn byte_array_allocator<'gc>(
         unreachable!("A ByteArray subclass should have ByteArray in superclass chain")
     });
 
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(ByteArrayObject(Gc::new(
         activation.context.gc_context,
@@ -72,7 +71,7 @@ impl fmt::Debug for ByteArrayObject<'_> {
 #[repr(C, align(8))]
 pub struct ByteArrayObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     storage: RefCell<ByteArrayStorage>,
 }
@@ -89,7 +88,7 @@ impl<'gc> ByteArrayObject<'gc> {
         bytes: ByteArrayStorage,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().bytearray;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
 
         let instance: Object<'gc> = ByteArrayObject(Gc::new(
             activation.context.gc_context,
@@ -112,7 +111,7 @@ impl<'gc> ByteArrayObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible
@@ -137,7 +136,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
             }
         }
 
-        self.0.base.borrow().get_property_local(name, activation)
+        self.base().get_property_local(name, activation)
     }
 
     fn get_index_property(self, index: usize) -> Option<Value<'gc>> {
@@ -170,13 +169,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
             }
         }
 
-        unlock!(
-            Gc::write(activation.gc(), self.0),
-            ByteArrayObjectData,
-            base
-        )
-        .borrow_mut()
-        .set_property_local(name, value, activation)
+        self.base().set_property_local(name, value, activation)
     }
 
     fn init_property_local(
@@ -198,13 +191,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
             }
         }
 
-        unlock!(
-            Gc::write(activation.gc(), self.0),
-            ByteArrayObjectData,
-            base
-        )
-        .borrow_mut()
-        .init_property_local(name, value, activation)
+        self.base().init_property_local(name, value, activation)
     }
 
     fn delete_property_local(
@@ -221,13 +208,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
             }
         }
 
-        Ok(unlock!(
-            Gc::write(activation.gc(), self.0),
-            ByteArrayObjectData,
-            base
-        )
-        .borrow_mut()
-        .delete_property_local(name))
+        Ok(self.base().delete_property_local(activation.gc(), name))
     }
 
     fn has_own_property(self, name: &Multiname<'gc>) -> bool {
@@ -239,7 +220,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
             }
         }
 
-        self.0.base.borrow().has_own_property(name)
+        self.base().has_own_property(name)
     }
 
     fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -78,8 +78,7 @@ pub struct ByteArrayObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(ByteArrayObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<ByteArrayObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<ByteArrayObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> ByteArrayObject<'gc> {

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -76,9 +76,8 @@ pub struct ClassObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ClassObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<ClassObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<ClassObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> ClassObject<'gc> {
     /// Allocate the prototype for this class.

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -492,9 +492,8 @@ pub struct Context3DData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(Context3DData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<Context3DData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<Context3DData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> TObject<'gc> for Context3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -8,7 +8,6 @@ use crate::avm2::Error;
 use crate::avm2_stub_method;
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::context::RenderContext;
-use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcCell, GcWeak, Mutation};
 use ruffle_render::backend::{
     BufferUsage, Context3D, Context3DBlendFactor, Context3DCommand, Context3DCompareMode,
@@ -43,7 +42,7 @@ impl<'gc> Context3DObject<'gc> {
         let this: Object<'gc> = Context3DObject(Gc::new(
             activation.gc(),
             Context3DData {
-                base: RefLock::new(ScriptObjectData::new(class)),
+                base: ScriptObjectData::new(class),
                 render_context: Cell::new(Some(context)),
                 stage3d,
             },
@@ -484,7 +483,7 @@ impl<'gc> Context3DObject<'gc> {
 #[repr(C, align(8))]
 pub struct Context3DData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     #[collect(require_static)]
     render_context: Cell<Option<Box<dyn Context3D>>>,
@@ -498,7 +497,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for Context3DObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -81,9 +81,8 @@ pub struct DateObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(DateObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<DateObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<DateObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> TObject<'gc> for DateObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -5,7 +5,6 @@ use crate::avm2::value::{Hint, Value};
 use crate::avm2::Error;
 use chrono::{DateTime, Utc};
 use core::fmt;
-use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::cell::Cell;
 
@@ -17,7 +16,7 @@ pub fn date_allocator<'gc>(
     Ok(DateObject(Gc::new(
         activation.gc(),
         DateObjectData {
-            base: RefLock::new(ScriptObjectData::new(class)),
+            base: ScriptObjectData::new(class),
             date_time: Cell::new(None),
         },
     ))
@@ -45,7 +44,7 @@ impl<'gc> DateObject<'gc> {
         date_time: DateTime<Utc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().date;
-        let base = RefLock::new(ScriptObjectData::new(class));
+        let base = ScriptObjectData::new(class);
 
         let instance: Object<'gc> = DateObject(Gc::new(
             activation.context.gc_context,
@@ -76,7 +75,7 @@ impl<'gc> DateObject<'gc> {
 #[repr(C, align(8))]
 pub struct DateObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     date_time: Cell<Option<DateTime<Utc>>>,
 }
@@ -87,7 +86,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for DateObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -55,8 +55,7 @@ pub struct DictionaryObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(DictionaryObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<DictionaryObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<DictionaryObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> DictionaryObject<'gc> {

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -57,7 +57,7 @@ impl fmt::Debug for DispatchObject<'_> {
 #[repr(C, align(8))]
 pub struct DispatchObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The dispatch list this object holds.
     dispatch: RefLock<DispatchList<'gc>>,
@@ -71,7 +71,7 @@ const _: () = assert!(
 impl<'gc> DispatchObject<'gc> {
     /// Construct an empty dispatch list.
     pub fn empty_list(activation: &mut Activation<'_, 'gc>) -> Object<'gc> {
-        let base = ScriptObjectData::new(activation.avm2().classes().object).into();
+        let base = ScriptObjectData::new(activation.avm2().classes().object);
 
         DispatchObject(Gc::new(
             activation.context.gc_context,
@@ -85,7 +85,7 @@ impl<'gc> DispatchObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for DispatchObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -64,9 +64,8 @@ pub struct DispatchObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(DispatchObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<DispatchObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<DispatchObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> DispatchObject<'gc> {
     /// Construct an empty dispatch list.

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -56,9 +56,8 @@ pub struct DomainObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(DomainObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<DomainObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<DomainObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> DomainObject<'gc> {
     /// Create a new object for a given domain.

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -8,10 +8,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use core::fmt;
 use gc_arena::barrier::unlock;
-use gc_arena::{
-    lock::{Lock, RefLock},
-    Collect, Gc, GcWeak, Mutation,
-};
+use gc_arena::{lock::Lock, Collect, Gc, GcWeak, Mutation};
 
 /// A class instance allocator that allocates AppDomain objects.
 pub fn application_domain_allocator<'gc>(
@@ -19,7 +16,7 @@ pub fn application_domain_allocator<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let domain = activation.domain();
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(DomainObject(Gc::new(
         activation.context.gc_context,
@@ -52,7 +49,7 @@ impl fmt::Debug for DomainObject<'_> {
 #[repr(C, align(8))]
 pub struct DomainObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The domain this object holds
     domain: Lock<Domain<'gc>>,
@@ -73,7 +70,7 @@ impl<'gc> DomainObject<'gc> {
         domain: Domain<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().application_domain;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
         let this: Object<'gc> = DomainObject(Gc::new(
             activation.context.gc_context,
             DomainObjectData {
@@ -95,7 +92,7 @@ impl<'gc> DomainObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for DomainObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -58,9 +58,8 @@ pub struct ErrorObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ErrorObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<ErrorObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<ErrorObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> ErrorObject<'gc> {
     pub fn display(&self) -> Result<WString, Error<'gc>> {

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -21,7 +21,7 @@ pub fn event_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(EventObject(Gc::new(
         activation.context.gc_context,
@@ -46,7 +46,7 @@ pub struct EventObjectWeak<'gc>(pub GcWeak<'gc, EventObjectData<'gc>>);
 #[repr(C, align(8))]
 pub struct EventObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The event this object holds.
     event: RefLock<Event<'gc>>,
@@ -352,7 +352,7 @@ impl<'gc> EventObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for EventObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible
@@ -381,7 +381,7 @@ impl<'gc> Debug for EventObject<'gc> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("EventObject")
             .field("type", &self.0.event.borrow().event_type())
-            .field("class", &self.0.base.borrow().debug_class_name())
+            .field("class", &self.base().debug_class_name())
             .field("ptr", &Gc::as_ptr(self.0))
             .finish()
     }

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -53,9 +53,8 @@ pub struct EventObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(EventObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<EventObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<EventObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> EventObject<'gc> {
     /// Create a bare Event instance while skipping the usual `construct()` pipeline.
@@ -82,7 +81,7 @@ impl<'gc> EventObject<'gc> {
         S: Into<AvmString<'gc>>,
     {
         let class = context.avm2.classes().event;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
 
         let mut event = Event::new(event_type);
         event.set_bubbles(bubbles);

--- a/core/src/avm2/object/file_reference_object.rs
+++ b/core/src/avm2/object/file_reference_object.rs
@@ -94,8 +94,7 @@ pub struct FileReferenceObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(FileReferenceObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<FileReferenceObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<FileReferenceObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl fmt::Debug for FileReferenceObject<'_> {

--- a/core/src/avm2/object/file_reference_object.rs
+++ b/core/src/avm2/object/file_reference_object.rs
@@ -3,7 +3,7 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::{Activation, Error};
 use crate::backend::ui::FileDialogResult;
-use gc_arena::{lock::RefLock, Collect, Gc};
+use gc_arena::{Collect, Gc};
 use gc_arena::{GcWeak, Mutation};
 use std::cell::{Cell, Ref, RefCell};
 use std::fmt;
@@ -12,7 +12,7 @@ pub fn file_reference_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(FileReferenceObject(Gc::new(
         activation.context.gc(),
@@ -34,7 +34,7 @@ pub struct FileReferenceObject<'gc>(pub Gc<'gc, FileReferenceObjectData<'gc>>);
 pub struct FileReferenceObjectWeak<'gc>(pub GcWeak<'gc, FileReferenceObjectData<'gc>>);
 
 impl<'gc> TObject<'gc> for FileReferenceObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible
@@ -85,7 +85,7 @@ pub enum FileReference {
 #[repr(C, align(8))]
 pub struct FileReferenceObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     reference: RefCell<FileReference>,
 

--- a/core/src/avm2/object/font_object.rs
+++ b/core/src/avm2/object/font_object.rs
@@ -4,7 +4,7 @@ use crate::avm2::value::Value;
 use crate::avm2::{Activation, ClassObject, Error};
 use crate::character::Character;
 use crate::font::Font;
-use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::fmt;
 
 /// A class instance allocator that allocates Font objects.
@@ -12,7 +12,7 @@ pub fn font_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     let font = if let Some((movie, id)) = activation
         .context
@@ -63,7 +63,7 @@ impl<'gc> FontObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for FontObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible
@@ -89,7 +89,7 @@ impl<'gc> TObject<'gc> for FontObject<'gc> {
 #[repr(C, align(8))]
 pub struct FontObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     font: Option<Font<'gc>>,
 }

--- a/core/src/avm2/object/font_object.rs
+++ b/core/src/avm2/object/font_object.rs
@@ -50,7 +50,7 @@ pub struct FontObjectWeak<'gc>(pub GcWeak<'gc, FontObjectData<'gc>>);
 
 impl<'gc> FontObject<'gc> {
     pub fn for_font(mc: &Mutation<'gc>, class: ClassObject<'gc>, font: Font<'gc>) -> Object<'gc> {
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
         FontObject(Gc::new(
             mc,
             FontObjectData {
@@ -95,9 +95,8 @@ pub struct FontObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(FontObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<FontObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<FontObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl fmt::Debug for FontObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -27,7 +27,7 @@ pub fn function_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     let dummy = Gc::new(
         activation.context.gc_context,
@@ -83,7 +83,7 @@ impl fmt::Debug for FunctionObject<'_> {
 #[repr(C, align(8))]
 pub struct FunctionObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// Executable code
     exec: RefLock<BoundMethod<'gc>>,
@@ -136,7 +136,7 @@ impl<'gc> FunctionObject<'gc> {
         FunctionObject(Gc::new(
             activation.context.gc_context,
             FunctionObjectData {
-                base: ScriptObjectData::new(fn_class).into(),
+                base: ScriptObjectData::new(fn_class),
                 exec: RefLock::new(exec),
                 prototype: Lock::new(None),
             },
@@ -157,7 +157,7 @@ impl<'gc> FunctionObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for FunctionObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -93,9 +93,8 @@ pub struct FunctionObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(FunctionObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<FunctionObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<FunctionObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> FunctionObject<'gc> {
     /// Construct a function from an ABC method and the current closure scope.

--- a/core/src/avm2/object/index_buffer_3d_object.rs
+++ b/core/src/avm2/object/index_buffer_3d_object.rs
@@ -77,8 +77,7 @@ pub struct IndexBuffer3DObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(IndexBuffer3DObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<IndexBuffer3DObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<IndexBuffer3DObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> TObject<'gc> for IndexBuffer3DObject<'gc> {

--- a/core/src/avm2/object/index_buffer_3d_object.rs
+++ b/core/src/avm2/object/index_buffer_3d_object.rs
@@ -5,7 +5,6 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::backend::IndexBuffer;
 use std::cell::{Cell, RefCell, RefMut};
@@ -31,7 +30,7 @@ impl<'gc> IndexBuffer3DObject<'gc> {
         let this: Object<'gc> = IndexBuffer3DObject(Gc::new(
             activation.gc(),
             IndexBuffer3DObjectData {
-                base: RefLock::new(ScriptObjectData::new(class)),
+                base: ScriptObjectData::new(class),
                 context3d,
                 handle: RefCell::new(handle),
                 count: Cell::new(0),
@@ -67,7 +66,7 @@ impl<'gc> IndexBuffer3DObject<'gc> {
 #[repr(C, align(8))]
 pub struct IndexBuffer3DObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     handle: RefCell<Box<dyn IndexBuffer>>,
 
@@ -83,7 +82,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for IndexBuffer3DObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -93,7 +93,7 @@ impl fmt::Debug for LoaderInfoObject<'_> {
 #[repr(C, align(8))]
 pub struct LoaderInfoObjectData<'gc> {
     /// All normal script data.
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The loaded stream that this gets its info from.
     loaded_stream: RefLock<LoaderStream<'gc>>,
@@ -137,7 +137,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         loader: Option<Object<'gc>>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().loaderinfo;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
         let loaded_stream = LoaderStream::Swf(movie, root);
 
         let this: Object<'gc> = LoaderInfoObject(Gc::new(
@@ -186,7 +186,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         is_stage: bool,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().loaderinfo;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
 
         let this: Object<'gc> = LoaderInfoObject(Gc::new(
             activation.context.gc_context,
@@ -396,7 +396,7 @@ impl<'gc> LoaderInfoObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for LoaderInfoObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -124,8 +124,7 @@ pub struct LoaderInfoObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(LoaderInfoObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<LoaderInfoObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<LoaderInfoObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> LoaderInfoObject<'gc> {

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -57,8 +57,7 @@ pub struct LocalConnectionObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(LocalConnectionObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<LocalConnectionObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<LocalConnectionObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> LocalConnectionObject<'gc> {

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -9,7 +9,7 @@ use crate::local_connection::{LocalConnectionHandle, LocalConnections};
 use crate::string::AvmString;
 use core::fmt;
 use flash_lso::types::Value as AmfValue;
-use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::cell::RefCell;
 
 /// A class instance allocator that allocates LocalConnection objects.
@@ -17,7 +17,7 @@ pub fn local_connection_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(LocalConnectionObject(Gc::new(
         activation.context.gc_context,
@@ -50,7 +50,7 @@ impl fmt::Debug for LocalConnectionObject<'_> {
 #[repr(C, align(8))]
 pub struct LocalConnectionObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     connection_handle: RefCell<Option<LocalConnectionHandle>>,
 }
@@ -150,7 +150,7 @@ impl<'gc> LocalConnectionObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for LocalConnectionObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -67,8 +67,7 @@ pub struct NamespaceObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(NamespaceObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<NamespaceObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<NamespaceObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> NamespaceObject<'gc> {

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -9,17 +9,14 @@ use crate::avm2::Namespace;
 use crate::string::AvmString;
 use core::fmt;
 use gc_arena::barrier::unlock;
-use gc_arena::{
-    lock::{Lock, RefLock},
-    Collect, Gc, GcWeak, Mutation,
-};
+use gc_arena::{lock::Lock, Collect, Gc, GcWeak, Mutation};
 
 /// A class instance allocator that allocates namespace objects.
 pub fn namespace_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     let namespace = activation.context.avm2.public_namespace_base_version;
     Ok(NamespaceObject(Gc::new(
@@ -59,7 +56,7 @@ impl fmt::Debug for NamespaceObject<'_> {
 #[repr(C, align(8))]
 pub struct NamespaceObjectData<'gc> {
     /// All normal script data.
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The namespace name this object is associated with.
     namespace: Lock<Namespace<'gc>>,
@@ -81,7 +78,7 @@ impl<'gc> NamespaceObject<'gc> {
         namespace: Namespace<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().namespace;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
 
         let this: Object<'gc> = NamespaceObject(Gc::new(
             activation.context.gc_context,
@@ -121,7 +118,7 @@ impl<'gc> NamespaceObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for NamespaceObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -6,7 +6,6 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::net_connection::NetConnectionHandle;
-use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::cell::Cell;
 use std::fmt;
@@ -16,7 +15,7 @@ pub fn net_connection_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
     let this: Object<'gc> = NetConnectionObject(Gc::new(
         activation.context.gc_context,
         NetConnectionObjectData {
@@ -41,7 +40,7 @@ pub struct NetConnectionObjectWeak<'gc>(pub GcWeak<'gc, NetConnectionObjectData<
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct NetConnectionObjectData<'gc> {
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     handle: Cell<Option<NetConnectionHandle>>,
 }
@@ -53,7 +52,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for NetConnectionObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -47,8 +47,7 @@ pub struct NetConnectionObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(NetConnectionObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<NetConnectionObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<NetConnectionObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> TObject<'gc> for NetConnectionObject<'gc> {

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -47,8 +47,7 @@ pub struct NetStreamObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(NetStreamObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<NetStreamObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<NetStreamObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> TObject<'gc> for NetStreamObject<'gc> {

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -6,14 +6,14 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::streams::NetStream;
-use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::fmt::Debug;
 
 pub fn netstream_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     let ns = NetStream::new(activation.context.gc_context, None);
     let this: Object<'gc> = NetStreamObject(Gc::new(
@@ -41,7 +41,7 @@ pub struct NetStreamObjectWeak<'gc>(pub GcWeak<'gc, NetStreamObjectData<'gc>>);
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct NetStreamObjectData<'gc> {
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
     ns: NetStream<'gc>,
 }
 
@@ -52,7 +52,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for NetStreamObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -59,8 +59,7 @@ pub struct PrimitiveObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(PrimitiveObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<PrimitiveObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<PrimitiveObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> PrimitiveObject<'gc> {

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -17,7 +17,7 @@ pub fn primitive_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(PrimitiveObject(Gc::new(
         activation.context.gc_context,
@@ -51,7 +51,7 @@ impl fmt::Debug for PrimitiveObject<'_> {
 #[repr(C, align(8))]
 pub struct PrimitiveObjectData<'gc> {
     /// All normal script data.
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The primitive value this object represents.
     primitive: RefLock<Value<'gc>>,
@@ -93,7 +93,7 @@ impl<'gc> PrimitiveObject<'gc> {
             _ => unreachable!(),
         };
 
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
         let this: Object<'gc> = PrimitiveObject(Gc::new(
             activation.context.gc_context,
             PrimitiveObjectData {
@@ -114,7 +114,7 @@ impl<'gc> PrimitiveObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for PrimitiveObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -5,7 +5,6 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::backend::ShaderModule;
 use std::cell::RefCell;
@@ -32,7 +31,7 @@ impl<'gc> Program3DObject<'gc> {
         let this: Object<'gc> = Program3DObject(Gc::new(
             activation.gc(),
             Program3DObjectData {
-                base: RefLock::new(base),
+                base,
                 context3d,
                 shader_module_handle: RefCell::new(None),
             },
@@ -59,7 +58,7 @@ impl<'gc> Program3DObject<'gc> {
 #[repr(C, align(8))]
 pub struct Program3DObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     context3d: Context3DObject<'gc>,
 
@@ -73,7 +72,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for Program3DObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -67,8 +67,7 @@ pub struct Program3DObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(Program3DObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<Program3DObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<Program3DObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> TObject<'gc> for Program3DObject<'gc> {

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -49,9 +49,8 @@ pub struct ProxyObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(ProxyObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<ProxyObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<ProxyObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> TObject<'gc> for ProxyObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -8,14 +8,14 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
 use core::fmt;
-use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak, Mutation};
 
 /// A class instance allocator that allocates Proxy objects.
 pub fn proxy_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(ProxyObject(Gc::new(
         activation.context.gc_context,
@@ -45,7 +45,7 @@ impl fmt::Debug for ProxyObject<'_> {
 #[repr(C, align(8))]
 pub struct ProxyObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 }
 
 const _: () = assert!(std::mem::offset_of!(ProxyObjectData, base) == 0);
@@ -54,7 +54,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for ProxyObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -59,9 +59,8 @@ pub struct QNameObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(QNameObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<QNameObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<QNameObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> QNameObject<'gc> {
     /// Box a Multiname into an object.

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -18,7 +18,7 @@ pub fn q_name_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(QNameObject(Gc::new(
         activation.context.gc_context,
@@ -52,7 +52,7 @@ impl fmt::Debug for QNameObject<'_> {
 #[repr(C, align(8))]
 pub struct QNameObjectData<'gc> {
     /// All normal script data.
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The Multiname this object is associated with.
     name: RefLock<Multiname<'gc>>,
@@ -70,7 +70,7 @@ impl<'gc> QNameObject<'gc> {
         name: Multiname<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().qname;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
 
         let this: Object<'gc> = QNameObject(Gc::new(
             activation.context.gc_context,
@@ -138,7 +138,7 @@ impl<'gc> QNameObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for QNameObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -56,9 +56,8 @@ pub struct RegExpObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(RegExpObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<RegExpObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<RegExpObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> RegExpObject<'gc> {
     pub fn from_regexp(

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -17,7 +17,7 @@ pub fn reg_exp_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(RegExpObject(Gc::new(
         activation.context.gc_context,
@@ -50,7 +50,7 @@ impl fmt::Debug for RegExpObject<'_> {
 #[repr(C, align(8))]
 pub struct RegExpObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     regexp: RefLock<RegExp<'gc>>,
 }
@@ -66,7 +66,7 @@ impl<'gc> RegExpObject<'gc> {
         regexp: RegExp<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().regexp;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
 
         let this: Object<'gc> = RegExpObject(Gc::new(
             activation.context.gc_context,
@@ -85,7 +85,7 @@ impl<'gc> RegExpObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for RegExpObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/responder_object.rs
+++ b/core/src/avm2/object/responder_object.rs
@@ -114,8 +114,7 @@ pub struct ResponderObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(ResponderObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<ResponderObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<ResponderObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl fmt::Debug for ResponderObject<'_> {

--- a/core/src/avm2/object/responder_object.rs
+++ b/core/src/avm2/object/responder_object.rs
@@ -6,10 +6,7 @@ use crate::context::UpdateContext;
 use crate::net_connection::ResponderCallback;
 use flash_lso::types::Value as AMFValue;
 use gc_arena::barrier::unlock;
-use gc_arena::{
-    lock::{Lock, RefLock},
-    Collect, Gc, GcWeak, Mutation,
-};
+use gc_arena::{lock::Lock, Collect, Gc, GcWeak, Mutation};
 use std::fmt;
 
 /// A class instance allocator that allocates Responder objects.
@@ -17,7 +14,7 @@ pub fn responder_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(ResponderObject(Gc::new(
         activation.context.gc(),
@@ -39,7 +36,7 @@ pub struct ResponderObject<'gc>(pub Gc<'gc, ResponderObjectData<'gc>>);
 pub struct ResponderObjectWeak<'gc>(pub GcWeak<'gc, ResponderObjectData<'gc>>);
 
 impl<'gc> TObject<'gc> for ResponderObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible
@@ -106,7 +103,7 @@ impl<'gc> ResponderObject<'gc> {
 #[repr(C, align(8))]
 pub struct ResponderObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// Method to call with any result
     result: Lock<Option<FunctionObject<'gc>>>,

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -23,7 +23,7 @@ pub fn scriptobject_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(ScriptObject(Gc::new(activation.context.gc_context, base)).into())
 }

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -10,7 +10,12 @@ use crate::avm2::vtable::VTable;
 use crate::avm2::Multiname;
 use crate::avm2::{Error, QName};
 use crate::string::AvmString;
-use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
+use gc_arena::barrier::unlock;
+use gc_arena::{
+    lock::{Lock, RefLock},
+    Collect, Gc, GcWeak, Mutation,
+};
+use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 
 /// A class instance allocator that allocates `ScriptObject`s.
@@ -26,11 +31,11 @@ pub fn scriptobject_allocator<'gc>(
 /// Default implementation of `avm2::Object`.
 #[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
-pub struct ScriptObject<'gc>(pub Gc<'gc, RefLock<ScriptObjectData<'gc>>>);
+pub struct ScriptObject<'gc>(pub Gc<'gc, ScriptObjectData<'gc>>);
 
 #[derive(Clone, Collect, Copy, Debug)]
 #[collect(no_drop)]
-pub struct ScriptObjectWeak<'gc>(pub GcWeak<'gc, RefLock<ScriptObjectData<'gc>>>);
+pub struct ScriptObjectWeak<'gc>(pub GcWeak<'gc, ScriptObjectData<'gc>>);
 
 /// Base data common to all `TObject` implementations.
 ///
@@ -42,26 +47,26 @@ pub struct ScriptObjectWeak<'gc>(pub GcWeak<'gc, RefLock<ScriptObjectData<'gc>>>
 #[repr(align(8))]
 pub struct ScriptObjectData<'gc> {
     /// Values stored on this object.
-    pub values: DynamicMap<DynamicKey<'gc>, Value<'gc>>,
+    values: RefLock<DynamicMap<DynamicKey<'gc>, Value<'gc>>>,
 
     /// Slots stored on this object.
-    slots: Vec<Value<'gc>>,
+    slots: RefLock<Vec<Value<'gc>>>,
 
     /// Methods stored on this object.
-    bound_methods: Vec<Option<FunctionObject<'gc>>>,
+    bound_methods: RefLock<Vec<Option<FunctionObject<'gc>>>>,
 
     /// Implicit prototype of this script object.
-    proto: Option<Object<'gc>>,
+    proto: Lock<Option<Object<'gc>>>,
 
     /// The `Class` that this is an instance of.
     instance_class: Class<'gc>,
 
     /// The table used for non-dynamic property lookups.
-    vtable: Option<VTable<'gc>>,
+    vtable: Lock<Option<VTable<'gc>>>,
 }
 
 impl<'gc> TObject<'gc> for ScriptObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         self.0
     }
 
@@ -106,7 +111,7 @@ impl<'gc> ScriptObject<'gc> {
     ) -> Object<'gc> {
         ScriptObject(Gc::new(
             mc,
-            RefLock::new(ScriptObjectData::custom_new(class, proto, class_obj)),
+            ScriptObjectData::custom_new(class, proto, class_obj),
         ))
         .into()
     }
@@ -114,19 +119,24 @@ impl<'gc> ScriptObject<'gc> {
     /// A special case for `newcatch` implementation. Basically a variable (q)name
     /// which maps to slot 1.
     pub fn catch_scope(activation: &mut Activation<'_, 'gc>, qname: &QName<'gc>) -> Object<'gc> {
+        let mc = activation.context.gc_context;
+
         // TODO: use a proper ClassObject here; purposefully crafted bytecode
         // can observe (the lack of) it.
-        let mut base = ScriptObjectData::custom_new(
-            activation.avm2().classes().object.inner_class_definition(),
-            None,
-            None,
-        );
+        let base = ScriptObjectWrapper(Gc::new(
+            mc,
+            ScriptObjectData::custom_new(
+                activation.avm2().classes().object.inner_class_definition(),
+                None,
+                None,
+            ),
+        ));
 
-        let vt = VTable::newcatch(activation.context.gc_context, qname);
-        base.set_vtable(vt);
-        base.install_instance_slots();
+        let vt = VTable::newcatch(mc, qname);
+        base.set_vtable(mc, vt);
+        base.install_instance_slots(mc);
 
-        ScriptObject(Gc::new(activation.context.gc_context, RefLock::new(base))).into()
+        ScriptObject(base.0).into()
     }
 }
 
@@ -152,20 +162,46 @@ impl<'gc> ScriptObjectData<'gc> {
         instance_of: Option<ClassObject<'gc>>,
     ) -> Self {
         ScriptObjectData {
-            values: Default::default(),
-            slots: Vec::new(),
-            bound_methods: Vec::new(),
-            proto,
+            values: RefLock::new(Default::default()),
+            slots: RefLock::new(Vec::new()),
+            bound_methods: RefLock::new(Vec::new()),
+            proto: Lock::new(proto),
             instance_class,
-            vtable: instance_of.map(|cls| cls.instance_vtable()),
+            vtable: Lock::new(instance_of.map(|cls| cls.instance_vtable())),
         }
     }
+}
 
+#[derive(Clone, Copy)]
+pub struct ScriptObjectWrapper<'gc>(pub Gc<'gc, ScriptObjectData<'gc>>);
+
+impl<'gc> ScriptObjectWrapper<'gc> {
     /// Retrieve the values stored directly on this ScriptObjectData.
-    ///
-    /// This should only be used for debugging purposes.
-    pub fn values(&self) -> &DynamicMap<DynamicKey<'gc>, Value<'gc>> {
-        &self.values
+    pub fn values(&self) -> Ref<DynamicMap<DynamicKey<'gc>, Value<'gc>>> {
+        self.0.values.borrow()
+    }
+
+    pub fn values_mut(
+        &self,
+        mc: &Mutation<'gc>,
+    ) -> RefMut<DynamicMap<DynamicKey<'gc>, Value<'gc>>> {
+        unlock!(Gc::write(mc, self.0), ScriptObjectData, values).borrow_mut()
+    }
+
+    fn slots(&self) -> Ref<Vec<Value<'gc>>> {
+        self.0.slots.borrow()
+    }
+
+    fn slots_mut(&self, mc: &Mutation<'gc>) -> RefMut<Vec<Value<'gc>>> {
+        unlock!(Gc::write(mc, self.0), ScriptObjectData, slots).borrow_mut()
+    }
+
+    fn bound_methods(&self) -> Ref<Vec<Option<FunctionObject<'gc>>>> {
+        self.0.bound_methods.borrow()
+    }
+
+    fn bound_methods_mut(&self, mc: &Mutation<'gc>) -> RefMut<Vec<Option<FunctionObject<'gc>>>> {
+        unlock!(Gc::write(mc, self.0), ScriptObjectData, bound_methods).borrow_mut()
     }
 
     pub fn get_property_local(
@@ -195,7 +231,8 @@ impl<'gc> ScriptObjectData<'gc> {
         // Unbelievably cursed special case in avmplus:
         // https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/ScriptObject.cpp#L195-L199
         let key = maybe_int_property(local_name);
-        let value = self.values.as_hashmap().get(&key);
+        let values = self.values();
+        let value = values.as_hashmap().get(&key);
         if let Some(value) = value {
             return Ok(value.value);
         }
@@ -204,7 +241,8 @@ impl<'gc> ScriptObjectData<'gc> {
         let mut proto = self.proto();
         while let Some(obj) = proto {
             let obj = obj.base();
-            let value = obj.values.as_hashmap().get(&key);
+            let values = obj.values();
+            let value = values.as_hashmap().get(&key);
             if let Some(value) = value {
                 return Ok(value.value);
             }
@@ -227,7 +265,7 @@ impl<'gc> ScriptObjectData<'gc> {
     }
 
     pub fn set_property_local(
-        &mut self,
+        &self,
         multiname: &Multiname<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
@@ -254,12 +292,12 @@ impl<'gc> ScriptObjectData<'gc> {
         // https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/ScriptObject.cpp#L311-L315
         let key = maybe_int_property(local_name);
 
-        self.values.insert(key, value);
+        self.values_mut(activation.gc()).insert(key, value);
         Ok(())
     }
 
     pub fn init_property_local(
-        &mut self,
+        &self,
         multiname: &Multiname<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
@@ -267,13 +305,13 @@ impl<'gc> ScriptObjectData<'gc> {
         self.set_property_local(multiname, value, activation)
     }
 
-    pub fn delete_property_local(&mut self, multiname: &Multiname<'gc>) -> bool {
+    pub fn delete_property_local(&self, mc: &Mutation<'gc>, multiname: &Multiname<'gc>) -> bool {
         if !multiname.contains_public_namespace() {
             return false;
         }
         if let Some(name) = multiname.local_name() {
             let key = maybe_int_property(name);
-            self.values.remove(&key);
+            self.values_mut(mc).remove(&key);
             true
         } else {
             false
@@ -281,7 +319,7 @@ impl<'gc> ScriptObjectData<'gc> {
     }
 
     pub fn get_slot(&self, id: u32) -> Result<Value<'gc>, Error<'gc>> {
-        self.slots
+        self.slots()
             .get(id as usize)
             .cloned()
             .ok_or_else(|| format!("Slot index {id} out of bounds!").into())
@@ -289,12 +327,12 @@ impl<'gc> ScriptObjectData<'gc> {
 
     /// Set a slot by its index.
     pub fn set_slot(
-        &mut self,
+        &self,
         id: u32,
         value: Value<'gc>,
-        _mc: &Mutation<'gc>,
+        mc: &Mutation<'gc>,
     ) -> Result<(), Error<'gc>> {
-        if let Some(slot) = self.slots.get_mut(id as usize) {
+        if let Some(slot) = self.slots_mut(mc).get_mut(id as usize) {
             *slot = value;
             Ok(())
         } else {
@@ -302,37 +340,41 @@ impl<'gc> ScriptObjectData<'gc> {
         }
     }
 
-    pub fn install_instance_slots(&mut self) {
+    pub fn install_instance_slots(&self, mc: &Mutation<'gc>) {
         use std::ops::Deref;
-        let vtable = self.vtable.unwrap();
+        let vtable = self.vtable().unwrap();
         let default_slots = vtable.default_slots();
+        let mut slots = self.slots_mut(mc);
+
         for value in default_slots.deref() {
             if let Some(value) = value {
-                self.slots.push(*value);
+                slots.push(*value);
             } else {
-                self.slots.push(Value::Undefined)
+                slots.push(Value::Undefined)
             }
         }
     }
 
     /// Set a slot by its index. This does extend the array if needed.
     /// This should only be used during AVM initialization, not at runtime.
-    pub fn install_const_slot_late(&mut self, id: u32, value: Value<'gc>) {
-        if self.slots.len() < id as usize + 1 {
-            self.slots.resize(id as usize + 1, Value::Undefined);
+    pub fn install_const_slot_late(&self, mc: &Mutation<'gc>, id: u32, value: Value<'gc>) {
+        let mut slots = self.slots_mut(mc);
+
+        if slots.len() < id as usize + 1 {
+            slots.resize(id as usize + 1, Value::Undefined);
         }
-        if let Some(slot) = self.slots.get_mut(id as usize) {
+        if let Some(slot) = slots.get_mut(id as usize) {
             *slot = value;
         }
     }
 
     /// Retrieve a bound method from the method table.
     pub fn get_bound_method(&self, id: u32) -> Option<FunctionObject<'gc>> {
-        self.bound_methods.get(id as usize).and_then(|v| *v)
+        self.bound_methods().get(id as usize).and_then(|v| *v)
     }
 
     pub fn has_trait(&self, name: &Multiname<'gc>) -> bool {
-        match self.vtable {
+        match self.vtable() {
             //Class instances have instance traits from any class in the base
             //class chain.
             Some(vtable) => vtable.has_trait(name),
@@ -348,7 +390,7 @@ impl<'gc> ScriptObjectData<'gc> {
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {
                 let key = maybe_int_property(name);
-                return self.values.as_hashmap().get(&key).is_some();
+                return self.values().as_hashmap().get(&key).is_some();
             }
         }
         false
@@ -359,19 +401,21 @@ impl<'gc> ScriptObjectData<'gc> {
     }
 
     pub fn proto(&self) -> Option<Object<'gc>> {
-        self.proto
+        self.0.proto.get()
     }
 
-    pub fn set_proto(&mut self, proto: Object<'gc>) {
-        self.proto = Some(proto)
+    pub fn set_proto(&self, mc: &Mutation<'gc>, proto: Object<'gc>) {
+        unlock!(Gc::write(mc, self.0), ScriptObjectData, proto).set(Some(proto));
     }
 
     pub fn get_next_enumerant(&self, last_index: u32) -> Option<u32> {
-        self.values.next(last_index as usize).map(|val| val as u32)
+        self.values()
+            .next(last_index as usize)
+            .map(|val| val as u32)
     }
 
     pub fn get_enumerant_name(&self, index: u32) -> Option<Value<'gc>> {
-        self.values.key_at(index as usize).map(|key| match key {
+        self.values().key_at(index as usize).map(|key| match key {
             DynamicKey::String(name) => Value::String(*name),
             DynamicKey::Object(obj) => Value::Object(*obj),
             DynamicKey::Uint(val) => Value::Number(*val as f64),
@@ -380,45 +424,56 @@ impl<'gc> ScriptObjectData<'gc> {
 
     pub fn property_is_enumerable(&self, name: AvmString<'gc>) -> bool {
         let key = maybe_int_property(name);
-        self.values
+        self.values()
             .as_hashmap()
             .get(&key)
             .map_or(false, |prop| prop.enumerable)
     }
 
-    pub fn set_local_property_is_enumerable(&mut self, name: AvmString<'gc>, is_enumerable: bool) {
+    pub fn set_local_property_is_enumerable(
+        &self,
+        mc: &Mutation<'gc>,
+        name: AvmString<'gc>,
+        is_enumerable: bool,
+    ) {
         let key = maybe_int_property(name);
-        self.values.entry(key).and_modify(|v| {
+        self.values_mut(mc).entry(key).and_modify(|v| {
             v.enumerable = is_enumerable;
         });
     }
 
     /// Install a method into the object.
-    pub fn install_bound_method(&mut self, disp_id: u32, function: FunctionObject<'gc>) {
-        if self.bound_methods.len() <= disp_id as usize {
-            self.bound_methods
-                .resize_with(disp_id as usize + 1, Default::default);
+    pub fn install_bound_method(
+        &self,
+        mc: &Mutation<'gc>,
+        disp_id: u32,
+        function: FunctionObject<'gc>,
+    ) {
+        let mut bound_methods = self.bound_methods_mut(mc);
+
+        if bound_methods.len() <= disp_id as usize {
+            bound_methods.resize_with(disp_id as usize + 1, Default::default);
         }
 
-        *self.bound_methods.get_mut(disp_id as usize).unwrap() = Some(function);
+        *bound_methods.get_mut(disp_id as usize).unwrap() = Some(function);
     }
 
     /// Get the `Class` for this object.
     pub fn instance_class(&self) -> Class<'gc> {
-        self.instance_class
+        self.0.instance_class
     }
 
     /// Get the vtable for this object, if it has one.
     pub fn vtable(&self) -> Option<VTable<'gc>> {
-        self.vtable
+        self.0.vtable.get()
     }
 
     pub fn is_sealed(&self) -> bool {
         self.instance_class().is_sealed()
     }
 
-    pub fn set_vtable(&mut self, vtable: VTable<'gc>) {
-        self.vtable = Some(vtable);
+    pub fn set_vtable(&self, mc: &Mutation<'gc>, vtable: VTable<'gc>) {
+        unlock!(Gc::write(mc, self.0), ScriptObjectData, vtable).set(Some(vtable));
     }
 
     pub fn debug_class_name(&self) -> Box<dyn std::fmt::Debug + 'gc> {
@@ -428,13 +483,9 @@ impl<'gc> ScriptObjectData<'gc> {
 
 impl<'gc> Debug for ScriptObject<'gc> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        let mut f = f.debug_struct("ScriptObject");
-
-        match self.0.try_borrow() {
-            Ok(obj) => f.field("name", &obj.debug_class_name()),
-            Err(err) => f.field("name", &err),
-        };
-
-        f.field("ptr", &self.0.as_ptr()).finish()
+        f.debug_struct("ScriptObject")
+            .field("name", &ScriptObjectWrapper(self.0).debug_class_name())
+            .field("ptr", &Gc::as_ptr(self.0))
+            .finish()
     }
 }

--- a/core/src/avm2/object/shader_data_object.rs
+++ b/core/src/avm2/object/shader_data_object.rs
@@ -65,8 +65,7 @@ pub struct ShaderDataObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(ShaderDataObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<ShaderDataObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<ShaderDataObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> TObject<'gc> for ShaderDataObject<'gc> {

--- a/core/src/avm2/object/shader_data_object.rs
+++ b/core/src/avm2/object/shader_data_object.rs
@@ -6,7 +6,6 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use core::fmt;
-use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::pixel_bender::PixelBenderShaderHandle;
 use std::cell::Cell;
@@ -19,7 +18,7 @@ pub fn shader_data_allocator<'gc>(
     Ok(ShaderDataObject(Gc::new(
         activation.gc(),
         ShaderDataObjectData {
-            base: RefLock::new(ScriptObjectData::new(class)),
+            base: ScriptObjectData::new(class),
             shader: Cell::new(None),
         },
     ))
@@ -59,7 +58,7 @@ impl<'gc> ShaderDataObject<'gc> {
 #[repr(C, align(8))]
 pub struct ShaderDataObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     shader: Cell<Option<PixelBenderShaderHandle>>,
 }
@@ -71,7 +70,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for ShaderDataObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/socket_object.rs
+++ b/core/src/avm2/object/socket_object.rs
@@ -4,7 +4,7 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::{Activation, Error};
 use crate::socket::SocketHandle;
-use gc_arena::{lock::RefLock, Collect, Gc};
+use gc_arena::{Collect, Gc};
 use gc_arena::{GcWeak, Mutation};
 use std::cell::{Cell, RefCell, RefMut};
 use std::fmt;
@@ -14,7 +14,7 @@ pub fn socket_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(SocketObject(Gc::new(
         activation.context.gc(),
@@ -41,7 +41,7 @@ pub struct SocketObject<'gc>(pub Gc<'gc, SocketObjectData<'gc>>);
 pub struct SocketObjectWeak<'gc>(pub GcWeak<'gc, SocketObjectData<'gc>>);
 
 impl<'gc> TObject<'gc> for SocketObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible
@@ -201,8 +201,8 @@ impl_read!(read_float 4; f32, read_double 8; f64, read_int 4; i32, read_unsigned
 #[repr(C, align(8))]
 pub struct SocketObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
-    #[collect(require_static)]
+    base: ScriptObjectData<'gc>,
+
     handle: Cell<Option<SocketHandle>>,
 
     endian: Cell<Endian>,

--- a/core/src/avm2/object/socket_object.rs
+++ b/core/src/avm2/object/socket_object.rs
@@ -215,9 +215,8 @@ pub struct SocketObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(SocketObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<SocketObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<SocketObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl fmt::Debug for SocketObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -28,7 +28,7 @@ pub fn sound_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(SoundObject(Gc::new(
         activation.context.gc_context,
@@ -64,7 +64,7 @@ impl fmt::Debug for SoundObject<'_> {
 #[repr(C, align(8))]
 pub struct SoundObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The sound this object holds.
     sound_data: RefLock<SoundData<'gc>>,
@@ -281,7 +281,7 @@ fn play_queued<'gc>(
 }
 
 impl<'gc> TObject<'gc> for SoundObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -74,9 +74,8 @@ pub struct SoundObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(SoundObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<SoundObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<SoundObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 #[derive(Collect)]
 #[collect(no_drop)]

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -9,7 +9,7 @@ use crate::backend::audio::SoundInstanceHandle;
 use crate::context::UpdateContext;
 use crate::display_object::SoundTransform;
 use core::fmt;
-use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::cell::{Cell, RefCell};
 
 /// A class instance allocator that allocates SoundChannel objects.
@@ -17,7 +17,7 @@ pub fn sound_channel_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(SoundChannelObject(Gc::new(
         activation.context.gc_context,
@@ -54,7 +54,7 @@ impl fmt::Debug for SoundChannelObject<'_> {
 #[repr(C, align(8))]
 pub struct SoundChannelObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The sound this object holds.
     sound_channel_data: RefCell<SoundChannelData>,
@@ -83,7 +83,7 @@ impl<'gc> SoundChannelObject<'gc> {
     /// Convert a bare sound instance into it's object representation.
     pub fn empty(activation: &mut Activation<'_, 'gc>) -> Result<Self, Error<'gc>> {
         let class = activation.avm2().classes().soundchannel;
-        let base = ScriptObjectData::new(class).into();
+        let base = ScriptObjectData::new(class);
 
         let sound_object = SoundChannelObject(Gc::new(
             activation.context.gc_context,
@@ -207,7 +207,7 @@ impl<'gc> SoundChannelObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for SoundChannelObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -65,8 +65,7 @@ pub struct SoundChannelObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(SoundChannelObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<SoundChannelObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<SoundChannelObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 pub enum SoundChannelData {

--- a/core/src/avm2/object/stage3d_object.rs
+++ b/core/src/avm2/object/stage3d_object.rs
@@ -7,7 +7,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use core::fmt;
 use gc_arena::barrier::unlock;
-use gc_arena::lock::{Lock, RefLock};
+use gc_arena::lock::Lock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::cell::Cell;
 
@@ -19,7 +19,7 @@ pub fn stage_3d_allocator<'gc>(
     Ok(Stage3DObject(Gc::new(
         activation.gc(),
         Stage3DObjectData {
-            base: RefLock::new(ScriptObjectData::new(class)),
+            base: ScriptObjectData::new(class),
             context3d: Lock::new(None),
             visible: Cell::new(true),
         },
@@ -66,7 +66,7 @@ impl<'gc> Stage3DObject<'gc> {
 #[repr(C, align(8))]
 pub struct Stage3DObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The context3D object associated with this Stage3D object,
     /// if it's been created with `requestContext3D`
@@ -80,7 +80,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for Stage3DObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/stage3d_object.rs
+++ b/core/src/avm2/object/stage3d_object.rs
@@ -75,9 +75,8 @@ pub struct Stage3DObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(Stage3DObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<Stage3DObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<Stage3DObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> TObject<'gc> for Stage3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -29,9 +29,8 @@ pub struct StageObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(StageObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<StageObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<StageObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> StageObject<'gc> {
     /// Allocate the AVM2 side of a display object intended to be of a given

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -56,8 +56,7 @@ pub struct TextFormatObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(TextFormatObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<TextFormatObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<TextFormatObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> TextFormatObject<'gc> {

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -7,7 +7,6 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::html::{TextDisplay, TextFormat};
 use core::fmt;
-use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use std::cell::{Ref, RefCell, RefMut};
 
@@ -19,7 +18,7 @@ pub fn textformat_allocator<'gc>(
     Ok(TextFormatObject(Gc::new(
         activation.gc(),
         TextFormatObjectData {
-            base: RefLock::new(ScriptObjectData::new(class)),
+            base: ScriptObjectData::new(class),
             text_format: RefCell::new(TextFormat {
                 display: Some(TextDisplay::Block),
                 ..Default::default()
@@ -50,7 +49,7 @@ impl fmt::Debug for TextFormatObject<'_> {
 #[repr(C, align(8))]
 pub struct TextFormatObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     text_format: RefCell<TextFormat>,
 }
@@ -71,7 +70,7 @@ impl<'gc> TextFormatObject<'gc> {
         let this: Object<'gc> = Self(Gc::new(
             activation.gc(),
             TextFormatObjectData {
-                base: RefLock::new(ScriptObjectData::new(class)),
+                base: ScriptObjectData::new(class),
                 text_format: RefCell::new(text_format),
             },
         ))
@@ -83,7 +82,7 @@ impl<'gc> TextFormatObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for TextFormatObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/texture_object.rs
+++ b/core/src/avm2/object/texture_object.rs
@@ -5,7 +5,6 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::backend::{Context3DTextureFormat, Texture};
 use std::rc::Rc;
@@ -31,7 +30,7 @@ impl<'gc> TextureObject<'gc> {
         let this: Object<'gc> = TextureObject(Gc::new(
             activation.gc(),
             TextureObjectData {
-                base: RefLock::new(ScriptObjectData::new(class)),
+                base: ScriptObjectData::new(class),
                 context3d,
                 original_format,
                 handle,
@@ -63,7 +62,7 @@ impl<'gc> TextureObject<'gc> {
 #[repr(C, align(8))]
 pub struct TextureObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     context3d: Context3DObject<'gc>,
 
@@ -80,7 +79,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for TextureObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/texture_object.rs
+++ b/core/src/avm2/object/texture_object.rs
@@ -74,9 +74,8 @@ pub struct TextureObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(TextureObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<TextureObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<TextureObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> TObject<'gc> for TextureObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -63,9 +63,8 @@ pub struct VectorObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(VectorObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<VectorObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<VectorObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> VectorObject<'gc> {
     /// Wrap an existing vector in an object.

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -5,7 +5,6 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 use ruffle_render::backend::VertexBuffer;
 use std::rc::Rc;
@@ -32,7 +31,7 @@ impl<'gc> VertexBuffer3DObject<'gc> {
         let this: Object<'gc> = VertexBuffer3DObject(Gc::new(
             activation.gc(),
             VertexBuffer3DObjectData {
-                base: RefLock::new(ScriptObjectData::new(class)),
+                base: ScriptObjectData::new(class),
                 context3d,
                 handle,
                 data32_per_vertex,
@@ -64,7 +63,7 @@ impl<'gc> VertexBuffer3DObject<'gc> {
 #[repr(C, align(8))]
 pub struct VertexBuffer3DObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     context3d: Context3DObject<'gc>,
 
@@ -84,7 +83,7 @@ const _: () = assert!(
 );
 
 impl<'gc> TObject<'gc> for VertexBuffer3DObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -78,8 +78,7 @@ pub struct VertexBuffer3DObjectData<'gc> {
 
 const _: () = assert!(std::mem::offset_of!(VertexBuffer3DObjectData, base) == 0);
 const _: () = assert!(
-    std::mem::align_of::<VertexBuffer3DObjectData>()
-        == std::mem::align_of::<RefLock<ScriptObjectData>>()
+    std::mem::align_of::<VertexBuffer3DObjectData>() == std::mem::align_of::<ScriptObjectData>()
 );
 
 impl<'gc> TObject<'gc> for VertexBuffer3DObject<'gc> {

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -364,9 +364,8 @@ pub struct XmlListObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(XmlListObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<XmlListObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<XmlListObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 /// Holds either an `E4XNode` or an `XmlObject`. This can be converted
 /// in-place to an `XmlObject` via `get_or_create_xml`.
@@ -1068,7 +1067,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
     fn get_enumerant_name(
         self,
         index: u32,
-        activation: &mut Activation<'_, 'gc>,
+        _activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let children_len = self.0.children.borrow().len() as u32;
         if children_len >= index {

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -23,7 +23,7 @@ pub fn xml_list_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class).into();
+    let base = ScriptObjectData::new(class);
 
     Ok(XmlListObject(Gc::new(
         activation.context.gc_context,
@@ -71,7 +71,7 @@ impl<'gc> XmlListObject<'gc> {
         target_object: Option<XmlOrXmlListObject<'gc>>,
         target_property: Option<Multiname<'gc>>,
     ) -> XmlListObject<'gc> {
-        let base = ScriptObjectData::new(activation.context.avm2.classes().xml_list).into();
+        let base = ScriptObjectData::new(activation.context.avm2.classes().xml_list);
         XmlListObject(Gc::new(
             activation.context.gc_context,
             XmlListObjectData {
@@ -348,7 +348,7 @@ impl<'gc> XmlListObject<'gc> {
 #[repr(C, align(8))]
 pub struct XmlListObjectData<'gc> {
     /// Base script object
-    base: RefLock<ScriptObjectData<'gc>>,
+    base: ScriptObjectData<'gc>,
 
     /// The children stored by this list.
     children: RefLock<Vec<E4XOrXml<'gc>>>,
@@ -473,7 +473,7 @@ impl<'gc> From<XmlObject<'gc>> for XmlOrXmlListObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for XmlListObject<'gc> {
-    fn gc_base(&self) -> Gc<'gc, RefLock<ScriptObjectData<'gc>>> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
         // SAFETY: Object data is repr(C), and a compile-time assert ensures
         // that the ScriptObjectData stays at offset 0 of the struct- so the
         // layouts are compatible
@@ -1078,7 +1078,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                 .unwrap_or(Value::Undefined))
         } else {
             Ok(self
-                .base_mut(activation.context.gc_context)
+                .base()
                 .get_enumerant_name(index - children_len)
                 .unwrap_or(Value::Undefined))
         }

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -63,16 +63,15 @@ pub struct XmlObjectData<'gc> {
 }
 
 const _: () = assert!(std::mem::offset_of!(XmlObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<XmlObjectData>() == std::mem::align_of::<RefLock<ScriptObjectData>>()
-);
+const _: () =
+    assert!(std::mem::align_of::<XmlObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> XmlObject<'gc> {
     pub fn new(node: E4XNode<'gc>, activation: &mut Activation<'_, 'gc>) -> Self {
         XmlObject(Gc::new(
             activation.context.gc_context,
             XmlObjectData {
-                base: ScriptObjectData::new(activation.context.avm2.classes().xml).into(),
+                base: ScriptObjectData::new(activation.context.avm2.classes().xml),
                 node: Lock::new(node),
             },
         ))


### PR DESCRIPTION
This depended on #17321 and #17343, and should hopefully have bigger perf impact than either of them.