### PR TITLE
desktop: Add "Exit Full Screen" option to context menu

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -787,6 +787,12 @@ impl Player {
         context.stage.root_clip()
     }
 
+    pub fn is_fullscreen(&mut self) -> bool {
+        self.mutate_with_update_context(|context| {
+            context.stage.display_state() != StageDisplayState::Normal
+        })
+    }
+
     pub fn set_fullscreen(&mut self, is_fullscreen: bool) {
         self.mutate_with_update_context(|context| {
             let display_state = if is_fullscreen {

--- a/desktop/assets/texts/en-US/context_menu.ftl
+++ b/desktop/assets/texts/en-US/context_menu.ftl
@@ -1,0 +1,1 @@
+context-menu-exit-fullscreen = Exit Full Screen

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -8,7 +8,7 @@ use crate::util::{
 };
 use anyhow::{Context, Error};
 use gilrs::{Event, EventType, Gilrs};
-use ruffle_core::{PlayerEvent, StageDisplayState};
+use ruffle_core::PlayerEvent;
 use ruffle_render::backend::ViewportDimensions;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -339,14 +339,7 @@ impl App {
                                 ..
                             } = event
                             {
-                                if let Some(mut player) = self.player.get() {
-                                    if player.is_playing() {
-                                        player.update(|uc| {
-                                            uc.stage
-                                                .set_display_state(uc, StageDisplayState::Normal);
-                                        })
-                                    }
-                                }
+                                let _ = event_loop_proxy.send_event(RuffleEvent::ExitFullScreen);
                             }
 
                             let key_code = winit_to_ruffle_key_code(&event);
@@ -509,6 +502,14 @@ impl App {
                 winit::event::Event::UserEvent(RuffleEvent::CloseFile) => {
                     self.window.set_title("Ruffle"); // Reset title since file has been closed.
                     self.player.destroy();
+                }
+
+                winit::event::Event::UserEvent(RuffleEvent::ExitFullScreen) => {
+                    if let Some(mut player) = self.player.get() {
+                        if player.is_playing() {
+                            player.set_fullscreen(false);
+                        }
+                    }
                 }
 
                 winit::event::Event::UserEvent(RuffleEvent::ExitRequested) => {

--- a/desktop/src/custom_event.rs
+++ b/desktop/src/custom_event.rs
@@ -19,6 +19,9 @@ pub enum RuffleEvent {
     /// The user requested to close the current SWF.
     CloseFile,
 
+    /// The user requested to exit full screen.
+    ExitFullScreen,
+
     /// The user requested to exit Ruffle.
     ExitRequested,
 

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -166,7 +166,7 @@ impl RuffleGui {
             }
 
             if let Some(context_menu) = &mut self.context_menu {
-                if !context_menu.show(egui_ctx, &self.event_loop) {
+                if !context_menu.show(&locale, egui_ctx, &self.event_loop, player.is_fullscreen()) {
                     self.close_context_menu(player);
                 }
             }

--- a/desktop/src/gui/context_menu.rs
+++ b/desktop/src/gui/context_menu.rs
@@ -1,10 +1,13 @@
 use crate::custom_event::RuffleEvent;
 use egui::{
-    vec2, Align, Area, Button, Checkbox, Color32, Frame, Id, Key, Layout, Modifiers, Order, Pos2,
-    Stroke, Style, Widget,
+    vec2, Align, Area, Button, Checkbox, Color32, Frame, Id, Key, KeyboardShortcut, Layout,
+    Modifiers, Order, Pos2, Stroke, Style, Widget,
 };
 use ruffle_core::{ContextMenuItem, PlayerEvent};
+use unic_langid::LanguageIdentifier;
 use winit::event_loop::EventLoopProxy;
+
+use super::text;
 
 pub struct ContextMenu {
     items: Vec<ContextMenuItem>,
@@ -27,8 +30,10 @@ impl ContextMenu {
 
     pub fn show(
         &mut self,
+        locale: &LanguageIdentifier,
         egui_ctx: &egui::Context,
         event_loop: &EventLoopProxy<RuffleEvent>,
+        fullscreen: bool,
     ) -> bool {
         let mut item_clicked = false;
         self.position = self.position.or(egui_ctx.pointer_latest_pos());
@@ -58,6 +63,22 @@ impl ContextMenu {
                             if clicked {
                                 let _ =
                                     event_loop.send_event(RuffleEvent::ContextMenuItemClicked(i));
+                                item_clicked = true;
+                            }
+                        }
+
+                        if fullscreen {
+                            ui.separator();
+                            if Button::new(text(locale, "context-menu-exit-fullscreen"))
+                                .shortcut_text(ui.ctx().format_shortcut(&KeyboardShortcut::new(
+                                    Modifiers::NONE,
+                                    Key::Escape,
+                                )))
+                                .wrap_mode(egui::TextWrapMode::Extend)
+                                .ui(ui)
+                                .clicked()
+                            {
+                                let _ = event_loop.send_event(RuffleEvent::ExitFullScreen);
                                 item_clicked = true;
                             }
                         }


### PR DESCRIPTION
This option allows the user to exit full screen without knowing the <kbd>Esc</kbd> shortcut.

![image](https://github.com/user-attachments/assets/324c68db-0156-4f18-b4c0-41a117d4f8a3)
