### PR TITLE
avm2: Throw special XML parsing error for unmatched end tag at the root level

### DIFF
--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -865,6 +865,15 @@ impl<'gc> E4XNode<'gc> {
                     }
                     return Err(make_error_1085(activation, &expected));
                 }
+                Err(XmlError::IllFormed(IllFormedError::UnmatchedEndTag(_)))
+                    if open_tags.is_empty() =>
+                {
+                    return Err(Error::AvmError(type_error(
+                        activation,
+                        "Error #1088: The markup in the document following the root element must be well-formed.",
+                        1088,
+                    )?));
+                }
                 Err(err) => return Err(make_xml_error(activation, err)),
             };
 

--- a/tests/tests/swfs/from_avmplus/e4x/XML/kXMLMarkupMustBeWellFormedErr/test.toml
+++ b/tests/tests/swfs/from_avmplus/e4x/XML/kXMLMarkupMustBeWellFormedErr/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
I am frankly not sure why this weird case needs a special error, but whatever.