### PR TITLE
avm2: Pass in `Gc<'gc, BytecodeMethod<'gc>>` to `optimize`

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -274,7 +274,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // Run verifier for bytecode methods
         if let Method::Bytecode(method) = method {
             if method.verified_info.read().is_none() {
-                method.verify(&mut created_activation)?;
+                BytecodeMethod::verify(method, &mut created_activation)?;
             }
         }
 
@@ -442,7 +442,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         // Everything is now setup for the verifier to run
         if method.verified_info.read().is_none() {
-            method.verify(self)?;
+            BytecodeMethod::verify(method, self)?;
         }
 
         let verified_info = method.verified_info.read();

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -240,11 +240,14 @@ impl<'gc> BytecodeMethod<'gc> {
     }
 
     #[inline(never)]
-    pub fn verify(&self, activation: &mut Activation<'_, 'gc>) -> Result<(), Error<'gc>> {
+    pub fn verify(
+        this: Gc<'gc, BytecodeMethod<'gc>>,
+        activation: &mut Activation<'_, 'gc>,
+    ) -> Result<(), Error<'gc>> {
         // TODO: avmplus seems to eaglerly verify some methods
 
-        *self.verified_info.write(activation.context.gc_context) =
-            Some(crate::avm2::verify::verify_method(activation, self)?);
+        *this.verified_info.write(activation.context.gc_context) =
+            Some(crate::avm2::verify::verify_method(activation, this)?);
 
         Ok(())
     }

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -307,7 +307,7 @@ fn has_simple_scope_structure(
 
 pub fn optimize<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    method: &BytecodeMethod<'gc>,
+    method: Gc<'gc, BytecodeMethod<'gc>>,
     code: &mut Vec<Op<'gc>>,
     resolved_parameters: &[ResolvedParamConfig<'gc>],
     return_type: Option<Class<'gc>>,

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -66,7 +66,7 @@ pub enum JumpSource {
 
 pub fn verify_method<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    method: &BytecodeMethod<'gc>,
+    method: Gc<'gc, BytecodeMethod<'gc>>,
 ) -> Result<VerifiedMethodInfo<'gc>, Error<'gc>> {
     let body = method
         .body()


### PR DESCRIPTION
This allows us to pretty-print a method name from within `optimize` using `display_function` (which needs to do `Gc::ptr_eq`)