### PR TITLE
render: Reintroduce the `render_trace` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,9 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -447,6 +450,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -500,6 +509,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -2617,6 +2629,7 @@ checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -3185,6 +3198,7 @@ dependencies = [
  "indexmap",
  "log",
  "rustc-hash",
+ "serde",
  "spirv",
  "termcolor",
  "thiserror",
@@ -4164,7 +4178,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cookie",
  "cookie_store",
@@ -4242,6 +4256,18 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.6.0",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4591,7 +4617,7 @@ name = "ruffle_web"
 version = "0.1.0"
 dependencies = [
  "async-channel",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "console_error_panic_hook",
  "futures",
@@ -4720,7 +4746,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -6231,6 +6257,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle",
+ "serde",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -6259,7 +6286,9 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle",
+ "ron",
  "rustc-hash",
+ "serde",
  "smallvec",
  "thiserror",
  "wgpu-hal",
@@ -6319,6 +6348,7 @@ checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",
+ "serde",
  "web-sys",
 ]
 

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -74,6 +74,7 @@ tracy = ["tracing-tracy", "ruffle_render_wgpu/profile-with-tracy"]
 
 # wgpu features
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]
+render_trace = ["ruffle_render_wgpu/render_trace"]
 
 # sandboxing
 sandbox = []

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -103,6 +103,11 @@ pub struct Opt {
     #[clap(long, action)]
     pub force_scale: bool,
 
+    /// Location to store a wgpu trace output
+    #[clap(long)]
+    #[cfg(feature = "render_trace")]
+    trace_path: Option<std::path::PathBuf>,
+
     /// Location to store save data for games.
     ///
     /// This option has no effect if `storage` is not `disk`.
@@ -266,6 +271,17 @@ fn parse_gamepad_button(mapping: &str) -> Result<(GamepadButton, KeyCode), Error
 }
 
 impl Opt {
+    #[cfg(feature = "render_trace")]
+    pub fn trace_path(&self) -> Option<&Path> {
+        if let Some(path) = &self.trace_path {
+            let _ = std::fs::create_dir_all(path);
+            Some(path)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(not(feature = "render_trace"))]
     pub fn trace_path(&self) -> Option<&Path> {
         None
     }

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -24,4 +24,5 @@ anyhow = { workspace = true }
 [features]
 avm_debug = ["ruffle_core/avm_debug"]
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]
+render_trace = ["ruffle_render_wgpu/render_trace"]
 lzma = ["ruffle_core/lzma"]

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -73,6 +73,11 @@ struct Opt {
     #[clap(long, short, default_value = "high")]
     power: PowerPreference,
 
+    /// Location to store a wgpu trace output
+    #[clap(long)]
+    #[cfg(feature = "render_trace")]
+    trace_path: Option<PathBuf>,
+
     /// Skip unsupported movie types (currently AVM 2)
     #[clap(long, action)]
     skip_unsupported: bool,
@@ -377,6 +382,17 @@ fn capture_multiple_swfs(descriptors: Arc<Descriptors>, opt: &Opt) -> Result<()>
     Ok(())
 }
 
+#[cfg(feature = "render_trace")]
+fn trace_path(opt: &Opt) -> Option<&Path> {
+    if let Some(path) = &opt.trace_path {
+        let _ = std::fs::create_dir_all(path);
+        Some(path)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(feature = "render_trace"))]
 fn trace_path(_opt: &Opt) -> Option<&Path> {
     None
 }

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -38,6 +38,7 @@ features = ["HtmlCanvasElement"]
 
 [features]
 render_debug_labels = []
+render_trace = ["wgpu/trace"]
 webgl = ["wgpu/webgl"]
 profile-with-tracy = ["profiling", "profiling/profile-with-tracy"]
 


### PR DESCRIPTION
This reverts commit 799b5367663f20e71a9772a68cc52c7c498e8a98, part of https://github.com/ruffle-rs/ruffle/pull/17176.

Since the removal was supposed to be temporary.
To be merged once https://github.com/gfx-rs/wgpu/issues/5974 is fixed, if ever.