### PR TITLE
desktop: Add filesystem access dialog

### DIFF
--- a/desktop/assets/texts/en-US/filesystem_access_dialog.ftl
+++ b/desktop/assets/texts/en-US/filesystem_access_dialog.ftl
@@ -1,0 +1,7 @@
+filesystem-access-dialog-title = Requesting Filesystem Access
+
+filesystem-access-dialog-message = The current movie is attempting to read the following file. Do you want to allow it?
+filesystem-access-dialog-allow-remember-message = Do not ask again for files from the following directory for the duration of this session:
+
+filesystem-access-dialog-allow = Allow
+filesystem-access-dialog-allow-remember = Allow and Remember

--- a/desktop/src/backends/navigator.rs
+++ b/desktop/src/backends/navigator.rs
@@ -3,13 +3,17 @@ use ruffle_frontend_utils::backends::navigator::NavigatorInterface;
 use std::fs::File;
 use std::io;
 use std::io::ErrorKind;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
 use url::Url;
 use winit::event_loop::EventLoopProxy;
 
+use crate::cli::FilesystemAccessMode;
 use crate::custom_event::RuffleEvent;
+use crate::gui::dialogs::filesystem_access_dialog::{
+    FilesystemAccessDialogConfiguration, FilesystemAccessDialogResult,
+};
 use crate::gui::dialogs::network_access_dialog::{
     NetworkAccessDialogConfiguration, NetworkAccessDialogResult,
 };
@@ -20,13 +24,45 @@ use crate::util::open_url;
 pub struct DesktopNavigatorInterface {
     // Arc + Mutex due to macOS
     event_loop: Arc<Mutex<EventLoopProxy<RuffleEvent>>>,
+
+    filesystem_access_mode: FilesystemAccessMode,
+
+    // TODO Make this more generic, maybe a manager?
+    allowed_paths: Arc<Mutex<Vec<PathBuf>>>,
 }
 
 impl DesktopNavigatorInterface {
-    pub fn new(event_loop: EventLoopProxy<RuffleEvent>) -> Self {
+    pub fn new(
+        event_loop: EventLoopProxy<RuffleEvent>,
+        movie_path: Option<PathBuf>,
+        filesystem_access_mode: FilesystemAccessMode,
+    ) -> Self {
         Self {
             event_loop: Arc::new(Mutex::new(event_loop)),
+            allowed_paths: Arc::new(Mutex::new(if let Some(movie_path) = movie_path {
+                vec![movie_path]
+            } else {
+                Vec::new()
+            })),
+            filesystem_access_mode,
         }
+    }
+
+    async fn ask_for_filesystem_access(&self, path: &Path) -> bool {
+        let (notifier, receiver) = oneshot::channel();
+        let _ = self
+            .event_loop
+            .lock()
+            .expect("Non-poisoned event loop")
+            .send_event(RuffleEvent::OpenDialog(DialogDescriptor::FilesystemAccess(
+                FilesystemAccessDialogConfiguration::new(
+                    notifier,
+                    self.allowed_paths.clone(),
+                    path.to_path_buf(),
+                ),
+            )));
+
+        receiver.await == Ok(FilesystemAccessDialogResult::Allow)
     }
 }
 
@@ -45,6 +81,18 @@ impl NavigatorInterface for DesktopNavigatorInterface {
     }
 
     async fn open_file(&self, path: &Path) -> io::Result<File> {
+        let path = &path.canonicalize()?;
+
+        let allow = match self.filesystem_access_mode {
+            FilesystemAccessMode::Allow => true,
+            FilesystemAccessMode::Deny => false,
+            FilesystemAccessMode::Ask => self.ask_for_filesystem_access(path).await,
+        };
+
+        if !allow {
+            return Err(ErrorKind::PermissionDenied.into());
+        }
+
         File::open(path).or_else(|e| {
             if cfg!(feature = "sandbox") {
                 use rfd::FileDialog;

--- a/desktop/src/backends/navigator.rs
+++ b/desktop/src/backends/navigator.rs
@@ -37,13 +37,19 @@ impl DesktopNavigatorInterface {
         movie_path: Option<PathBuf>,
         filesystem_access_mode: FilesystemAccessMode,
     ) -> Self {
+        let mut allowed_paths = Vec::new();
+        if let Some(movie_path) = movie_path {
+            if let Some(parent) = movie_path.parent() {
+                // TODO Be smarter here, we do not necessarily want to allow
+                //   access to the SWF's dir, but we also do not want to present
+                //   the dialog to the user too often.
+                allowed_paths.push(parent.to_path_buf());
+            }
+            allowed_paths.push(movie_path);
+        }
         Self {
             event_loop: Arc::new(Mutex::new(event_loop)),
-            allowed_paths: Arc::new(Mutex::new(if let Some(movie_path) = movie_path {
-                vec![movie_path]
-            } else {
-                Vec::new()
-            })),
+            allowed_paths: Arc::new(Mutex::new(allowed_paths)),
             filesystem_access_mode,
         }
     }

--- a/desktop/src/backends/navigator.rs
+++ b/desktop/src/backends/navigator.rs
@@ -44,7 +44,7 @@ impl NavigatorInterface for DesktopNavigatorInterface {
             .send_event(RuffleEvent::OpenDialog(DialogDescriptor::OpenUrl(url)));
     }
 
-    fn open_file(&self, path: &Path) -> io::Result<File> {
+    async fn open_file(&self, path: &Path) -> io::Result<File> {
         File::open(path).or_else(|e| {
             if cfg!(feature = "sandbox") {
                 use rfd::FileDialog;

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -181,6 +181,10 @@ pub struct Opt {
     #[clap(long, default_value = "allow")]
     pub open_url_mode: OpenURLMode,
 
+    /// How to handle non-interactive filesystem access.
+    #[clap(long, default_value = "allow")]
+    pub filesystem_access_mode: FilesystemAccessMode,
+
     /// Provide a dummy (completely empty) External Interface to the movie.
     /// This may break some movies that expect an External Interface to be functional,
     /// but may fix others that always require an External Interface.
@@ -414,4 +418,16 @@ enum NamedKeyCode {
     Backslash = 220,
     RBracket = 221,
     Apostrophe = 222,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
+pub enum FilesystemAccessMode {
+    /// Always allow non-interactive access to the filesystem.
+    Allow,
+
+    /// Refuse all non-interactive access to the filesystem.
+    Deny,
+
+    /// Ask the user before accessing the filesystem non-interactively.
+    Ask,
 }

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -182,7 +182,7 @@ pub struct Opt {
     pub open_url_mode: OpenURLMode,
 
     /// How to handle non-interactive filesystem access.
-    #[clap(long, default_value = "allow")]
+    #[clap(long, default_value = "ask")]
     pub filesystem_access_mode: FilesystemAccessMode,
 
     /// Provide a dummy (completely empty) External Interface to the movie.

--- a/desktop/src/gui/dialogs/filesystem_access_dialog.rs
+++ b/desktop/src/gui/dialogs/filesystem_access_dialog.rs
@@ -1,0 +1,215 @@
+use crate::gui::text;
+use egui::{Align2, ComboBox, Ui, Window};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+use tokio::sync::oneshot::Sender;
+use unic_langid::LanguageIdentifier;
+
+#[derive(PartialEq, Eq, Clone)]
+pub enum FilesystemAccessDialogResult {
+    Allow,
+    Cancel,
+}
+
+pub struct FilesystemAccessDialogConfiguration {
+    notifier: Option<Sender<FilesystemAccessDialogResult>>,
+
+    /// Collection of already allowed paths that can be updated.
+    ///
+    /// TODO Make this more generic, maybe a manager?
+    allowed_paths: Arc<Mutex<Vec<PathBuf>>>,
+
+    /// Path of the file to access.
+    path: PathBuf,
+}
+
+impl FilesystemAccessDialogConfiguration {
+    pub fn new(
+        notifier: Sender<FilesystemAccessDialogResult>,
+        allowed_paths: Arc<Mutex<Vec<PathBuf>>>,
+        path: PathBuf,
+    ) -> Self {
+        Self {
+            notifier: Some(notifier),
+            allowed_paths,
+            path,
+        }
+    }
+}
+
+pub struct FilesystemAccessDialog {
+    config: FilesystemAccessDialogConfiguration,
+
+    /// Whether the user already allowed access to this path.
+    allowed: bool,
+
+    /// Whether the user wants to allow permanent access.
+    remember_access: bool,
+
+    /// What path the user wants to allow permanent access to.
+    selected_path: PathBuf,
+
+    /// Available paths to allow permanent access to.
+    selectable_paths: Vec<PathBuf>,
+}
+
+impl Drop for FilesystemAccessDialog {
+    fn drop(&mut self) {
+        self.respond(FilesystemAccessDialogResult::Cancel);
+    }
+}
+
+impl FilesystemAccessDialog {
+    pub fn new(config: FilesystemAccessDialogConfiguration) -> Self {
+        let allowed = Self::is_path_allowed(&config);
+        let selectable_paths = Self::get_selectable_paths(&config);
+        let selected_path = selectable_paths
+            .first()
+            .cloned()
+            .unwrap_or_else(PathBuf::new);
+
+        Self {
+            config,
+            allowed,
+            remember_access: false,
+            selected_path,
+            selectable_paths,
+        }
+    }
+
+    /// Returns paths that will be shown in the dropdown menu.
+    ///
+    /// It returns parents of the file that the movie wants to access.
+    /// For instance, for the file `/a/b/c/d/e`, this method will return:
+    /// * `/a/b/c/d`,
+    /// * `/a/b/c`,
+    /// * `/a/b`.
+    fn get_selectable_paths(config: &FilesystemAccessDialogConfiguration) -> Vec<PathBuf> {
+        let mut selectable_paths = Vec::new();
+        let mut current_path = config.path.as_path().parent();
+        while let Some(path) = current_path {
+            // Do not return paths shorter than 2 components,
+            // that's usually a bad idea to grant such wide permissions.
+            // Windows does not have a unified filesystem so that does not apply there.
+            if !cfg!(windows) && path.components().count() <= 2 {
+                break;
+            }
+            selectable_paths.push(path.to_path_buf());
+            current_path = path.parent();
+        }
+        selectable_paths
+    }
+
+    /// Checks whether the user already allowed access to the file.
+    ///
+    /// This check needs to be done as late as possible, because we want the
+    /// user's decision to apply to every future dialog,
+    /// not only those requested after the decision.
+    fn is_path_allowed(config: &FilesystemAccessDialogConfiguration) -> bool {
+        for path_prefix in config
+            .allowed_paths
+            .lock()
+            .expect("Non-poisoned lock")
+            .as_slice()
+        {
+            if config.path.starts_with(path_prefix) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn respond(&mut self, result: FilesystemAccessDialogResult) {
+        if let Some(notifier) = std::mem::take(&mut self.config.notifier) {
+            let _ = notifier.send(result);
+        }
+    }
+
+    pub fn show(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) -> bool {
+        if self.allowed {
+            self.respond(FilesystemAccessDialogResult::Allow);
+            return false;
+        }
+
+        let mut keep_open = true;
+        let mut should_close = false;
+
+        Window::new(text(locale, "filesystem-access-dialog-title"))
+            .open(&mut keep_open)
+            .anchor(Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .collapsible(false)
+            .resizable(false)
+            .show(egui_ctx, |ui| {
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    should_close = self.render_window_contents(locale, ui)
+                });
+            });
+
+        keep_open && !should_close
+    }
+
+    pub fn render_window_contents(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) -> bool {
+        let mut should_close = false;
+
+        ui.label(text(locale, "filesystem-access-dialog-message"));
+        ui.label("");
+        ui.monospace(self.config.path.to_string_lossy());
+        ui.label("");
+
+        if !self.selectable_paths.is_empty() {
+            ui.horizontal(|ui| {
+                self.render_checkbox(locale, ui);
+            });
+            ui.label("");
+        }
+
+        ui.horizontal(|ui| {
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                let primary_text = if self.remember_access {
+                    text(locale, "filesystem-access-dialog-allow-remember")
+                } else {
+                    text(locale, "filesystem-access-dialog-allow")
+                };
+                if ui.button(primary_text).clicked() {
+                    if self.remember_access {
+                        self.config
+                            .allowed_paths
+                            .lock()
+                            .expect("Non-poisoned lock")
+                            .push(self.selected_path.clone());
+                    }
+                    self.respond(FilesystemAccessDialogResult::Allow);
+                    should_close = true;
+                }
+                if ui.button(text(locale, "dialog-cancel")).clicked() {
+                    should_close = true;
+                }
+            })
+        });
+
+        should_close
+    }
+
+    fn render_checkbox(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) {
+        ui.checkbox(&mut self.remember_access, "");
+        ui.vertical(|ui| {
+            ui.label(text(
+                locale,
+                "filesystem-access-dialog-allow-remember-message",
+            ));
+            ComboBox::from_id_salt("allow-remember-path-combobox")
+                .selected_text(self.selected_path.to_string_lossy())
+                .show_ui(ui, |ui| {
+                    for path in self.selectable_paths.as_slice() {
+                        ui.selectable_value(
+                            &mut self.selected_path,
+                            path.clone(),
+                            path.to_string_lossy(),
+                        );
+                    }
+                });
+        });
+    }
+}

--- a/frontend-utils/src/content.rs
+++ b/frontend-utils/src/content.rs
@@ -1,8 +1,7 @@
+use crate::backends::navigator::NavigatorInterface;
 use crate::bundle::Bundle;
 use std::fmt::{Debug, Formatter};
-use std::fs::File;
 use std::io::{ErrorKind, Read};
-use std::path::Path;
 use url::Url;
 
 pub enum PlayingContent {
@@ -41,10 +40,10 @@ impl PlayingContent {
         }
     }
 
-    pub fn get_local_file(
+    pub async fn get_local_file(
         &self,
         url: &Url,
-        open_file: impl FnOnce(&Path) -> std::io::Result<File>,
+        interface: impl NavigatorInterface,
     ) -> Result<Vec<u8>, std::io::Error> {
         match self {
             PlayingContent::DirectFile(_) => {
@@ -52,7 +51,7 @@ impl PlayingContent {
                     .to_file_path()
                     .map_err(|_| std::io::Error::other("Could not turn url into file path"))?;
                 let mut result = vec![];
-                let mut file = open_file(&path)?;
+                let mut file = interface.open_file(&path).await?;
                 file.read_to_end(&mut result)?;
                 Ok(result)
             }


### PR DESCRIPTION
This is an attempt to address the issue of movies having unrestricted filesystem access.

When a movie wants to access a local file, a dialog is shown which asks for permission. They user may allow access to the file or to one of the parent directories.

<image src="https://github.com/user-attachments/assets/52a961d2-9b8c-449d-b6e7-112ba3129331" width="500"/>

This behavior can be changed with:
* `--filesystem-access-mode allow`
* `--filesystem-access-mode deny`
* `--filesystem-access-mode ask` (default)

Comments and suggestions are welcome!