### PR TITLE
desktop: Update Freedesktop categories

### DIFF
--- a/desktop/packages/linux/rs.ruffle.Ruffle.desktop
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.desktop
@@ -6,5 +6,5 @@ Comment=Play Flash games & movies
 Icon=rs.ruffle.Ruffle
 Exec=ruffle %u
 MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie
-Categories=Game;Utility;Graphics;AudioVideo;Player;Viewer
+Categories=AudioVideo;Player;Graphics;Viewer;Utility;Game
 Keywords=flash;swf;player;emulator;rust

--- a/desktop/packages/linux/rs.ruffle.Ruffle.desktop
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.desktop
@@ -6,5 +6,5 @@ Comment=Play Flash games & movies
 Icon=rs.ruffle.Ruffle
 Exec=ruffle %u
 MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie
-Categories=AudioVideo;Player;Graphics;Viewer;Utility;Game
+Categories=AudioVideo;Player;Graphics;Viewer;VectorGraphics;Utility;Game
 Keywords=flash;swf;player;emulator;rust

--- a/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
@@ -35,6 +35,7 @@
         <category>Player</category>
         <category>Graphics</category>
         <category>Viewer</category>
+        <category>VectorGraphics</category>
         <category>Utility</category>
         <category>Game</category>
     </categories>

--- a/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
@@ -31,12 +31,12 @@
         </p>
     </description>
     <categories>
-        <category>Game</category>
-        <category>Utility</category>
-        <category>Graphics</category>
         <category>AudioVideo</category>
         <category>Player</category>
+        <category>Graphics</category>
         <category>Viewer</category>
+        <category>Utility</category>
+        <category>Game</category>
     </categories>
     <keywords>
         <keyword>flash</keyword>


### PR DESCRIPTION
1. Change order of categories. — Apparently the order matters when desktop environments decide to include the app only in one category. It seems that we should list more important categories first.
2. Add `VectorGraphics` Freedesktop category — Ruffle handles SWF files, which are generally vector graphic animations.