### PR TITLE
core: fix: Revert an accidental condition negation in AVM2 stub reporting

### DIFF
--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -370,7 +370,7 @@ impl Definition {
     ) {
         for class_trait in traits {
             if !class_trait.name().namespace().is_public()
-                && class_trait
+                && !class_trait
                     .name()
                     .namespace()
                     .exact_version_match(avm2.as3_namespace)


### PR DESCRIPTION
Fixup for https://github.com/ruffle-rs/ruffle/pull/17771, will probably fix https://github.com/ruffle-rs/ruffle/issues/17783.