### PR TITLE
ci: Set the "render" kind on tests that need renderer, mark them as heavy for nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,5 @@
-# TODO: Figure out why these specific tests are flaky on CI, fix them, then delete this file.
+# This is needed so we don't try to run too many visual tests at the same time,
+# as they tend to crash on GitHub Actions runners - maybe due to not enough memory.
 [[profile.ci.overrides]]
-filter = "test(avm2/pixelbender_shaderdata) or test(avm2/graphics_round_rects)"
-retries = 4
+filter = "test(/^\\[render\\] /)"
+threads-required = 4

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,4 +2,4 @@
 # as they tend to crash on GitHub Actions runners - maybe due to not enough memory.
 [[profile.ci.overrides]]
 filter = "test(/^\\[render\\] /)"
-threads-required = 4
+threads-required = 1

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -57,8 +57,12 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt install -y libasound2-dev gdb libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
+          sudo apt update
+          sudo apt install -y libasound2-dev gdb libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev ubuntu-dbgsym-keyring lsb-release
+          echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ddebs.list
+          echo -e "deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse\ndeb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ddebs.list
+          sudo apt update
+          sudo apt install mesa-vulkan-drivers-dbgsym
 
       # Needed after: https://github.com/rust-lang/rust/pull/124129
       # See also: https://github.com/dtolnay/linkme/issues/94

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -58,7 +58,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
+          sudo apt install -y libasound2-dev gdb libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
 
       # Needed after: https://github.com/rust-lang/rust/pull/124129
       # See also: https://github.com/dtolnay/linkme/issues/94
@@ -81,7 +81,10 @@ jobs:
 
       - name: Run tests with image tests
         if: runner.os != 'macOS'
-        run: cargo nextest run --profile ci --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features imgtests,lzma,jpegxr
+        run: |
+          set +e
+          cargo nextest run --profile ci --cargo-profile ci --workspace --locked -j 4 --features imgtests,lzma,jpegxr render
+          cat $(find . -name gdb.bt)
         env:
           # This is to counteract the disabling by rust-cache.
           # See: https://github.com/Swatinem/rust-cache/issues/43
@@ -92,6 +95,7 @@ jobs:
           # Workaround for: https://github.com/nextest-rs/nextest/issues/1493
           # See also: https://github.com/rust-lang/rustup/issues/3825
           RUSTUP_WINDOWS_PATH_ADD_BIN: '1'
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "./bt.sh"
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 
       - name: Run tests without image tests

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -83,7 +83,7 @@ jobs:
         if: runner.os != 'macOS'
         run: |
           set +e
-          cargo nextest run --profile ci --cargo-profile ci --workspace --locked -j 4 --features imgtests,lzma,jpegxr render
+          cargo nextest run --profile ci --cargo-profile ci --workspace --locked -j 4 --features imgtests,lzma,jpegxr
           cat $(find . -name gdb.bt)
         env:
           # This is to counteract the disabling by rust-cache.

--- a/bt.sh
+++ b/bt.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# sauce : https://stackoverflow.com/a/63901492
+# kredit: https://blog.cryptomilk.org/2010/12/23/gdb-backtrace-to-file/
+
+ex=(
+    -ex "run"
+    -ex "set logging overwrite off"
+    -ex "set logging file gdb.bt"
+    -ex "set logging on"
+    -ex "set pagination off"
+    -ex "handle SIG33 pass nostop noprint"
+    -ex "echo backtrace:\n"
+    -ex "backtrace full"
+    -ex "echo \n\nregisters:\n"
+    -ex "info registers"
+    -ex "echo \n\ncurrent instructions:\n"
+    -ex "x/16i \$pc"
+    -ex "echo \n\nthreads backtrace:\n"
+    -ex "thread apply all backtrace"
+    -ex "set logging off"
+    -ex "quit"
+)
+echo 0 | gdb -batch-silent "${ex[@]}" --args "$@"
+

--- a/bt.sh
+++ b/bt.sh
@@ -8,6 +8,7 @@ ex=(
     -ex "set logging overwrite off"
     -ex "set logging file gdb.bt"
     -ex "set logging on"
+    -ex "set debuginfod enabled"
     -ex "set pagination off"
     -ex "handle SIG33 pass nostop noprint"
     -ex "echo backtrace:\n"

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -218,6 +218,10 @@ impl PlayerOptions {
             })
     }
 
+    pub fn needs_renderer(&self) -> bool {
+        self.with_renderer.is_some()
+    }
+
     pub fn create_renderer(
         &self,
         environment: &impl Environment,

--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -15,6 +15,26 @@ pub struct Font {
     pub italic: bool,
 }
 
+#[derive(Clone, Copy)]
+pub enum TestKind {
+    Render,
+}
+
+impl TestKind {
+    pub fn name(self) -> &'static str {
+        match self {
+            TestKind::Render => "render",
+        }
+    }
+
+    pub fn ord(kind: &str) -> impl Ord {
+        match kind {
+            "render" => 0,
+            _ => 1,
+        }
+    }
+}
+
 pub struct Test {
     pub options: TestOptions,
     pub swf_path: VfsPath,
@@ -41,6 +61,14 @@ impl Test {
             root_path: test_dir,
             name,
         })
+    }
+
+    pub fn kind(&self) -> Option<TestKind> {
+        if self.options.player_options.needs_renderer() {
+            Some(TestKind::Render)
+        } else {
+            None
+        }
     }
 
     pub fn create_test_runner(&self, environment: &impl Environment) -> Result<TestRunner> {

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -166,6 +166,7 @@ fn run_test(args: &Arguments, file: &Path, name: &str) -> Trial {
     .unwrap();
 
     let ignore = !test.should_run(!args.list, &NativeEnvironment);
+    let kind = test.kind();
 
     let mut trial = Trial::test(test.name.to_string(), move || {
         let test = AssertUnwindSafe(test);
@@ -197,6 +198,9 @@ fn run_test(args: &Arguments, file: &Path, name: &str) -> Trial {
             }
         }
     });
+    if let Some(kind) = kind {
+        trial = trial.with_kind(kind.name());
+    }
     if ignore {
         trial = trial.with_ignored_flag(true);
     }


### PR DESCRIPTION
~~But it doesn't seem to work locally for me...? :face_with_spiral_eyes:~~

Turns out, updating `cargo-nextest` fixed it for me...

Relevant docs pages:
https://nexte.st/docs/configuration/threads-required/
https://nexte.st/docs/filtersets/reference/

This will hopefully stop random crashes of visual tests (especially on `avm2/pixelbender_shaderdata` and `avm2/graphics_round_rects`) on GHA.