### PR TITLE
web: Fix logged error when defining an ExternalInterface method twice

### DIFF
--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -43,6 +43,7 @@ export class RufflePlayerElement extends HTMLElement implements Player {
                                 args,
                             );
                         },
+                        configurable: true,
                     });
                 } catch (error) {
                     console.warn(


### PR DESCRIPTION
Noticed the error here: https://github.com/ruffle-rs/ruffle/issues/16492#issuecomment-2276380003

Realistically it's just noise though, because we're replacing the method with the same method (a "call a callback by the name of foo"), so it works out anyway. This silences the warning by making the property configurable (aka "it can be redefined")