### PR TITLE
avm2: Put more Multinames behind a Gc

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -16,7 +16,7 @@ use crate::context::UpdateContext;
 use crate::string::WString;
 use bitflags::bitflags;
 use fnv::FnvHashMap;
-use gc_arena::{Collect, GcCell, Mutation};
+use gc_arena::{Collect, Gc, GcCell, Mutation};
 
 use std::cell::Ref;
 use std::collections::HashSet;
@@ -524,7 +524,7 @@ impl<'gc> Class<'gc> {
                     // A 'callable' class doesn't have a signature - let the
                     // method do any needed coercions
                     vec![],
-                    Multiname::any(),
+                    Gc::new(activation.gc(), Multiname::any()),
                     true,
                     activation.context.gc_context,
                 );
@@ -1031,7 +1031,7 @@ impl<'gc> Class<'gc> {
             activation.context.gc_context,
             Trait::from_const(
                 name,
-                Multiname::new(activation.avm2().public_namespace_base_version, "Function"),
+                activation.avm2().multinames.function,
                 Some(value),
             ),
         );
@@ -1049,7 +1049,7 @@ impl<'gc> Class<'gc> {
                 activation.context.gc_context,
                 Trait::from_const(
                     QName::new(namespace, name),
-                    Multiname::new(activation.avm2().public_namespace_base_version, "Number"),
+                    activation.avm2().multinames.number,
                     Some(value.into()),
                 ),
             );
@@ -1068,7 +1068,7 @@ impl<'gc> Class<'gc> {
                 activation.context.gc_context,
                 Trait::from_const(
                     QName::new(namespace, name),
-                    Multiname::new(activation.avm2().public_namespace_base_version, "uint"),
+                    activation.avm2().multinames.uint,
                     Some(value.into()),
                 ),
             );
@@ -1087,7 +1087,7 @@ impl<'gc> Class<'gc> {
                 activation.context.gc_context,
                 Trait::from_const(
                     QName::new(namespace, name),
-                    Multiname::new(activation.avm2().public_namespace_base_version, "int"),
+                    activation.avm2().multinames.int,
                     Some(value.into()),
                 ),
             );
@@ -1121,7 +1121,7 @@ impl<'gc> Class<'gc> {
             &'static str,
             NativeMethodImpl,
             Vec<ParamConfig<'gc>>,
-            Multiname<'gc>,
+            Gc<'gc, Multiname<'gc>>,
         )>,
     ) {
         for (name, value, params, return_type) in items {
@@ -1198,7 +1198,7 @@ impl<'gc> Class<'gc> {
                 activation.context.gc_context,
                 Trait::from_const(
                     QName::new(namespace, name),
-                    Multiname::new(activation.avm2().public_namespace_base_version, "int"),
+                    activation.avm2().multinames.int,
                     Some(value.into()),
                 ),
             );

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -524,7 +524,7 @@ impl<'gc> Class<'gc> {
                     // A 'callable' class doesn't have a signature - let the
                     // method do any needed coercions
                     vec![],
-                    Gc::new(activation.gc(), Multiname::any()),
+                    activation.avm2().multinames.any,
                     true,
                     activation.context.gc_context,
                 );
@@ -1029,11 +1029,7 @@ impl<'gc> Class<'gc> {
     ) {
         self.define_instance_trait(
             activation.context.gc_context,
-            Trait::from_const(
-                name,
-                activation.avm2().multinames.function,
-                Some(value),
-            ),
+            Trait::from_const(name, activation.avm2().multinames.function, Some(value)),
         );
     }
 

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -2,7 +2,6 @@ use crate::avm2::activation::Activation;
 use crate::avm2::api_version::ApiVersion;
 use crate::avm2::class::Class;
 use crate::avm2::domain::Domain;
-use crate::avm2::multiname::Multiname;
 use crate::avm2::object::{ClassObject, ScriptObject, TObject};
 use crate::avm2::scope::{Scope, ScopeChain};
 use crate::avm2::script::Script;
@@ -613,7 +612,7 @@ pub fn load_player_globals<'gc>(
         // right now.
         global_traits.push(Trait::from_const(
             qname,
-            Multiname::new(public_ns, "Function"),
+            activation.avm2().multinames.function,
             Some(Value::Null),
         ));
     }

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -433,10 +433,7 @@ fn describe_internal_body<'gc>(
                     let setter = vtable
                         .get_full_method(*set)
                         .unwrap_or_else(|| panic!("Missing 'set' method for id {set:?}"));
-                    (
-                        setter.method.signature()[0].param_type_name.clone(),
-                        setter.class,
-                    )
+                    (setter.method.signature()[0].param_type_name, setter.class)
                 } else {
                     unreachable!();
                 };

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -302,7 +302,8 @@ fn describe_internal_body<'gc>(
                 if !flags.contains(DescribeTypeFlags::INCLUDE_VARIABLES) {
                     continue;
                 }
-                let prop_class_name = vtable.slot_class_name(mc, *slot_id)?;
+                let prop_class_name =
+                    vtable.slot_class_name(&mut activation.borrow_gc(), *slot_id)?;
 
                 let access = match prop {
                     Property::ConstSlot { .. } => "readonly",
@@ -356,7 +357,10 @@ fn describe_internal_body<'gc>(
                     continue;
                 }
 
-                let return_type_name = method.method.return_type().to_qualified_name_or_star(mc);
+                let return_type_name = method
+                    .method
+                    .return_type()
+                    .to_qualified_name_or_star(&mut activation.borrow_gc());
                 let declared_by = method.class;
 
                 if flags.contains(DescribeTypeFlags::HIDE_OBJECT)
@@ -453,7 +457,8 @@ fn describe_internal_body<'gc>(
                     Some(ns.as_uri())
                 };
 
-                let accessor_type = method_type.to_qualified_name_or_star(mc);
+                let accessor_type =
+                    method_type.to_qualified_name_or_star(&mut activation.borrow_gc());
                 let declared_by = defining_class.dollar_removed_name(mc).to_qualified_name(mc);
 
                 let accessor_obj = activation
@@ -541,7 +546,7 @@ fn write_params<'gc>(
     for param in method.signature() {
         let param_type_name = param
             .param_type_name
-            .to_qualified_name_or_star(activation.context.gc_context);
+            .to_qualified_name_or_star(&mut activation.borrow_gc());
         let optional = param.default_value.is_some();
         let param_obj = activation
             .avm2()

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -9,6 +9,8 @@ use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::{AvmString, Error, Multiname, QName};
 
+use gc_arena::Gc;
+
 /// Implements `int`'s instance initializer.
 fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
@@ -227,10 +229,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             "<int instance initializer>",
             vec![ParamConfig {
                 param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
-                param_type_name: Multiname::any(),
+                param_type_name: Gc::new(mc, Multiname::any()),
                 default_value: Some(Value::Integer(0)),
             }],
-            Multiname::any(),
+            Gc::new(mc, Multiname::any()),
             true,
             mc,
         ),

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -7,9 +7,7 @@ use crate::avm2::globals::number::print_with_radix;
 use crate::avm2::method::{Method, NativeMethodImpl, ParamConfig};
 use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
-use crate::avm2::{AvmString, Error, Multiname, QName};
-
-use gc_arena::Gc;
+use crate::avm2::{AvmString, Error, QName};
 
 /// Implements `int`'s instance initializer.
 fn instance_init<'gc>(
@@ -229,10 +227,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             "<int instance initializer>",
             vec![ParamConfig {
                 param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
-                param_type_name: Gc::new(mc, Multiname::any()),
+                param_type_name: activation.avm2().multinames.any,
                 default_value: Some(Value::Integer(0)),
             }],
-            Gc::new(mc, Multiname::any()),
+            activation.avm2().multinames.any,
             true,
             mc,
         ),

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -10,6 +10,8 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::QName;
 
+use gc_arena::Gc;
+
 /// Implements `Object`'s instance initializer.
 pub fn instance_init<'gc>(
     _activation: &mut Activation<'_, 'gc>,
@@ -279,30 +281,30 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             has_own_property,
             vec![ParamConfig::optional(
                 "name",
-                Multiname::any(),
+                Gc::new(gc_context, Multiname::any()),
                 Value::Undefined,
             )],
-            Multiname::new(activation.avm2().public_namespace_base_version, "Boolean"),
+            activation.avm2().multinames.boolean,
         ),
         (
             "isPrototypeOf",
             is_prototype_of,
             vec![ParamConfig::optional(
                 "theClass",
-                Multiname::any(),
+                Gc::new(gc_context, Multiname::any()),
                 Value::Undefined,
             )],
-            Multiname::new(activation.avm2().public_namespace_base_version, "Boolean"),
+            activation.avm2().multinames.boolean,
         ),
         (
             "propertyIsEnumerable",
             property_is_enumerable,
             vec![ParamConfig::optional(
                 "name",
-                Multiname::any(),
+                Gc::new(gc_context, Multiname::any()),
                 Value::Undefined,
             )],
-            Multiname::new(activation.avm2().public_namespace_base_version, "Boolean"),
+            activation.avm2().multinames.boolean,
         ),
     ];
     object_i_class.define_builtin_instance_methods_with_sig(
@@ -337,7 +339,7 @@ pub fn create_c_class<'gc>(
         gc_context,
         Trait::from_const(
             QName::new(activation.avm2().public_namespace_base_version, "length"),
-            Multiname::new(activation.avm2().public_namespace_base_version, "int"),
+            activation.avm2().multinames.int,
             Some(1.into()),
         ),
     );

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -7,10 +7,7 @@ use crate::avm2::object::{FunctionObject, Object, TObject};
 use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::avm2::Multiname;
 use crate::avm2::QName;
-
-use gc_arena::Gc;
 
 /// Implements `Object`'s instance initializer.
 pub fn instance_init<'gc>(
@@ -281,7 +278,7 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             has_own_property,
             vec![ParamConfig::optional(
                 "name",
-                Gc::new(gc_context, Multiname::any()),
+                activation.avm2().multinames.any,
                 Value::Undefined,
             )],
             activation.avm2().multinames.boolean,
@@ -291,7 +288,7 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             is_prototype_of,
             vec![ParamConfig::optional(
                 "theClass",
-                Gc::new(gc_context, Multiname::any()),
+                activation.avm2().multinames.any,
                 Value::Undefined,
             )],
             activation.avm2().multinames.boolean,
@@ -301,7 +298,7 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             property_is_enumerable,
             vec![ParamConfig::optional(
                 "name",
-                Gc::new(gc_context, Multiname::any()),
+                activation.avm2().multinames.any,
                 Value::Undefined,
             )],
             activation.avm2().multinames.boolean,

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -9,6 +9,8 @@ use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::{AvmString, Error, Multiname, QName};
 
+use gc_arena::Gc;
+
 /// Implements `uint`'s instance initializer.
 fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
@@ -228,10 +230,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             "<uint instance initializer>",
             vec![ParamConfig {
                 param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
-                param_type_name: Multiname::any(),
+                param_type_name: Gc::new(mc, Multiname::any()),
                 default_value: Some(Value::Integer(0)),
             }],
-            Multiname::any(),
+            Gc::new(mc, Multiname::any()),
             true,
             mc,
         ),

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -7,9 +7,7 @@ use crate::avm2::globals::number::print_with_radix;
 use crate::avm2::method::{Method, NativeMethodImpl, ParamConfig};
 use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
-use crate::avm2::{AvmString, Error, Multiname, QName};
-
-use gc_arena::Gc;
+use crate::avm2::{AvmString, Error, QName};
 
 /// Implements `uint`'s instance initializer.
 fn instance_init<'gc>(
@@ -230,10 +228,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             "<uint instance initializer>",
             vec![ParamConfig {
                 param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
-                param_type_name: Gc::new(mc, Multiname::any()),
+                param_type_name: activation.avm2().multinames.any,
                 default_value: Some(Value::Integer(0)),
             }],
-            Gc::new(mc, Multiname::any()),
+            activation.avm2().multinames.any,
             true,
             mc,
         ),

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -166,7 +166,7 @@ impl<'gc> BytecodeMethod<'gc> {
 
         let abc = txunit.abc();
         let mut signature = Vec::new();
-        let mut return_type = Gc::new(mc, Multiname::any());
+        let mut return_type = activation.avm2().multinames.any;
         let mut abc_method_body = None;
 
         if abc.methods.get(abc_method.0 as usize).is_some() {

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -464,9 +464,11 @@ impl<'gc> Multiname<'gc> {
 
     /// Like `to_qualified_name`, but returns `*` if `self.is_any()` is true.
     /// This is used by `describeType`
-    pub fn to_qualified_name_or_star(&self, mc: &Mutation<'gc>) -> AvmString<'gc> {
+    pub fn to_qualified_name_or_star(&self, context: &mut GcContext<'_, 'gc>) -> AvmString<'gc> {
+        let mc = context.gc_context;
+
         if self.is_any_name() {
-            AvmString::new_utf8(mc, "*")
+            context.interner.get_char(mc, '*' as u16)
         } else {
             self.to_qualified_name(mc)
         }

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -523,6 +523,8 @@ impl<'gc> From<QName<'gc>> for Multiname<'gc> {
 #[derive(Collect)]
 #[collect(no_drop)]
 pub struct CommonMultinames<'gc> {
+    pub any: Gc<'gc, Multiname<'gc>>,
+
     pub boolean: Gc<'gc, Multiname<'gc>>,
     pub function: Gc<'gc, Multiname<'gc>>,
     pub int: Gc<'gc, Multiname<'gc>>,
@@ -535,9 +537,11 @@ impl<'gc> CommonMultinames<'gc> {
         context: &mut GcContext<'_, 'gc>,
         public_namespace_base_version: Namespace<'gc>,
     ) -> Self {
+        let mc = context.gc_context;
+
         let mut create_pub_multiname = |local_name: &'static [u8]| -> Gc<'gc, Multiname<'gc>> {
             Gc::new(
-                context.gc_context,
+                mc,
                 Multiname::new(
                     public_namespace_base_version,
                     context
@@ -548,6 +552,7 @@ impl<'gc> CommonMultinames<'gc> {
         };
 
         Self {
+            any: Gc::new(mc, Multiname::any()),
             boolean: create_pub_multiname(b"Boolean"),
             function: create_pub_multiname(b"Function"),
             int: create_pub_multiname(b"int"),

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -8,7 +8,7 @@ use crate::avm2::object::script_object::{ScriptObject, ScriptObjectData};
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::scope::ScopeChain;
 use crate::avm2::value::Value;
-use crate::avm2::{Error, Multiname};
+use crate::avm2::Error;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{
@@ -39,7 +39,7 @@ pub fn function_allocator<'gc>(
             name: "<Empty Function>",
             signature: vec![],
             resolved_signature: GcCell::new(mc, None),
-            return_type: Gc::new(mc, Multiname::any()),
+            return_type: activation.avm2().multinames.any,
             is_variadic: true,
         },
     );

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -30,20 +30,22 @@ pub fn function_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
+    let mc = activation.gc();
+
     let dummy = Gc::new(
-        activation.context.gc_context,
+        mc,
         NativeMethod {
             method: |_, _, _| Ok(Value::Undefined),
             name: "<Empty Function>",
             signature: vec![],
-            resolved_signature: GcCell::new(activation.context.gc_context, None),
-            return_type: Multiname::any(),
+            resolved_signature: GcCell::new(mc, None),
+            return_type: Gc::new(mc, Multiname::any()),
             is_variadic: true,
         },
     );
 
     Ok(FunctionObject(Gc::new(
-        activation.context.gc_context,
+        mc,
         FunctionObjectData {
             base,
             exec: RefLock::new(BoundMethod::from_method(

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -5,6 +5,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::TranslationUnit;
 use crate::avm2::Value;
+use crate::context::GcContext;
 use crate::string::AvmString;
 use gc_arena::{Collect, Gc, Mutation};
 
@@ -128,11 +129,13 @@ impl<'gc> PropertyClass<'gc> {
         }
     }
 
-    pub fn get_name(&self, mc: &Mutation<'gc>) -> AvmString<'gc> {
+    pub fn get_name(&self, context: &mut GcContext<'_, 'gc>) -> AvmString<'gc> {
+        let mc = context.gc_context;
+
         match self {
             PropertyClass::Class(class) => class.name().to_qualified_name(mc),
-            PropertyClass::Name(gc) => gc.0.to_qualified_name_or_star(mc),
-            PropertyClass::Any => AvmString::new_utf8(mc, "*"),
+            PropertyClass::Name(gc) => gc.0.to_qualified_name_or_star(context),
+            PropertyClass::Any => context.interner.get_char(mc, '*' as u16),
         }
     }
 }

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -392,8 +392,7 @@ impl<'gc> TranslationUnit<'gc> {
         context: &mut UpdateContext<'gc>,
     ) -> Result<Gc<'gc, Multiname<'gc>>, Error<'gc>> {
         if multiname_index.0 == 0 {
-            let mc = context.gc_context;
-            Ok(Gc::new(mc, Multiname::any()))
+            Ok(context.avm2.multinames.any)
         } else {
             self.pool_multiname_static(multiname_index, context)
         }

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -10,8 +10,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::QName;
 use bitflags::bitflags;
-use gc_arena::Collect;
-use std::ops::Deref;
+use gc_arena::{Collect, Gc};
 use swf::avm2::types::{
     DefaultValue as AbcDefaultValue, Trait as AbcTrait, TraitKind as AbcTraitKind,
 };
@@ -75,7 +74,7 @@ pub enum TraitKind<'gc> {
     /// to.
     Slot {
         slot_id: u32,
-        type_name: Multiname<'gc>,
+        type_name: Gc<'gc, Multiname<'gc>>,
         default_value: Value<'gc>,
         unit: Option<TranslationUnit<'gc>>,
     },
@@ -100,7 +99,7 @@ pub enum TraitKind<'gc> {
     /// be overridden.
     Const {
         slot_id: u32,
-        type_name: Multiname<'gc>,
+        type_name: Gc<'gc, Multiname<'gc>>,
         default_value: Value<'gc>,
         unit: Option<TranslationUnit<'gc>>,
     },
@@ -157,7 +156,7 @@ impl<'gc> Trait<'gc> {
 
     pub fn from_slot(
         name: QName<'gc>,
-        type_name: Multiname<'gc>,
+        type_name: Gc<'gc, Multiname<'gc>>,
         default_value: Option<Value<'gc>>,
     ) -> Self {
         Trait {
@@ -175,7 +174,7 @@ impl<'gc> Trait<'gc> {
 
     pub fn from_const(
         name: QName<'gc>,
-        type_name: Multiname<'gc>,
+        type_name: Gc<'gc, Multiname<'gc>>,
         default_value: Option<Value<'gc>>,
     ) -> Self {
         Trait {
@@ -205,10 +204,7 @@ impl<'gc> Trait<'gc> {
                 type_name,
                 value,
             } => {
-                let type_name = unit
-                    .pool_multiname_static_any(*type_name, activation.context)?
-                    .deref()
-                    .clone();
+                let type_name = unit.pool_multiname_static_any(*type_name, activation.context)?;
                 let default_value = slot_default_value(unit, value, &type_name, activation)?;
                 Trait {
                     name,
@@ -272,10 +268,7 @@ impl<'gc> Trait<'gc> {
                 type_name,
                 value,
             } => {
-                let type_name = unit
-                    .pool_multiname_static_any(*type_name, activation.context)?
-                    .deref()
-                    .clone();
+                let type_name = unit.pool_multiname_static_any(*type_name, activation.context)?;
                 let default_value = slot_default_value(unit, value, &type_name, activation)?;
                 Trait {
                     name,

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -112,13 +112,17 @@ impl<'gc> VTable<'gc> {
         self.0.read().disp_metadata_table.get(disp_id).cloned()
     }
 
-    pub fn slot_class_name(&self, slot_id: u32) -> Result<Multiname<'gc>, Error<'gc>> {
+    pub fn slot_class_name(
+        &self,
+        mc: &Mutation<'gc>,
+        slot_id: u32,
+    ) -> Result<AvmString<'gc>, Error<'gc>> {
         self.0
             .read()
             .slot_classes
             .get(slot_id as usize)
             .ok_or_else(|| "Invalid slot ID".into())
-            .map(|c| c.get_name())
+            .map(|c| c.get_name(mc))
     }
 
     pub fn get_trait(self, name: &Multiname<'gc>) -> Option<Property> {

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -460,13 +460,13 @@ impl<'gc> VTable<'gc> {
                             type_name, unit, ..
                         } => (
                             Property::new_slot(new_slot_id),
-                            PropertyClass::name(mc, type_name.clone(), *unit),
+                            PropertyClass::name(mc, *type_name, *unit),
                         ),
                         TraitKind::Const {
                             type_name, unit, ..
                         } => (
                             Property::new_const_slot(new_slot_id),
-                            PropertyClass::name(mc, type_name.clone(), *unit),
+                            PropertyClass::name(mc, *type_name, *unit),
                         ),
                         TraitKind::Class { class, .. } => (
                             Property::new_const_slot(new_slot_id),

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -8,6 +8,7 @@ use crate::avm2::scope::ScopeChain;
 use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::value::Value;
 use crate::avm2::{Class, Error, Multiname, Namespace, QName};
+use crate::context::GcContext;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::cell::Ref;
@@ -114,7 +115,7 @@ impl<'gc> VTable<'gc> {
 
     pub fn slot_class_name(
         &self,
-        mc: &Mutation<'gc>,
+        context: &mut GcContext<'_, 'gc>,
         slot_id: u32,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         self.0
@@ -122,7 +123,7 @@ impl<'gc> VTable<'gc> {
             .slot_classes
             .get(slot_id as usize)
             .ok_or_else(|| "Invalid slot ID".into())
-            .map(|c| c.get_name(mc))
+            .map(|c| c.get_name(context))
     }
 
     pub fn get_trait(self, name: &Multiname<'gc>) -> Option<Property> {


### PR DESCRIPTION
Return types, slot types, and parameter types are all behind Gcs now. To avoid recreating the same Multiname several times while adding traits to classes, a `CommonMultinames` structure storing some common multinames has been added to `Avm2`.