### PR TITLE
avm2: Box E4XNamespace in E4XNodeData

### DIFF
--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -36,7 +36,7 @@ pub struct E4XNode<'gc>(GcCell<'gc, E4XNodeData<'gc>>);
 #[collect(no_drop)]
 pub struct E4XNodeData<'gc> {
     parent: Option<E4XNode<'gc>>,
-    namespace: Option<E4XNamespace<'gc>>,
+    namespace: Option<Box<E4XNamespace<'gc>>>,
     local_name: Option<AvmString<'gc>>,
     kind: E4XNodeKind<'gc>,
     notification: Option<FunctionObject<'gc>>,
@@ -198,7 +198,7 @@ impl<'gc> E4XNode<'gc> {
             mc,
             E4XNodeData {
                 parent,
-                namespace,
+                namespace: namespace.map(Box::new),
                 local_name: Some(name),
                 kind: E4XNodeKind::Element {
                     attributes: vec![],
@@ -334,7 +334,7 @@ impl<'gc> E4XNode<'gc> {
             mc,
             E4XNodeData {
                 parent: None,
-                namespace: this.namespace,
+                namespace: this.namespace.clone(),
                 local_name: this.local_name,
                 kind,
                 notification: None,
@@ -1054,7 +1054,7 @@ impl<'gc> E4XNode<'gc> {
 
             let attribute_data = E4XNodeData {
                 parent: None,
-                namespace,
+                namespace: namespace.map(Box::new),
                 local_name: Some(name),
                 kind: E4XNodeKind::Attribute(value),
                 notification: None,
@@ -1091,7 +1091,7 @@ impl<'gc> E4XNode<'gc> {
 
         let data = E4XNodeData {
             parent: None,
-            namespace,
+            namespace: namespace.map(Box::new),
             local_name: Some(name),
             kind: E4XNodeKind::Element {
                 attributes: attribute_nodes,
@@ -1114,11 +1114,11 @@ impl<'gc> E4XNode<'gc> {
     }
 
     pub fn set_namespace(&self, namespace: Option<E4XNamespace<'gc>>, mc: &Mutation<'gc>) {
-        self.0.write(mc).namespace = namespace;
+        self.0.write(mc).namespace = namespace.map(Box::new);
     }
 
     pub fn namespace(&self) -> Option<E4XNamespace<'gc>> {
-        self.0.read().namespace
+        self.0.read().namespace.as_deref().copied()
     }
 
     pub fn set_local_name(&self, name: AvmString<'gc>, mc: &Mutation<'gc>) {
@@ -1218,7 +1218,7 @@ impl<'gc> E4XNode<'gc> {
         match self.namespace() {
             Some(self_ns) if self_ns.prefix == Some(prefix) => {
                 // 2.f.i. Let x.[[Name]].prefix = undefined
-                self.0.write(gc).namespace = Some(E4XNamespace::new_uri(self_ns.uri));
+                self.set_namespace(Some(E4XNamespace::new_uri(self_ns.uri)), gc);
             }
             _ => {}
         }
@@ -1232,7 +1232,7 @@ impl<'gc> E4XNode<'gc> {
                 // 2.g.i. If attr.[[Name]].[[Prefix]] == N.prefix, let attr.[[Name]].prefix = undefined
                 match attr.namespace() {
                     Some(attr_ns) if attr_ns.prefix == Some(prefix) => {
-                        attr.0.write(gc).namespace = Some(E4XNamespace::new_uri(attr_ns.uri));
+                        attr.set_namespace(Some(E4XNamespace::new_uri(attr_ns.uri)), gc);
                     }
                     _ => {}
                 }


### PR DESCRIPTION
Most XML nodes are in the default namespace, which uses `None`.  This reduces the size of `E4XNodeData` on x86-64 from 152 to 120 bytes.

Supersedes #17449.