### PR TITLE
avm2: Return actual VerifyErrors for constant pool errors

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -732,9 +732,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         method: Gc<'gc, BytecodeMethod<'gc>>,
         index: Index<AbcNamespace>,
     ) -> Result<Namespace<'gc>, Error<'gc>> {
-        method
-            .translation_unit()
-            .pool_namespace(index, self.context)
+        method.translation_unit().pool_namespace(self, index)
     }
 
     /// Retrieve a method entry from the current ABC file's method table.

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -439,45 +439,39 @@ impl<'gc> Class<'gc> {
             .ok_or_else(|| "LoadError: Instance index not valid".into());
         let abc_instance = abc_instance?;
 
-        let name = QName::from_abc_multiname(unit, abc_instance.name, activation.context)?;
+        let name = QName::from_abc_multiname(activation, unit, abc_instance.name)?;
+
         let super_class = if abc_instance.super_name.0 == 0 {
             None
         } else {
-            let multiname =
-                unit.pool_multiname_static(abc_instance.super_name, activation.context)?;
+            let multiname = unit.pool_multiname_static(activation, abc_instance.super_name)?;
 
             Some(
                 activation
                     .domain()
                     .get_class(activation.context, &multiname)
                     .ok_or_else(|| {
-                        make_error_1014(
-                            activation,
-                            multiname.to_qualified_name(activation.context.gc_context),
-                        )
+                        make_error_1014(activation, multiname.to_qualified_name(activation.gc()))
                     })?,
             )
         };
 
         let protected_namespace = if let Some(ns) = &abc_instance.protected_namespace {
-            Some(unit.pool_namespace(*ns, activation.context)?)
+            Some(unit.pool_namespace(activation, *ns)?)
         } else {
             None
         };
 
         let mut interfaces = Vec::with_capacity(abc_instance.interfaces.len());
         for interface_name in &abc_instance.interfaces {
-            let multiname = unit.pool_multiname_static(*interface_name, activation.context)?;
+            let multiname = unit.pool_multiname_static(activation, *interface_name)?;
 
             interfaces.push(
                 activation
                     .domain()
                     .get_class(activation.context, &multiname)
                     .ok_or_else(|| {
-                        make_error_1014(
-                            activation,
-                            multiname.to_qualified_name(activation.context.gc_context),
-                        )
+                        make_error_1014(activation, multiname.to_qualified_name(activation.gc()))
                     })?,
             );
         }

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -255,6 +255,16 @@ pub fn make_error_1032<'gc>(activation: &mut Activation<'_, 'gc>, index: u32) ->
 
 #[inline(never)]
 #[cold]
+pub fn make_error_1033<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
+    let err = verify_error(activation, "Error #1033: Cpool entry is wrong type.", 1033);
+    match err {
+        Ok(err) => Error::AvmError(err),
+        Err(err) => err,
+    }
+}
+
+#[inline(never)]
+#[cold]
 pub fn make_error_1054<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
     let err = verify_error(
         activation,
@@ -279,6 +289,20 @@ pub fn make_error_1065<'gc>(
         activation,
         &format!("Error #1065: Variable {qualified_name} is not defined."),
         1065,
+    );
+    match err {
+        Ok(err) => Error::AvmError(err),
+        Err(err) => err,
+    }
+}
+
+#[inline(never)]
+#[cold]
+pub fn make_error_1080<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
+    let err = type_error(
+        activation,
+        "Error #1080: Illegal value for namespace.",
+        1080,
     );
     match err {
         Ok(err) => Error::AvmError(err),
@@ -540,6 +564,20 @@ pub fn make_error_2008<'gc>(activation: &mut Activation<'_, 'gc>, param_name: &s
 
 #[inline(never)]
 #[cold]
+pub fn make_error_2025<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
+    let err = argument_error(
+        activation,
+        "Error #2025: The supplied DisplayObject must be a child of the caller.",
+        2025,
+    );
+    match err {
+        Ok(err) => Error::AvmError(err),
+        Err(err) => err,
+    }
+}
+
+#[inline(never)]
+#[cold]
 pub fn make_error_2027<'gc>(activation: &mut Activation<'_, 'gc>, value: i32) -> Error<'gc> {
     let err = range_error(
         activation,
@@ -593,20 +631,6 @@ pub fn make_error_2097<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
         activation,
         "Error #2097: The FileFilter Array is not in the correct format.",
         2097,
-    );
-    match err {
-        Ok(err) => Error::AvmError(err),
-        Err(err) => err,
-    }
-}
-
-#[inline(never)]
-#[cold]
-pub fn make_error_2025<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
-    let err = argument_error(
-        activation,
-        "Error #2025: The supplied DisplayObject must be a child of the caller.",
-        2025,
     );
     match err {
         Ok(err) => Error::AvmError(err),

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -79,7 +79,7 @@ impl<'gc> ParamConfig<'gc> {
         } else {
             AvmString::from("<Unnamed Parameter>")
         };
-        let param_type_name = txunit.pool_multiname_static_any(config.kind, activation.context)?;
+        let param_type_name = txunit.pool_multiname_static_any(activation, config.kind)?;
 
         let default_value = if let Some(dv) = &config.default_value {
             Some(abc_default_value(txunit, dv, activation)?)
@@ -175,8 +175,7 @@ impl<'gc> BytecodeMethod<'gc> {
                 signature.push(ParamConfig::from_abc_param(param, txunit, activation)?);
             }
 
-            return_type =
-                txunit.pool_multiname_static_any(method.return_type, activation.context)?;
+            return_type = txunit.pool_multiname_static_any(activation, method.return_type)?;
 
             if let Some(body) = method.body {
                 abc_method_body = Some(body.0);

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -1,5 +1,5 @@
+use crate::avm2::activation::Activation;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use crate::string::{AvmAtom, AvmString};
 use crate::{avm2::script::TranslationUnit, context::GcContext};
 use gc_arena::{Collect, Gc};
@@ -82,13 +82,15 @@ impl<'gc> Namespace<'gc> {
     /// otherwise you run a risk of creating a duplicate of private ns singleton.
     /// Based on https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/AbcParser.cpp#L1459
     pub fn from_abc_namespace(
+        activation: &mut Activation<'_, 'gc>,
         translation_unit: TranslationUnit<'gc>,
         namespace_index: Index<AbcNamespace>,
-        context: &mut UpdateContext<'gc>,
     ) -> Result<Self, Error<'gc>> {
         if namespace_index.0 == 0 {
             return Ok(Self::any());
         }
+
+        let mc = activation.gc();
 
         let actual_index = namespace_index.0 as usize - 1;
         let abc = translation_unit.abc();
@@ -109,12 +111,13 @@ impl<'gc> Namespace<'gc> {
             | AbcNamespace::Private(idx) => idx,
         };
 
-        let mut namespace_name = translation_unit.pool_string(index.0, &mut context.borrow_gc())?;
+        let mut namespace_name =
+            translation_unit.pool_string(index.0, &mut activation.borrow_gc())?;
 
         // Private namespaces don't get any of the namespace version checks
         if let AbcNamespace::Private(_) = abc_namespace {
             return Ok(Self(Some(Gc::new(
-                context.gc_context,
+                mc,
                 NamespaceData::Private(namespace_name),
             ))));
         }
@@ -159,14 +162,14 @@ impl<'gc> Namespace<'gc> {
         let api_version = if index.0 != 0 {
             let is_playerglobals = translation_unit
                 .domain()
-                .is_playerglobals_domain(context.avm2);
+                .is_playerglobals_domain(activation.avm2());
 
             let mut api_version = ApiVersion::AllVersions;
             let stripped = strip_version_mark(namespace_name.as_wstr(), is_playerglobals);
             let has_version_mark = stripped.is_some();
             if let Some((stripped, version)) = stripped {
-                let stripped_string = AvmString::new(context.gc_context, stripped);
-                namespace_name = context.interner.intern(context.gc_context, stripped_string);
+                let stripped_string = AvmString::new(mc, stripped);
+                namespace_name = activation.context.interner.intern(mc, stripped_string);
                 api_version = version;
             }
 
@@ -191,9 +194,9 @@ impl<'gc> Namespace<'gc> {
                 // However, there's no reason to hold on to invalid API versions for the
                 // current active series (player runtime), so let's just do the conversion immediately.
                 api_version =
-                    api_version.to_valid_playerglobals_version(context.avm2.player_runtime);
+                    api_version.to_valid_playerglobals_version(activation.avm2().player_runtime);
             } else if is_public {
-                api_version = translation_unit.api_version(context.avm2);
+                api_version = translation_unit.api_version(activation.avm2());
             };
             api_version
         } else {
@@ -201,7 +204,7 @@ impl<'gc> Namespace<'gc> {
             // However, Flash Player appears to always use the root SWF api version
             // for all swfs (e.g. those loaded through `Loader`). We can simply our code
             // by skipping walking the stack, and just using the API version of our root SWF.
-            context.avm2.root_api_version
+            activation.avm2().root_api_version
         };
 
         let ns = match abc_namespace {
@@ -214,7 +217,7 @@ impl<'gc> Namespace<'gc> {
             AbcNamespace::StaticProtected(_) => NamespaceData::StaticProtected(namespace_name),
             AbcNamespace::Private(_) => unreachable!(),
         };
-        Ok(Self(Some(Gc::new(context.gc_context, ns))))
+        Ok(Self(Some(Gc::new(mc, ns))))
     }
 
     pub fn any() -> Self {

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -65,7 +65,7 @@ impl<'gc> PropertyClass<'gc> {
             PropertyClass::Class(class) => (Some(*class), false),
             PropertyClass::Name(gc) => {
                 let (name, unit) = &**gc;
-                if name.is_any_name() {
+                if name.is_any_namespace() && name.is_any_name() {
                     *self = PropertyClass::Any;
                     (None, true)
                 } else {
@@ -108,7 +108,7 @@ impl<'gc> PropertyClass<'gc> {
             PropertyClass::Class(class) => Ok(Some(*class)),
             PropertyClass::Name(gc) => {
                 let (name, unit) = &**gc;
-                if name.is_any_name() {
+                if name.is_any_namespace() && name.is_any_name() {
                     *self = PropertyClass::Any;
                     Ok(None)
                 } else {

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -196,7 +196,7 @@ impl<'gc> Trait<'gc> {
         abc_trait: &AbcTrait,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
-        let name = QName::from_abc_multiname(unit, abc_trait.name, activation.context)?;
+        let name = QName::from_abc_multiname(activation, unit, abc_trait.name)?;
 
         Ok(match &abc_trait.kind {
             AbcTraitKind::Slot {
@@ -204,7 +204,7 @@ impl<'gc> Trait<'gc> {
                 type_name,
                 value,
             } => {
-                let type_name = unit.pool_multiname_static_any(*type_name, activation.context)?;
+                let type_name = unit.pool_multiname_static_any(activation, *type_name)?;
                 let default_value = slot_default_value(unit, value, &type_name, activation)?;
                 Trait {
                     name,
@@ -268,7 +268,7 @@ impl<'gc> Trait<'gc> {
                 type_name,
                 value,
             } => {
-                let type_name = unit.pool_multiname_static_any(*type_name, activation.context)?;
+                let type_name = unit.pool_multiname_static_any(activation, *type_name)?;
                 let default_value = slot_default_value(unit, value, &type_name, activation)?;
                 Trait {
                     name,

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -534,7 +534,7 @@ pub fn abc_default_value<'gc>(
         | AbcDefaultValue::Explicit(ns)
         | AbcDefaultValue::StaticProtected(ns)
         | AbcDefaultValue::Private(ns) => {
-            let ns = translation_unit.pool_namespace(*ns, activation.context)?;
+            let ns = translation_unit.pool_namespace(activation, *ns)?;
             NamespaceObject::from_namespace(activation, ns).map(Into::into)
         }
     }

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -314,7 +314,7 @@ pub fn verify_method<'gc>(
                 AbcOp::FindDef { index } => {
                     let multiname = method
                         .translation_unit()
-                        .pool_maybe_uninitialized_multiname(index, activation.context)?;
+                        .pool_maybe_uninitialized_multiname(activation, index)?;
 
                     if multiname.has_lazy_component() {
                         return Err(Error::AvmError(verify_error(
@@ -328,7 +328,7 @@ pub fn verify_method<'gc>(
                 AbcOp::GetLex { index } => {
                     let multiname = method
                         .translation_unit()
-                        .pool_maybe_uninitialized_multiname(index, activation.context)?;
+                        .pool_maybe_uninitialized_multiname(activation, index)?;
 
                     if multiname.has_lazy_component() {
                         return Err(Error::AvmError(verify_error(
@@ -370,7 +370,7 @@ pub fn verify_method<'gc>(
                 | AbcOp::Coerce { index: name_index } => {
                     let multiname = method
                         .translation_unit()
-                        .pool_maybe_uninitialized_multiname(name_index, activation.context)?;
+                        .pool_maybe_uninitialized_multiname(activation, name_index)?;
 
                     if multiname.has_lazy_component() {
                         // This matches FP's error message
@@ -419,7 +419,7 @@ pub fn verify_method<'gc>(
         } else {
             let pooled_type_name = method
                 .translation_unit()
-                .pool_maybe_uninitialized_multiname(exception.type_name, activation.context)?;
+                .pool_maybe_uninitialized_multiname(activation, exception.type_name)?;
 
             if pooled_type_name.has_lazy_component() {
                 // This matches FP's error message
@@ -444,7 +444,7 @@ pub fn verify_method<'gc>(
         } else {
             let pooled_variable_name = method
                 .translation_unit()
-                .pool_maybe_uninitialized_multiname(exception.variable_name, activation.context)?;
+                .pool_maybe_uninitialized_multiname(activation, exception.variable_name)?;
 
             // FIXME: avmplus also seems to check the namespace(s)?
             if pooled_variable_name.has_lazy_component()
@@ -831,11 +831,9 @@ fn pool_multiname<'gc>(
     translation_unit: TranslationUnit<'gc>,
     index: Index<AbcMultiname>,
 ) -> Result<Gc<'gc, Multiname<'gc>>, Error<'gc>> {
-    if index.0 == 0 {
-        return Err(make_error_1032(activation, 0));
-    }
-
-    translation_unit.pool_maybe_uninitialized_multiname(index, activation.context)
+    // `Multiname::from_abc_index` will do constant pool range checks anyway, so
+    // don't perform an extra one here
+    translation_unit.pool_maybe_uninitialized_multiname(activation, index)
 }
 
 fn pool_string<'gc>(


### PR DESCRIPTION
This requires passing around an Activation in some places. The PR also adds better verification for `Class` and slot names.

`Any` namespaces can now only be found in Multinames with a `NamespaceSet::Single`.