### PR TITLE
ci: Run nextest with profile "ci", add a test-specific override to allow retries for `avm2/pixelbender_shaderdata`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+# TODO: Figure out why this specific test is flaky on CI, fix it, then delete this file.
+[[profile.ci.overrides]]
+filter = "test(avm2/pixelbender_shaderdata)"
+retries = 3

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Run tests with image tests
         if: runner.os != 'macOS'
-        run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features imgtests,lzma,jpegxr
+        run: cargo nextest run --profile ci --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features imgtests,lzma,jpegxr
         env:
           # This is to counteract the disabling by rust-cache.
           # See: https://github.com/Swatinem/rust-cache/issues/43
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run tests without image tests
         if: runner.os == 'macOS'
-        run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features lzma,jpegxr
+        run: cargo nextest run --profile ci --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features lzma,jpegxr
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 


### PR DESCRIPTION
I'm not saying this is a nice solution (because it's not at all), but the flaky CI annoyed me too much...
Somewhat related: https://github.com/ruffle-rs/ruffle/pull/17385