### PR TITLE
desktop: Remove Utility Freedesktop category

### DIFF
--- a/desktop/packages/linux/rs.ruffle.Ruffle.desktop
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.desktop
@@ -6,5 +6,5 @@ Comment=Play Flash games & movies
 Icon=rs.ruffle.Ruffle
 Exec=ruffle %u
 MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie
-Categories=AudioVideo;Player;Graphics;Viewer;VectorGraphics;Utility;Game
+Categories=AudioVideo;Player;Graphics;Viewer;VectorGraphics;Game
 Keywords=flash;swf;player;emulator;rust

--- a/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml
@@ -36,7 +36,6 @@
         <category>Graphics</category>
         <category>Viewer</category>
         <category>VectorGraphics</category>
-        <category>Utility</category>
         <category>Game</category>
     </categories>
     <keywords>


### PR DESCRIPTION
As per the documentation [1,2], Ruffle hardly fits in this category.

[1] https://specifications.freedesktop.org/menu-spec/latest/category-registry.html#main-category-registry
[2] https://specifications.freedesktop.org/menu-spec/latest/additional-category-registry.html

Please share your thoughts about this change. See also https://github.com/ruffle-rs/ruffle/pull/17909#issuecomment-2351176256, https://github.com/ruffle-rs/ruffle/pull/17909#issuecomment-2351649359

CC @evilpie 