### PR TITLE
avm2: Make ScriptObjectData vtable non-Optional

### DIFF
--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -202,29 +202,24 @@ pub fn recursive_serialize<'gc>(
     object_table: &mut ObjectTable<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(static_properties) = static_properties {
-        if let Some(vtable) = obj.vtable() {
-            let mut props = vtable.public_properties();
-            // Flash appears to use vtable iteration order, but we sort ours
-            // to make our test output consistent.
-            props.sort_by_key(|(name, _)| name.to_utf8_lossy().to_string());
-            for (name, prop) in props {
-                if let Property::Virtual { get, set } = prop {
-                    if !(get.is_some() && set.is_some()) {
-                        continue;
-                    }
+        let vtable = obj.vtable();
+        let mut props = vtable.public_properties();
+        // Flash appears to use vtable iteration order, but we sort ours
+        // to make our test output consistent.
+        props.sort_by_key(|(name, _)| name.to_utf8_lossy().to_string());
+        for (name, prop) in props {
+            if let Property::Virtual { get, set } = prop {
+                if !(get.is_some() && set.is_some()) {
+                    continue;
                 }
-                let value = obj.get_public_property(name, activation)?;
-                let name = name.to_utf8_lossy().to_string();
-                if let Some(elem) = get_or_create_element(
-                    activation,
-                    name.clone(),
-                    value,
-                    object_table,
-                    amf_version,
-                ) {
-                    elements.push(elem);
-                    static_properties.push(name);
-                }
+            }
+            let value = obj.get_public_property(name, activation)?;
+            let name = name.to_utf8_lossy().to_string();
+            if let Some(elem) =
+                get_or_create_element(activation, name.clone(), value, object_table, amf_version)
+            {
+                elements.push(elem);
+                static_properties.push(name);
             }
         }
     }

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -514,23 +514,35 @@ pub fn load_player_globals<'gc>(
     domain.export_class(class_i_class.name(), class_i_class, mc);
     domain.export_class(fn_classdef.name(), fn_classdef, mc);
 
+    // Initialize the global object. This gives it a temporary vtable until the
+    // global ClassObject is constructed and we have the true vtable.
+    let globals = ScriptObject::custom_object(mc, global_classdef, None, global_classdef.vtable());
     // Initialize the script
-    let globals = ScriptObject::custom_object(mc, global_classdef, None, None);
     let script = Script::empty_script(mc, globals, domain);
 
     let gs = ScopeChain::new(domain).chain(mc, &[Scope::new(globals)]);
     activation.set_outer(gs);
 
     let object_class = ClassObject::from_class_partial(activation, object_i_class, None)?;
-    let object_proto = ScriptObject::custom_object(mc, object_i_class, Some(object_class), None);
+    let object_proto =
+        ScriptObject::custom_object(mc, object_i_class, None, object_class.instance_vtable());
 
     let class_class =
         ClassObject::from_class_partial(activation, class_i_class, Some(object_class))?;
-    let class_proto =
-        ScriptObject::custom_object(mc, object_i_class, Some(object_class), Some(object_proto));
+    let class_proto = ScriptObject::custom_object(
+        mc,
+        object_i_class,
+        Some(object_proto),
+        object_class.instance_vtable(),
+    );
 
     let fn_class = ClassObject::from_class_partial(activation, fn_classdef, Some(object_class))?;
-    let fn_proto = ScriptObject::custom_object(mc, fn_classdef, Some(fn_class), Some(object_proto));
+    let fn_proto = ScriptObject::custom_object(
+        mc,
+        fn_classdef,
+        Some(object_proto),
+        fn_class.instance_vtable(),
+    );
 
     // Now to weave the Gordian knot...
     object_class.link_prototype(activation, object_proto)?;

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -173,7 +173,10 @@ impl<'gc> ClassObject<'gc> {
         let class_object = ClassObject(Gc::new(
             activation.context.gc_context,
             ClassObjectData {
-                base: ScriptObjectData::custom_new(c_class, None, None),
+                // We pass `custom_new` the temporary vtable of the class object
+                // because we don't have the full vtable created yet. We'll
+                // set it to the true vtable in `into_finished_class`.
+                base: ScriptObjectData::custom_new(c_class, None, c_class.vtable()),
                 class,
                 prototype: Lock::new(None),
                 class_scope: scope,

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -204,19 +204,21 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         arguments: &[Value<'gc>],
     ) -> Result<Object<'gc>, Error<'gc>> {
+        let object_class = activation.avm2().classes().object;
+
         let prototype = if let Some(proto) = self.prototype() {
             proto
         } else {
-            let proto = activation.avm2().classes().object.prototype();
+            let proto = object_class.prototype();
             self.set_prototype(Some(proto), activation.gc());
             proto
         };
 
         let instance = ScriptObject::custom_object(
             activation.context.gc_context,
-            activation.avm2().classes().object.inner_class_definition(),
-            Some(activation.avm2().classes().object),
+            object_class.inner_class_definition(),
             Some(prototype),
+            object_class.instance_vtable(),
         );
 
         self.call(instance.into(), arguments, activation)?;

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -181,10 +181,9 @@ impl<'gc> ScopeChain<'gc> {
                 // NOTE: We are manually searching the vtable's traits so we can figure out which namespace the trait
                 // belongs to.
                 let values = scope.values();
-                if let Some(vtable) = values.vtable() {
-                    if let Some((namespace, _)) = vtable.get_trait_with_ns(multiname) {
-                        return Ok(Some((Some(namespace), values)));
-                    }
+                let vtable = values.vtable();
+                if let Some((namespace, _)) = vtable.get_trait_with_ns(multiname) {
+                    return Ok(Some((Some(namespace), values)));
                 }
 
                 // Wasn't in the objects traits, let's try dynamic properties if this is a with scope.

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -639,7 +639,7 @@ impl<'gc> Script<'gc> {
 
             let scope = ScopeChain::new(domain);
 
-            globals.vtable().unwrap().init_vtable(
+            globals.vtable().init_vtable(
                 globals.instance_class(),
                 self.0.read().global_class_obj,
                 &self.traits()?,

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -288,10 +288,10 @@ impl Avm2ObjectWindow {
     ) {
         let mut entries = Vec::<(String, Namespace<'gc>, Property)>::new();
         // We can't access things whilst we iterate the vtable, so clone and sort it all here
-        if let Some(vtable) = object.vtable() {
-            for (name, ns, prop) in vtable.resolved_traits().iter() {
-                entries.push((name.to_string(), ns, *prop));
-            }
+        let vtable = object.vtable();
+
+        for (name, ns, prop) in vtable.resolved_traits().iter() {
+            entries.push((name.to_string(), ns, *prop));
         }
         entries.sort_by(|a, b| a.0.cmp(&b.0));
 


### PR DESCRIPTION
This is required to change `ScriptObjectData.slots` from `RefLock<Vec<Value>>` to `Vec<Lock<Value>>`