### PR TITLE
avm2: Added all missing `[API()]` to classes from the list

### DIFF
--- a/core/src/avm2/globals/flash/concurrent/Condition.as
+++ b/core/src/avm2/globals/flash/concurrent/Condition.as
@@ -1,4 +1,5 @@
 package flash.concurrent {
+    [API("684")]
     public final class Condition {
         public static const isSupported: Boolean = false;
 

--- a/core/src/avm2/globals/flash/concurrent/Mutex.as
+++ b/core/src/avm2/globals/flash/concurrent/Mutex.as
@@ -1,4 +1,5 @@
 package flash.concurrent {
+    [API("684")]
     public final class Mutex {
         public static const isSupported: Boolean = false;
         

--- a/core/src/avm2/globals/flash/display3D/Context3D.as
+++ b/core/src/avm2/globals/flash/display3D/Context3D.as
@@ -9,6 +9,7 @@ package flash.display3D {
     import __ruffle__.stub_method;
     import __ruffle__.stub_getter;
 
+    [API("674")]
     public final class Context3D extends EventDispatcher {
         public native function clear(red:Number = 0.0, green:Number = 0.0, blue:Number = 0.0, alpha:Number = 1.0, depth:Number = 1.0, stencil:uint = 0, mask:uint = 0xffffffff):void;
 
@@ -49,11 +50,13 @@ package flash.display3D {
 
         public native function get profile():String;
 
+        [API("700")]
         public function get maxBackBufferWidth():int {
             stub_getter("flash.display3D.Context3D", "maxBackBufferWidth");
             return 2048;
         }
 
+        [API("700")]
         public function get maxBackBufferHeight():int {
             stub_getter("flash.display3D.Context3D", "maxBackBufferHeight");
             return 2048;

--- a/core/src/avm2/globals/flash/display3D/Context3DBufferUsage.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DBufferUsage.as
@@ -6,6 +6,7 @@
 package flash.display3D
 {
 
+    [API("692")] // the docs say 694, that's wrong
     public final class Context3DBufferUsage
     {
         // Indicates the buffer will be used for drawing and be updated frequently

--- a/core/src/avm2/globals/flash/display3D/Context3DMipFilter.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DMipFilter.as
@@ -6,6 +6,7 @@
 package flash.display3D
 {
 
+    [API("686")]
     public final class Context3DMipFilter
     {
         // Select the two closest MIP levels and linearly blend between them (the highest quality mode, but has some performance cost).

--- a/core/src/avm2/globals/flash/display3D/Context3DProfile.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DProfile.as
@@ -6,6 +6,7 @@
 package flash.display3D
 {
 
+    [API("682")]
     public final class Context3DProfile
     {
         // Use the default feature support profile.
@@ -15,15 +16,19 @@ package flash.display3D
         public static const BASELINE_CONSTRAINED:String = "baselineConstrained";
 
         // Use an extended feature support profile to target newer GPUs which support larger textures This profile increases the maximum 2D Texture and RectangleTexture size to 4096x4096
+        [API("690")]
         public static const BASELINE_EXTENDED:String = "baselineExtended";
 
         // Use an standard profile to target GPUs which support MRT, AGAL2 and float textures.
+        [API("698")]
         public static const STANDARD:String = "standard";
 
         // Use an standard profile to target GPUs which support AGAL2 and float textures.
+        [API("702")]
         public static const STANDARD_CONSTRAINED:String = "standardConstrained";
 
         // Use standard extended profile to target GPUs which support AGAL3 and instanced drawing feature.
+        [API("704")] // the docs say 706, that's wrong
         public static const STANDARD_EXTENDED:String = "standardExtended";
 
     }

--- a/core/src/avm2/globals/flash/display3D/Context3DProgramType.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DProgramType.as
@@ -6,7 +6,7 @@
 package flash.display3D
 {
     
-    
+    [API("674")]
     public final class Context3DProgramType
     {
         // A fragment (or pixel) program.

--- a/core/src/avm2/globals/flash/display3D/Context3DRenderMode.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DRenderMode.as
@@ -6,6 +6,7 @@
 package flash.display3D
 {
 
+    [API("674")]
     public final class Context3DRenderMode
     {
         // Automatically choose rendering engine.

--- a/core/src/avm2/globals/flash/display3D/Context3DStencilAction.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DStencilAction.as
@@ -6,6 +6,7 @@
 package flash.display3D
 {
 
+    [API("674")]
     public final class Context3DStencilAction
     {
         // Decrement the stencil buffer value, clamping at 0, the minimum value.

--- a/core/src/avm2/globals/flash/display3D/Context3DTextureFilter.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DTextureFilter.as
@@ -6,18 +6,23 @@
 package flash.display3D
 {
 
+    [API("686")]
     public final class Context3DTextureFilter
     {
         // Use anisotropic filter with radio 16 when upsampling textures
+        [API("698")]
         public static const ANISOTROPIC16X:String = "anisotropic16x";
 
         // Use anisotropic filter with radio 2 when upsampling textures
+        [API("698")]
         public static const ANISOTROPIC2X:String = "anisotropic2x";
 
         // Use anisotropic filter with radio 4 when upsampling textures
+        [API("698")]
         public static const ANISOTROPIC4X:String = "anisotropic4x";
 
         // Use anisotropic filter with radio 8 when upsampling textures
+        [API("698")]
         public static const ANISOTROPIC8X:String = "anisotropic8x";
 
         // Use linear interpolation when upsampling textures (gives a smooth, blurry look).

--- a/core/src/avm2/globals/flash/display3D/Context3DTextureFormat.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DTextureFormat.as
@@ -6,20 +6,25 @@
 package flash.display3D
 {
 
+    [API("674")]
     public final class Context3DTextureFormat
     {
         public static const BGRA:String = "bgra";
 
         // 16 bit, bgra packed as 4:4:4:4
+        [API("688")]
         public static const BGRA_PACKED:String = "bgraPacked4444";
 
         // 16 bit, bgr packed as 5:6:5
+        [API("688")]
         public static const BGR_PACKED:String = "bgrPacked565";
 
         public static const COMPRESSED:String = "compressed";
 
+        [API("682")]
         public static const COMPRESSED_ALPHA:String = "compressedAlpha";
 
+        [API("698")]
         public static const RGBA_HALF_FLOAT:String = "rgbaHalfFloat";
 
     }

--- a/core/src/avm2/globals/flash/display3D/Context3DTriangleFace.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DTriangleFace.as
@@ -6,6 +6,7 @@
 package flash.display3D
 {
 
+    [API("674")]
     public final class Context3DTriangleFace
     {
         public static const BACK:String = "back";

--- a/core/src/avm2/globals/flash/display3D/Context3DVertexBufferFormat.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DVertexBufferFormat.as
@@ -6,6 +6,7 @@
 package flash.display3D
 {
 
+    [API("674")]
     public final class Context3DVertexBufferFormat
     {
         public static const BYTES_4:String = "bytes4";

--- a/core/src/avm2/globals/flash/display3D/Context3DWrapMode.as
+++ b/core/src/avm2/globals/flash/display3D/Context3DWrapMode.as
@@ -6,18 +6,21 @@
 package flash.display3D
 {
 
+    [API("686")]
     public final class Context3DWrapMode
     {
         // Clamp texture coordinates outside the 0..1 range.
         public static const CLAMP:String = "clamp";
 
         // Clamp in U axis but Repeat in V axis.
+        [API("696")] // the docs don't mention it, but this is correct
         public static const CLAMP_U_REPEAT_V:String = "clamp_u_repeat_v";
 
         // Repeat (tile) texture coordinates outside the 0..1 range.
         public static const REPEAT:String = "repeat";
 
         // Repeat in U axis but Clamp in V axis.
+        [API("696")] // the docs don't mention it, but this is correct
         public static const REPEAT_U_CLAMP_V:String = "repeat_u_clamp_v";
 
     }

--- a/core/src/avm2/globals/flash/display3D/IndexBuffer3D.as
+++ b/core/src/avm2/globals/flash/display3D/IndexBuffer3D.as
@@ -3,6 +3,7 @@ package flash.display3D {
     import flash.utils.ByteArray;
     
     [Ruffle(InstanceAllocator)]
+    [API("674")]
     public final class IndexBuffer3D {
         public native function uploadFromByteArray(data:ByteArray, byteArrayOffset:int, startOffset:int, count:int):void;
         public native function uploadFromVector(data:Vector.<uint>, startOffset:int, count:int):void;

--- a/core/src/avm2/globals/flash/display3D/Program3D.as
+++ b/core/src/avm2/globals/flash/display3D/Program3D.as
@@ -2,6 +2,7 @@ package flash.display3D {
     import __ruffle__.stub_method;
     import flash.utils.ByteArray;
 
+    [API("674")]
     public final class Program3D {
         public native function upload(vertexProgram:ByteArray, fragmentProgram:ByteArray):void;
 

--- a/core/src/avm2/globals/flash/display3D/VertexBuffer3D.as
+++ b/core/src/avm2/globals/flash/display3D/VertexBuffer3D.as
@@ -3,6 +3,7 @@ package flash.display3D {
     import flash.utils.ByteArray;
     
     [Ruffle(InstanceAllocator)]
+    [API("674")]
     public final class VertexBuffer3D {
         public native function uploadFromByteArray(data:ByteArray, byteArrayOffset:int, startVertex:int, numVertices:int):void
         public native function uploadFromVector(data:Vector.<Number>, startVertex:int, numVertices:int):void

--- a/core/src/avm2/globals/flash/display3D/textures/TextureBase.as
+++ b/core/src/avm2/globals/flash/display3D/textures/TextureBase.as
@@ -2,6 +2,7 @@ package flash.display3D.textures {
     import flash.events.EventDispatcher;
     import __ruffle__.stub_method;
 
+    [API("674")]
     public class TextureBase extends EventDispatcher {
         public function dispose():void {
             stub_method("flash.display3D.textures.TextureBase", "dispose");

--- a/core/src/avm2/globals/flash/events/AudioOutputChangeEvent.as
+++ b/core/src/avm2/globals/flash/events/AudioOutputChangeEvent.as
@@ -4,6 +4,7 @@
 // It won't be regenerated in the future, so feel free to edit and/or fix
 package flash.events
 {
+    // TODO: [API("724")]
     public class AudioOutputChangeEvent extends Event
     {
         public static const AUDIO_OUTPUT_CHANGE:String = "audioOutputChange"; // Defines the value of the type property of a AudioOutputChangeEvent event object.

--- a/core/src/avm2/globals/flash/events/DRMAuthenticationCompleteEvent.as
+++ b/core/src/avm2/globals/flash/events/DRMAuthenticationCompleteEvent.as
@@ -7,6 +7,7 @@ package flash.events
     
     import flash.utils.ByteArray;
     
+    [API("667")]
     public class DRMAuthenticationCompleteEvent extends Event
     {
         // The string constant to use for the authentication complete event in the type parameter when adding and removing event listeners.

--- a/core/src/avm2/globals/flash/events/DRMAuthenticationErrorEvent.as
+++ b/core/src/avm2/globals/flash/events/DRMAuthenticationErrorEvent.as
@@ -5,6 +5,7 @@
 package flash.events
 {
     
+    [API("667")]
     public class DRMAuthenticationErrorEvent extends ErrorEvent
     {
         // The string constant to use for the authentication error event in the type parameter when adding and removing event listeners.

--- a/core/src/avm2/globals/flash/events/DRMReturnVoucherCompleteEvent.as
+++ b/core/src/avm2/globals/flash/events/DRMReturnVoucherCompleteEvent.as
@@ -5,6 +5,7 @@
 package flash.events
 {
     
+    [API("690")]
     public class DRMReturnVoucherCompleteEvent extends Event
     {
         // The string constant to use for the return voucher complete event in the type parameter when adding and removing event listeners.

--- a/core/src/avm2/globals/flash/events/FullScreenEvent.as
+++ b/core/src/avm2/globals/flash/events/FullScreenEvent.as
@@ -30,6 +30,7 @@ package flash.events {
             return this._fullScreen;
         }
 
+        [API("680")]
         public function get interactive() : Boolean
         {
             return this._interactive;

--- a/core/src/avm2/globals/flash/events/GameInputEvent.as
+++ b/core/src/avm2/globals/flash/events/GameInputEvent.as
@@ -1,4 +1,5 @@
 package flash.events {
+    [API("688")] // the docs say 689 (AIR-only), that's wrong
     public final class GameInputEvent extends Event {
         public static const DEVICE_ADDED:String = "deviceAdded";
         public static const DEVICE_REMOVED:String = "deviceRemoved";

--- a/core/src/avm2/globals/flash/events/ThrottleEvent.as
+++ b/core/src/avm2/globals/flash/events/ThrottleEvent.as
@@ -5,6 +5,7 @@
 package flash.events
 {
     
+    [API("676")] // the docs say 674, that's wrong
     public class ThrottleEvent extends Event
     {
         public static const THROTTLE:String = "throttle"; // Defines the value of the type property of a ThrottleEvent event object.

--- a/core/src/avm2/globals/flash/events/ThrottleType.as
+++ b/core/src/avm2/globals/flash/events/ThrottleType.as
@@ -1,6 +1,7 @@
 package flash.events
 {
 
+    [API("676")] // the docs say 674, that's wrong
     public class ThrottleType
     {
         // This constant is used for the status property in the ThrottleEvent class.

--- a/core/src/avm2/globals/flash/media/AudioDecoder.as
+++ b/core/src/avm2/globals/flash/media/AudioDecoder.as
@@ -6,6 +6,7 @@
 package flash.media
 {
 
+    [API("674")]
     public final class AudioDecoder
     {
         // Dolby Digital Audio, which is also known as AC-3.

--- a/core/src/avm2/globals/flash/media/AudioOutputChangeReason.as
+++ b/core/src/avm2/globals/flash/media/AudioOutputChangeReason.as
@@ -6,6 +6,7 @@
 package flash.media
 {
 
+    // TODO: [API("724")]
     public final class AudioOutputChangeReason
     {
         // Audio Output is changed because system device has been added or removed.

--- a/core/src/avm2/globals/flash/media/H264Level.as
+++ b/core/src/avm2/globals/flash/media/H264Level.as
@@ -6,6 +6,7 @@
 package flash.media
 {
 
+    [API("674")]
     public final class H264Level
     {
         // Constant for H.264 level 1.

--- a/core/src/avm2/globals/flash/media/H264Profile.as
+++ b/core/src/avm2/globals/flash/media/H264Profile.as
@@ -6,6 +6,7 @@
 package flash.media
 {
 
+    [API("674")]
     public final class H264Profile
     {
         // Constant for H.264/AVC baseline profile.

--- a/core/src/avm2/globals/flash/media/Microphone.as
+++ b/core/src/avm2/globals/flash/media/Microphone.as
@@ -2,6 +2,8 @@ package flash.media {
     import flash.events.EventDispatcher;
 
     public final class Microphone extends EventDispatcher {
+        
+        [API("672")]
         public static function getEnhancedMicrophone(index:int = -1):Microphone {
             __ruffle__.stub_method("flash.media.Microphone", "getEnhancedMicrophone");
             return new Microphone();
@@ -56,11 +58,13 @@ package flash.media {
             __ruffle__.stub_setter("flash.media.Microphone", "encodeQuality");
         }
 
+        [API("672")]
         public function get enhancedOptions():MicrophoneEnhancedOptions {
             __ruffle__.stub_getter("flash.media.Microphone", "enhancedOptions");
             return new MicrophoneEnhancedOptions();
         }
 
+        [API("672")]
         public function set enhancedOptions(params:MicrophoneEnhancedOptions) {
             __ruffle__.stub_setter("flash.media.Microphone", "enhancedOptions");
         }

--- a/core/src/avm2/globals/flash/media/MicrophoneEnhancedMode.as
+++ b/core/src/avm2/globals/flash/media/MicrophoneEnhancedMode.as
@@ -6,6 +6,7 @@
 package flash.media
 {
 
+    [API("672")]
     public final class MicrophoneEnhancedMode
     {
         // Use this mode to allow both parties to talk at the same time.

--- a/core/src/avm2/globals/flash/media/MicrophoneEnhancedOptions.as
+++ b/core/src/avm2/globals/flash/media/MicrophoneEnhancedOptions.as
@@ -1,4 +1,5 @@
 package flash.media {
+    [API("672")]
     public final class MicrophoneEnhancedOptions {
         public var echoPath: int;
         public var isVoiceDetected: int;

--- a/core/src/avm2/globals/flash/media/StageVideoAvailability.as
+++ b/core/src/avm2/globals/flash/media/StageVideoAvailability.as
@@ -6,6 +6,7 @@
 package flash.media
 {
 
+    [API("670")]
     public final class StageVideoAvailability
     {
         // Stage video is currently available.

--- a/core/src/avm2/globals/flash/media/StageVideoAvailabilityReason.as
+++ b/core/src/avm2/globals/flash/media/StageVideoAvailabilityReason.as
@@ -6,6 +6,7 @@
 package flash.media
 {
 
+    [API("688")] // the docs say 670, that's wrong
     public final class StageVideoAvailabilityReason
     {
         // Stage video is not currently available, the driver is too old or black listed

--- a/core/src/avm2/globals/flash/media/VideoCodec.as
+++ b/core/src/avm2/globals/flash/media/VideoCodec.as
@@ -6,6 +6,7 @@
 package flash.media
 {
 
+    [API("674")]
     public final class VideoCodec
     {
         // Constant value indicating that H.264/AVC codec is used for compressing video.

--- a/core/src/avm2/globals/flash/media/VideoStatus.as
+++ b/core/src/avm2/globals/flash/media/VideoStatus.as
@@ -6,6 +6,7 @@
 package flash.media
 {
 
+    [API("670")]
     public final class VideoStatus
     {
         // Indicates hardware-accelerated (GPU) video decoding.

--- a/core/src/avm2/globals/flash/media/VideoStreamSettings.as
+++ b/core/src/avm2/globals/flash/media/VideoStreamSettings.as
@@ -7,6 +7,7 @@ package flash.media
 {
     import __ruffle__.stub_method;
 
+    [API("674")]
     public class VideoStreamSettings
     {
         // Retrieve the maximum amount of bandwidth that the current outgoing video feed can use, in bytes per second.

--- a/core/src/avm2/globals/flash/profiler/Telemetry.as
+++ b/core/src/avm2/globals/flash/profiler/Telemetry.as
@@ -1,4 +1,5 @@
 package flash.profiler {
+    [API("678")] // the docs say 682, that's wrong
     public final class Telemetry {
         public static const connected: Boolean = false;
         public static const spanMarker: Number = 0;

--- a/core/src/avm2/globals/flash/security/X500DistinguishedName.as
+++ b/core/src/avm2/globals/flash/security/X500DistinguishedName.as
@@ -1,5 +1,6 @@
 package flash.security
 {
+    [API("674")]
     public final class X500DistinguishedName
     {
         private var _commonName: String;

--- a/core/src/avm2/globals/flash/security/X509Certificate.as
+++ b/core/src/avm2/globals/flash/security/X509Certificate.as
@@ -1,5 +1,6 @@
 package flash.security
 {
+    [API("674")]
     public final class X509Certificate
     {
         import flash.utils.ByteArray;

--- a/core/src/avm2/globals/flash/system/MessageChannel.as
+++ b/core/src/avm2/globals/flash/system/MessageChannel.as
@@ -1,6 +1,7 @@
 package flash.system {
     import flash.events.EventDispatcher;
 
+    [API("682")]
     public final class MessageChannel extends EventDispatcher {
         public function MessageChannel() {
             super();

--- a/core/src/avm2/globals/flash/system/MessageChannelState.as
+++ b/core/src/avm2/globals/flash/system/MessageChannelState.as
@@ -6,6 +6,7 @@
 package flash.system
 {
 
+    [API("682")]
     public final class MessageChannelState
     {
         // This state indicates that the message channel has been closed and doesn't have any more messages to deliver.

--- a/core/src/avm2/globals/flash/system/Worker.as
+++ b/core/src/avm2/globals/flash/system/Worker.as
@@ -1,6 +1,7 @@
 package flash.system {
     import flash.events.EventDispatcher;
 
+    [API("682")]
     public final class Worker extends EventDispatcher {
         public function Worker() {
             throw new ArgumentError("Error #2012: Worker$ class cannot be instantiated.", 2012);

--- a/core/src/avm2/globals/flash/system/WorkerDomain.as
+++ b/core/src/avm2/globals/flash/system/WorkerDomain.as
@@ -1,4 +1,5 @@
 package flash.system {
+    [API("680")] // the docs say 682, that's wrong
     public final class WorkerDomain {
         public static const isSupported: Boolean = false;
 

--- a/core/src/avm2/globals/flash/system/WorkerState.as
+++ b/core/src/avm2/globals/flash/system/WorkerState.as
@@ -6,6 +6,7 @@
 package flash.system
 {
 
+    [API("682")]
     public final class WorkerState
     {
         // This state indicates that an object that represents the new worker has been created, but the worker is not executing code.


### PR DESCRIPTION
Dinnerbone's list - https://gist.github.com/Dinnerbone/0cfad60f4587292005d41e566368c709

Plus some others I discovered randomly.

Hope I didn't make a mistake anywhere.