### PR TITLE
avm2: Added all missing `[API()]` to methods from the list

### DIFF
--- a/core/src/avm2/globals/flash/display/BitmapData.as
+++ b/core/src/avm2/globals/flash/display/BitmapData.as
@@ -22,6 +22,7 @@ package flash.display {
         public native function get transparent():Boolean;
 
         public native function getPixels(rect:Rectangle):ByteArray;
+        [API("682")]
         public native function copyPixelsToByteArray(rect:Rectangle, data:ByteArray):void;
         public native function getVector(rect:Rectangle):Vector.<uint>;
         public native function getPixel(x:int, y:int):uint;
@@ -45,6 +46,7 @@ package flash.display {
         public native function draw(
             source:IBitmapDrawable, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false
         ):void;
+        [API("680")]
         public native function drawWithQuality(
             source:IBitmapDrawable, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false, quality:String = null
         ):void;

--- a/core/src/avm2/globals/flash/display/Graphics.as
+++ b/core/src/avm2/globals/flash/display/Graphics.as
@@ -35,6 +35,7 @@ package flash.display
         public native function lineGradientStyle(
             type:String, colors:Array, alphas:Array, ratios:Array, matrix:Matrix = null, spreadMethod:String = "pad", interpolationMethod:String = "rgb", focalPointRatio:Number = 0
         ):void;
+        [API("674")]
         public native function cubicCurveTo(controlX1:Number, controlY1:Number, controlX2:Number, controlY2:Number, anchorX:Number, anchorY:Number):void;
         public native function copyFrom(sourceGraphics:Graphics):void;
         public native function drawPath(commands:Vector.<int>, data:Vector.<Number>, winding:String = "evenOdd"):void;
@@ -45,6 +46,7 @@ package flash.display
         public native function drawGraphicsData(graphicsData:Vector.<IGraphicsData>):void;
         //public native function lineShaderStyle(shader:Shader, matrix:Matrix = null):void;
         public native function lineBitmapStyle(bitmap:BitmapData, matrix:Matrix = null, repeat:Boolean = true, smooth:Boolean = false):void;
+        [API("686")]
         public native function readGraphicsData(recurse:Boolean = true):Vector.<IGraphicsData>;
     }
 }

--- a/core/src/avm2/globals/flash/display/GraphicsPath.as
+++ b/core/src/avm2/globals/flash/display/GraphicsPath.as
@@ -11,6 +11,7 @@ package flash.display {
             this.winding = winding;
         }
 
+        [API("694")]
         public function cubicCurveTo(controlX1:Number, controlY1:Number, controlX2:Number, controlY2:Number, anchorX:Number, anchorY:Number):void {
             if (commands == null) {
                 commands = new Vector.<int>();

--- a/core/src/avm2/globals/flash/display3D/textures/CubeTexture.as
+++ b/core/src/avm2/globals/flash/display3D/textures/CubeTexture.as
@@ -4,8 +4,11 @@ package flash.display3D.textures {
     import __ruffle__.stub_method;
     
     public final class CubeTexture extends TextureBase {
+        [API("674")]
         public native function uploadFromBitmapData(source:BitmapData, side:uint, miplevel:uint = 0):void;
+        [API("674")]
         public native function uploadFromByteArray(data:ByteArray, byteArrayOffset:uint, side:uint, miplevel:uint = 0);
+        [API("674")]
         public native function uploadCompressedTextureFromByteArray(data:ByteArray, byteArrayOffset:uint, async:Boolean = false):void;
     }
 }

--- a/core/src/avm2/globals/flash/display3D/textures/RectangleTexture.as
+++ b/core/src/avm2/globals/flash/display3D/textures/RectangleTexture.as
@@ -3,7 +3,9 @@ package flash.display3D.textures {
     import flash.utils.ByteArray;
     
     public final class RectangleTexture extends TextureBase {
+        [API("690")]
         public native function uploadFromBitmapData(source:BitmapData):void;
+        [API("690")]
         public native function uploadFromByteArray(data:ByteArray, byteArrayOffset:uint):void;
     }
 }

--- a/core/src/avm2/globals/flash/display3D/textures/Texture.as
+++ b/core/src/avm2/globals/flash/display3D/textures/Texture.as
@@ -5,8 +5,11 @@ package flash.display3D.textures {
     import flash.utils.setTimeout;
 
     public final class Texture extends TextureBase {
+        [API("674")]
         public native function uploadFromBitmapData(source:BitmapData, miplevel:uint = 0):void;
+        [API("674")]
         public native function uploadFromByteArray(data:ByteArray, byteArrayOffset:uint, miplevel:uint = 0):void;
+        [API("674")]
         public function uploadCompressedTextureFromByteArray(data:ByteArray, byteArrayOffset:uint, async:Boolean = false):void {
             if (async) {
                 var self = this;

--- a/core/src/avm2/globals/flash/media/Camera.as
+++ b/core/src/avm2/globals/flash/media/Camera.as
@@ -5,14 +5,17 @@ package flash.media {
     import flash.display.BitmapData;
 
     public final class Camera extends EventDispatcher {
+        [API("682")]
         public function copyToByteArray(rect:Rectangle, destination:ByteArray) {
             __ruffle__.stub_method("flash.media.Camera", "copyToByteArray");
         }
 
+        [API("682")]
         public function copyToVector(rect:Rectangle, destination:Vector.<uint>) {
             __ruffle__.stub_method("flash.media.Camera", "copyToVector");
         }
 
+        [API("682")]
         public function drawToBitmapData(destination:BitmapData) {
             __ruffle__.stub_method("flash.media.Camera", "drawToBitmapData");
         }

--- a/core/src/avm2/globals/flash/media/Sound.as
+++ b/core/src/avm2/globals/flash/media/Sound.as
@@ -22,7 +22,9 @@ package flash.media {
         public native function extract(target:ByteArray, length:Number, startPosition:Number = -1):Number;
         public native function close():void;
         public native function load(stream:URLRequest, context:SoundLoaderContext = null):void;
+        [API("674")]
         public native function loadCompressedDataFromByteArray(bytes:ByteArray, bytesLength:uint):void;
+        [API("674")]
         public native function loadPCMFromByteArray(bytes:ByteArray, samples:uint, format:String = "float", stereo:Boolean = true, sampleRate:Number = 44100.0):void
     }
 }

--- a/core/src/avm2/globals/flash/net/NetStream.as
+++ b/core/src/avm2/globals/flash/net/NetStream.as
@@ -45,6 +45,7 @@ package flash.net {
             stub_method("flash.net.NetStream", "close");
         }
 
+        [API("674")]
         public function dispose() {
             stub_method("flash.net.NetStream", "dispose");
         }
@@ -78,6 +79,7 @@ package flash.net {
             stub_method("flash.net.NetStream", "receiveVideoFPS");
         }
 
+        [API("690")]
         public static function resetDRMVouchers() {
             stub_method("flash.net.NetStream", "resetDRMVouchers");
         }
@@ -322,11 +324,13 @@ package flash.net {
             stub_setter("flash.net.NetStream", "useHardwareDecoder");
         };
 
+        [API("680")]
         public function get useJitterBuffer(): Boolean {
             stub_getter("flash.net.NetStream", "useJitterBuffer");
             return false;
         };
 
+        [API("680")]
         public function set useJitterBuffer(jbuf:Boolean) {
             stub_setter("flash.net.NetStream", "useJitterBuffer");
         };
@@ -349,11 +353,13 @@ package flash.net {
             stub_setter("flash.net.NetStream", "videoSampleAccess");
         };
 
+        [API("674")]
         public function get videoStreamSettings(): VideoStreamSettings {
             stub_getter("flash.net.NetStream", "videoStreamSettings");
             return null;
         };
 
+        [API("674")]
         public function set videoStreamSettings(settings: VideoStreamSettings) {
             stub_setter("flash.net.NetStream", "videoStreamSettings");
         };


### PR DESCRIPTION
Dinnerbone's list - https://gist.github.com/Dinnerbone/0cfad60f4587292005d41e566368c709

except one - "String static has extra method "fromCharCode"