### PR TITLE
avm2: Intern XML node name

### DIFF
--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1012,7 +1012,14 @@ impl<'gc> E4XNode<'gc> {
             let value = AvmString::new_utf8_bytes(activation.gc(), value_str.as_bytes());
 
             let (ns, local_name) = parser.resolve_attribute(attribute.key);
-            let name = AvmString::new_utf8_bytes(activation.gc(), local_name.into_inner());
+
+            let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
+            let name = activation
+                .context
+                .interner
+                .intern_wstr(activation.gc(), local_name)
+                .into();
+
             let namespace = match ns {
                 ResolveResult::Bound(ns) if ns.into_inner() == b"http://www.w3.org/2000/xmlns/" => {
                     namespaces.push(E4XNamespace {
@@ -1064,8 +1071,14 @@ impl<'gc> E4XNode<'gc> {
         }
 
         let (ns, local_name) = parser.resolve_element(bs.name());
-        let name =
-            AvmString::new_utf8_bytes(activation.context.gc_context, local_name.into_inner());
+
+        let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
+        let name = activation
+            .context
+            .interner
+            .intern_wstr(activation.gc(), local_name)
+            .into();
+
         let namespace = match ns {
             ResolveResult::Bound(ns) => {
                 let prefix = bs


### PR DESCRIPTION
This is intentionally a very minimal PR (only interns element and attribute local name), to minimize refactoring/bikeshedding and get pareto-style 80% of benefit for 20% of the work c: Any more work can be done in follow-ups.

Note that technically this isn't free in terms of time, since interning requires more passes over the string than before: first `ruffle_wstr::from_utf8_bytes` checks whether copying to a WString is needed (very unlikely, since node names are usually ascii); then second and third pass to hash it and compare in the interner. This means some XML parsing microbenchmarks can regress, but very slightly.
(though this can also improve lookups, since comparisons will fast-path on pointer equality more often)

I did a memory test with
```as
            var s = "<test attr=\"1\"></test>";
            s = s + s; // repeated 21 times
            s = "<data>" + s + "</data>";
            this.xml = new XML(s);
```
And memory use dropped from 1460MB to 1140MB.