### PR TITLE
desktop: Change fullscreen fscommand to use event loop events

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -504,6 +504,14 @@ impl App {
                     self.player.destroy();
                 }
 
+                winit::event::Event::UserEvent(RuffleEvent::EnterFullScreen) => {
+                    if let Some(mut player) = self.player.get() {
+                        if player.is_playing() {
+                            player.set_fullscreen(true);
+                        }
+                    }
+                }
+
                 winit::event::Event::UserEvent(RuffleEvent::ExitFullScreen) => {
                     if let Some(mut player) = self.player.get() {
                         if player.is_playing() {

--- a/desktop/src/backends/fscommand.rs
+++ b/desktop/src/backends/fscommand.rs
@@ -1,13 +1,10 @@
 use crate::custom_event::RuffleEvent;
 
 use ruffle_core::external::FsCommandProvider;
-use std::sync::Arc;
 use winit::event_loop::EventLoopProxy;
-use winit::window::{Fullscreen, Window};
 
 pub struct DesktopFSCommandProvider {
     pub event_loop: EventLoopProxy<RuffleEvent>,
-    pub window: Arc<Window>,
 }
 
 impl FsCommandProvider for DesktopFSCommandProvider {
@@ -18,10 +15,12 @@ impl FsCommandProvider for DesktopFSCommandProvider {
             }
             "fullscreen" => {
                 match args {
-                    "true" => self
-                        .window
-                        .set_fullscreen(Some(Fullscreen::Borderless(None))),
-                    "false" => self.window.set_fullscreen(None),
+                    "true" => {
+                        let _ = self.event_loop.send_event(RuffleEvent::EnterFullScreen);
+                    }
+                    "false" => {
+                        let _ = self.event_loop.send_event(RuffleEvent::ExitFullScreen);
+                    }
                     _ => {}
                 };
             }

--- a/desktop/src/custom_event.rs
+++ b/desktop/src/custom_event.rs
@@ -19,6 +19,9 @@ pub enum RuffleEvent {
     /// The user requested to close the current SWF.
     CloseFile,
 
+    /// The user requested to enter full screen.
+    EnterFullScreen,
+
     /// The user requested to exit full screen.
     ExitFullScreen,
 

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -264,7 +264,6 @@ impl ActivePlayer {
             .with_storage(preferences.storage_backend().create_backend(&opt))
             .with_fs_commands(Box::new(DesktopFSCommandProvider {
                 event_loop: event_loop.clone(),
-                window: window.clone(),
             }))
             .with_ui(
                 DesktopUiBackend::new(


### PR DESCRIPTION
Previously the fullscreen state was set on the window directly causing a desync with the rest of the player code.

Fixes #17617