### PR TITLE
desktop: Install Ruffle metadata in PKGBUILD

### DIFF
--- a/desktop/packages/linux/aur/ruffle-nightly-bin/PKGBUILD
+++ b/desktop/packages/linux/aur/ruffle-nightly-bin/PKGBUILD
@@ -17,4 +17,7 @@ package() {
 	install -Dm755 -t "$pkgdir/usr/bin/" ruffle
 	install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
 	install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE.md
+	install -Dm644 -t "$pkgdir/usr/share/icons/hicolor/scalable/apps/" extras/rs.ruffle.Ruffle.svg
+	install -Dm644 -t "$pkgdir/usr/share/applications/" extras/rs.ruffle.Ruffle.desktop
+	install -Dm644 -t "$pkgdir/usr/share/metainfo/" extras/rs.ruffle.Ruffle.metainfo.xml
 }


### PR DESCRIPTION
This most importantly adds a way of opening Ruffle using GUI.

Tested on Manjaro GNOME, would appreciate if someone else also tested it!
