### PR TITLE
avm2: Fix GraphicsPath.cubicCurveTo() [API()] version

### DIFF
--- a/core/src/avm2/globals/flash/display/GraphicsPath.as
+++ b/core/src/avm2/globals/flash/display/GraphicsPath.as
@@ -11,7 +11,7 @@ package flash.display {
             this.winding = winding;
         }
 
-        [API("694")]
+        [API("674")] // The online docs say 694, but that's a lie. This is the correct number from playerglobal.swc.
         public function cubicCurveTo(controlX1:Number, controlY1:Number, controlX2:Number, controlY2:Number, anchorX:Number, anchorY:Number):void {
             if (commands == null) {
                 commands = new Vector.<int>();


### PR DESCRIPTION
Turns out, the docs were wrong again.
Making right the amendment I made at https://github.com/ruffle-rs/ruffle/pull/17523#discussion_r1720849567.
My apologies for doubting you, @MartySVK.