### PR TITLE
avm2: Ensure global objects always have correct vtable

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use crate::avm2::class::AllocatorFn;
 use crate::avm2::error::make_error_1107;
-use crate::avm2::globals::SystemClasses;
+use crate::avm2::globals::{SystemClassDefs, SystemClasses};
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::scope::ScopeChain;
 use crate::avm2::script::{Script, TranslationUnit};
@@ -126,6 +126,9 @@ pub struct Avm2<'gc> {
     /// System classes.
     system_classes: Option<SystemClasses<'gc>>,
 
+    /// System class definitions.
+    system_class_defs: Option<SystemClassDefs<'gc>>,
+
     /// Top-level global object. It contains most top-level types (Object, Class) and functions.
     /// However, it's not strictly defined which items end up there.
     toplevel_global_object: Option<Object<'gc>>,
@@ -221,6 +224,7 @@ impl<'gc> Avm2<'gc> {
             playerglobals_domain,
             stage_domain,
             system_classes: None,
+            system_class_defs: None,
             toplevel_global_object: None,
 
             public_namespace_base_version: Namespace::package("", ApiVersion::AllVersions, context),
@@ -287,6 +291,13 @@ impl<'gc> Avm2<'gc> {
     /// This function panics if the interpreter has not yet been initialized.
     pub fn classes(&self) -> &SystemClasses<'gc> {
         self.system_classes.as_ref().unwrap()
+    }
+
+    /// Return the current set of system class definitions.
+    ///
+    /// This function panics if the interpreter has not yet been initialized.
+    pub fn class_defs(&self) -> &SystemClassDefs<'gc> {
+        self.system_class_defs.as_ref().unwrap()
     }
 
     pub fn toplevel_global_object(&self) -> Option<Object<'gc>> {

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1754,7 +1754,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn op_get_slot(&mut self, index: u32) -> Result<FrameControl<'gc>, Error<'gc>> {
         let object = self.pop_stack().coerce_to_object_or_typeerror(self, None)?;
-        let value = object.get_slot(index)?;
+        let value = object.get_slot(index);
 
         self.push_stack(value);
 
@@ -1774,7 +1774,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value = self.pop_stack();
         let object = self.pop_stack().coerce_to_object_or_typeerror(self, None)?;
 
-        object.set_slot_no_coerce(index, value, self.context.gc_context)?;
+        object.set_slot_no_coerce(index, value, self.context.gc_context);
 
         Ok(FrameControl::Continue)
     }
@@ -1783,7 +1783,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value = self
             .global_scope()
             .map(|global| global.get_slot(index))
-            .transpose()?
             .unwrap_or(Value::Undefined);
 
         self.push_stack(value);

--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -118,8 +118,7 @@ pub fn serialize_value<'gc>(
                         })
                         .collect();
 
-                    let val_type = val_type
-                        .unwrap_or(activation.avm2().classes().object.inner_class_definition());
+                    let val_type = val_type.unwrap_or(activation.avm2().class_defs().object);
 
                     let name = class_to_alias(activation, val_type);
                     Some(AmfValue::VectorObject(obj_vec, name, vec.is_fixed()))

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -367,7 +367,7 @@ impl<'gc> Class<'gc> {
             ),
             object_vector_i_class.instance_init(),
             object_vector_c_class.instance_init(),
-            context.avm2.classes().class.inner_class_definition(),
+            context.avm2.class_defs().class,
             mc,
         );
 
@@ -573,7 +573,7 @@ impl<'gc> Class<'gc> {
             ClassData {
                 name: c_name,
                 param: None,
-                super_class: Some(activation.avm2().classes().class.inner_class_definition()),
+                super_class: Some(activation.avm2().class_defs().class),
                 attributes: ClassAttributes::FINAL,
                 protected_namespace,
                 direct_interfaces: Vec::new(),
@@ -871,7 +871,7 @@ impl<'gc> Class<'gc> {
             ClassData {
                 name: c_name,
                 param: None,
-                super_class: Some(activation.avm2().classes().class.inner_class_definition()),
+                super_class: Some(activation.avm2().class_defs().class),
                 attributes: ClassAttributes::FINAL,
                 protected_namespace: None,
                 direct_interfaces: Vec::new(),
@@ -1228,6 +1228,10 @@ impl<'gc> Class<'gc> {
         Ref::map(self.0.read(), |c| &c.traits)
     }
 
+    pub fn set_traits(&self, mc: &Mutation<'gc>, traits: Vec<Trait<'gc>>) {
+        self.0.write(mc).traits = traits;
+    }
+
     /// Get this class's instance allocator.
     ///
     /// If `None`, then you should use the instance allocator of the superclass
@@ -1311,6 +1315,10 @@ impl<'gc> Class<'gc> {
         self.0.write(mc).linked_class = ClassLink::LinkToClass(c_class);
     }
 
+    pub fn is_c_class(self) -> bool {
+        matches!(self.0.read().linked_class, ClassLink::LinkToInstance(_))
+    }
+
     pub fn i_class(self) -> Option<Class<'gc>> {
         if let ClassLink::LinkToInstance(i_class) = self.0.read().linked_class {
             Some(i_class)
@@ -1323,5 +1331,9 @@ impl<'gc> Class<'gc> {
         assert!(matches!(self.0.read().linked_class, ClassLink::Unlinked));
 
         self.0.write(mc).linked_class = ClassLink::LinkToInstance(i_class);
+    }
+
+    pub fn is_i_class(self) -> bool {
+        matches!(self.0.read().linked_class, ClassLink::LinkToClass(_))
     }
 }

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -268,9 +268,9 @@ pub fn display_function<'gc>(
                     .map(|b| Gc::ptr_eq(b, *method))
                     .unwrap_or(false)
                 {
-                    if bound_class.c_class().is_none() {
-                        // If the associated class has no c_class, it is a c_class,
-                        // and the instance initializer is the class initializer.
+                    if bound_class.is_c_class() {
+                        // If the associated class is a c_class, its initializer
+                        // method is a class initializer.
                         output.push_utf8("cinit");
                     }
                     // We purposely do nothing for instance initializers

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -595,7 +595,6 @@ pub fn load_player_globals<'gc>(
     // operates on the global object until it gets its true vtable, so this should
     // be fine.
     let globals = ScriptObject::custom_object(mc, global_classdef, None, global_classdef.vtable());
-    globals.install_instance_slots(mc);
 
     let scope = ScopeChain::new(domain);
     let gs = scope.chain(mc, &[Scope::new(globals)]);

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -1247,10 +1247,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Array"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<Array instance initializer>", mc),
         Method::from_builtin(class_init, "<Array class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -377,7 +377,7 @@ fn describe_internal_body<'gc>(
                 let declared_by = method.class;
 
                 if flags.contains(DescribeTypeFlags::HIDE_OBJECT)
-                    && declared_by == activation.avm2().classes().object.inner_class_definition()
+                    && declared_by == activation.avm2().class_defs().object
                 {
                     continue;
                 }

--- a/core/src/avm2/globals/boolean.rs
+++ b/core/src/avm2/globals/boolean.rs
@@ -136,10 +136,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Boolean"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<Boolean instance initializer>", mc),
         Method::from_builtin(class_init, "<Boolean class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -1326,10 +1326,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Date"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<Date instance initializer>", mc),
         Method::from_builtin(class_init, "<Date class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -8,6 +8,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
 use crate::avm2::method::Method;
 use crate::avm2::object::Object;
+use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::QName;
@@ -21,40 +22,22 @@ pub fn instance_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Implements `global`'s class constructor.
-pub fn class_init<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _this: Object<'gc>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(Value::Undefined)
-}
-
 /// Construct `global`'s class.
 pub fn create_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    object_classdef: Class<'gc>,
-    class_classdef: Class<'gc>,
+    traits: Vec<Trait<'gc>>,
 ) -> Class<'gc> {
     let mc = activation.context.gc_context;
-    let class = Class::new(
+    let class = Class::custom_new(
         QName::new(activation.avm2().public_namespace_base_version, "global"),
-        Some(object_classdef),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<global instance initializer>", mc),
-        Method::from_builtin(class_init, "<global class initializer>", mc),
-        class_classdef,
         mc,
     );
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.set_traits(mc, traits);
+    class.mark_traits_loaded(mc);
     class
-        .init_vtable(activation.context)
-        .expect("Native class's vtable should initialize");
-
-    let c_class = class.c_class().expect("Class::new returns an i_class");
-
-    c_class.mark_traits_loaded(activation.context.gc_context);
-    c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -221,7 +221,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "int"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin_and_params(
             instance_init,
             "<int instance initializer>",
@@ -235,7 +235,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             mc,
         ),
         Method::from_builtin(class_init, "<int class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -174,10 +174,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Namespace"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<Namespace instance initializer>", mc),
         Method::from_builtin(class_init, "<Namespace class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 

--- a/core/src/avm2/globals/number.rs
+++ b/core/src/avm2/globals/number.rs
@@ -376,10 +376,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Number"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<Number instance initializer>", mc),
         Method::from_builtin(class_init, "<Number class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -689,10 +689,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "String"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<String instance initializer>", mc),
         Method::from_builtin(class_init, "<String class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -222,7 +222,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "uint"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin_and_params(
             instance_init,
             "<uint instance initializer>",
@@ -236,7 +236,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             mc,
         ),
         Method::from_builtin(class_init, "<uint class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -901,10 +901,10 @@ pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().vector_public_namespace, "Vector"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin(generic_init, "<Vector instance initializer>", mc),
         Method::from_builtin(generic_init, "<Vector class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 
@@ -947,10 +947,10 @@ pub fn create_builtin_class<'gc>(
 
     let class = Class::new(
         name,
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<Vector.<T> instance initializer>", mc),
         Method::from_builtin(class_init, "<Vector.<T> class initializer>", mc),
-        activation.avm2().classes().class.inner_class_definition(),
+        activation.avm2().class_defs().class,
         mc,
     );
 

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -16,7 +16,6 @@ use crate::avm2::vtable::{ClassBoundMethod, VTable};
 use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
-use crate::avm2::QName;
 use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::display_object::DisplayObject;
 use crate::html::TextFormat;
@@ -858,23 +857,6 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         let base = self.base();
 
         base.install_bound_method(mc, disp_id, function)
-    }
-
-    /// Install a const trait on the global object.
-    /// This should only ever be called on the `global` object, during initialization.
-    #[no_dynamic]
-    fn install_const_late(
-        &self,
-        mc: &Mutation<'gc>,
-        name: QName<'gc>,
-        value: Value<'gc>,
-        class: Class<'gc>,
-    ) {
-        let new_slot_id = self
-            .vtable()
-            .install_const_trait_late(mc, name, value, class);
-
-        self.base().install_const_slot_late(mc, new_slot_id, value);
     }
 
     #[no_dynamic]

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -859,11 +859,6 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         base.install_bound_method(mc, disp_id, function)
     }
 
-    #[no_dynamic]
-    fn install_instance_slots(&self, mc: &Mutation<'gc>) {
-        self.base().install_instance_slots(mc);
-    }
-
     /// Call the object.
     fn call(
         self,

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -86,7 +86,6 @@ impl<'gc> ArrayObject<'gc> {
             },
         ))
         .into();
-        instance.install_instance_slots(activation.context.gc_context);
 
         class.call_native_init(instance.into(), &[], activation)?;
 

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -88,7 +88,6 @@ impl<'gc> BitmapDataObject<'gc> {
         .into();
 
         bitmap_data.init_object2(activation.context.gc_context, instance);
-        instance.install_instance_slots(activation.context.gc_context);
 
         // We call the custom BitmapData class with width and height...
         // but, it always seems to be 1 in Flash Player when constructed from timeline?

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -97,7 +97,6 @@ impl<'gc> ByteArrayObject<'gc> {
             },
         ))
         .into();
-        instance.install_instance_slots(activation.context.gc_context);
 
         class.call_native_init(instance.into(), &[], activation)?;
 

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -261,7 +261,6 @@ impl<'gc> ClassObject<'gc> {
         );
 
         self.set_vtable(activation.context.gc_context, class_vtable);
-        self.base().install_instance_slots(activation.gc());
 
         self.run_class_initializer(activation)?;
 
@@ -801,8 +800,6 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         let instance_allocator = self.instance_allocator();
 
         let instance = instance_allocator(self, activation)?;
-
-        instance.install_instance_slots(activation.context.gc_context);
 
         self.call_init(instance.into(), arguments, activation)?;
 

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -48,7 +48,6 @@ impl<'gc> Context3DObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.gc());
 
         class.call_native_init(this.into(), &[], activation)?;
 

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -54,7 +54,6 @@ impl<'gc> DateObject<'gc> {
             },
         ))
         .into();
-        instance.install_instance_slots(activation.context.gc_context);
 
         class.call_native_init(instance.into(), &[], activation)?;
 

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -78,7 +78,6 @@ impl<'gc> DomainObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.context.gc_context);
 
         // Note - we do *not* call the normal constructor, since that
         // creates a new domain using the system domain as a parent.

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -68,7 +68,7 @@ impl<'gc> ErrorObject<'gc> {
         // by hardcoded slot id. Our `Error` class definition should fully match
         // Flash Player, and we have lots of test coverage around error, so
         // there should be very little risk to doing this.
-        let name = match self.base().get_slot(0)? {
+        let name = match self.base().get_slot(0) {
             Value::String(string) => string,
             Value::Null => "null".into(),
             Value::Undefined => "undefined".into(),
@@ -78,7 +78,7 @@ impl<'gc> ErrorObject<'gc> {
                 ))
             }
         };
-        let message = match self.base().get_slot(1)? {
+        let message = match self.base().get_slot(1) {
             Value::String(string) => string,
             Value::Null => "null".into(),
             Value::Undefined => "undefined".into(),

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -95,10 +95,6 @@ impl<'gc> EventObject<'gc> {
             },
         ));
 
-        // not needed, as base Event has no instance slots.
-        // yes, this is flimsy. Could call this if install_instance_slots only took gc_context.
-        // event_object.install_instance_slots(activation);
-
         event_object.into()
     }
 

--- a/core/src/avm2/object/index_buffer_3d_object.rs
+++ b/core/src/avm2/object/index_buffer_3d_object.rs
@@ -37,7 +37,6 @@ impl<'gc> IndexBuffer3DObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.gc());
 
         class.call_native_init(this.into(), &[], activation)?;
 

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -166,7 +166,6 @@ impl<'gc> LoaderInfoObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.context.gc_context);
 
         class.call_native_init(this.into(), &[], activation)?;
 
@@ -214,7 +213,6 @@ impl<'gc> LoaderInfoObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.context.gc_context);
 
         class.call_native_init(this.into(), &[], activation)?;
 

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -92,7 +92,6 @@ impl<'gc> NamespaceObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.context.gc_context);
 
         class.call_native_init(this.into(), &[], activation)?;
 

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -101,7 +101,6 @@ impl<'gc> PrimitiveObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.context.gc_context);
 
         //We explicitly DO NOT CALL the native initializers of primitives here.
         //If we did so, then those primitive initializers' method types would

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -37,7 +37,6 @@ impl<'gc> Program3DObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.gc());
 
         class.call_native_init(this.into(), &[], activation)?;
 

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -79,7 +79,6 @@ impl<'gc> QNameObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.context.gc_context);
 
         Ok(this)
     }

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -75,7 +75,6 @@ impl<'gc> RegExpObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.context.gc_context);
 
         class.call_native_init(this.into(), &[], activation)?;
 

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -95,7 +95,6 @@ impl<'gc> ScriptObject<'gc> {
     /// This should *not* be used unless you really need
     /// to do something low-level, weird or lazily initialize the object.
     /// You shouldn't let scripts observe this weirdness.
-    /// Another exception is ES3 class-less objects, which we don't really understand well :)
     ///
     /// The "everyday" way to create a normal empty ScriptObject (AS "Object") is to call
     /// `avm2.classes().object.construct(self, &[])`.
@@ -352,19 +351,6 @@ impl<'gc> ScriptObjectWrapper<'gc> {
             } else {
                 slots.push(Value::Undefined)
             }
-        }
-    }
-
-    /// Set a slot by its index. This does extend the array if needed.
-    /// This should only be used during AVM initialization, not at runtime.
-    pub fn install_const_slot_late(&self, mc: &Mutation<'gc>, id: u32, value: Value<'gc>) {
-        let mut slots = self.slots_mut(mc);
-
-        if slots.len() < id as usize + 1 {
-            slots.resize(id as usize + 1, Value::Undefined);
-        }
-        if let Some(slot) = slots.get_mut(id as usize) {
-            *slot = value;
         }
     }
 

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -95,7 +95,6 @@ impl<'gc> SoundChannelObject<'gc> {
                 position: Cell::new(0.0),
             },
         ));
-        sound_object.install_instance_slots(activation.context.gc_context);
 
         class.call_native_init(Value::Object(sound_object.into()), &[], activation)?;
 

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -55,7 +55,6 @@ impl<'gc> StageObject<'gc> {
                 display_object,
             },
         ));
-        instance.install_instance_slots(activation.context.gc_context);
 
         Ok(instance)
     }
@@ -105,7 +104,6 @@ impl<'gc> StageObject<'gc> {
                 display_object,
             },
         ));
-        this.install_instance_slots(activation.context.gc_context);
 
         // note: for Graphics, there's no need to call init.
 

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -74,7 +74,6 @@ impl<'gc> TextFormatObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.gc());
 
         Ok(this)
     }

--- a/core/src/avm2/object/texture_object.rs
+++ b/core/src/avm2/object/texture_object.rs
@@ -37,7 +37,6 @@ impl<'gc> TextureObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.gc());
 
         class.call_native_init(this.into(), &[], activation)?;
 

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -86,8 +86,6 @@ impl<'gc> VectorObject<'gc> {
         ))
         .into();
 
-        object.install_instance_slots(activation.context.gc_context);
-
         Ok(object)
     }
 }

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -38,7 +38,6 @@ impl<'gc> VertexBuffer3DObject<'gc> {
             },
         ))
         .into();
-        this.install_instance_slots(activation.gc());
 
         class.call_native_init(this.into(), &[], activation)?;
 

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -100,7 +100,7 @@ impl<'gc> OptValue<'gc> {
             || self.class == Some(classes.uint.inner_class_definition())
             || self.class == Some(classes.number.inner_class_definition())
             || self.class == Some(classes.boolean.inner_class_definition())
-            || self.class == Some(classes.void_def)
+            || self.class == Some(activation.avm2().class_defs().void)
     }
 
     pub fn merged_with(self, other: OptValue<'gc>) -> OptValue<'gc> {
@@ -344,7 +344,7 @@ pub fn optimize<'gc>(
             .classes()
             .function
             .inner_class_definition(),
-        void: activation.avm2().classes().void_def,
+        void: activation.avm2().class_defs().void,
         namespace: activation
             .avm2()
             .classes()

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -565,7 +565,6 @@ impl<'gc> Script<'gc> {
             object_class.proto(), // Just use Object's prototype
             global_obj_vtable,
         );
-        global_object.install_instance_slots(mc);
 
         self.0.write(mc).globals = Some(global_object);
 

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -6,10 +6,11 @@ use crate::avm2::class::Class;
 use crate::avm2::domain::Domain;
 use crate::avm2::globals::global_scope;
 use crate::avm2::method::{BytecodeMethod, Method};
-use crate::avm2::object::{ClassObject, Object, TObject};
+use crate::avm2::object::{Object, ScriptObject, TObject};
 use crate::avm2::scope::ScopeChain;
 use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::value::Value;
+use crate::avm2::vtable::VTable;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::{Avm2, Error};
@@ -18,7 +19,6 @@ use crate::string::{AvmAtom, AvmString};
 use crate::tag_utils::SwfMovie;
 use crate::PlayerRuntime;
 use gc_arena::{Collect, Gc, GcCell, Mutation};
-use std::cell::Ref;
 use std::fmt::Debug;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -254,28 +254,7 @@ impl<'gc> TranslationUnit<'gc> {
 
         drop(read);
 
-        let object_class = activation.avm2().classes().object;
-        let class_classdef = activation.avm2().classes().class.inner_class_definition();
-
-        let global_classdef = global_scope::create_class(
-            activation,
-            object_class.inner_class_definition(),
-            class_classdef,
-        );
-
-        let global_class =
-            ClassObject::from_class(activation, global_classdef, Some(object_class))?;
-
-        let global_obj = global_class.construct(activation, &[])?;
-
-        let script = Script::from_abc_index(
-            self,
-            script_index,
-            global_obj,
-            global_class,
-            domain,
-            activation,
-        )?;
+        let script = Script::from_abc_index(self, script_index, domain, activation)?;
         self.0.write(activation.context.gc_context).scripts[script_index as usize] = Some(script);
 
         script.load_traits(self, script_index, activation)?;
@@ -430,22 +409,13 @@ pub struct Script<'gc>(pub GcCell<'gc, ScriptData<'gc>>);
 #[collect(no_drop)]
 pub struct ScriptData<'gc> {
     /// The global object for the script.
-    globals: Object<'gc>,
-
-    /// The class of this script's global object.
-    global_class: Option<Class<'gc>>,
-
-    /// The ClassObject of this script's global object.
-    global_class_obj: Option<ClassObject<'gc>>,
+    globals: Option<Object<'gc>>,
 
     /// The domain associated with this script.
     domain: Domain<'gc>,
 
     /// The initializer method to run for the script.
     init: Method<'gc>,
-
-    /// Traits that this script uses.
-    traits: Vec<Trait<'gc>>,
 
     /// Whether or not we loaded our traits.
     traits_loaded: bool,
@@ -474,16 +444,13 @@ impl<'gc> Script<'gc> {
         Self(GcCell::new(
             mc,
             ScriptData {
-                globals,
-                global_class: None,
-                global_class_obj: None,
+                globals: Some(globals),
                 domain,
                 init: Method::from_builtin(
                     |_, _, _| Ok(Value::Undefined),
                     "<Built-in script initializer>",
                     mc,
                 ),
-                traits: Vec::new(),
                 traits_loaded: true,
                 initialized: false,
                 translation_unit: None,
@@ -504,8 +471,6 @@ impl<'gc> Script<'gc> {
     pub fn from_abc_index(
         unit: TranslationUnit<'gc>,
         script_index: u32,
-        globals: Object<'gc>,
-        global_class_obj: ClassObject<'gc>,
         domain: Domain<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
@@ -521,12 +486,9 @@ impl<'gc> Script<'gc> {
         Ok(Self(GcCell::new(
             activation.context.gc_context,
             ScriptData {
-                globals,
-                global_class: Some(global_class_obj.inner_class_definition()),
-                global_class_obj: Some(global_class_obj),
+                globals: None,
                 domain,
                 init,
-                traits: Vec::new(),
                 traits_loaded: false,
                 initialized: false,
                 translation_unit: Some(unit),
@@ -547,7 +509,9 @@ impl<'gc> Script<'gc> {
         script_index: u32,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mut write = self.0.write(activation.context.gc_context);
+        let mc = activation.gc();
+
+        let mut write = self.0.write(mc);
 
         if write.traits_loaded {
             return Ok(());
@@ -561,30 +525,49 @@ impl<'gc> Script<'gc> {
             .get(script_index as usize)
             .ok_or_else(|| "LoadError: Script index not valid".into());
         let script = script?;
+        let mut domain = write.domain;
+
+        let mut traits = Vec::new();
 
         for abc_trait in script.traits.iter() {
             let newtrait = Trait::from_abc_trait(unit, abc_trait, activation)?;
-            write
-                .domain
-                .export_definition(newtrait.name(), self, activation.context.gc_context);
+            domain.export_definition(newtrait.name(), self, mc);
             if let TraitKind::Class { class, .. } = newtrait.kind() {
-                write
-                    .domain
-                    .export_class(newtrait.name(), *class, activation.context.gc_context);
+                domain.export_class(newtrait.name(), *class, mc);
             }
 
-            write.traits.push(newtrait.clone());
-            write
-                .global_class
-                .expect("Global class should be initialized")
-                .define_instance_trait(activation.context.gc_context, newtrait);
+            traits.push(newtrait);
         }
 
         drop(write);
 
-        self.global_class()
-            .mark_traits_loaded(activation.context.gc_context);
-        self.global_class().init_vtable(activation.context)?;
+        // Now that we have the traits, create the global class for this script
+        // and use it to initialize a vtable and global object.
+
+        let global_class = global_scope::create_class(activation, traits);
+
+        let scope = ScopeChain::new(domain);
+        let object_class = activation.avm2().classes().object;
+
+        let global_obj_vtable = VTable::empty(mc);
+        global_obj_vtable.init_vtable(
+            global_class,
+            Some(object_class),
+            &global_class.traits(),
+            Some(scope),
+            Some(object_class.instance_vtable()),
+            mc,
+        );
+
+        let global_object = ScriptObject::custom_object(
+            mc,
+            global_class,
+            object_class.proto(), // Just use Object's prototype
+            global_obj_vtable,
+        );
+        global_object.install_instance_slots(mc);
+
+        self.0.write(mc).globals = Some(global_object);
 
         Ok(())
     }
@@ -592,7 +575,9 @@ impl<'gc> Script<'gc> {
     /// Return the entrypoint for the script and the scope it should run in.
     pub fn init(self) -> (Method<'gc>, Object<'gc>, Domain<'gc>) {
         let read = self.0.read();
-        (read.init, read.globals, read.domain)
+        let globals = read.globals.expect("Global object should be initialized");
+
+        (read.init, globals, read.domain)
     }
 
     pub fn domain(self) -> Domain<'gc> {
@@ -610,16 +595,9 @@ impl<'gc> Script<'gc> {
     pub fn global_class(self) -> Class<'gc> {
         self.0
             .read()
-            .global_class
-            .expect("Global class should be initialized if it is accessed")
-    }
-
-    pub fn set_global_class(self, mc: &Mutation<'gc>, global_class: Class<'gc>) {
-        self.0.write(mc).global_class = Some(global_class);
-    }
-
-    pub fn set_global_class_obj(self, mc: &Mutation<'gc>, global_class_obj: ClassObject<'gc>) {
-        self.0.write(mc).global_class_obj = Some(global_class_obj);
+            .globals
+            .expect("Global object should be initialized")
+            .instance_class()
     }
 
     /// Return the global scope for the script.
@@ -629,46 +607,16 @@ impl<'gc> Script<'gc> {
     pub fn globals(self, context: &mut UpdateContext<'gc>) -> Result<Object<'gc>, Error<'gc>> {
         let mut write = self.0.write(context.gc_context);
 
+        let globals = write.globals.expect("Global object should be initialized");
+
         if !write.initialized {
             write.initialized = true;
-
-            let globals = write.globals;
-            let domain = write.domain;
-
             drop(write);
 
-            let scope = ScopeChain::new(domain);
-
-            globals.vtable().init_vtable(
-                globals.instance_class(),
-                Some(context.avm2.classes().object),
-                &self.traits()?,
-                Some(scope),
-                None,
-                context.gc_context,
-            );
-            globals.install_instance_slots(context.gc_context);
-
             Avm2::run_script_initializer(self, context)?;
-
-            Ok(globals)
-        } else {
-            Ok(write.globals)
-        }
-    }
-
-    /// Return traits for this script.
-    ///
-    /// This function will return an error if it is incorrectly called before
-    /// traits are loaded.
-    pub fn traits<'a>(&'a self) -> Result<Ref<'a, [Trait<'gc>]>, Error<'gc>> {
-        let read = self.0.read();
-
-        if !read.traits_loaded {
-            return Err("LoadError: Script traits accessed before they were loaded!".into());
         }
 
-        Ok(Ref::map(read, |read| &read.traits[..]))
+        Ok(globals)
     }
 }
 

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -1007,7 +1007,7 @@ impl<'gc> Value<'gc> {
         }
 
         if matches!(self, Value::Undefined) || matches!(self, Value::Null) {
-            if class == activation.avm2().classes().void_def {
+            if class == activation.avm2().class_defs().void {
                 return Ok(Value::Undefined);
             }
             return Ok(Value::Null);
@@ -1104,7 +1104,7 @@ impl<'gc> Value<'gc> {
         }
 
         if let Value::Undefined = self {
-            if type_object == activation.avm2().classes().void_def {
+            if type_object == activation.avm2().class_defs().void {
                 return true;
             }
         }

--- a/core/src/avm2/vector.rs
+++ b/core/src/avm2/vector.rs
@@ -140,7 +140,7 @@ impl<'gc> VectorStorage<'gc> {
     /// Get the value type this vector coerces things to.
     pub fn value_type_for_coercion(&self, activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         self.value_type
-            .unwrap_or_else(|| activation.avm2().classes().object.inner_class_definition())
+            .unwrap_or_else(|| activation.avm2().class_defs().object)
     }
 
     /// Check if a vector index is in bounds.

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -534,28 +534,6 @@ impl<'gc> VTable<'gc> {
         )
     }
 
-    /// Install a const trait on the global object.
-    /// This should only ever be called via `Object::install_const_late`,
-    /// on the `global` object.
-    pub fn install_const_trait_late(
-        self,
-        mc: &Mutation<'gc>,
-        name: QName<'gc>,
-        value: Value<'gc>,
-        class: Class<'gc>,
-    ) -> u32 {
-        let mut write = self.0.write(mc);
-
-        write.default_slots.push(Some(value));
-        let new_slot_id = write.default_slots.len() as u32 - 1;
-        write
-            .resolved_traits
-            .insert(name, Property::new_const_slot(new_slot_id));
-        write.slot_classes.push(PropertyClass::Class(class));
-
-        new_slot_id
-    }
-
     /// Install an existing trait under a new name, provided by interface.
     /// This should only ever be called by `link_interfaces`.
     pub fn copy_property_for_interface(

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -364,7 +364,7 @@ impl Avm2ObjectWindow {
                     label_col(&mut row);
                     row.col(|ui| {
                         let value = object.get_slot(slot_id);
-                        ValueResultWidget::new(activation, value).show(ui, messages);
+                        ValueResultWidget::new(activation, Ok(value)).show(ui, messages);
                     });
                     row.col(|_| {});
                 });


### PR DESCRIPTION
...and this allows us to change `ScriptObjectData.slots` from `RefLock<Vec<Value>>` to `Vec<Lock<Value>>`, which results in a very small perf improvement.