### PR TITLE
avm2: Correctly differentiate between Any and null Multiname

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -518,7 +518,7 @@ impl<'gc> Class<'gc> {
                     // A 'callable' class doesn't have a signature - let the
                     // method do any needed coercions
                     vec![],
-                    activation.avm2().multinames.any,
+                    None,
                     true,
                     activation.context.gc_context,
                 );
@@ -1022,8 +1022,12 @@ impl<'gc> Class<'gc> {
         value: Value<'gc>,
     ) {
         self.define_instance_trait(
-            activation.context.gc_context,
-            Trait::from_const(name, activation.avm2().multinames.function, Some(value)),
+            activation.gc(),
+            Trait::from_const(
+                name,
+                Some(activation.avm2().multinames.function),
+                Some(value),
+            ),
         );
     }
 
@@ -1036,10 +1040,10 @@ impl<'gc> Class<'gc> {
     ) {
         for &(name, value) in items {
             self.define_class_trait(
-                activation.context.gc_context,
+                activation.gc(),
                 Trait::from_const(
                     QName::new(namespace, name),
-                    activation.avm2().multinames.number,
+                    Some(activation.avm2().multinames.number),
                     Some(value.into()),
                 ),
             );
@@ -1055,10 +1059,10 @@ impl<'gc> Class<'gc> {
     ) {
         for &(name, value) in items {
             self.define_class_trait(
-                activation.context.gc_context,
+                activation.gc(),
                 Trait::from_const(
                     QName::new(namespace, name),
-                    activation.avm2().multinames.uint,
+                    Some(activation.avm2().multinames.uint),
                     Some(value.into()),
                 ),
             );
@@ -1077,7 +1081,7 @@ impl<'gc> Class<'gc> {
                 activation.context.gc_context,
                 Trait::from_const(
                     QName::new(namespace, name),
-                    activation.avm2().multinames.int,
+                    Some(activation.avm2().multinames.int),
                     Some(value.into()),
                 ),
             );
@@ -1111,7 +1115,7 @@ impl<'gc> Class<'gc> {
             &'static str,
             NativeMethodImpl,
             Vec<ParamConfig<'gc>>,
-            Gc<'gc, Multiname<'gc>>,
+            Option<Gc<'gc, Multiname<'gc>>>,
         )>,
     ) {
         for (name, value, params, return_type) in items {
@@ -1188,7 +1192,7 @@ impl<'gc> Class<'gc> {
                 activation.context.gc_context,
                 Trait::from_const(
                     QName::new(namespace, name),
-                    activation.avm2().multinames.int,
+                    Some(activation.avm2().multinames.int),
                     Some(value.into()),
                 ),
             );

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -1106,6 +1106,7 @@ impl<'gc> Class<'gc> {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     #[inline(never)]
     pub fn define_builtin_instance_methods_with_sig(
         self,

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -221,7 +221,7 @@ impl<'gc> Domain<'gc> {
 
         if let Some(class) = class {
             if let Some(param) = multiname.param() {
-                if !param.is_any_name() {
+                if let Some(param) = param {
                     if let Some(resolved_param) = self.get_class(context, &param) {
                         return Some(Class::with_type_param(context, class, Some(resolved_param)));
                     }

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -118,10 +118,10 @@ impl<'gc> BoundMethod<'gc> {
         }
     }
 
-    pub fn return_type(&self) -> &Multiname<'gc> {
+    pub fn return_type(&self) -> Option<Gc<'gc, Multiname<'gc>>> {
         match &self.method {
-            Method::Native(method) => &method.return_type,
-            Method::Bytecode(method) => &method.return_type,
+            Method::Native(method) => method.return_type,
+            Method::Bytecode(method) => method.return_type,
         }
     }
 }

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -612,7 +612,7 @@ pub fn load_player_globals<'gc>(
         // right now.
         global_traits.push(Trait::from_const(
             qname,
-            activation.avm2().multinames.function,
+            Some(activation.avm2().multinames.function),
             Some(Value::Null),
         ));
     }

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -227,10 +227,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             "<int instance initializer>",
             vec![ParamConfig {
                 param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
-                param_type_name: activation.avm2().multinames.any,
+                param_type_name: None,
                 default_value: Some(Value::Integer(0)),
             }],
-            activation.avm2().multinames.any,
+            None,
             true,
             mc,
         ),

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -276,32 +276,20 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         (
             "hasOwnProperty",
             has_own_property,
-            vec![ParamConfig::optional(
-                "name",
-                activation.avm2().multinames.any,
-                Value::Undefined,
-            )],
-            activation.avm2().multinames.boolean,
+            vec![ParamConfig::optional("name", None, Value::Undefined)],
+            Some(activation.avm2().multinames.boolean),
         ),
         (
             "isPrototypeOf",
             is_prototype_of,
-            vec![ParamConfig::optional(
-                "theClass",
-                activation.avm2().multinames.any,
-                Value::Undefined,
-            )],
-            activation.avm2().multinames.boolean,
+            vec![ParamConfig::optional("theClass", None, Value::Undefined)],
+            Some(activation.avm2().multinames.boolean),
         ),
         (
             "propertyIsEnumerable",
             property_is_enumerable,
-            vec![ParamConfig::optional(
-                "name",
-                activation.avm2().multinames.any,
-                Value::Undefined,
-            )],
-            activation.avm2().multinames.boolean,
+            vec![ParamConfig::optional("name", None, Value::Undefined)],
+            Some(activation.avm2().multinames.boolean),
         ),
     ];
     object_i_class.define_builtin_instance_methods_with_sig(
@@ -336,7 +324,7 @@ pub fn create_c_class<'gc>(
         gc_context,
         Trait::from_const(
             QName::new(activation.avm2().public_namespace_base_version, "length"),
-            activation.avm2().multinames.int,
+            Some(activation.avm2().multinames.int),
             Some(1.into()),
         ),
     );

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -228,10 +228,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             "<uint instance initializer>",
             vec![ParamConfig {
                 param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
-                param_type_name: activation.avm2().multinames.any,
+                param_type_name: None,
                 default_value: Some(Value::Integer(0)),
             }],
-            activation.avm2().multinames.any,
+            None,
             true,
             mc,
         ),

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -39,7 +39,7 @@ pub fn function_allocator<'gc>(
             name: "<Empty Function>",
             signature: vec![],
             resolved_signature: GcCell::new(mc, None),
-            return_type: activation.avm2().multinames.any,
+            return_type: None,
             is_variadic: true,
         },
     );

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -720,6 +720,9 @@ fn handle_input_multiname<'gc>(
 ) -> Multiname<'gc> {
     // Special case to handle code like: xml["@attr"]
     // FIXME: Figure out the exact semantics.
+    // NOTE: It is very important the code within the if-statement is not run
+    // when the passed name has the Any namespace. Otherwise, we run the risk of
+    // creating a NamespaceSet::Multiple with an Any namespace in it.
     if !name.has_explicit_namespace()
         && !name.is_attribute()
         && !name.is_any_name()

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -7,7 +7,7 @@ use crate::avm2::TranslationUnit;
 use crate::avm2::Value;
 use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::{Collect, Gc, Mutation};
+use gc_arena::{Collect, Gc};
 
 use super::class::Class;
 
@@ -36,22 +36,17 @@ pub enum Property {
 #[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub enum PropertyClass<'gc> {
-    /// The type `*` (Multiname::is_any()). This allows
-    /// `Value::Undefined`, so it needs to be distinguished
-    /// from the `Object` class
+    /// The type `*`. This allows `Value::Undefined`, so it needs to
+    /// be distinguished from the `Object` class
     Any,
     Class(Class<'gc>),
-    Name(Gc<'gc, (Gc<'gc, Multiname<'gc>>, Option<TranslationUnit<'gc>>)>),
+    Name(Gc<'gc, Multiname<'gc>>, Option<TranslationUnit<'gc>>),
 }
 
 impl<'gc> PropertyClass<'gc> {
-    pub fn name(
-        mc: &Mutation<'gc>,
-        name: Option<Gc<'gc, Multiname<'gc>>>,
-        unit: Option<TranslationUnit<'gc>>,
-    ) -> Self {
+    pub fn name(name: Option<Gc<'gc, Multiname<'gc>>>, unit: Option<TranslationUnit<'gc>>) -> Self {
         if let Some(name) = name {
-            PropertyClass::Name(Gc::new(mc, (name, unit)))
+            PropertyClass::Name(name, unit)
         } else {
             PropertyClass::Any
         }
@@ -67,9 +62,7 @@ impl<'gc> PropertyClass<'gc> {
     ) -> Result<(Value<'gc>, bool), Error<'gc>> {
         let (class, changed) = match self {
             PropertyClass::Class(class) => (Some(*class), false),
-            PropertyClass::Name(gc) => {
-                let (name, unit) = &**gc;
-
+            PropertyClass::Name(name, unit) => {
                 // Note - we look up the class in the domain by name, which allows us to look up private classes.
                 // This also has the advantage of letting us coerce to a class while the `ClassObject`
                 // is still being constructed (since the `Class` will already exist in the domain).
@@ -104,9 +97,7 @@ impl<'gc> PropertyClass<'gc> {
     ) -> Result<Option<Class<'gc>>, Error<'gc>> {
         match self {
             PropertyClass::Class(class) => Ok(Some(*class)),
-            PropertyClass::Name(gc) => {
-                let (name, unit) = &**gc;
-
+            PropertyClass::Name(name, unit) => {
                 let domain = unit.map_or(activation.avm2().playerglobals_domain, |u| u.domain());
                 if let Some(class) = domain.get_class(activation.context, name) {
                     *self = PropertyClass::Class(class);
@@ -125,7 +116,7 @@ impl<'gc> PropertyClass<'gc> {
     pub fn get_name(&self, context: &mut GcContext<'_, 'gc>) -> AvmString<'gc> {
         match self {
             PropertyClass::Class(class) => class.name().to_qualified_name(context.gc_context),
-            PropertyClass::Name(gc) => gc.0.to_qualified_name_or_star(context),
+            PropertyClass::Name(name, _) => name.to_qualified_name_or_star(context),
             PropertyClass::Any => context.interner.get_ascii_char('*'),
         }
     }

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -386,16 +386,17 @@ impl<'gc> TranslationUnit<'gc> {
     /// Retrieve a static, or non-runtime, multiname from the current constant
     /// pool.
     ///
-    /// This version of the function treats index 0 as the any-type `*`.
+    /// This version of the function returns None for index 0.
     pub fn pool_multiname_static_any(
         self,
         activation: &mut Activation<'_, 'gc>,
         multiname_index: Index<AbcMultiname>,
-    ) -> Result<Gc<'gc, Multiname<'gc>>, Error<'gc>> {
+    ) -> Result<Option<Gc<'gc, Multiname<'gc>>>, Error<'gc>> {
         if multiname_index.0 == 0 {
-            Ok(activation.avm2().multinames.any)
+            Ok(None)
         } else {
             self.pool_multiname_static(activation, multiname_index)
+                .map(Some)
         }
     }
 }

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -64,7 +64,7 @@ fn format_signature(params: &[ParamConfig], is_variadic: bool) -> Vec<ParamInfo>
         result.push(ParamInfo {
             type_info: param
                 .param_type_name
-                .local_name()
+                .and_then(|m| m.local_name())
                 .map(|n| n.to_string())
                 .unwrap_or_else(|| "*".to_string()),
             value: param.default_value.and_then(|v| format_value(&v)),
@@ -158,7 +158,7 @@ impl FunctionInfo {
         Self {
             returns: method
                 .return_type()
-                .local_name()
+                .and_then(|m| m.local_name())
                 .map(|n| n.to_string())
                 .unwrap_or_else(|| "void".to_string()),
             args: format_signature(method.signature(), method.is_variadic()),
@@ -170,7 +170,7 @@ impl FunctionInfo {
         Self {
             returns: executable
                 .return_type()
-                .local_name()
+                .and_then(|m| m.local_name())
                 .map(|n| n.to_string())
                 .unwrap_or_else(|| "void".to_string()),
             args: format_signature(executable.signature(), executable.is_variadic()),
@@ -390,7 +390,9 @@ impl Definition {
                         .insert(
                             trait_name,
                             VariableInfo {
-                                type_info: type_name.local_name().map(|n| n.to_string()),
+                                type_info: type_name
+                                    .and_then(|m| m.local_name())
+                                    .map(|n| n.to_string()),
                                 value: format_value(default_value),
                                 stubbed: false,
                             },
@@ -411,7 +413,7 @@ impl Definition {
                             type_info: Some(
                                 method
                                     .return_type()
-                                    .local_name()
+                                    .and_then(|m| m.local_name())
                                     .map(|n| n.to_string())
                                     .unwrap_or_else(|| "*".to_string()),
                             ),
@@ -429,7 +431,8 @@ impl Definition {
                                 method
                                     .signature()
                                     .first()
-                                    .and_then(|p| p.param_type_name.local_name())
+                                    .and_then(|p| p.param_type_name)
+                                    .and_then(|m| m.local_name())
                                     .map(|t| t.to_string())
                                     .unwrap_or_else(|| "*".to_string()),
                             ),
@@ -451,7 +454,9 @@ impl Definition {
                         .insert(
                             trait_name,
                             VariableInfo {
-                                type_info: type_name.local_name().map(|n| n.to_string()),
+                                type_info: type_name
+                                    .and_then(|m| m.local_name())
+                                    .map(|n| n.to_string()),
                                 value: format_value(default_value),
                                 stubbed: false,
                             },

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -98,7 +98,7 @@ pub fn verify_method<'gc>(
     }
 
     let resolved_param_config = resolve_param_config(activation, method.signature())?;
-    let resolved_return_type = resolve_return_type(activation, &method.return_type)?;
+    let resolved_return_type = resolve_return_type(activation, method.return_type)?;
 
     let mut seen_exception_indices = HashSet::new();
 
@@ -671,26 +671,24 @@ pub fn resolve_param_config<'gc>(
     let mut resolved_param_config = Vec::new();
 
     for param in param_config {
-        if param.param_type_name.has_lazy_component() {
-            return Err(make_error_1014(activation, "[]".into()));
-        }
+        let resolved_class = if let Some(param_type_name) = param.param_type_name {
+            if param_type_name.has_lazy_component() {
+                return Err(make_error_1014(activation, "[]".into()));
+            }
 
-        let resolved_class = if param.param_type_name.is_any_name() {
-            None
+            Some(
+                activation
+                    .domain()
+                    .get_class(activation.context, &param_type_name)
+                    .ok_or_else(|| {
+                        make_error_1014(
+                            activation,
+                            param_type_name.to_qualified_name(activation.gc()),
+                        )
+                    })?,
+            )
         } else {
-            let lookedup_class = activation
-                .domain()
-                .get_class(activation.context, &param.param_type_name)
-                .ok_or_else(|| {
-                    make_error_1014(
-                        activation,
-                        param
-                            .param_type_name
-                            .to_qualified_name(activation.context.gc_context),
-                    )
-                })?;
-
-            Some(lookedup_class)
+            None
         };
 
         resolved_param_config.push(ResolvedParamConfig {
@@ -705,27 +703,24 @@ pub fn resolve_param_config<'gc>(
 
 fn resolve_return_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    return_type: &Multiname<'gc>,
+    return_type: Option<Gc<'gc, Multiname<'gc>>>,
 ) -> Result<Option<Class<'gc>>, Error<'gc>> {
-    if return_type.has_lazy_component() {
-        return Err(make_error_1014(activation, "[]".into()));
-    }
+    if let Some(return_type) = return_type {
+        if return_type.has_lazy_component() {
+            return Err(make_error_1014(activation, "[]".into()));
+        }
 
-    if return_type.is_any_name() {
-        return Ok(None);
+        Ok(Some(
+            activation
+                .domain()
+                .get_class(activation.context, &return_type)
+                .ok_or_else(|| {
+                    make_error_1014(activation, return_type.to_qualified_name(activation.gc()))
+                })?,
+        ))
+    } else {
+        Ok(None)
     }
-
-    Ok(Some(
-        activation
-            .domain()
-            .get_class(activation.context, return_type)
-            .ok_or_else(|| {
-                make_error_1014(
-                    activation,
-                    return_type.to_qualified_name(activation.context.gc_context),
-                )
-            })?,
-    ))
 }
 
 // Taken from avmplus's opcodes.tbl

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -461,13 +461,13 @@ impl<'gc> VTable<'gc> {
                             type_name, unit, ..
                         } => (
                             Property::new_slot(new_slot_id),
-                            PropertyClass::name(mc, *type_name, *unit),
+                            PropertyClass::name(*type_name, *unit),
                         ),
                         TraitKind::Const {
                             type_name, unit, ..
                         } => (
                             Property::new_const_slot(new_slot_id),
-                            PropertyClass::name(mc, *type_name, *unit),
+                            PropertyClass::name(*type_name, *unit),
                         ),
                         TraitKind::Class { class, .. } => (
                             Property::new_const_slot(new_slot_id),


### PR DESCRIPTION
For example, we now throw a class lookup VerifyError ("`Class *::* could not be found`") when trying to call a method with return type `QName(null, null)` instead of incorrectly assuming that the name is the Any name.

This removes the `any` Multiname from `CommonMultinames`.