### PR TITLE
avm2: For AIR report the correct OS in flash.system.Capabilities

### DIFF
--- a/core/src/avm2/globals/flash/system/Capabilities.as
+++ b/core/src/avm2/globals/flash/system/Capabilities.as
@@ -1,23 +1,13 @@
 package flash.system {
     import __ruffle__.stub_getter;
     public final class Capabilities {
-        public static function get os(): String {
-            stub_getter("flash.system.Capabilities", "os");
-            return "Windows 8"
-        }
-    
+        public native static function get os(): String;
         public native static function get playerType(): String;
-        
         public native static function get version(): String;
-		
         public native static function get screenResolutionX():Number;
-		
         public native static function get screenResolutionY():Number;
-		
         public native static function get pixelAspectRatio():Number;
-		
         public native static function get screenDPI():Number;
-        
         public static function get manufacturer(): String {
             stub_getter("flash.system.Capabilities", "manufacturer");
             return "Adobe Windows"
@@ -29,6 +19,5 @@ package flash.system {
         public static function get isDebugger(): Boolean {
             return false
         }
-		
     }
 }

--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -3,16 +3,50 @@
 use crate::avm2::{Activation, AvmString, Error, Object, Value};
 use crate::player::PlayerRuntime;
 
+/// Implements `flash.system.Capabilities.os`
+pub fn get_os<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let os = match activation.avm2().player_runtime {
+        // For most normal Flash Player usage, the OS should not matter,
+        // so let's pretend it's Windows for the broadest possible compatibility.
+        PlayerRuntime::FlashPlayer => "Windows 8",
+        PlayerRuntime::AIR => {
+            if cfg!(windows) {
+                "Windows 10"
+            } else if cfg!(target_os = "macos") {
+                "Mac OS 10.5.2"
+            } else {
+                "Linux 5.10.49"
+            }
+        }
+    };
+    Ok(AvmString::new_utf8(activation.gc(), os).into())
+}
+
 /// Implements `flash.system.Capabilities.version`
 pub fn get_version<'gc>(
     activation: &mut Activation<'_, 'gc>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    // TODO: Report the correct OS instead of always reporting Windows
+    let os = match activation.avm2().player_runtime {
+        PlayerRuntime::FlashPlayer => "WIN",
+        PlayerRuntime::AIR => {
+            if cfg!(windows) {
+                "WIN"
+            } else if cfg!(target_os = "macos") {
+                "MAC"
+            } else {
+                "LNX"
+            }
+        }
+    };
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
-        format!("WIN {},0,0,0", activation.avm2().player_version),
+        activation.gc(),
+        format!("{os} {},0,0,0", activation.avm2().player_version),
     )
     .into())
 }


### PR DESCRIPTION
This is my alternative suggestion for #17517 @Mesteery that keeps reporting the OS as windows for FlashPlayer (so not AIR) usage.