### PR TITLE
video: Prefer loading system OpenH264 library to downloading it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,6 +4601,7 @@ dependencies = [
  "slotmap",
  "swf",
  "tempfile",
+ "thiserror",
  "tracing",
 ]
 

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -224,16 +224,16 @@ impl ActivePlayer {
             #[cfg(feature = "external_video")]
             {
                 use ruffle_video_external::backend::ExternalVideoBackend;
-                let path = tokio::task::block_in_place(ExternalVideoBackend::get_openh264);
-                let openh264_path = match path {
-                    Ok(path) => Some(path),
+                let openh264 = tokio::task::block_in_place(ExternalVideoBackend::load_openh264);
+                let openh264 = match openh264 {
+                    Ok(codec) => Some(codec),
                     Err(e) => {
-                        tracing::error!("Couldn't get OpenH264: {}", e);
+                        tracing::error!("Failed to load OpenH264: {}", e);
                         None
                     }
                 };
 
-                builder = builder.with_video(ExternalVideoBackend::new(openh264_path));
+                builder = builder.with_video(ExternalVideoBackend::new(openh264));
             }
         } else {
             #[cfg(feature = "software_video")]

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -178,11 +178,11 @@ impl PlayerOptions {
             #[cfg(feature = "ruffle_video_external")]
             {
                 use ruffle_video_external::backend::ExternalVideoBackend;
-                let openh264_path = ExternalVideoBackend::get_openh264()
-                    .map_err(|e| anyhow!("Couldn't get OpenH264: {}", e))?;
+                let openh264 = ExternalVideoBackend::load_openh264()
+                    .map_err(|e| anyhow!("Couldn't load OpenH264: {}", e))?;
 
                 player_builder =
-                    player_builder.with_video(ExternalVideoBackend::new(Some(openh264_path)));
+                    player_builder.with_video(ExternalVideoBackend::new(Some(openh264)));
             }
 
             #[cfg(all(

--- a/video/external/Cargo.toml
+++ b/video/external/Cargo.toml
@@ -14,6 +14,7 @@ swf = { path = "../../swf" }
 slotmap = { workspace = true }
 tracing = { workspace = true }
 ruffle_video_software = { path = "../software" }
+thiserror = { workspace = true }
 
 # Needed for OpenH264:
 libloading = "0.8.5"

--- a/video/external/src/decoder/openh264.rs
+++ b/video/external/src/decoder/openh264.rs
@@ -63,26 +63,17 @@ pub struct H264Decoder {
     /// How many bytes are used to store the length of the NALU (1, 2, 3, or 4).
     length_size: u8,
 
-    openh264: OpenH264,
+    openh264: Arc<OpenH264>,
     decoder: *mut ISVCDecoder,
 }
 
 impl H264Decoder {
     /// `extradata` should hold "AVCC (MP4) format" decoder configuration, including PPS and SPS.
     /// Make sure it has any start code emulation prevention "three bytes" removed.
-    pub fn new(openh264_lib_filename: &std::path::Path) -> Self {
+    pub fn new(h264: &OpenH264Codec) -> Self {
+        let openh264 = h264.openh264.clone();
         let mut decoder: *mut ISVCDecoder = ptr::null_mut();
         unsafe {
-            let openh264 = OpenH264::new(openh264_lib_filename).unwrap();
-
-            let version = openh264.WelsGetCodecVersion();
-
-            assert_eq!(
-                (version.uMajor, version.uMinor, version.uRevision),
-                (2, 4, 1),
-                "Unexpected OpenH264 version"
-            );
-
             openh264.WelsCreateDecoder(&mut decoder);
 
             let decoder_vtbl = (*decoder).as_ref().unwrap();

--- a/video/external/src/decoder/openh264_sys.rs
+++ b/video/external/src/decoder/openh264_sys.rs
@@ -1359,11 +1359,11 @@ pub struct OpenH264 {
         Result<unsafe extern "C" fn(pVersion: *mut OpenH264Version), ::libloading::Error>,
 }
 impl OpenH264 {
-    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    pub unsafe fn new<P>(filename: P) -> Result<Self, ::libloading::Error>
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let library = ::libloading::Library::new(path)?;
+        let library = ::libloading::Library::new(filename)?;
         Self::from_library(library)
     }
     pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>


### PR DESCRIPTION
Some systems do have OpenH264 installed and in order to get rid of the delay caused by downloading the library (and needlessly downloading it in the first place), an attempt is made first to load OpenH264 as a system library. When loading fails (or version is mismatched), only then Ruffle downloads OpenH264 and uses that version of the library.

This also will make it possible to support OpenH264 in Flatpak.