### PR TITLE
ci: Fix missing checksum in AUR package

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -578,9 +578,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update PKGBUILD
-        working-directory: desktop/packages/linux/aur/ruffle-nightly-bin
         run: >
-          sed -i ./PKGBUILD
+          sed -i desktop/packages/linux/aur/ruffle-nightly-bin/PKGBUILD
           -e "s/@VERSION@/${{ steps.current_time_dots.outputs.formattedTime }}/"
           -e "s/@SHA512SUM@/$(sha512sum ${{ needs.create-nightly-release.outputs.package_prefix }}-linux-x86_64.tar.gz | cut -d' ' -f1)/"
 


### PR DESCRIPTION
Fixes a whoopsie introduced in https://github.com/ruffle-rs/ruffle/pull/17429.

The `sha512sum` command hidden within a subshell required to be executed in the repo root directory.

See:
* https://github.com/ruffle-rs/ruffle/actions/runs/10729997045/job/29758052349#step:7:5
* https://aur.archlinux.org/cgit/aur.git/commit/?h=ruffle-nightly-bin&id=930e21a846965df8fef8e39d2932bf94a1f23f16