### PR TITLE
core,desktop: Update to `winit` `v0.30.5` and latest `egui` from git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
  "bitflags 2.6.0",
@@ -103,9 +103,9 @@ dependencies = [
  "jni-sys",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror",
 ]
@@ -212,7 +212,7 @@ checksum = "9fb4009533e8ff8f1450a5bcbc30f4242a1d34442221f72314bea1f5dc9c7f89"
 dependencies = [
  "clipboard-win",
  "log",
- "objc2 0.5.2",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "parking_lot",
@@ -264,7 +264,7 @@ dependencies = [
  "url",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.1",
+ "wayland-protocols",
  "zbus",
 ]
 
@@ -528,31 +528,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
-name = "block2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
-dependencies = [
- "block-sys",
- "objc2 0.4.1",
-]
-
-[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2 0.5.2",
+ "objc2",
 ]
 
 [[package]]
@@ -658,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
  "bitflags 2.6.0",
  "log",
@@ -672,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop",
  "rustix",
@@ -1058,7 +1039,7 @@ dependencies = [
  "js-sys",
  "libc",
  "mach2",
- "ndk",
+ "ndk 0.8.0",
  "ndk-context",
  "oboe",
  "wasm-bindgen",
@@ -1434,9 +1415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dpi"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
+
+[[package]]
 name = "ecolor"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
+source = "git+https://github.com/emilk/egui.git?rev=f4697bc007447c6c2674beb4e25f599fb7afa093#f4697bc007447c6c2674beb4e25f599fb7afa093"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1445,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
+source = "git+https://github.com/emilk/egui.git?rev=f4697bc007447c6c2674beb4e25f599fb7afa093#f4697bc007447c6c2674beb4e25f599fb7afa093"
 dependencies = [
  "ahash",
  "emath",
@@ -1457,7 +1444,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
+source = "git+https://github.com/emilk/egui.git?rev=f4697bc007447c6c2674beb4e25f599fb7afa093#f4697bc007447c6c2674beb4e25f599fb7afa093"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1467,7 +1454,7 @@ dependencies = [
  "log",
  "thiserror",
  "type-map",
- "web-time 0.2.4",
+ "web-time",
  "wgpu",
  "winit",
 ]
@@ -1475,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
+source = "git+https://github.com/emilk/egui.git?rev=f4697bc007447c6c2674beb4e25f599fb7afa093#f4697bc007447c6c2674beb4e25f599fb7afa093"
 dependencies = [
  "ahash",
  "arboard",
@@ -1483,7 +1470,7 @@ dependencies = [
  "log",
  "raw-window-handle",
  "smithay-clipboard",
- "web-time 0.2.4",
+ "web-time",
  "webbrowser",
  "winit",
 ]
@@ -1491,7 +1478,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
+source = "git+https://github.com/emilk/egui.git?rev=f4697bc007447c6c2674beb4e25f599fb7afa093#f4697bc007447c6c2674beb4e25f599fb7afa093"
 dependencies = [
  "ahash",
  "egui",
@@ -1509,7 +1496,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
+source = "git+https://github.com/emilk/egui.git?rev=f4697bc007447c6c2674beb4e25f599fb7afa093#f4697bc007447c6c2674beb4e25f599fb7afa093"
 dependencies = [
  "bytemuck",
 ]
@@ -1638,17 +1625,23 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=37b1e1504db14697c39ce1c3bb5e58f4f2b819bf#37b1e1504db14697c39ce1c3bb5e58f4f2b819bf"
+source = "git+https://github.com/emilk/egui.git?rev=f4697bc007447c6c2674beb4e25f599fb7afa093#f4697bc007447c6c2674beb4e25f599fb7afa093"
 dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
+ "epaint_default_fonts",
  "log",
  "nohash-hasher",
  "parking_lot",
 ]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.28.1"
+source = "git+https://github.com/emilk/egui.git?rev=f4697bc007447c6c2674beb4e25f599fb7afa093#f4697bc007447c6c2674beb4e25f599fb7afa093"
 
 [[package]]
 name = "equivalent"
@@ -2524,17 +2517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icrate"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
-dependencies = [
- "block2 0.3.0",
- "dispatch",
- "objc2 0.4.1",
-]
-
-[[package]]
 name = "id3"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3211,7 +3193,21 @@ dependencies = [
  "bitflags 2.6.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.6.0",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror",
@@ -3228,6 +3224,15 @@ name = "ndk-sys"
 version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -3421,22 +3426,12 @@ checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
-dependencies = [
- "objc-sys",
- "objc2-encode 3.0.0",
-]
-
-[[package]]
-name = "objc2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
- "objc2-encode 4.0.3",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -3446,13 +3441,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
+ "block2",
  "libc",
- "objc2 0.5.2",
+ "objc2",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation",
  "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3462,8 +3481,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -3473,17 +3492,23 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
  "objc2-metal",
 ]
 
 [[package]]
-name = "objc2-encode"
-version = "3.0.0"
+name = "objc2-core-location"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-contacts",
+ "objc2-foundation",
+]
 
 [[package]]
 name = "objc2-encode"
@@ -3498,10 +3523,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
+ "block2",
  "dispatch",
  "libc",
- "objc2 0.5.2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3511,8 +3548,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -3523,10 +3560,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3545,7 +3637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
  "jni",
- "ndk",
+ "ndk 0.8.0",
  "ndk-context",
  "num-derive",
  "num-traits",
@@ -4010,15 +4102,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -4175,10 +4258,10 @@ version = "0.14.1"
 source = "git+https://github.com/PolyMeilex/rfd.git?rev=e0e725ec9a426acf7c93d9877c41e230fcee3fac#e0e725ec9a426acf7c93d9877c41e230fcee3fac"
 dependencies = [
  "ashpd",
- "block2 0.5.1",
+ "block2",
  "js-sys",
  "log",
- "objc2 0.5.2",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "pollster",
@@ -4275,7 +4358,7 @@ dependencies = [
  "url",
  "wasm-bindgen-futures",
  "weak-table",
- "web-time 1.1.0",
+ "web-time",
 ]
 
 [[package]]
@@ -4753,9 +4836,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.8.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
  "ab_glyph",
  "log",
@@ -4960,9 +5043,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
  "bitflags 2.6.0",
  "calloop",
@@ -4977,7 +5060,7 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
@@ -4985,9 +5068,9 @@ dependencies = [
 
 [[package]]
 name = "smithay-clipboard"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c091e7354ea8059d6ad99eace06dd13ddeedbb0ac72d40a9a6e7ff790525882d"
+checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
 dependencies = [
  "libc",
  "smithay-client-toolkit",
@@ -6002,9 +6085,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e9e6b6d4a2bb4e7e69433e0b35c7923b95d4dc8503a84d25ec917a4bbfdf07"
+checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -6016,9 +6099,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.3"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e63801c85358a431f986cffa74ba9599ff571fc5774ac113ed3b490c19a1133"
+checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
 dependencies = [
  "bitflags 2.6.0",
  "rustix",
@@ -6050,21 +6133,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d0f1056570486e26a3773ec633885124d79ae03827de05ba6c85f79904026c"
+checksum = "62989625a776e827cc0f15d41444a3cea5205b963c3a25be48ae1b52d6b4daaa"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -6074,27 +6145,27 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.2.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+checksum = "f79f2d57c7fcc6ab4d602adba364bf59a5c24de57bd194486bf9b8360e06bfc4"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.2.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+checksum = "fd993de54a40a40fbe5601d9f1fbcaef0aebcc5fda447d7dc8f6dcbaae4f8953"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -6111,9 +6182,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.2"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105b1842da6554f91526c14a2a2172897b7f745a805d62af4ce698706be79c12"
+checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
 dependencies = [
  "dlib",
  "log",
@@ -6139,16 +6210,6 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
@@ -6163,13 +6224,13 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
 dependencies = [
- "block2 0.5.1",
+ "block2",
  "core-foundation",
  "home",
  "jni",
  "log",
  "ndk-context",
- "objc2 0.5.2",
+ "objc2",
  "objc2-foundation",
  "url",
  "web-sys",
@@ -6268,7 +6329,7 @@ dependencies = [
  "log",
  "metal",
  "naga",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
  "parking_lot",
@@ -6649,47 +6710,51 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.29.15"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d59ad965a635657faf09c8f062badd885748428933dad8e8bdd64064d92e5ca"
+checksum = "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67"
 dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
  "bitflags 2.6.0",
+ "block2",
  "bytemuck",
  "calloop",
- "cfg_aliases 0.1.1",
+ "cfg_aliases 0.2.1",
+ "concurrent-queue",
  "core-foundation",
  "core-graphics",
  "cursor-icon",
- "icrate",
+ "dpi",
  "js-sys",
  "libc",
- "log",
  "memmap2",
- "ndk",
- "ndk-sys",
- "objc2 0.4.1",
- "once_cell",
+ "ndk 0.9.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
+ "pin-project",
  "raw-window-handle",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "rustix",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
+ "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
- "web-time 0.2.4",
- "windows-sys 0.48.0",
+ "web-time",
+ "windows-sys 0.52.0",
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 naga = { version = "22.1.0", features = ["wgsl-out"] }
 wgpu = "22.1.0"
-egui = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf" }
+egui = { git = "https://github.com/emilk/egui.git", rev = "f4697bc007447c6c2674beb4e25f599fb7afa093" }
 clap = { version = "4.5.17", features = ["derive"] }
 anyhow = "1.0"
 slotmap = "1.0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.10.1"
 egui = { workspace = true, optional = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf", default-features = false, optional = true }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "f4697bc007447c6c2674beb4e25f599fb7afa093", default-features = false, optional = true }
 png = { version = "0.17.13", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -250,7 +250,7 @@ impl DisplayObjectWindow {
                 ui.label("Focus Rect");
                 let focus_rect = object.focus_rect();
                 let mut new_focus_rect = focus_rect;
-                ComboBox::from_id_source(ui.id().with("focus_rect"))
+                ComboBox::from_id_salt(ui.id().with("focus_rect"))
                     .selected_text(optional_boolean_switch_value(focus_rect))
                     .show_ui(ui, |ui| {
                         for value in [None, Some(true), Some(false)] {
@@ -395,7 +395,7 @@ impl DisplayObjectWindow {
                 ui.label("Autosize");
                 ui.horizontal(|ui| {
                     let mut autosize = object.autosize();
-                    ComboBox::from_id_source(ui.id().with("autosize"))
+                    ComboBox::from_id_salt(ui.id().with("autosize"))
                         .selected_text(format!("{:?}", autosize))
                         .show_ui(ui, |ui| {
                             for value in [
@@ -476,7 +476,7 @@ impl DisplayObjectWindow {
             });
 
         CollapsingHeader::new("Span List")
-            .id_source(ui.id().with("spans"))
+            .id_salt(ui.id().with("spans"))
             .show(ui, |ui| {
                 Grid::new(ui.id().with("spans"))
                     .num_columns(7)
@@ -598,7 +598,7 @@ impl DisplayObjectWindow {
             });
 
         CollapsingHeader::new("Frame List")
-            .id_source(ui.id().with("frames"))
+            .id_salt(ui.id().with("frames"))
             .show(ui, |ui| {
                 Grid::new(ui.id().with("frames"))
                     .num_columns(5)
@@ -715,7 +715,7 @@ impl DisplayObjectWindow {
             "automatic"
         };
         CollapsingHeader::new(format!("Tab Order ({})", tab_order_suffix))
-            .id_source(ui.id().with("tab_order"))
+            .id_salt(ui.id().with("tab_order"))
             .show(ui, |ui| {
                 Grid::new(ui.id().with("tab_order_grid"))
                     .num_columns(3)
@@ -877,7 +877,7 @@ impl DisplayObjectWindow {
                 ui.label("Blend mode");
                 let old_blend = object.blend_mode();
                 let mut new_blend = old_blend;
-                ComboBox::from_id_source(ui.id().with("blendmode"))
+                ComboBox::from_id_salt(ui.id().with("blendmode"))
                     .selected_text(blend_mode_name(old_blend))
                     .show_ui(ui, |ui| {
                         for mode in ALL_BLEND_MODES {
@@ -921,7 +921,7 @@ impl DisplayObjectWindow {
         let filters = object.filters();
         if !filters.is_empty() {
             CollapsingHeader::new(format!("Filters ({})", filters.len()))
-                .id_source(ui.id().with("filters"))
+                .id_salt(ui.id().with("filters"))
                 .show(ui, |ui| {
                     for filter in filters {
                         ui.label(format!("{:?}", filter));

--- a/core/src/debug_ui/domain.rs
+++ b/core/src/debug_ui/domain.rs
@@ -63,7 +63,7 @@ impl DomainListWindow {
                     }
 
                     CollapsingHeader::new(format!("Class {class_name}"))
-                        .id_source(ui.id().with(class.0.as_ptr()))
+                        .id_salt(ui.id().with(class.0.as_ptr()))
                         .show(ui, |ui| {
                             for class_obj in &*class.class_objects() {
                                 let button = ui.button(format!("{class_obj:?}"));

--- a/core/src/debug_ui/movie.rs
+++ b/core/src/debug_ui/movie.rs
@@ -229,7 +229,7 @@ impl MovieWindow {
 
         if !movie.parameters().is_empty() {
             CollapsingHeader::new("Parameters")
-                .id_source(ui.id().with("parameters"))
+                .id_salt(ui.id().with("parameters"))
                 .default_open(false)
                 .show(ui, |ui| {
                     Grid::new(ui.id().with("parameters"))

--- a/deny.toml
+++ b/deny.toml
@@ -77,7 +77,7 @@ unknown-git = "deny"
 #  github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
-    # TODO: Remove once a release with https://github.com/emilk/egui/pull/4847 in it is out.
+    # TODO: Remove once a release with https://github.com/emilk/egui/pull/4939 in it is out.
     "emilk",
     # TODO: Remove once a release with https://github.com/PolyMeilex/rfd/pull/209 in it is out.
     "PolyMeilex",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 clap = { workspace = true }
 cpal = "0.15.3"
 egui = { workspace = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf", default-features = false, features = ["image"] }
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf", features = ["winit"] }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "f4697bc007447c6c2674beb4e25f599fb7afa093", default-features = false, features = ["image"] }
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "f4697bc007447c6c2674beb4e25f599fb7afa093", features = ["winit"] }
 image = { workspace = true, features = ["png"] }
-egui-winit = { git = "https://github.com/emilk/egui.git", rev = "37b1e1504db14697c39ce1c3bb5e58f4f2b819bf" }
+egui-winit = { git = "https://github.com/emilk/egui.git", rev = "f4697bc007447c6c2674beb4e25f599fb7afa093" }
 fontdb = "0.21"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }
@@ -28,7 +28,7 @@ ruffle_frontend_utils = { path = "../frontend-utils" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = "0.2.3"
-winit = "0.29.15"
+winit = "0.30.5"
 webbrowser = "1.0.1"
 url = { workspace = true }
 dirs = "5.0"

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -99,8 +99,14 @@ impl GuiController {
 
         let theme_controller =
             ThemeController::new(window.clone(), preferences.clone(), egui_ctx.clone()).await;
-        let mut egui_winit =
-            egui_winit::State::new(egui_ctx, ViewportId::ROOT, window.as_ref(), None, None);
+        let mut egui_winit = egui_winit::State::new(
+            egui_ctx,
+            ViewportId::ROOT,
+            window.as_ref(),
+            None,
+            None,
+            None,
+        );
         egui_winit.set_max_texture_side(descriptors.limits.max_texture_dimension_2d as usize);
 
         let movie_view_renderer = Arc::new(MovieViewRenderer::new(

--- a/desktop/src/gui/dialogs/open_dialog.rs
+++ b/desktop/src/gui/dialogs/open_dialog.rs
@@ -407,7 +407,7 @@ impl OpenDialog {
 
                 // TODO: This should probably be a global setting somewhere, not per load
                 ui.label(text(locale, "open-url-mode"));
-                ComboBox::from_id_source("open-file-advanced-options-open-url-mode")
+                ComboBox::from_id_salt("open-file-advanced-options-open-url-mode")
                     .selected_text(match self.options.open_url_mode {
                         OpenURLMode::Allow => text(locale, "open-url-mode-allow"),
                         OpenURLMode::Confirm => text(locale, "open-url-mode-confirm"),
@@ -764,7 +764,7 @@ impl<T: Copy + PartialEq> InnerField for EnumDropdownField<T> {
     }
 
     fn ui(&self, ui: &mut Ui, value: &mut Self::Value, _error: bool, locale: &LanguageIdentifier) {
-        ComboBox::from_id_source(self.id)
+        ComboBox::from_id_salt(self.id)
             .selected_text((self.value_to_name)(*value, locale))
             .show_ui(ui, |ui| {
                 for possible_value in &self.possible_values {
@@ -811,7 +811,7 @@ impl InnerField for BooleanDropdownField {
     }
 
     fn ui(&self, ui: &mut Ui, value: &mut Self::Value, _error: bool, locale: &LanguageIdentifier) {
-        ComboBox::from_id_source(self.id)
+        ComboBox::from_id_salt(self.id)
             .selected_text((self.value_to_name)(*value, locale))
             .show_ui(ui, |ui| {
                 ui.selectable_value(value, false, (self.value_to_name)(false, locale));

--- a/desktop/src/gui/dialogs/preferences_dialog.rs
+++ b/desktop/src/gui/dialogs/preferences_dialog.rs
@@ -171,7 +171,7 @@ impl PreferencesDialog {
                 .on_hover_text(locked_text);
         } else {
             let previous = self.graphics_backend;
-            ComboBox::from_id_source("graphics-backend")
+            ComboBox::from_id_salt("graphics-backend")
                 .selected_text(graphics_backend_name(locale, self.graphics_backend))
                 .show_ui(ui, |ui| {
                     ui.selectable_value(
@@ -220,7 +220,7 @@ impl PreferencesDialog {
                 .on_hover_text(locked_text);
         } else {
             let previous = self.power_preference;
-            ComboBox::from_id_source("graphics-power")
+            ComboBox::from_id_salt("graphics-power")
                 .selected_text(graphics_power_name(locale, self.power_preference))
                 .show_ui(ui, |ui| {
                     ui.selectable_value(
@@ -244,7 +244,7 @@ impl PreferencesDialog {
     fn show_language_preferences(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) {
         ui.label(text(locale, "language"));
         let previous = self.language.clone();
-        ComboBox::from_id_source("language")
+        ComboBox::from_id_salt("language")
             .selected_text(language_name(&self.language))
             .show_ui(ui, |ui| {
                 for language in available_languages() {
@@ -264,7 +264,7 @@ impl PreferencesDialog {
     fn show_theme_preferences(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) {
         ui.label(text(locale, "theme"));
         let previous = self.theme_preference;
-        ComboBox::from_id_source("theme")
+        ComboBox::from_id_salt("theme")
             .selected_text(theme_preference_name(locale, self.theme_preference))
             .show_ui(ui, |ui| {
                 ui.selectable_value(
@@ -294,7 +294,7 @@ impl PreferencesDialog {
 
         let previous = self.output_device.clone();
         let default = text(locale, "audio-output-device-default");
-        ComboBox::from_id_source("audio-output-device")
+        ComboBox::from_id_salt("audio-output-device")
             .selected_text(self.output_device.as_deref().unwrap_or(default.as_ref()))
             .show_ui(ui, |ui| {
                 ui.selectable_value(&mut self.output_device, None, default);
@@ -350,7 +350,7 @@ impl PreferencesDialog {
         ui.label(text(locale, "log-filename-pattern"));
 
         let previous = self.log_filename_pattern;
-        ComboBox::from_id_source("log-filename-pattern")
+        ComboBox::from_id_salt("log-filename-pattern")
             .selected_text(filename_pattern_name(locale, self.log_filename_pattern))
             .show_ui(ui, |ui| {
                 ui.selectable_value(
@@ -383,7 +383,7 @@ impl PreferencesDialog {
                 .on_hover_text(locked_text);
         } else {
             let previous = self.storage_backend;
-            ComboBox::from_id_source("storage-backend")
+            ComboBox::from_id_salt("storage-backend")
                 .selected_text(storage_backend_name(locale, self.storage_backend))
                 .show_ui(ui, |ui| {
                     ui.selectable_value(

--- a/desktop/src/util.rs
+++ b/desktop/src/util.rs
@@ -1,4 +1,3 @@
-use crate::custom_event::RuffleEvent;
 use anyhow::{anyhow, Error};
 use gilrs::Button;
 use ruffle_core::events::{GamepadButton, KeyCode, TextControlCode};
@@ -6,8 +5,8 @@ use std::path::Path;
 use url::Url;
 use winit::dpi::PhysicalSize;
 use winit::event::{KeyEvent, Modifiers};
-use winit::event_loop::EventLoop;
 use winit::keyboard::{Key, KeyLocation, NamedKey};
+use winit::window::Window;
 
 /// Converts a winit event to a Ruffle `TextControlCode`.
 /// Returns `None` if there is no match.
@@ -205,13 +204,13 @@ pub fn gilrs_button_to_gamepad_button(button: Button) -> Option<GamepadButton> {
     }
 }
 
-pub fn get_screen_size(event_loop: &EventLoop<RuffleEvent>) -> PhysicalSize<u32> {
+pub fn get_screen_size(window: &Window) -> PhysicalSize<u32> {
     let mut min_x = 0;
     let mut min_y = 0;
     let mut max_x = 0;
     let mut max_y = 0;
 
-    for monitor in event_loop.available_monitors() {
+    for monitor in window.available_monitors() {
         let size = monitor.size();
         let position = monitor.position();
         min_x = min_x.min(position.x);


### PR DESCRIPTION
Still needs some cleanup and porting and migrating away from deprecated stuff to the new and shiny new trait-based APIs I think.

~~Not latest minor version, because:~~
~~https://github.com/emilk/egui/pull/4849#issuecomment-2258111041~~

~~But soon it probably can be:~~
~~https://github.com/rust-windowing/winit/pull/3849~~

Supersedes https://github.com/ruffle-rs/ruffle/pull/16835.