### PR TITLE
ci: Grant write permission for contents to nightly web build job

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -313,7 +313,7 @@ jobs:
       actions: read
       attestations: write
       checks: read
-      contents: read
+      contents: write
       id-token: write
       pull-requests: read
       statuses: write


### PR DESCRIPTION
Follow-up for: https://github.com/ruffle-rs/ruffle/pull/17618 https://github.com/ruffle-rs/ruffle/pull/17629 https://github.com/ruffle-rs/ruffle/pull/17322
See: https://github.com/ruffle-rs/ruffle/actions/runs/10537036436/job/29197923957#step:11:15