### PR TITLE
avm2: Remove Copy impl and Gc field from PropertyClass

### DIFF
--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -5,7 +5,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::TranslationUnit;
 use crate::avm2::Value;
-use gc_arena::{Collect, Gc, Mutation};
+use gc_arena::Collect;
 
 use super::class::Class;
 
@@ -39,16 +39,12 @@ pub enum PropertyClass<'gc> {
     /// from the `Object` class
     Any,
     Class(Class<'gc>),
-    Name(Gc<'gc, (Multiname<'gc>, Option<TranslationUnit<'gc>>)>),
+    Name(Box<(Multiname<'gc>, Option<TranslationUnit<'gc>>)>),
 }
 
 impl<'gc> PropertyClass<'gc> {
-    pub fn name(
-        mc: &Mutation<'gc>,
-        name: Multiname<'gc>,
-        unit: Option<TranslationUnit<'gc>>,
-    ) -> Self {
-        PropertyClass::Name(Gc::new(mc, (name, unit)))
+    pub fn name(name: Multiname<'gc>, unit: Option<TranslationUnit<'gc>>) -> Self {
+        PropertyClass::Name(Box::new((name, unit)))
     }
 
     /// Returns `value` coerced to the type of this `PropertyClass`.

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -457,13 +457,13 @@ impl<'gc> VTable<'gc> {
                             type_name, unit, ..
                         } => (
                             Property::new_slot(new_slot_id),
-                            PropertyClass::name(mc, type_name.clone(), *unit),
+                            PropertyClass::name(type_name.clone(), *unit),
                         ),
                         TraitKind::Const {
                             type_name, unit, ..
                         } => (
                             Property::new_const_slot(new_slot_id),
-                            PropertyClass::name(mc, type_name.clone(), *unit),
+                            PropertyClass::name(type_name.clone(), *unit),
                         ),
                         TraitKind::Class { class, .. } => (
                             Property::new_const_slot(new_slot_id),


### PR DESCRIPTION
We now produce return a new PropertyClass instance
(instead of updating in-place and returning `true`) in order
to cache class name lookups. I've also adjusted the call sites to
ensure that we're always storing an resolved `PropertyClass` back
in the vtable.

To avoid growing the property maps, I've replaced the `Gc` with a `Box` in the less-common `PropertyClass::Name` variant