### PR TITLE
avm2: Add `[API("674")]` to Rectangle.copyFrom

### DIFF
--- a/core/src/avm2/globals/flash/geom/Rectangle.as
+++ b/core/src/avm2/globals/flash/geom/Rectangle.as
@@ -183,6 +183,7 @@ package flash.geom {
             return "(x=" + this.x + ", y=" + this.y + ", w=" + this.width + ", h=" + this.height + ")";
         }
 
+        [API("674")]
         public function copyFrom(sourceRect: Rectangle): void {
             this.x = sourceRect.x;
             this.y = sourceRect.y;


### PR DESCRIPTION
This fixes old classes that extend Rectangle and define `copyFrom` without marking it as an override
Fixes #17423