### PR TITLE
avm2: Do not allocate for `Namespace::any()`

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -524,7 +524,7 @@ impl<'gc> Class<'gc> {
                     // A 'callable' class doesn't have a signature - let the
                     // method do any needed coercions
                     vec![],
-                    Multiname::any(activation.context.gc_context),
+                    Multiname::any(),
                     true,
                     activation.context.gc_context,
                 );

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1706,13 +1706,13 @@ pub fn string_to_multiname<'gc>(
 ) -> Multiname<'gc> {
     if let Some(name) = name.strip_prefix(b'@') {
         if name == b"*" {
-            return Multiname::any_attribute(activation.gc());
+            return Multiname::any_attribute();
         }
 
         let name = AvmString::new(activation.context.gc_context, name);
         Multiname::attribute(activation.avm2().public_namespace_base_version, name)
     } else if &*name == b"*" {
-        Multiname::any(activation.context.gc_context)
+        Multiname::any()
     } else {
         Multiname::new(activation.avm2().public_namespace_base_version, name)
     }

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -315,7 +315,7 @@ fn describe_internal_body<'gc>(
                     continue;
                 }
                 let prop_class_name = vtable
-                    .slot_class_name(*slot_id, activation.context.gc_context)?
+                    .slot_class_name(*slot_id)?
                     .to_qualified_name_or_star(activation.context.gc_context);
 
                 let access = match prop {

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -227,10 +227,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             "<int instance initializer>",
             vec![ParamConfig {
                 param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
-                param_type_name: Multiname::any(activation.context.gc_context),
+                param_type_name: Multiname::any(),
                 default_value: Some(Value::Integer(0)),
             }],
-            Multiname::any(activation.context.gc_context),
+            Multiname::any(),
             true,
             mc,
         ),

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -55,7 +55,7 @@ pub fn instance_init<'gc>(
                 let ns = qname
                     .uri()
                     .map(|uri| Namespace::package(uri, api_version, &mut activation.borrow_gc()))
-                    .unwrap_or_else(|| Namespace::any(activation.context.gc_context));
+                    .unwrap_or_else(Namespace::any);
                 if ns.as_uri().is_empty() {
                     (Some("".into()), ns)
                 } else {

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -279,7 +279,7 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             has_own_property,
             vec![ParamConfig::optional(
                 "name",
-                Multiname::any(activation.context.gc_context),
+                Multiname::any(),
                 Value::Undefined,
             )],
             Multiname::new(activation.avm2().public_namespace_base_version, "Boolean"),
@@ -289,7 +289,7 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             is_prototype_of,
             vec![ParamConfig::optional(
                 "theClass",
-                Multiname::any(activation.context.gc_context),
+                Multiname::any(),
                 Value::Undefined,
             )],
             Multiname::new(activation.avm2().public_namespace_base_version, "Boolean"),
@@ -299,7 +299,7 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             property_is_enumerable,
             vec![ParamConfig::optional(
                 "name",
-                Multiname::any(activation.context.gc_context),
+                Multiname::any(),
                 Value::Undefined,
             )],
             Multiname::new(activation.avm2().public_namespace_base_version, "Boolean"),

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -228,10 +228,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             "<uint instance initializer>",
             vec![ParamConfig {
                 param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
-                param_type_name: Multiname::any(activation.context.gc_context),
+                param_type_name: Multiname::any(),
                 default_value: Some(Value::Integer(0)),
             }],
-            Multiname::any(activation.context.gc_context),
+            Multiname::any(),
             true,
             mc,
         ),

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -576,7 +576,7 @@ pub fn children<'gc>(
         activation,
         children,
         Some(xml.into()),
-        Some(Multiname::any(activation.gc())),
+        Some(Multiname::any()),
     )
     .into())
 }
@@ -646,7 +646,7 @@ pub fn attributes<'gc>(
         activation,
         attributes,
         Some(xml.into()),
-        Some(Multiname::any_attribute(activation.gc())),
+        Some(Multiname::any_attribute()),
     )
     .into())
 }
@@ -733,7 +733,7 @@ pub fn append_child<'gc>(
     let child = crate::avm2::e4x::maybe_escape_child(activation, child)?;
 
     // 1. Let children be the result of calling the [[Get]] method of x with argument "*"
-    let name = Multiname::any(activation.gc());
+    let name = Multiname::any();
     let children = xml.get_property_local(&name, activation)?;
 
     // 2. Call the [[Put]] method of children with arguments children.[[Length]] and child
@@ -1102,7 +1102,7 @@ pub fn set_children<'gc>(
     let value = args.get_value(0);
 
     // 1. Call the [[Put]] method of x with arguments "*" and value
-    xml.set_property_local(&Multiname::any(activation.gc()), value, activation)?;
+    xml.set_property_local(&Multiname::any(), value, activation)?;
 
     // 2. Return x
     Ok(xml.into())

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -226,7 +226,7 @@ pub fn children<'gc>(
         activation,
         sub_children,
         Some(list.into()),
-        Some(Multiname::any(activation.gc())),
+        Some(Multiname::any()),
     )
     .into())
 }
@@ -320,7 +320,7 @@ pub fn attributes<'gc>(
         activation,
         child_attrs,
         Some(list.into()),
-        Some(Multiname::any_attribute(activation.gc())),
+        Some(Multiname::any_attribute()),
     )
     .into())
 }

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -165,7 +165,7 @@ impl<'gc> BytecodeMethod<'gc> {
     ) -> Result<Self, Error<'gc>> {
         let abc = txunit.abc();
         let mut signature = Vec::new();
-        let mut return_type = Multiname::any(activation.gc());
+        let mut return_type = Multiname::any();
 
         if abc.methods.get(abc_method.0 as usize).is_some() {
             let method = &abc.methods[abc_method.0 as usize];
@@ -429,7 +429,7 @@ impl<'gc> Method<'gc> {
                 signature: Vec::new(),
                 resolved_signature: GcCell::new(mc, None),
                 // FIXME - take in the real return type. This is needed for 'describeType'
-                return_type: Multiname::any(mc),
+                return_type: Multiname::any(),
                 is_variadic: true,
             },
         ))

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -328,9 +328,9 @@ impl<'gc> Multiname<'gc> {
     }
 
     /// Indicates the any type (any name in any namespace).
-    pub fn any(mc: &Mutation<'gc>) -> Self {
+    pub fn any() -> Self {
         Self {
-            ns: NamespaceSet::single(Namespace::any(mc)),
+            ns: NamespaceSet::single(Namespace::any()),
             name: None,
             param: None,
             flags: Default::default(),
@@ -338,9 +338,9 @@ impl<'gc> Multiname<'gc> {
     }
 
     /// Indicates the any attribute type (any attribute in any namespace).
-    pub fn any_attribute(mc: &Mutation<'gc>) -> Self {
+    pub fn any_attribute() -> Self {
         Self {
-            ns: NamespaceSet::single(Namespace::any(mc)),
+            ns: NamespaceSet::single(Namespace::any()),
             name: None,
             param: None,
             flags: MultinameFlags::ATTRIBUTE,

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -37,7 +37,7 @@ pub fn function_allocator<'gc>(
             name: "<Empty Function>",
             signature: vec![],
             resolved_signature: GcCell::new(activation.context.gc_context, None),
-            return_type: Multiname::any(activation.context.gc_context),
+            return_type: Multiname::any(),
             is_variadic: true,
         },
     );

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -24,7 +24,7 @@ pub fn q_name_allocator<'gc>(
         activation.context.gc_context,
         QNameObjectData {
             base,
-            name: RefLock::new(Multiname::any(activation.context.gc_context)),
+            name: RefLock::new(Multiname::any()),
         },
     ))
     .into())

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -991,11 +991,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                         // 2.h.i. Call the [[Put]] method of x[i] with arguments "*" and V
                         self.xml_object_child(index, activation)
                             .unwrap()
-                            .set_property_local(
-                                &Multiname::any(activation.gc()),
-                                value,
-                                activation,
-                            )?;
+                            .set_property_local(&Multiname::any(), value, activation)?;
                     }
 
                     // NOTE: Not specified in the spec, but avmplus returns here, so we do the same.

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -127,11 +127,11 @@ impl<'gc> PropertyClass<'gc> {
         }
     }
 
-    pub fn get_name(&self, mc: &Mutation<'gc>) -> Multiname<'gc> {
+    pub fn get_name(&self) -> Multiname<'gc> {
         match self {
             PropertyClass::Class(class) => class.name().into(),
             PropertyClass::Name(gc) => gc.0.clone(),
-            PropertyClass::Any => Multiname::any(mc),
+            PropertyClass::Any => Multiname::any(),
         }
     }
 }

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -393,7 +393,7 @@ impl<'gc> TranslationUnit<'gc> {
     ) -> Result<Gc<'gc, Multiname<'gc>>, Error<'gc>> {
         if multiname_index.0 == 0 {
             let mc = context.gc_context;
-            Ok(Gc::new(mc, Multiname::any(mc)))
+            Ok(Gc::new(mc, Multiname::any()))
         } else {
             self.pool_multiname_static(multiname_index, context)
         }

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -370,7 +370,10 @@ impl Definition {
     ) {
         for class_trait in traits {
             if !class_trait.name().namespace().is_public()
-                && class_trait.name().namespace() != avm2.as3_namespace
+                && class_trait
+                    .name()
+                    .namespace()
+                    .exact_version_match(avm2.as3_namespace)
             {
                 continue;
             }

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -112,17 +112,13 @@ impl<'gc> VTable<'gc> {
         self.0.read().disp_metadata_table.get(disp_id).cloned()
     }
 
-    pub fn slot_class_name(
-        &self,
-        slot_id: u32,
-        mc: &Mutation<'gc>,
-    ) -> Result<Multiname<'gc>, Error<'gc>> {
+    pub fn slot_class_name(&self, slot_id: u32) -> Result<Multiname<'gc>, Error<'gc>> {
         self.0
             .read()
             .slot_classes
             .get(slot_id as usize)
             .ok_or_else(|| "Invalid slot ID".into())
-            .map(|c| c.get_name(mc))
+            .map(|c| c.get_name())
     }
 
     pub fn get_trait(self, name: &Multiname<'gc>) -> Option<Property> {


### PR DESCRIPTION
`Namespace` now holds a `Option<Gc<_>>` internally, with `None` representing the Any namespace.

This is closer to how avmplus represents namespaces internally (they use a `NULL` pointer for the Any case), and allows creating the Any namespace without a `&Mutation<'gc>`.