### PR TITLE
avm2: Declare 'namespace AS3' and validate bytecode in playerglobals

### DIFF
--- a/core/src/avm2/globals/README.md
+++ b/core/src/avm2/globals/README.md
@@ -32,6 +32,20 @@ In addition to potential copyright issues around redistributing Flash's `playerg
 many of its classes rely on specific 'native' methods being provided
 by the Flash VM, which Ruffle does not implement.
 
+## Calling AS3 methods
+
+Under some circumstances, it may be necessarily to call a method with an explicitly-qualified AS3 namespace:
+
+```
+var xml = <accessor />;
+xml.AS3::appendChild(elem);
+```
+
+In order for this to generate efficient bytecode, you must have `namespace AS3 = "http://adobe.com/AS3/2006/builtin";` inside
+your package declaration (see `GroupElement.as` for an example). If you forget to do this, you'll get an error at compile-time:
+
+Found getlex of "AS3" in method body. Make sure you have `namespace AS3 = "http://adobe.com/AS3/2006/builtin";` in your `package` block
+
 ## Native methods
 
 We support defining native methods (instance methods, class methods, and freestanding functions)

--- a/core/src/avm2/globals/avmplus.as
+++ b/core/src/avm2/globals/avmplus.as
@@ -1,4 +1,6 @@
 package avmplus {
+    namespace AS3 = "http://adobe.com/AS3/2006/builtin";
+
     public native function getQualifiedClassName(value:*):String;
     internal native function describeTypeJSON(o:*, flags:uint):Object;
 

--- a/core/src/avm2/globals/flash/filters/ColorMatrixFilter.as
+++ b/core/src/avm2/globals/flash/filters/ColorMatrixFilter.as
@@ -1,4 +1,5 @@
 ﻿package flash.filters {
+	namespace AS3 = "http://adobe.com/AS3/2006/builtin";
 	public final class ColorMatrixFilter extends BitmapFilter {
 		private var _matrix: Array;
 

--- a/core/src/avm2/globals/flash/net/URLVariables.as
+++ b/core/src/avm2/globals/flash/net/URLVariables.as
@@ -1,4 +1,6 @@
 package flash.net {
+    namespace AS3 = "http://adobe.com/AS3/2006/builtin";
+
     import flash.utils.escapeMultiByte;
     import flash.utils.unescapeMultiByte;
     public dynamic class URLVariables {

--- a/core/src/avm2/globals/flash/text/engine/GroupElement.as
+++ b/core/src/avm2/globals/flash/text/engine/GroupElement.as
@@ -1,4 +1,6 @@
 package flash.text.engine {
+    namespace AS3 = "http://adobe.com/AS3/2006/builtin";
+
     import __ruffle__.stub_method;
 
     import flash.events.EventDispatcher;

--- a/core/src/avm2/globals/flash/xml/XMLDocument.as
+++ b/core/src/avm2/globals/flash/xml/XMLDocument.as
@@ -1,6 +1,7 @@
 package flash.xml
 {
 
+namespace AS3 = "http://adobe.com/AS3/2006/builtin";
 import flash.xml.XMLNode;
 import flash.xml.XMLNodeType;
 

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -1,6 +1,12 @@
 // List is ordered alphabetically, except where superclasses/interfaces
 // need to come before subclasses and implementations.
 
+package {
+    // This names 'self.AS3::SomeMethod()' calls in 'XML.as' use a 'callproperty'
+    // opcode, instead of a weird dynamic lookup of the 'AS3' namespace
+    namespace AS3 = "http://adobe.com/AS3/2006/builtin";
+}
+
 include "__ruffle__/stubs.as"
 
 include "Error.as"


### PR DESCRIPTION
In order for asc.jar to generate efficient bytecode (a direct 'callproperty' instead of a dynamic namespace and method lookup), we need to have 'namespace AS3' in each package where we do a qualified 'obj.AS3::SomeMethod()' call.

I've adjusted `build_playerglobal` to scan all of our playerglobal method bodies to ensure that we don't have the bad bytecode. This uncovered several places where we were missing `namespace AS3'

Before this change, we were creating a new bound method within all of our prototype methods in `XML/XMLList`, since they used 'self.AS3::SomeXmlMethod()' calls to delegate to the AS3 native method.

This saves several hundred megabytes on
`https://s1106-r2game-sq.7road.net`, since we no longer create bound `FunctionObject`s for all of the distinct XML/XMLList objects that the swf creates.