### PR TITLE
desktop: Reformat description in metainfo

### DIFF
--- a/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
@@ -11,24 +11,9 @@
     <update_contact>ruffle@ruffle.rs</update_contact>
     <launchable type="desktop-id">rs.ruffle.Ruffle.desktop</launchable>
     <description>
-        <p>
-            Ruffle is a Flash Player emulator written in Rust.
-            Leveraging the safety guarantees of Rust, we can confidently avoid all
-            the security pitfalls that Flash had a reputation for.
-            Ruffle puts Flash back on the web, where it belongs!
-        </p>
-        <p>
-            This application lets you run Flash content on your computer without a browser in-between,
-            and take full advantage of your GPU and system resources to get those extra frames when playing intense games.
-        </p>
-        <p>
-            Ruffle is an entirely open source project maintained by volunteers.
-            We're all passionate about the preservation of internet history, and we were drawn to working on this
-            project to help preserve the many websites and plethora of content that will no longer be accessible
-            when users can no longer run the official Flash Player.
-            If you would like to help support this project, we welcome all contributions of any kind –
-            even if it's just playing some old games and seeing how well they run.
-        </p>
+        <p>Ruffle is a Flash Player emulator written in Rust. Leveraging the safety guarantees of Rust, we can confidently avoid all the security pitfalls that Flash had a reputation for. Ruffle puts Flash back on the web, where it belongs!</p>
+        <p>This application lets you run Flash content on your computer without a browser in-between, and take full advantage of your GPU and system resources to get those extra frames when playing intense games.</p>
+        <p>Ruffle is an entirely open source project maintained by volunteers. We're all passionate about the preservation of internet history, and we were drawn to working on this project to help preserve the many websites and plethora of content that will no longer be accessible when users can no longer run the official Flash Player. If you would like to help support this project, we welcome all contributions of any kind – even if it's just playing some old games and seeing how well they run.</p>
     </description>
     <categories>
         <category>Game</category>


### PR DESCRIPTION
Some stores do not ignore whitespace and newlines, treating the description as preformatted text (e.g. GNOME Software, Mintinstall).

<image width="400" src="https://github.com/user-attachments/assets/bec7c7d7-91d2-4540-acbf-985c58ed220b"/>