### PR TITLE
extension: Register navigator polyfill script with allFrames: true

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -189,6 +189,7 @@ async function enable() {
                     "https://*.edgenuity.com/*",
                 ],
                 runAt: "document_start",
+                allFrames: true,
                 world: "MAIN",
             },
             {


### PR DESCRIPTION
This causes the browser to inject our polyfill script into iframes as well as the main document. This ensures that we can always inject the fake 'Shockwave Flash' plugin before the page's javascript has a change to check 'navigator.plugins'

This fixes an inconsistent 'Flash Player Missing' error on 7Road Wartune