### PR TITLE
chore: Bump Binaryen to version 119

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -355,7 +355,7 @@ jobs:
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
-          tag: version_118
+          tag: version_119
           name: wasm-opt
 
       - name: Install node packages

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -37,7 +37,7 @@ jobs:
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
-          tag: version_118
+          tag: version_119
           name: wasm-opt
 
       - name: Install fclones

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -71,7 +71,7 @@ jobs:
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
-          tag: version_118
+          tag: version_119
           name: wasm-opt
 
       - name: Build

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -6,9 +6,9 @@ FROM node:20
 
 # Installing wasm-opt from GitHub:
 # Keep the version number in sync with the ones in the Actions workflows!
-RUN wget --progress=:giga https://github.com/WebAssembly/binaryen/releases/download/version_118/binaryen-version_118-x86_64-linux.tar.gz
-RUN tar xzf binaryen-version_118-x86_64-linux.tar.gz binaryen-version_118/bin/wasm-opt
-RUN mv binaryen-version_118/bin/wasm-opt /usr/local/bin
+RUN wget --progress=:giga https://github.com/WebAssembly/binaryen/releases/download/version_119/binaryen-version_119-x86_64-linux.tar.gz
+RUN tar xzf binaryen-version_119-x86_64-linux.tar.gz binaryen-version_119/bin/wasm-opt
+RUN mv binaryen-version_119/bin/wasm-opt /usr/local/bin
 
 # Installing Rust using rustup:
 RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown


### PR DESCRIPTION
Came out yesterday: https://github.com/WebAssembly/binaryen/blob/main/CHANGELOG.md#v119