### PR TITLE
ci: Fix failing doctests and run them in CI

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FEATURES: lzma,jpegxr
+
 jobs:
   changes:
     name: Paths filter
@@ -67,6 +70,11 @@ jobs:
         if: runner.os == 'Linux'
         run: echo RUSTFLAGS=${RUSTFLAGS}\ --cfg=web_sys_unstable_apis\ -Clink-args=-znostart-stop-gc >> $GITHUB_ENV
 
+      - name: Enable image tests
+        if: runner.os != 'macOS'
+        shell: bash
+        run: echo FEATURES=${FEATURES},imgtests | tee -a $GITHUB_ENV
+
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2
         with:
@@ -78,9 +86,9 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Run tests with image tests
-        if: runner.os != 'macOS'
-        run: cargo nextest run --profile ci --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features imgtests,lzma,jpegxr
+      - name: Run tests
+        shell: bash
+        run: cargo nextest run --profile ci --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features ${FEATURES}
         env:
           # This is to counteract the disabling by rust-cache.
           # See: https://github.com/Swatinem/rust-cache/issues/43
@@ -91,12 +99,6 @@ jobs:
           # Workaround for: https://github.com/nextest-rs/nextest/issues/1493
           # See also: https://github.com/rust-lang/rustup/issues/3825
           RUSTUP_WINDOWS_PATH_ADD_BIN: '1'
-          XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
-
-      - name: Run tests without image tests
-        if: runner.os == 'macOS'
-        run: cargo nextest run --profile ci --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features lzma,jpegxr
-        env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 
       - name: Upload images

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -12,6 +12,22 @@ concurrency:
 
 env:
   FEATURES: lzma,jpegxr
+  TEST_OPTS: --workspace --locked --no-fail-fast -j 4
+
+  # This is to counteract the disabling by rust-cache.
+  # See: https://github.com/Swatinem/rust-cache/issues/43
+  CARGO_INCREMENTAL: '1'
+
+  # Supposedly makes "Updating crates.io index" faster on Windows.
+  # See: https://github.com/rust-lang/cargo/issues/9167
+  CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
+
+  # Workaround for: https://github.com/nextest-rs/nextest/issues/1493
+  # See also: https://github.com/rust-lang/rustup/issues/3825
+  RUSTUP_WINDOWS_PATH_ADD_BIN: '1'
+
+  # (Linux) Just to silence warnings about it missing
+  XDG_RUNTIME_DIR: ''
 
 jobs:
   changes:
@@ -88,18 +104,11 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: cargo nextest run --profile ci --cargo-profile ci --workspace --locked --no-fail-fast -j 4 --features ${FEATURES}
-        env:
-          # This is to counteract the disabling by rust-cache.
-          # See: https://github.com/Swatinem/rust-cache/issues/43
-          CARGO_INCREMENTAL: '1'
-          # Supposedly makes "Updating crates.io index" faster on Windows.
-          # See: https://github.com/rust-lang/cargo/issues/9167
-          CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
-          # Workaround for: https://github.com/nextest-rs/nextest/issues/1493
-          # See also: https://github.com/rust-lang/rustup/issues/3825
-          RUSTUP_WINDOWS_PATH_ADD_BIN: '1'
-          XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
+        run: cargo nextest run --profile ci --cargo-profile ci ${TEST_OPTS} --features ${FEATURES}
+
+      - name: Run doctests
+        shell: bash
+        run: cargo test --doc --profile ci ${TEST_OPTS} --features ${FEATURES}
 
       - name: Upload images
         if: failure()

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -64,8 +64,7 @@ jobs:
       # See also: https://github.com/dtolnay/linkme/issues/94
       # Additionally: https://lld.llvm.org/ELF/start-stop-gc
       - name: Disable linker start-stop-gc
-        # Note: We also use `rust-lld` on Windows, see `config.toml`.
-        if: runner.os != 'macOS'
+        if: runner.os == 'Linux'
         run: echo RUSTFLAGS=${RUSTFLAGS}\ --cfg=web_sys_unstable_apis\ -Clink-args=-znostart-stop-gc >> $GITHUB_ENV
 
       - name: Cache Cargo output

--- a/core/build_playerglobal/src/lib.rs
+++ b/core/build_playerglobal/src/lib.rs
@@ -303,7 +303,7 @@ fn strip_metadata(abc: &mut AbcFile) {
 /// If we don't properly declare 'namespace AS3' in the input to asc.jar, then
 /// a call like `self.AS3::toXMLString()` will end up getting compiled to weird bytecode like this:
 ///
-/// ```
+/// ```pcode
 /// getlex Multiname("AS3",[PackageNamespace(""),PrivateNamespace(null,"35"),PackageInternalNs(""),PrivateNamespace(null,"33"),ProtectedNamespace("XML"),StaticProtectedNs("XML")])
 /// coerce QName(PackageNamespace(""),"Namespace")
 /// getproperty RTQName("toXMLString")

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -226,7 +226,7 @@ impl<'gc> Stack<'gc> {
 
 /// Checks if the method fits the following pattern:
 ///
-/// ```
+/// ```text
 /// [Debug/DebugFile/DebugLine] zero or more times
 /// GetLocal { index: 0 }
 /// [Debug/DebugFile/DebugLine] zero or more times


### PR DESCRIPTION
Unfortunately nextest does not support doctests yet (https://github.com/nextest-rs/nextest/issues/16), they need to be run using cargo test.

This adds ~10s on Linux and macOS and ~15s on Windows.