### PR TITLE
avm2: Added missing `[API()]` to variables from the list

### DIFF
--- a/core/src/avm2/globals/flash/display/DisplayObject.as
+++ b/core/src/avm2/globals/flash/display/DisplayObject.as
@@ -93,7 +93,9 @@ package flash.display {
         public native function get visible():Boolean;
         public native function set visible(value:Boolean):void;
 
+        [API("686")]
         public native function get metaData():Object;
+        [API("686")]
         public native function set metaData(value:Object):void;
 
         public native function get mouseX():Number;

--- a/core/src/avm2/globals/flash/display/InteractiveObject.as
+++ b/core/src/avm2/globals/flash/display/InteractiveObject.as
@@ -26,17 +26,21 @@ package flash.display {
         public native function get mouseEnabled():Boolean;
         public native function set mouseEnabled(value:Boolean):void;
 
+        [API("670")]
         public function get needsSoftKeyboard():Boolean {
             return this._needsSoftKeyboard;
         }
+        [API("670")]
         public function set needsSoftKeyboard(value:Boolean):void {
             stub_setter("flash.display.InteractiveObject", "needsSoftKeyboard");
             this._needsSoftKeyboard = value;
         }
 
+        [API("670")]
         public function get softKeyboardInputAreaOfInterest():Rectangle {
             return this._softKeyboardInputAreaOfInterest;
         }
+        [API("670")]
         public function set softKeyboardInputAreaOfInterest(value:Rectangle):void {
             stub_setter("flash.display.InteractiveObject", "softKeyboardInputAreaOfInterest");
             this._softKeyboardInputAreaOfInterest = value;

--- a/core/src/avm2/globals/flash/display/Sprite.as
+++ b/core/src/avm2/globals/flash/display/Sprite.as
@@ -18,7 +18,9 @@ package flash.display {
         public native function get useHandCursor():Boolean;
         public native function set useHandCursor(useHandCursor:Boolean):void;
 
+        [API("667")]
         public native function startDrag(lockCenter:Boolean = false, bounds:Rectangle = null):void;
+        [API("667")]
         public native function stopDrag():void;
 
         public native function get hitArea():Sprite;

--- a/core/src/avm2/globals/flash/display/Stage.as
+++ b/core/src/avm2/globals/flash/display/Stage.as
@@ -192,11 +192,15 @@ package flash.display {
         public native function get align():String;
         public native function set align(value:String):void;
 
+        [API("700")]
         public native function get browserZoomFactor():Number;
 
+        [API("670")]
         public native function get color():uint;
+        [API("670")]
         public native function set color(value:uint):void;
 
+        [API("682")]
         public native function get contentsScaleFactor():Number;
 
         public native function get displayState():String;
@@ -238,13 +242,16 @@ package flash.display {
             return new Rectangle(0, 0, 0, 0);
         }
 
+        [API("670")]
         public native function get allowsFullScreen():Boolean;
 
+        [API("680")]
         public native function get allowsFullScreenInteractive():Boolean;
 
         public native function get quality():String;
         public native function set quality(value:String):void;
 
+        [API("674")]
         public native function get stage3Ds():Vector.<Stage3D>;
 
         public native function invalidate():void;
@@ -263,11 +270,13 @@ package flash.display {
             return ColorCorrectionSupport.UNSUPPORTED;
         }
 
+        [API("678")]
         public function get mouseLock():Boolean {
             stub_getter("flash.display.Stage", "mouseLock");
             return this._mouseLock;
         }
 
+        [API("678")]
         public function set mouseLock(value:Boolean):void {
             stub_setter("flash.display.Stage", "mouseLock");
             this._mouseLock = value;

--- a/core/src/avm2/globals/flash/events/Event.as
+++ b/core/src/avm2/globals/flash/events/Event.as
@@ -73,17 +73,22 @@ package flash.events {
 
 		public static const FULLSCREEN:String = "fullScreen";
 
+		[API("667")]
 		public static const CONTEXT3D_CREATE:String = "context3DCreate";
 
+		[API("667")]
 		public static const TEXTURE_READY:String = "textureReady";
 
+		[API("682")]
 		public static const VIDEO_FRAME:String = "videoFrame";
 
 		[API("681")]
 		public static const SUSPEND:String = "suspend";
 
+		[API("682")]
 		public static const CHANNEL_MESSAGE:String = "channelMessage";
 
+		[API("682")]
 		public static const CHANNEL_STATE:String = "channelState";
 
 		[API("682")]

--- a/core/src/avm2/globals/flash/events/HTTPStatusEvent.as
+++ b/core/src/avm2/globals/flash/events/HTTPStatusEvent.as
@@ -12,6 +12,7 @@ package flash.events
         public static const HTTP_STATUS:String = "httpStatus"; // The HTTPStatusEvent.HTTP_STATUS constant defines the value of the type property of a httpStatus event object.
 
         private var _status: int; // The HTTP status code returned by the server.
+        [API("690")]
         public var redirected: Boolean; // Indicates whether the request was redirected.
 
         [API("661")]

--- a/core/src/avm2/globals/flash/events/MouseEvent.as
+++ b/core/src/avm2/globals/flash/events/MouseEvent.as
@@ -41,7 +41,9 @@ package flash.events
         public var delta: int;
         private var _isRelatedObjectInaccessible: Boolean;
 
+        [API("678")]
         public var movementX: Number;
+        [API("678")]
         public var movementY: Number;
 
         public function MouseEvent(type:String, 

--- a/core/src/avm2/globals/flash/events/PressAndTapGestureEvent.as
+++ b/core/src/avm2/globals/flash/events/PressAndTapGestureEvent.as
@@ -1,5 +1,6 @@
 package flash.events
 {
+    [API("667")]
     public class PressAndTapGestureEvent extends GestureEvent
     {
         public static const GESTURE_PRESS_AND_TAP : String = "gesturePressAndTap";

--- a/core/src/avm2/globals/flash/events/VideoTextureEvent.as
+++ b/core/src/avm2/globals/flash/events/VideoTextureEvent.as
@@ -7,6 +7,7 @@ package flash.events
     
     public class VideoTextureEvent extends Event
     {
+        [API("706")]
         public static const RENDER_STATE:String = "renderState"; // The VideoTextureEvent.RENDER_STATE constant defines the value of the type property of a renderState event object.
 
         private var _status: String; // The status of the VideoTexture object.
@@ -17,15 +18,15 @@ package flash.events
             super(type,bubbles,cancelable);
             this._status = status;
             this._colorSpace = colorSpace;
-        }
-        
+        }        
 
+        [API("706")]
         public function get status() : String
         {
             return this._status;
         }
         
-
+        [API("706")]
         public function get colorSpace() : String
         {
             return this._colorSpace;

--- a/core/src/avm2/globals/flash/net/Socket.as
+++ b/core/src/avm2/globals/flash/net/Socket.as
@@ -26,6 +26,7 @@ package flash.net {
 
         public native function get bytesAvailable():uint;
 
+        [API("674")]
         public function get bytesPending():uint {
             stub_getter("flash.net.Socket", "bytesPending");
             return 0;

--- a/core/src/avm2/globals/flash/system/JPEGLoaderContext.as
+++ b/core/src/avm2/globals/flash/system/JPEGLoaderContext.as
@@ -5,6 +5,8 @@
 
 package flash.system
 {
+    // Both the docs and playerglobal.swc says this is "663", but it's actually available in regular Flash Player
+    [API("662")]
     public class JPEGLoaderContext extends LoaderContext
     {
         // Specifies the strength of the deblocking filter.

--- a/core/src/avm2/globals/flash/system/LoaderContext.as
+++ b/core/src/avm2/globals/flash/system/LoaderContext.as
@@ -5,8 +5,11 @@ package flash.system {
         public var allowCodeImport : Boolean;
         public var applicationDomain : ApplicationDomain;
         public var checkPolicyFile : Boolean;
+        [API("674")]
         public var imageDecodingPolicy : String;
+        [API("670")]
         public var parameters : Object; // unset by default
+        [API("670")]
         public var requestedContentParent : DisplayObjectContainer; // unset by default
         public var securityDomain : SecurityDomain;
 

--- a/core/src/avm2/globals/flash/text/TextField.as
+++ b/core/src/avm2/globals/flash/text/TextField.as
@@ -171,6 +171,7 @@ package flash.text {
             return true;
         }
 
+        [API("670")]
         public function get textInteractionMode():String {
             stub_getter("flash.text.TextField", "textInteractionMode");
             return TextInteractionMode.NORMAL;

--- a/core/src/avm2/globals/flash/text/engine/FontMetrics.as
+++ b/core/src/avm2/globals/flash/text/engine/FontMetrics.as
@@ -20,6 +20,7 @@ package flash.text.engine {
 
         public var superscriptScale:Number;
 
+        [API("674")]
         public var lineGap:Number;
       
         public function FontMetrics(emBox:Rectangle, strikethroughOffset:Number, strikethroughThickness:Number, underlineOffset:Number, underlineThickness:Number, subscriptOffset:Number, subscriptScale:Number, superscriptOffset:Number, superscriptScale:Number, lineGap:Number = 0) {

--- a/core/src/avm2/globals/flash/text/engine/LineJustification.as
+++ b/core/src/avm2/globals/flash/text/engine/LineJustification.as
@@ -13,6 +13,7 @@ package flash.text.engine
         public static const ALL_BUT_LAST:String = "allButLast";
         
         // Justify all but the last line and lines ending in mandatory breaks.
+        [API("674")]
         public static const ALL_BUT_MANDATORY_BREAK:String = "allButMandatoryBreak";
         
         // Justify all lines.


### PR DESCRIPTION
Dinnerbone's list - https://gist.github.com/Dinnerbone/0cfad60f4587292005d41e566368c709
- I could not find a lot of "metaData" variables

Plus some others I discovered randomly.