### PR TITLE
avm2: Declare correct signature for builtin rust-side getters/setters

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -1147,6 +1147,7 @@ impl<'gc> Class<'gc> {
     }
 
     #[inline(never)]
+    #[allow(clippy::type_complexity)]
     pub fn define_builtin_instance_properties(
         self,
         mc: &Mutation<'gc>,
@@ -1155,15 +1156,23 @@ impl<'gc> Class<'gc> {
             &'static str,
             Option<NativeMethodImpl>,
             Option<NativeMethodImpl>,
+            Option<Gc<'gc, Multiname<'gc>>>,
         )],
     ) {
-        for &(name, getter, setter) in items {
+        for (name, getter, setter, prop_type) in items {
             if let Some(getter) = getter {
                 self.define_instance_trait(
                     mc,
                     Trait::from_getter(
-                        QName::new(namespace, name),
-                        Method::from_builtin(getter, name, mc),
+                        QName::new(namespace, *name),
+                        Method::from_builtin_and_params(
+                            *getter,
+                            name,
+                            vec![],
+                            *prop_type,
+                            false,
+                            mc,
+                        ),
                     ),
                 );
             }
@@ -1171,8 +1180,15 @@ impl<'gc> Class<'gc> {
                 self.define_instance_trait(
                     mc,
                     Trait::from_setter(
-                        QName::new(namespace, name),
-                        Method::from_builtin(setter, name, mc),
+                        QName::new(namespace, *name),
+                        Method::from_builtin_and_params(
+                            *setter,
+                            name,
+                            vec![ParamConfig::of_type("val", *prop_type)],
+                            Some(Gc::new(mc, QName::new(namespace, "void").into())),
+                            false,
+                            mc,
+                        ),
                     ),
                 );
             }

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -7,10 +7,11 @@ use crate::avm2::error::range_error;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{array_allocator, ArrayObject, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
-use crate::avm2::Error;
 use crate::avm2::QName;
+use crate::avm2::{Error, Multiname};
 use crate::string::AvmString;
 use bitflags::bitflags;
+use gc_arena::Gc;
 use std::cmp::{min, Ordering};
 use std::mem::swap;
 
@@ -1349,15 +1350,19 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         Method::from_builtin(class_call, "<Array call handler>", mc),
     );
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &str,
-        Option<NativeMethodImpl>,
-        Option<NativeMethodImpl>,
-    )] = &[("length", Some(length), Some(set_length))];
+    let public_instance_properties = &[(
+        "length",
+        Some(length as _),
+        Some(set_length as _),
+        Some(Gc::new(
+            mc,
+            Multiname::new(activation.avm2().namespaces.public_all(), "uint"),
+        )),
+    )];
     class.define_builtin_instance_properties(
         mc,
         activation.avm2().namespaces.public_all(),
-        PUBLIC_INSTANCE_PROPERTIES,
+        public_instance_properties,
     );
 
     class.define_builtin_instance_methods(

--- a/core/src/avm2/globals/class.rs
+++ b/core/src/avm2/globals/class.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::method::Method;
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
@@ -79,15 +79,11 @@ pub fn create_i_class<'gc>(
         ),
     );
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &str,
-        Option<NativeMethodImpl>,
-        Option<NativeMethodImpl>,
-    )] = &[("prototype", Some(prototype), None)];
+    let public_instance_properties = &[("prototype", Some(prototype as _), None, None)];
     class_i_class.define_builtin_instance_properties(
         gc_context,
         namespaces.public_all(),
-        PUBLIC_INSTANCE_PROPERTIES,
+        public_instance_properties,
     );
 
     class_i_class.mark_traits_loaded(activation.context.gc_context);

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -1,5 +1,7 @@
 //! `String` impl
 
+use gc_arena::Gc;
+
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::error::make_error_1004;
@@ -7,9 +9,9 @@ use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::regexp::{RegExp, RegExpFlags};
 use crate::avm2::value::Value;
-use crate::avm2::Error;
 use crate::avm2::QName;
 use crate::avm2::{ArrayObject, ArrayStorage};
+use crate::avm2::{Error, Multiname};
 use crate::string::{AvmString, WString};
 
 // All of these methods will be defined as both
@@ -705,15 +707,16 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         Method::from_builtin(call_handler, "<String call handler>", mc),
     );
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &str,
-        Option<NativeMethodImpl>,
-        Option<NativeMethodImpl>,
-    )] = &[("length", Some(length), None)];
+    let public_instance_properties = &[(
+        "length",
+        Some(length as _),
+        None,
+        Some(Gc::new(mc, Multiname::new(namespaces.public_all(), "int"))),
+    )];
     class.define_builtin_instance_properties(
         mc,
         namespaces.public_all(),
-        PUBLIC_INSTANCE_PROPERTIES,
+        public_instance_properties,
     );
     class.define_builtin_instance_methods(mc, namespaces.as3, PUBLIC_INSTANCE_AND_PROTO_METHODS);
 

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -1,5 +1,7 @@
 //! `Vector` builtin/prototype
 
+use gc_arena::Gc;
+
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::error::{argument_error, type_error};
@@ -13,8 +15,8 @@ use crate::avm2::object::{
 };
 use crate::avm2::value::Value;
 use crate::avm2::vector::VectorStorage;
-use crate::avm2::Error;
 use crate::avm2::QName;
+use crate::avm2::{Error, Multiname};
 use crate::string::AvmString;
 use std::cmp::{max, min, Ordering};
 
@@ -963,18 +965,27 @@ pub fn create_builtin_class<'gc>(
         Method::from_builtin(class_call, "<Vector.<T> call handler>", mc),
     );
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &str,
-        Option<NativeMethodImpl>,
-        Option<NativeMethodImpl>,
-    )] = &[
-        ("length", Some(length), Some(set_length)),
-        ("fixed", Some(fixed), Some(set_fixed)),
+    let public_instance_properties = &[
+        (
+            "length",
+            Some(length as _),
+            Some(set_length as _),
+            Some(Gc::new(mc, Multiname::new(namespaces.public_all(), "uint"))),
+        ),
+        (
+            "fixed",
+            Some(fixed as _),
+            Some(set_fixed as _),
+            Some(Gc::new(
+                mc,
+                Multiname::new(namespaces.public_all(), "Boolean"),
+            )),
+        ),
     ];
     class.define_builtin_instance_properties(
         mc,
         namespaces.public_all(),
-        PUBLIC_INSTANCE_PROPERTIES,
+        public_instance_properties,
     );
 
     const AS3_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[


### PR DESCRIPTION
This only affects the handful of classes that we still implement entirely in Rust (with only an ActionScript stub when compiling playerglobals).

We now expose the proper signatures to `describeType`, and have more type information for future use in the optimizer.