### PR TITLE
desktop: Internationalize file pickers & improve filters

### DIFF
--- a/desktop/assets/texts/en-US/file_picker.ftl
+++ b/desktop/assets/texts/en-US/file_picker.ftl
@@ -1,3 +1,6 @@
 file-picker-title-open-file = Open a single file
-file-picker-filter-flash-files = Flash Files
-file-picker-filter-all-files = All Files
+file-picker-filter-supported = All Supported Files
+file-picker-filter-swf = SWF (*.swf)
+file-picker-filter-spl = FutureSplash Animator (*.spl)
+file-picker-filter-ruf = Ruffle Bundle (*.ruf)
+file-picker-filter-all = All Files

--- a/desktop/assets/texts/en-US/file_picker.ftl
+++ b/desktop/assets/texts/en-US/file_picker.ftl
@@ -1,0 +1,3 @@
+file-picker-title-open-file = Open a single file
+file-picker-filter-flash-files = Flash Files
+file-picker-filter-all-files = All Files

--- a/desktop/src/gui/dialogs.rs
+++ b/desktop/src/gui/dialogs.rs
@@ -66,7 +66,7 @@ impl Dialogs {
         window: Weak<winit::window::Window>,
         event_loop: EventLoopProxy<RuffleEvent>,
     ) -> Self {
-        let picker = FilePicker::new(window);
+        let picker = FilePicker::new(window, preferences.clone());
         Self {
             preferences_dialog: None,
             bookmarks_dialog: None,

--- a/desktop/src/gui/picker.rs
+++ b/desktop/src/gui/picker.rs
@@ -1,3 +1,5 @@
+use super::text;
+use crate::preferences::GlobalPreferences;
 use rfd::AsyncFileDialog;
 use std::{
     path::PathBuf,
@@ -16,14 +18,16 @@ pub struct FilePicker {
 struct FilePickerData {
     parent: Weak<Window>,
     picking: AtomicBool,
+    preferences: GlobalPreferences,
 }
 
 impl FilePicker {
-    pub fn new(parent: Weak<Window>) -> Self {
+    pub fn new(parent: Weak<Window>, preferences: GlobalPreferences) -> Self {
         Self {
             data: Arc::new(FilePickerData {
                 parent,
                 picking: AtomicBool::new(false),
+                preferences,
             }),
         }
     }
@@ -34,10 +38,14 @@ impl FilePicker {
             return None;
         }
 
+        let locale = &self.data.preferences.language();
         let mut dialog = AsyncFileDialog::new()
-            .add_filter("Flash Files", &["swf", "spl", "ruf"])
-            .add_filter("All Files", &["*"])
-            .set_title("Load a Flash File");
+            .add_filter(
+                text(locale, "file-picker-filter-flash-files"),
+                &["swf", "spl", "ruf"],
+            )
+            .add_filter(text(locale, "file-picker-filter-all-files"), &["*"])
+            .set_title(text(locale, "file-picker-title-open-file"));
 
         if let Some(dir) = dir {
             dialog = dialog.set_directory(dir);

--- a/desktop/src/gui/picker.rs
+++ b/desktop/src/gui/picker.rs
@@ -41,10 +41,13 @@ impl FilePicker {
         let locale = &self.data.preferences.language();
         let mut dialog = AsyncFileDialog::new()
             .add_filter(
-                text(locale, "file-picker-filter-flash-files"),
+                text(locale, "file-picker-filter-supported"),
                 &["swf", "spl", "ruf"],
             )
-            .add_filter(text(locale, "file-picker-filter-all-files"), &["*"])
+            .add_filter(text(locale, "file-picker-filter-swf"), &["swf"])
+            .add_filter(text(locale, "file-picker-filter-spl"), &["spl"])
+            .add_filter(text(locale, "file-picker-filter-ruf"), &["ruf"])
+            .add_filter(text(locale, "file-picker-filter-all"), &["*"])
             .set_title(text(locale, "file-picker-title-open-file"));
 
         if let Some(dir) = dir {


### PR DESCRIPTION
This PR adds internationalization to strings in file pickers and improves a bit their filters.

![image](https://github.com/user-attachments/assets/2e77f659-6312-4025-92e6-650f2789bf81)
