### PR TITLE
video: Check OpenH264 library downloads with SHA256 instead of MD5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3077,16 +3077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4558,11 +4548,11 @@ dependencies = [
  "bzip2",
  "hex",
  "libloading",
- "md-5",
  "reqwest",
  "ruffle_render",
  "ruffle_video",
  "ruffle_video_software",
+ "sha2",
  "slotmap",
  "swf",
  "tempfile",

--- a/video/external/Cargo.toml
+++ b/video/external/Cargo.toml
@@ -17,14 +17,8 @@ ruffle_video_software = { path = "../software" }
 
 # Needed for OpenH264:
 libloading = "0.8.5"
-md-5 = "0.10.6"
 reqwest = { version = "0.12.5", default-features = false, features = ["blocking"] }
 hex = "0.4.3"
 bzip2 = { version = "0.4.4", features = ["static"] }
 tempfile = "3.12.0"
-
-[package.metadata.cargo-machete]
-ignored = [
-    # Renames itself to "md5", see: https://github.com/bnjbvr/cargo-machete/issues/8
-    "md-5"
-]
+sha2 = "0.10.8"

--- a/video/external/src/decoder/README.md
+++ b/video/external/src/decoder/README.md
@@ -1,10 +1,20 @@
 To update to a new OpenH264 release:
 
- - Open the new release on https://github.com/cisco/openh264/releases
- - Update the binary file names and MD5 hashes
- - Add/remove supported architectures and platforms if added/dropped
- - Update the base URL and license if changed
- - Download the OpenH264 sources (at least `codec_api.h`)
- - Regenerate the bindings using the command in `decoder.rs`
- - Follow the API changes if necessary
- - Update the version number sanity check
+1. Open the new release on https://github.com/cisco/openh264/releases
+2. Update the binary file names and SHA256 hashes (see below)
+3. Add/remove supported architectures and platforms if added/dropped
+4. Update the base URL and license if changed
+5. Download the OpenH264 sources (at least `codec_api.h`)
+6. Regenerate the bindings using the command in `decoder.rs`
+7. Follow the API changes if necessary
+8. Update the version number sanity check
+
+Cisco provides only binaries and MD5 hashes over HTTP which is far from being secure.
+We want to use SHA256 in order to protect users from downloading malicious binaries.
+Currently, we have to calculate hashes ourselves from the downloaded binaries:
+
+1. Make sure you're using a secure network
+2. Download necessary libraries and unpack them
+3. Verify their MD5 checksums
+4. Calculate their SHA256 checksums
+5. If you're unsure, repeat this over a different network


### PR DESCRIPTION
Continuation of https://github.com/ruffle-rs/ruffle/pull/17243.

We want to be better than Cisco and give our users more security by replacing MD5 with SHA256 hashes. Calculating a SHA256 hash on a safe network after verifying MD5 is a lot more secure than using HTTP+MD5 everywhere.

Thanks to @Fullmetal5 for noticing it and submitting a patch.

My comment from the commit:

> Cisco distributes the OpenH264 binaries and their MD5 hashes over HTTP.
Knowing that HTTP is insecure, MD5 hashes may easily collide,
and both are served over the same medium, saying that
this method is ridiculous is an understatement.
> 
> Take into account that these are binaries we download and execute, and
we for sure do not want to turn Ruffle into a remote code execution framework.
> 
> This patch changes MD5 to SHA256 in order to increase security
and protect our users from attacks resulting from this vulnerability.
