### PR TITLE
ci: Allow more retries, for the `avm2/graphics_round_rects` test too

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
-# TODO: Figure out why this specific test is flaky on CI, fix it, then delete this file.
+# TODO: Figure out why these specific tests are flaky on CI, fix them, then delete this file.
 [[profile.ci.overrides]]
-filter = "test(avm2/pixelbender_shaderdata)"
-retries = 3
+filter = "test(avm2/pixelbender_shaderdata) or test(avm2/graphics_round_rects)"
+retries = 4


### PR DESCRIPTION
Since https://github.com/ruffle-rs/ruffle/pull/17574 haven't worked out (yet)...
Let's try "fixing" the Rust test flakyness this way.