### PR TITLE
wgpu: Include memory report in debug info

### DIFF
--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -442,6 +442,9 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         result.push(format!("Surface quality: {}", self.surface.quality()));
         result.push(format!("Surface samples: {}", self.surface.sample_count()));
         result.push(format!("Surface size: {:?}", self.surface.size()));
+        if let Some(report) = self.descriptors.wgpu_instance.generate_report() {
+            result.push(format!("wgpu memory report: {report:?}"));
+        }
 
         Cow::Owned(result.join("\n"))
     }


### PR DESCRIPTION
Sample report:
```
wgpu memory report: GlobalReport { surfaces: RegistryReport { num_allocated: 1, num_kept_from_user: 1, num_released_from_user: 0, num_error: 0, element_size: 592 }, vulkan: None, gl: Some(HubReport { adapters: RegistryReport { num_allocated: 1, num_kept_from_user: 1, num_released_from_user: 0, num_error: 0, element_size: 272 }, devices: RegistryReport { num_allocated: 1, num_kept_from_user: 1, num_released_from_user: 0, num_error: 0, element_size: 9720 }, queues: RegistryReport { num_allocated: 1, num_kept_from_user: 1, num_released_from_user: 0, num_error: 0, element_size: 88 }, pipeline_layouts: RegistryReport { num_allocated: 5, num_kept_from_user: 5, num_released_from_user: 1, num_error: 0, element_size: 216 }, shader_modules: RegistryReport { num_allocated: 19, num_kept_from_user: 19, num_released_from_user: 1, num_error: 0, element_size: 832 }, bind_group_layouts: RegistryReport { num_allocated: 12, num_kept_from_user: 12, num_released_from_user: 1, num_error: 0, element_size: 232 }, bind_groups: RegistryReport { num_allocated: 3, num_kept_from_user: 3, num_released_from_user: 0, num_error: 0, element_size: 304 }, command_buffers: RegistryReport { num_allocated: 1, num_kept_from_user: 1, num_released_from_user: 0, num_error: 0, element_size: 9192 }, render_bundles: RegistryReport { num_allocated: 0, num_kept_from_user: 0, num_released_from_user: 0, num_error: 0, element_size: 848 }, render_pipelines: RegistryReport { num_allocated: 84, num_kept_from_user: 84, num_released_from_user: 0, num_error: 0, element_size: 712 }, compute_pipelines: RegistryReport { num_allocated: 0, num_kept_from_user: 0, num_released_from_user: 0, num_error: 0, element_size: 280 }, pipeline_caches: RegistryReport { num_allocated: 0, num_kept_from_user: 0, num_released_from_user: 0, num_error: 0, element_size: 64 }, query_sets: RegistryReport { num_allocated: 0, num_kept_from_user: 0, num_released_from_user: 0, num_error: 0, element_size: 88 }, buffers: RegistryReport { num_allocated: 22, num_kept_from_user: 22, num_released_from_user: 0, num_error: 0, element_size: 280 }, textures: RegistryReport { num_allocated: 1, num_kept_from_user: 1, num_released_from_user: 0, num_error: 0, element_size: 776 }, texture_views: RegistryReport { num_allocated: 0, num_kept_from_user: 0, num_released_from_user: 1, num_error: 0, element_size: 208 }, samplers: RegistryReport { num_allocated: 25, num_kept_from_user: 25, num_released_from_user: 0, num_error: 0, element_size: 64 } }) }
```