### PR TITLE
desktop: Implement message dialogs in egui

### DIFF
--- a/desktop/assets/texts/en-US/message_dialogs.ftl
+++ b/desktop/assets/texts/en-US/message_dialogs.ftl
@@ -1,0 +1,2 @@
+message-dialog-root-movie-load-error-title = Movie Failed to Load
+message-dialog-root-movie-load-error-description = Failed to open or download this movie.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -500,8 +500,8 @@ impl App {
                         .create_movie(&mut self.player, *options, url);
                 }
 
-                winit::event::Event::UserEvent(RuffleEvent::AskToOpenUrl(url)) => {
-                    self.gui.borrow_mut().show_open_url_dialog(url);
+                winit::event::Event::UserEvent(RuffleEvent::OpenDialog(descriptor)) => {
+                    self.gui.borrow_mut().open_dialog(descriptor);
                 }
 
                 winit::event::Event::UserEvent(RuffleEvent::CloseFile) => {

--- a/desktop/src/backends/navigator.rs
+++ b/desktop/src/backends/navigator.rs
@@ -9,6 +9,7 @@ use url::Url;
 use winit::event_loop::EventLoopProxy;
 
 use crate::custom_event::RuffleEvent;
+use crate::gui::DialogDescriptor;
 use crate::util::open_url;
 
 #[derive(Clone)]
@@ -36,7 +37,7 @@ impl NavigatorInterface for DesktopNavigatorInterface {
             .event_loop
             .lock()
             .expect("Non-poisoned event loop")
-            .send_event(RuffleEvent::AskToOpenUrl(url));
+            .send_event(RuffleEvent::OpenDialog(DialogDescriptor::OpenUrl(url)));
     }
 
     fn open_file(&self, path: &Path) -> io::Result<File> {

--- a/desktop/src/custom_event.rs
+++ b/desktop/src/custom_event.rs
@@ -1,6 +1,6 @@
 //! Custom event type for desktop ruffle
 
-use crate::player::LaunchOptions;
+use crate::{gui::DialogDescriptor, player::LaunchOptions};
 
 /// User-defined events.
 pub enum RuffleEvent {
@@ -31,6 +31,6 @@ pub enum RuffleEvent {
     /// The user selected an item in the right-click context menu.
     ContextMenuItemClicked(usize),
 
-    /// The movie wants to open a URL link.
-    AskToOpenUrl(url::Url),
+    /// The movie wants to open a dialog.
+    OpenDialog(DialogDescriptor),
 }

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -1,6 +1,6 @@
 mod context_menu;
 mod controller;
-mod dialogs;
+pub mod dialogs;
 mod menu_bar;
 mod movie;
 mod picker;

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -77,6 +77,22 @@ pub fn text_with_args<'a, T: AsRef<str>>(
         })
 }
 
+pub enum LocalizableText {
+    #[allow(dead_code)]
+    NonLocalizedText(Cow<'static, str>),
+    LocalizedText(&'static str),
+}
+
+impl LocalizableText {
+    pub fn localize(&self, locale: &LanguageIdentifier) -> Cow<'_, str> {
+        match self {
+            LocalizableText::NonLocalizedText(Cow::Borrowed(text)) => Cow::Borrowed(text),
+            LocalizableText::NonLocalizedText(Cow::Owned(text)) => Cow::Borrowed(text),
+            LocalizableText::LocalizedText(id) => text(locale, id),
+        }
+    }
+}
+
 /// Size of the top menu bar in pixels.
 /// This is the offset at which the movie will be shown,
 /// and added to the window size if trying to match a movie.

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -79,7 +79,6 @@ pub fn text_with_args<'a, T: AsRef<str>>(
 }
 
 pub enum LocalizableText {
-    #[allow(dead_code)]
     NonLocalizedText(Cow<'static, str>),
     LocalizedText(&'static str),
 }

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -8,6 +8,7 @@ mod theme;
 mod widgets;
 
 pub use controller::GuiController;
+pub use dialogs::DialogDescriptor;
 pub use movie::MovieView;
 pub use picker::FilePicker;
 use std::borrow::Cow;

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -23,7 +23,7 @@ use winit::event_loop::EventLoop;
 use winit::keyboard::{Key, NamedKey};
 use winit::window::{Theme, Window};
 
-use super::FilePicker;
+use super::{DialogDescriptor, FilePicker};
 
 /// Integration layer connecting wgpu+winit to egui.
 pub struct GuiController {
@@ -397,8 +397,8 @@ impl GuiController {
         self.gui.dialogs.open_file_advanced()
     }
 
-    pub fn show_open_url_dialog(&mut self, url: Url) {
-        self.gui.dialogs.open_open_url(url);
+    pub fn open_dialog(&mut self, dialog_event: DialogDescriptor) {
+        self.gui.dialogs.open_dialog(dialog_event);
     }
 }
 

--- a/desktop/src/gui/dialogs.rs
+++ b/desktop/src/gui/dialogs.rs
@@ -131,23 +131,23 @@ impl Dialogs {
         egui_ctx: &egui::Context,
         player: Option<&mut Player>,
     ) {
-        self.open_dialog(locale, egui_ctx);
-        self.preferences_dialog(locale, egui_ctx);
-        self.bookmarks_dialog(locale, egui_ctx);
-        self.bookmark_add_dialog(locale, egui_ctx);
-        self.volume_controls(locale, egui_ctx, player);
-        self.about_dialog(locale, egui_ctx);
-        self.open_url_dialog(locale, egui_ctx);
+        self.show_open_dialog(locale, egui_ctx);
+        self.show_preferences_dialog(locale, egui_ctx);
+        self.show_bookmarks_dialog(locale, egui_ctx);
+        self.show_bookmark_add_dialog(locale, egui_ctx);
+        self.show_volume_controls(locale, egui_ctx, player);
+        self.show_about_dialog(locale, egui_ctx);
+        self.show_open_url_dialog(locale, egui_ctx);
     }
 
-    fn open_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
+    fn show_open_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
         if self.is_open_dialog_visible {
             let keep_open = self.open_dialog.show(locale, egui_ctx);
             self.is_open_dialog_visible = keep_open;
         }
     }
 
-    fn preferences_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
+    fn show_preferences_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
         let keep_open = if let Some(dialog) = &mut self.preferences_dialog {
             dialog.show(locale, egui_ctx)
         } else {
@@ -158,7 +158,7 @@ impl Dialogs {
         }
     }
 
-    fn bookmarks_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
+    fn show_bookmarks_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
         let keep_open = if let Some(dialog) = &mut self.bookmarks_dialog {
             dialog.show(locale, egui_ctx)
         } else {
@@ -169,7 +169,7 @@ impl Dialogs {
         }
     }
 
-    fn bookmark_add_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
+    fn show_bookmark_add_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
         let keep_open = if let Some(dialog) = &mut self.bookmark_add_dialog {
             dialog.show(locale, egui_ctx)
         } else {
@@ -180,7 +180,7 @@ impl Dialogs {
         }
     }
 
-    fn volume_controls(
+    fn show_volume_controls(
         &mut self,
         locale: &LanguageIdentifier,
         egui_ctx: &egui::Context,
@@ -194,14 +194,14 @@ impl Dialogs {
         }
     }
 
-    fn about_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
+    fn show_about_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
         if self.is_about_visible {
             let keep_open = about_dialog::show_about_dialog(locale, egui_ctx);
             self.is_about_visible = keep_open;
         }
     }
 
-    fn open_url_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
+    fn show_open_url_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
         let keep_open = if let Some(dialog) = &mut self.open_url_dialog {
             dialog.show(locale, egui_ctx)
         } else {

--- a/desktop/src/gui/dialogs.rs
+++ b/desktop/src/gui/dialogs.rs
@@ -1,5 +1,6 @@
 mod about_dialog;
 mod bookmarks_dialog;
+pub mod message_dialog;
 mod open_dialog;
 mod open_url_dialog;
 mod preferences_dialog;
@@ -9,6 +10,7 @@ use crate::custom_event::RuffleEvent;
 use crate::player::LaunchOptions;
 use crate::preferences::GlobalPreferences;
 use bookmarks_dialog::{BookmarkAddDialog, BookmarksDialog};
+use message_dialog::{MessageDialog, MessageDialogConfiguration};
 use open_dialog::OpenDialog;
 use open_url_dialog::OpenUrlDialog;
 use preferences_dialog::PreferencesDialog;
@@ -29,6 +31,7 @@ pub struct Dialogs {
     bookmarks_dialog: Option<BookmarksDialog>,
     bookmark_add_dialog: Option<BookmarkAddDialog>,
     open_url_dialog: Option<OpenUrlDialog>,
+    message_dialog: Option<MessageDialog>,
 
     open_dialog: OpenDialog,
     is_open_dialog_visible: bool,
@@ -43,6 +46,7 @@ pub struct Dialogs {
 
 pub enum DialogDescriptor {
     OpenUrl(url::Url),
+    ShowMessage(MessageDialogConfiguration),
 }
 
 impl Dialogs {
@@ -59,6 +63,7 @@ impl Dialogs {
             bookmarks_dialog: None,
             bookmark_add_dialog: None,
             open_url_dialog: None,
+            message_dialog: None,
 
             open_dialog: OpenDialog::new(
                 player_options,
@@ -130,6 +135,9 @@ impl Dialogs {
             DialogDescriptor::OpenUrl(url) => {
                 self.open_url_dialog = Some(OpenUrlDialog::new(url));
             }
+            DialogDescriptor::ShowMessage(config) => {
+                self.message_dialog = Some(MessageDialog::new(config));
+            }
         }
     }
 
@@ -146,6 +154,7 @@ impl Dialogs {
         self.show_volume_controls(locale, egui_ctx, player);
         self.show_about_dialog(locale, egui_ctx);
         self.show_open_url_dialog(locale, egui_ctx);
+        self.show_message_dialog(locale, egui_ctx);
     }
 
     fn show_open_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
@@ -217,6 +226,17 @@ impl Dialogs {
         };
         if !keep_open {
             self.open_url_dialog = None;
+        }
+    }
+
+    fn show_message_dialog(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) {
+        let keep_open = if let Some(dialog) = &mut self.message_dialog {
+            dialog.show(locale, egui_ctx)
+        } else {
+            true
+        };
+        if !keep_open {
+            self.message_dialog = None;
         }
     }
 }

--- a/desktop/src/gui/dialogs.rs
+++ b/desktop/src/gui/dialogs.rs
@@ -41,6 +41,10 @@ pub struct Dialogs {
     preferences: GlobalPreferences,
 }
 
+pub enum DialogDescriptor {
+    OpenUrl(url::Url),
+}
+
 impl Dialogs {
     pub fn new(
         preferences: GlobalPreferences,
@@ -121,8 +125,12 @@ impl Dialogs {
         self.is_about_visible = true;
     }
 
-    pub fn open_open_url(&mut self, url: Url) {
-        self.open_url_dialog = Some(OpenUrlDialog::new(url));
+    pub fn open_dialog(&mut self, event: DialogDescriptor) {
+        match event {
+            DialogDescriptor::OpenUrl(url) => {
+                self.open_url_dialog = Some(OpenUrlDialog::new(url));
+            }
+        }
     }
 
     pub fn show(

--- a/desktop/src/gui/dialogs/message_dialog.rs
+++ b/desktop/src/gui/dialogs/message_dialog.rs
@@ -1,0 +1,62 @@
+use crate::gui::{text, LocalizableText};
+use egui::{Align2, Ui, Window};
+use unic_langid::LanguageIdentifier;
+
+pub struct MessageDialogConfiguration {
+    title: LocalizableText,
+    body: LocalizableText,
+}
+
+impl MessageDialogConfiguration {
+    pub fn new(title: LocalizableText, body: LocalizableText) -> Self {
+        Self { title, body }
+    }
+}
+
+pub struct MessageDialog {
+    config: MessageDialogConfiguration,
+}
+
+impl MessageDialog {
+    pub fn new(config: MessageDialogConfiguration) -> Self {
+        Self { config }
+    }
+
+    pub fn show(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) -> bool {
+        let mut keep_open = true;
+        let mut should_close = false;
+
+        Window::new(self.config.title.localize(locale))
+            .open(&mut keep_open)
+            .anchor(Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .collapsible(false)
+            .resizable(false)
+            .show(egui_ctx, |ui| {
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    should_close = self.render_window_contents(locale, ui)
+                });
+            });
+
+        keep_open && !should_close
+    }
+
+    pub fn render_window_contents(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) -> bool {
+        let mut should_close = false;
+
+        ui.vertical_centered(|ui| {
+            ui.label("");
+            ui.label(self.config.body.localize(locale));
+            ui.label("");
+        });
+
+        ui.horizontal(|ui| {
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui.button(text(locale, "dialog-ok")).clicked() {
+                    should_close = true;
+                }
+            })
+        });
+
+        should_close
+    }
+}

--- a/desktop/src/gui/dialogs/open_dialog.rs
+++ b/desktop/src/gui/dialogs/open_dialog.rs
@@ -1,6 +1,6 @@
 use crate::custom_event::RuffleEvent;
 use crate::gui::widgets::PathOrUrlField;
-use crate::gui::{text, FilePicker};
+use crate::gui::{text, FilePicker, LocalizableText};
 use crate::player::LaunchOptions;
 use egui::{
     emath, Align2, Button, Checkbox, ComboBox, Grid, Layout, Slider, TextEdit, Ui, Widget, Window,
@@ -158,7 +158,7 @@ impl OpenDialog {
                         }
                     }),
                 ),
-                Box::new(|locale| text(locale, "align-force")),
+                LocalizableText::LocalizedText("align-force"),
                 false,
             ),
         );
@@ -189,10 +189,10 @@ impl OpenDialog {
                     StageScaleMode::ExactFit => Some(text(locale, "scale-mode-exactfit-tooltip")),
                     StageScaleMode::NoBorder => Some(text(locale, "scale-mode-noborder-tooltip")),
                 })),
-                Box::new(|locale| text(locale, "scale-mode-force")),
+                LocalizableText::LocalizedText("scale-mode-force"),
                 false,
             )
-            .with_checkbox_tooltip(Box::new(|locale| text(locale, "scale-mode-force-tooltip"))),
+            .with_checkbox_tooltip(LocalizableText::LocalizedText("scale-mode-force-tooltip")),
         );
         let load_behavior = OptionalField::new(
             defaults.player.load_behavior,
@@ -729,7 +729,6 @@ impl<T: emath::Numeric> InnerField for NumberField<T> {
 
 type ValueToTextFn<T> = dyn Fn(T, &LanguageIdentifier) -> Cow<'static, str>;
 type ValueToOptTextFn<T> = dyn Fn(T, &LanguageIdentifier) -> Option<Cow<'static, str>>;
-type LabelFn = dyn Fn(&LanguageIdentifier) -> Cow<'static, str>;
 
 struct EnumDropdownField<T: Copy> {
     id: egui::Id,
@@ -827,13 +826,13 @@ impl InnerField for BooleanDropdownField {
 
 struct FieldWithCheckbox<T: InnerField> {
     field: T,
-    checkbox_label: Box<LabelFn>,
+    checkbox_label: LocalizableText,
     checkbox_default: bool,
-    tooltip_label: Option<Box<LabelFn>>,
+    tooltip_label: Option<LocalizableText>,
 }
 
 impl<T: InnerField> FieldWithCheckbox<T> {
-    pub fn new(field: T, checkbox_label: Box<LabelFn>, checkbox_default: bool) -> Self {
+    pub fn new(field: T, checkbox_label: LocalizableText, checkbox_default: bool) -> Self {
         Self {
             field,
             checkbox_label,
@@ -842,7 +841,7 @@ impl<T: InnerField> FieldWithCheckbox<T> {
         }
     }
 
-    pub fn with_checkbox_tooltip(mut self, tooltip_label: Box<LabelFn>) -> Self {
+    pub fn with_checkbox_tooltip(mut self, tooltip_label: LocalizableText) -> Self {
         self.tooltip_label = Some(tooltip_label);
         self
     }
@@ -858,9 +857,9 @@ impl<T: InnerField> InnerField for FieldWithCheckbox<T> {
 
     fn ui(&self, ui: &mut Ui, value: &mut Self::Value, error: bool, locale: &LanguageIdentifier) {
         self.field.ui(ui, &mut value.0, error, locale);
-        let response = ui.checkbox(&mut value.1, (self.checkbox_label)(locale));
+        let response = ui.checkbox(&mut value.1, self.checkbox_label.localize(locale));
         if let Some(ref tooltip_label) = self.tooltip_label {
-            response.on_hover_text_at_pointer(tooltip_label(locale));
+            response.on_hover_text_at_pointer(tooltip_label.localize(locale));
         }
     }
 

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -268,6 +268,7 @@ impl ActivePlayer {
             .with_ui(
                 DesktopUiBackend::new(
                     window.clone(),
+                    event_loop.clone(),
                     opt.open_url_mode,
                     font_database,
                     preferences,


### PR DESCRIPTION
This PR implements MessageDialog in egui and replaces some usages of rfd with it. It provides the following improvements:

1. current dialogs do not have parent/child relationship with Ruffle, the newly added MessageDialog uses egui which renders over the content,
2. when opening a dialog Ruffle is now responsive,
3. dialogs are internationalized,
4. message dialogs are now consistent with other dialogs.

<image width="400" src="https://github.com/user-attachments/assets/399bb5d0-38e4-4b51-b2c5-dd6f8633306e"/>
