### PR TITLE
desktop: Change default value of Open Links to "Ask"

### DIFF
--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -166,7 +166,7 @@ pub struct Opt {
     pub frame_rate: Option<f64>,
 
     /// The handling mode of links opening a new website.
-    #[clap(long, default_value = "allow")]
+    #[clap(long, default_value = "confirm")]
     pub open_url_mode: OpenURLMode,
 
     /// Provide a dummy (completely empty) External Interface to the movie.


### PR DESCRIPTION
Change the default value of the "Open Links" setting from "Allow" to "Ask".
Having the default value of "Allow" may raise security concerns.

More details are in issue #17432, which this PR resolves.