### PR TITLE
core: Replace `on_exit_frame` with iteration over Loaders

### DIFF
--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -259,12 +259,15 @@ impl<'gc> LoaderInfoObject<'gc> {
         self.0.complete_event_fired.set(false);
     }
 
+    /// Fires the 'init' and 'complete' events if they haven't been fired yet.
+    /// Returns `true` if both events have been fired (either as a result of
+    /// this call, or due to a previous call).
     pub fn fire_init_and_complete_events(
         &self,
         context: &mut UpdateContext<'gc>,
         status: u16,
         redirected: bool,
-    ) {
+    ) -> bool {
         self.0.expose_content.set(true);
         if !self.0.init_event_fired.get() {
             self.0.init_event_fired.set(true);
@@ -313,8 +316,11 @@ impl<'gc> LoaderInfoObject<'gc> {
                 self.0.complete_event_fired.set(true);
                 let complete_evt = EventObject::bare_default_event(context, "complete");
                 Avm2::dispatch_event(context, complete_evt, (*self).into());
+                return true;
             }
+            return false;
         }
+        true
     }
 
     /// Unwrap this object's loader stream

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -8,6 +8,7 @@ use crate::avm2::{
 };
 use crate::context::{RenderContext, UpdateContext};
 use crate::drawing::Drawing;
+use crate::loader::LoadManager;
 use crate::prelude::*;
 use crate::string::{AvmString, WString};
 use crate::tag_utils::SwfMovie;
@@ -2070,15 +2071,7 @@ pub trait TDisplayObject<'gc>:
         let dobject_constr = context.avm2.classes().display_object;
         Avm2::broadcast_event(context, exit_frame_evt, dobject_constr);
 
-        self.on_exit_frame(context);
-    }
-
-    fn on_exit_frame(&self, context: &mut UpdateContext<'gc>) {
-        if let Some(container) = self.as_container() {
-            for child in container.iter_render_list() {
-                child.on_exit_frame(context);
-            }
-        }
+        LoadManager::run_exit_frame(context);
     }
 
     /// Called before the child is about to be rendered.

--- a/core/src/frame_lifecycle.rs
+++ b/core/src/frame_lifecycle.rs
@@ -96,9 +96,6 @@ pub fn run_all_phases_avm2(context: &mut UpdateContext<'_>) {
     stage.run_frame_scripts(context);
 
     *context.frame_phase = FramePhase::Exit;
-    Avm2::each_orphan_obj(context, |orphan, context| {
-        orphan.on_exit_frame(context);
-    });
     stage.exit_frame(context);
 
     // We cannot easily remove dead `GcWeak` instances from the orphan list
@@ -169,9 +166,6 @@ pub fn run_inner_goto_frame<'gc>(
     }
 
     *context.frame_phase = FramePhase::Exit;
-    Avm2::each_orphan_obj(context, |orphan, context| {
-        orphan.on_exit_frame(context);
-    });
     stage.exit_frame(context);
 
     // We cannot easily remove dead `GcWeak` instances from the orphan list


### PR DESCRIPTION
This removes the need to traverse the entire display object tree - we instead just try to fire events (when ready) on corresponding `MovieClip`s for our `Loader::Movie` instances