### PR TITLE
desktop: Update tracy + add avm2 calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5595,6 +5595,7 @@ checksum = "63de1e1d4115534008d8fd5788b39324d6f58fc707849090533828619351d855"
 dependencies = [
  "loom",
  "once_cell",
+ "rustc-demangle",
  "tracy-client-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4269,6 +4269,7 @@ dependencies = [
  "symphonia",
  "thiserror",
  "tracing",
+ "tracy-client",
  "ttf-parser",
  "unic-segment",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,9 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0f7f43585c34e4fdd7497d746bc32e14458cf11c69341cc0587b1d825dde42"
+checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
 dependencies = [
  "profiling-procmacros",
  "tracy-client",
@@ -3839,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce97fecd27bc49296e5e20518b5a1bb54a14f7d5fe6228bc9686ee2a74915cc8"
+checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
  "syn 2.0.76",
@@ -5567,9 +5567,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-tracy"
-version = "0.10.4"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6c7bf057d67aa107e076129a4f331aaac47ec379952d9f0775c6b1d838ee97"
+checksum = "9be7f8874d6438e4263f9874c84eded5095bda795d9c7da6ea0192e1750d3ffe"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
@@ -5589,9 +5589,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.16.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307e6b7030112fe9640fdd87988a40795549ba75c355f59485d14e6b444d2987"
+checksum = "63de1e1d4115534008d8fd5788b39324d6f58fc707849090533828619351d855"
 dependencies = [
  "loom",
  "once_cell",
@@ -5600,9 +5600,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.22.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d104d610dfa9dd154535102cc9c6164ae1fa37842bc2d9e83f9ac82b0ae0882"
+checksum = "98b98232a2447ce0a58f9a0bfb5f5e39647b5c597c994b63945fcccd1306fafb"
 dependencies = [
  "cc",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -68,6 +68,7 @@ unic-segment = "0.9.0"
 id3 = "1.14.0"
 either = "1.13.0"
 chardetng = "0.1.17"
+tracy-client = { version = "0.17.1", optional = true, default-features = false }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 workspace = true
@@ -79,6 +80,7 @@ version = "0.4.43"
 default = []
 lzma = ["lzma-rs", "swf/lzma"]
 avm_debug = []
+tracy_avm = ["dep:tracy-client"]
 deterministic = []
 timeline_debug = []
 mp3 = ["symphonia"]

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -184,6 +184,18 @@ pub fn exec<'gc>(
                 resolved_signature,
                 bound_class,
             )?;
+
+            #[cfg(feature = "tracy_avm")]
+            let _span = {
+                let mut name = WString::new();
+                display_function(&mut name, &method, bound_class);
+                let span = tracy_client::Client::running()
+                    .expect("tracy_client should be running")
+                    .span_alloc(None, &name.to_utf8_lossy(), "rust", 0, 0);
+                span.emit_color(0x2c4980);
+                span
+            };
+
             activation
                 .context
                 .avm2
@@ -210,6 +222,23 @@ pub fn exec<'gc>(
                 bound_class,
                 callee,
             )?;
+
+            #[cfg(feature = "tracy_avm")]
+            let _span = {
+                let mut name = WString::new();
+                display_function(&mut name, &method, bound_class);
+                let option = tracy_client::Client::running();
+                let span = option.expect("tracy_client should be running").span_alloc(
+                    None,
+                    &name.to_utf8_lossy(),
+                    bm.owner_movie().url(),
+                    line!(),
+                    0,
+                );
+                span.emit_color(0x425fa1);
+                span
+            };
+
             activation
                 .context
                 .avm2

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -47,7 +47,7 @@ gilrs = "0.10"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
 
 # Deliberately held back to match tracy client used by profiling crate
-tracing-tracy = { version = "=0.10.4", optional = true }
+tracing-tracy = { version = "=0.11.1", optional = true }
 rand = "0.8.5"
 thiserror.workspace = true
 

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -47,7 +47,7 @@ gilrs = "0.10"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
 
 # Deliberately held back to match tracy client used by profiling crate
-tracing-tracy = { version = "=0.11.1", optional = true }
+tracing-tracy = { version = "=0.11.1", optional = true, features = ["demangle"] }
 rand = "0.8.5"
 thiserror.workspace = true
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -15,6 +15,8 @@ mod gui;
 mod log;
 mod player;
 mod preferences;
+#[cfg(feature = "tracy")]
+mod tracy;
 mod util;
 
 use crate::preferences::GlobalPreferences;
@@ -31,7 +33,6 @@ use std::panic::PanicInfo;
 use tracing_subscriber::fmt::Layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-
 use url::Url;
 
 thread_local! {
@@ -175,7 +176,7 @@ async fn main() -> Result<(), Error> {
 
     #[cfg(feature = "tracy")]
     let subscriber = {
-        let tracy_subscriber = tracing_tracy::TracyLayer::new();
+        let tracy_subscriber = tracing_tracy::TracyLayer::new(tracy::RuffleTracyConfig::default());
         subscriber.with(tracy_subscriber)
     };
 

--- a/desktop/src/tracy.rs
+++ b/desktop/src/tracy.rs
@@ -1,0 +1,20 @@
+use tracing::Metadata;
+use tracing_subscriber::fmt::format::DefaultFields;
+use tracing_tracy::Config;
+
+#[derive(Default)]
+pub struct RuffleTracyConfig(DefaultFields);
+
+impl Config for RuffleTracyConfig {
+    type Formatter = DefaultFields;
+
+    fn formatter(&self) -> &Self::Formatter {
+        &self.0
+    }
+
+    fn stack_depth(&self, _metadata: &Metadata<'_>) -> u16 {
+        // How much, if any, of the stack trace to capture for each event
+        // Obviously, this adds overhead
+        0
+    }
+}

--- a/desktop/src/tracy.rs
+++ b/desktop/src/tracy.rs
@@ -1,9 +1,12 @@
 use tracing::Metadata;
 use tracing_subscriber::fmt::format::DefaultFields;
+use tracing_tracy::client::register_demangler;
 use tracing_tracy::Config;
 
 #[derive(Default)]
 pub struct RuffleTracyConfig(DefaultFields);
+
+register_demangler!();
 
 impl Config for RuffleTracyConfig {
     type Formatter = DefaultFields;


### PR DESCRIPTION
Now supports/requires tracy 0.11.0

With the new `avm2_profile` feature, AVM2 callstack is visible in tracy.

![image](https://github.com/user-attachments/assets/5a4d7253-41f0-4c2c-8369-ae55dca87cb9)
