### PR TITLE
ci: Set most GITHUB_TOKEN permissions back to defaults

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -310,20 +310,13 @@ jobs:
     if: needs.create-nightly-release.outputs.is_active == 'true'
     runs-on: ubuntu-22.04
     permissions:
-      actions: write
+      actions: read
       attestations: write
-      checks: write
-      contents: write
-      deployments: write
-      discussions: write
+      checks: read
+      contents: read
       id-token: write
-      issues: write
       metadata: read
-      packages: write
-      pages: write
-      pull-requests: write
-      repository-projects: write
-      security-events: write
+      pull-requests: read
       statuses: write
     strategy:
       matrix:

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -310,8 +310,21 @@ jobs:
     if: needs.create-nightly-release.outputs.is_active == 'true'
     runs-on: ubuntu-22.04
     permissions:
-      contents: read
+      actions: write
+      attestations: write
+      checks: write
+      contents: write
+      deployments: write
+      discussions: write
       id-token: write
+      issues: write
+      metadata: read
+      packages: write
+      pages: write
+      pull-requests: write
+      repository-projects: write
+      security-events: write
+      statuses: write
     strategy:
       matrix:
         demo: [false, true]


### PR DESCRIPTION
Should match https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token and these permissions, except for `id-token`:

![Screenshot from 2024-08-23 11-08-52](https://github.com/user-attachments/assets/9638e3c3-e3b2-4664-9882-0551683c60d4)
