### PR TITLE
desktop: Add network access dialog

### DIFF
--- a/desktop/assets/texts/en-US/network_access_dialog.ftl
+++ b/desktop/assets/texts/en-US/network_access_dialog.ftl
@@ -1,0 +1,6 @@
+network-access-dialog-title = Requesting Network Access
+
+network-access-dialog-message = The current movie is attempting to connect to the following host. Are you sure you want to allow it?
+network-access-dialog-port = (port { $port })
+
+network-access-dialog-allow = Allow

--- a/desktop/src/backends/navigator.rs
+++ b/desktop/src/backends/navigator.rs
@@ -1,14 +1,18 @@
-use rfd::{AsyncMessageDialog, MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
+use rfd::{MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
 use ruffle_frontend_utils::backends::navigator::NavigatorInterface;
 use std::fs::File;
 use std::io;
 use std::io::ErrorKind;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use tokio::sync::oneshot;
 use url::Url;
 use winit::event_loop::EventLoopProxy;
 
 use crate::custom_event::RuffleEvent;
+use crate::gui::dialogs::network_access_dialog::{
+    NetworkAccessDialogConfiguration, NetworkAccessDialogResult,
+};
 use crate::gui::DialogDescriptor;
 use crate::util::open_url;
 
@@ -66,8 +70,15 @@ impl NavigatorInterface for DesktopNavigatorInterface {
     }
 
     async fn confirm_socket(&self, host: &str, port: u16) -> bool {
-        AsyncMessageDialog::new().set_level(MessageLevel::Warning).set_description(format!("The current movie is attempting to connect to {:?} (port {}).\n\nTo allow it to do so, click Yes to grant network access to that host.\n\nOtherwise, click No to deny access.", host, port)).set_buttons(MessageButtons::YesNo)
-            .show()
-            .await == MessageDialogResult::Yes
+        let (notifier, receiver) = oneshot::channel();
+        let _ = self
+            .event_loop
+            .lock()
+            .expect("Non-poisoned event loop")
+            .send_event(RuffleEvent::OpenDialog(DialogDescriptor::NetworkAccess(
+                NetworkAccessDialogConfiguration::new(notifier, host, port),
+            )));
+        let result = receiver.await;
+        result == Ok(NetworkAccessDialogResult::Allow)
     }
 }

--- a/desktop/src/gui/dialogs/network_access_dialog.rs
+++ b/desktop/src/gui/dialogs/network_access_dialog.rs
@@ -1,0 +1,108 @@
+use crate::gui::{text, text_with_args};
+use egui::{Align2, Ui, Window};
+use fluent_templates::fluent_bundle::FluentValue;
+use std::collections::HashMap;
+use tokio::sync::oneshot::Sender;
+use unic_langid::LanguageIdentifier;
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum NetworkAccessDialogResult {
+    Allow,
+    Cancel,
+}
+
+pub struct NetworkAccessDialogConfiguration {
+    notifier: Option<Sender<NetworkAccessDialogResult>>,
+    host: String,
+    port: u16,
+}
+
+impl NetworkAccessDialogConfiguration {
+    pub fn new(
+        notifier: Sender<NetworkAccessDialogResult>,
+        host: impl Into<String>,
+        port: u16,
+    ) -> Self {
+        Self {
+            notifier: Some(notifier),
+            host: host.into(),
+            port,
+        }
+    }
+}
+
+pub struct NetworkAccessDialog {
+    config: NetworkAccessDialogConfiguration,
+}
+
+impl Drop for NetworkAccessDialog {
+    fn drop(&mut self) {
+        self.respond(NetworkAccessDialogResult::Cancel);
+    }
+}
+
+impl NetworkAccessDialog {
+    pub fn new(config: NetworkAccessDialogConfiguration) -> Self {
+        Self { config }
+    }
+
+    fn respond(&mut self, result: NetworkAccessDialogResult) {
+        if let Some(notifier) = std::mem::take(&mut self.config.notifier) {
+            let _ = notifier.send(result);
+        }
+    }
+
+    pub fn show(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) -> bool {
+        let mut keep_open = true;
+        let mut should_close = false;
+
+        Window::new(text(locale, "network-access-dialog-title"))
+            .open(&mut keep_open)
+            .anchor(Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .collapsible(false)
+            .resizable(false)
+            .show(egui_ctx, |ui| {
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    should_close = self.render_window_contents(locale, ui)
+                });
+            });
+
+        keep_open && !should_close
+    }
+
+    pub fn render_window_contents(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) -> bool {
+        let mut should_close = false;
+
+        ui.label(text(locale, "network-access-dialog-message"));
+        ui.label("");
+        ui.horizontal(|ui| {
+            ui.monospace(&self.config.host);
+            ui.label(text_with_args(
+                locale,
+                "network-access-dialog-port",
+                &HashMap::from([(
+                    "port",
+                    FluentValue::String(self.config.port.to_string().into()),
+                )]),
+            ));
+        });
+        ui.label("");
+
+        ui.horizontal(|ui| {
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui
+                    .button(text(locale, "network-access-dialog-allow"))
+                    .clicked()
+                {
+                    self.respond(NetworkAccessDialogResult::Allow);
+                    should_close = true;
+                }
+                if ui.button(text(locale, "dialog-cancel")).clicked() {
+                    should_close = true;
+                }
+            })
+        });
+
+        should_close
+    }
+}


### PR DESCRIPTION
Add network access dialog written in egui and replace rfd's socket confirmation with it.

<image width="400" src="https://github.com/user-attachments/assets/ae3e1286-12bb-4eb3-bab5-337a76822757"/>
