### PR TITLE
web: Add `ruffle()` (Version 1) API

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -117,7 +117,7 @@ export default tseslint.config(
             ],
             "jsdoc/check-tag-names": [
                 "error",
-                { definedTags: ["privateRemarks"] },
+                { definedTags: ["privateRemarks", "remarks"] },
             ],
         },
         settings: {

--- a/web/packages/core/README.md
+++ b/web/packages/core/README.md
@@ -43,7 +43,7 @@ If you want to control the Ruffle player, you may use our Javascript API.
         let player = ruffle.createPlayer();
         let container = document.getElementById("container");
         container.appendChild(player);
-        player.load("movie.swf");
+        player.ruffle().load("movie.swf");
     });
 </script>
 <script src="path/to/ruffle/ruffle.js"></script>

--- a/web/packages/core/src/internal/player/impl_v1.ts
+++ b/web/packages/core/src/internal/player/impl_v1.ts
@@ -1,0 +1,105 @@
+import { PlayerV1 } from "../../public/player";
+import { InnerPlayer, ReadyState } from "./inner";
+import type { DataLoadOptions, URLLoadOptions } from "../../public/config";
+import type { MovieMetadata } from "../../public/player";
+
+export class PlayerV1Impl implements PlayerV1 {
+    #inner: InnerPlayer;
+
+    constructor(inner: InnerPlayer) {
+        this.#inner = inner;
+    }
+
+    get onFSCommand(): ((command: string, args: string) => boolean) | null {
+        return this.#inner.onFSCommand;
+    }
+
+    set onFSCommand(
+        value: ((command: string, args: string) => boolean) | null,
+    ) {
+        this.#inner.onFSCommand = value;
+    }
+
+    get readyState(): ReadyState {
+        return this.#inner._readyState;
+    }
+
+    get metadata(): MovieMetadata | null {
+        return this.#inner.metadata;
+    }
+
+    get loadedConfig(): URLLoadOptions | DataLoadOptions | null {
+        return this.#inner.loadedConfig ?? null;
+    }
+
+    async reload(): Promise<void> {
+        await this.#inner.reload();
+    }
+
+    async load(
+        options: string | URLLoadOptions | DataLoadOptions,
+        isPolyfillElement: boolean = false,
+    ): Promise<void> {
+        await this.#inner.load(options, isPolyfillElement);
+    }
+
+    play(): void {
+        this.#inner.play();
+    }
+
+    get isPlaying(): boolean {
+        return this.#inner.isPlaying;
+    }
+
+    get volume(): number {
+        return this.#inner.volume;
+    }
+
+    set volume(value: number) {
+        this.#inner.volume = value;
+    }
+
+    get fullscreenEnabled(): boolean {
+        return this.#inner.fullscreenEnabled;
+    }
+
+    get isFullscreen(): boolean {
+        return this.#inner.isFullscreen;
+    }
+
+    setFullscreen(isFull: boolean): void {
+        this.#inner.setFullscreen(isFull);
+    }
+
+    enterFullscreen(): void {
+        this.#inner.enterFullscreen();
+    }
+
+    exitFullscreen(): void {
+        this.#inner.exitFullscreen();
+    }
+
+    async downloadSwf(): Promise<void> {
+        await this.#inner.downloadSwf();
+    }
+
+    displayMessage(message: string): void {
+        this.#inner.displayMessage(message);
+    }
+
+    pause(): void {
+        this.#inner.pause();
+    }
+
+    set traceObserver(observer: ((message: string) => void) | null) {
+        this.#inner.traceObserver = observer;
+    }
+
+    get config(): URLLoadOptions | DataLoadOptions | object {
+        return this.#inner.config;
+    }
+
+    set config(value: URLLoadOptions | DataLoadOptions | object) {
+        this.#inner.config = value;
+    }
+}

--- a/web/packages/core/src/internal/player/impl_v1.ts
+++ b/web/packages/core/src/internal/player/impl_v1.ts
@@ -10,14 +10,8 @@ export class PlayerV1Impl implements PlayerV1 {
         this.#inner = inner;
     }
 
-    get onFSCommand(): ((command: string, args: string) => boolean) | null {
-        return this.#inner.onFSCommand;
-    }
-
-    set onFSCommand(
-        value: ((command: string, args: string) => boolean) | null,
-    ) {
-        this.#inner.onFSCommand = value;
+    addFSCommandHandler(handler: (command: string, args: string) => void) {
+        this.#inner.addFSCommandHandler(handler);
     }
 
     get readyState(): ReadyState {

--- a/web/packages/core/src/internal/player/impl_v1.ts
+++ b/web/packages/core/src/internal/player/impl_v1.ts
@@ -102,4 +102,8 @@ export class PlayerV1Impl implements PlayerV1 {
     set config(value: URLLoadOptions | DataLoadOptions | object) {
         this.#inner.config = value;
     }
+
+    callExternalInterface(name: string, ...args: unknown[]): unknown {
+        return this.#inner.callExternalInterface(name, args);
+    }
 }

--- a/web/packages/core/src/internal/player/impl_v1.ts
+++ b/web/packages/core/src/internal/player/impl_v1.ts
@@ -71,7 +71,7 @@ export class PlayerV1Impl implements PlayerV1 {
         this.#inner.setFullscreen(isFull);
     }
 
-    enterFullscreen(): void {
+    requestFullscreen(): void {
         this.#inner.enterFullscreen();
     }
 

--- a/web/packages/core/src/internal/player/impl_v1.ts
+++ b/web/packages/core/src/internal/player/impl_v1.ts
@@ -43,7 +43,7 @@ export class PlayerV1Impl implements PlayerV1 {
         await this.#inner.load(options, isPolyfillElement);
     }
 
-    play(): void {
+    resume(): void {
         this.#inner.play();
     }
 
@@ -87,8 +87,12 @@ export class PlayerV1Impl implements PlayerV1 {
         this.#inner.displayMessage(message);
     }
 
-    pause(): void {
+    suspend(): void {
         this.#inner.pause();
+    }
+
+    get suspended(): boolean {
+        return !this.#inner.isPlaying;
     }
 
     set traceObserver(observer: ((message: string) => void) | null) {

--- a/web/packages/core/src/internal/player/impl_v1.ts
+++ b/web/packages/core/src/internal/player/impl_v1.ts
@@ -1,5 +1,5 @@
-import { PlayerV1 } from "../../public/player";
-import { InnerPlayer, ReadyState } from "./inner";
+import { PlayerV1, ReadyState } from "../../public/player";
+import { InnerPlayer } from "./inner";
 import type { DataLoadOptions, URLLoadOptions } from "../../public/config";
 import type { MovieMetadata } from "../../public/player";
 

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -191,6 +191,8 @@ export class InnerPlayer {
     private volumeSettings: VolumeControls;
     private readonly debugPlayerInfo: () => string;
     protected readonly onCallbackAvailable: (name: string) => void;
+    private readonly onFSCommand: ((command: string, args: string) => void)[] =
+        [];
 
     public constructor(
         element: HTMLElement,
@@ -201,7 +203,10 @@ export class InnerPlayer {
         this.debugPlayerInfo = debugPlayerInfo;
         this.onCallbackAvailable = onCallbackAvailable;
 
-        this.shadow = this.element.attachShadow({ mode: "open", delegatesFocus: true });
+        this.shadow = this.element.attachShadow({
+            mode: "open",
+            delegatesFocus: true,
+        });
         this.shadow.appendChild(ruffleShadowTemplate.content.cloneNode(true));
 
         this.dynamicStyles = this.shadow.getElementById(
@@ -309,7 +314,6 @@ export class InnerPlayer {
 
         this.instance = null;
         this.newZipWriter = null;
-        this.onFSCommand = null;
 
         this._readyState = ReadyState.HaveNothing;
         this.metadata = null;
@@ -318,15 +322,19 @@ export class InnerPlayer {
         this.setupPauseOnTabHidden();
     }
 
-    /**
-     * A movie can communicate with the hosting page using fscommand
-     * as long as script access is allowed.
-     *
-     * @param command A string passed to the host application for any use.
-     * @param args A string passed to the host application for any use.
-     * @returns True if the command was handled.
-     */
-    onFSCommand: ((command: string, args: string) => boolean) | null;
+    addFSCommandHandler(handler: (command: string, args: string) => void) {
+        this.onFSCommand.push(handler);
+    }
+
+    public callFSCommand(command: string, args: string): boolean {
+        if (this.onFSCommand.length == 0) {
+            return false;
+        }
+        for (const handler of this.onFSCommand) {
+            handler(command, args);
+        }
+        return true;
+    }
 
     /**
      * Any configuration that should apply to this specific player.

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -3,13 +3,13 @@ import {
     AutoPlay,
     ContextMenu,
     DataLoadOptions,
+    DEFAULT_CONFIG,
     NetworkingAccessMode,
     UnmuteOverlay,
     URLLoadOptions,
     WindowMode,
-    DEFAULT_CONFIG,
 } from "../../public/config";
-import type { MovieMetadata } from "../../public/player";
+import { MovieMetadata, ReadyState } from "../../public/player";
 import { ruffleShadowTemplate } from "../ui/shadow-template";
 import { text, textAsParagraphs } from "../i18n";
 import { swfFileName } from "../../swf-utils";
@@ -2045,26 +2045,6 @@ export class InnerPlayer {
         // TODO: Move this to whatever function changes the ReadyState to Loaded when we have streaming support.
         this.element.dispatchEvent(new CustomEvent(InnerPlayer.LOADED_DATA));
     }
-}
-
-/**
- * Describes the loading state of an SWF movie.
- */
-export enum ReadyState {
-    /**
-     * No movie is loaded, or no information is yet available about the movie.
-     */
-    HaveNothing = 0,
-
-    /**
-     * The movie is still loading, but it has started playback, and metadata is available.
-     */
-    Loading = 1,
-
-    /**
-     * The movie has completely loaded.
-     */
-    Loaded = 2,
 }
 
 /**

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -1,6 +1,8 @@
 import type { DataLoadOptions, URLLoadOptions } from "../../public/config";
 import type { MovieMetadata, PlayerElement } from "../../public/player";
 import { InnerPlayer, ReadyState } from "./inner";
+import { APIVersions } from "../../public/player";
+import { PlayerV1Impl } from "./impl_v1";
 
 /**
  * The ruffle player element that should be inserted onto the page.
@@ -52,6 +54,14 @@ export class RufflePlayerElement extends HTMLElement implements PlayerElement {
                 }
             },
         );
+    }
+
+    ruffle<V extends keyof APIVersions = 1>(version?: V): APIVersions[V] {
+        const v = version ?? 1;
+        if (v === 1) {
+            return new PlayerV1Impl(this.#inner) as APIVersions[V];
+        }
+        throw new Error(`Version ${version} not supported.`);
     }
 
     get loadedConfig(): URLLoadOptions | DataLoadOptions | null {
@@ -145,7 +155,7 @@ export class RufflePlayerElement extends HTMLElement implements PlayerElement {
 
     public PercentLoaded(): number {
         // [NA] This is a stub - we need to research how this is actually implemented (is it just base swf loadedBytes?)
-        if (this.readyState === ReadyState.Loaded) {
+        if (this.#inner._readyState === ReadyState.Loaded) {
             return 100;
         } else {
             return 0;

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -11,15 +11,15 @@ import { PlayerV1Impl } from "./impl_v1";
  */
 export class RufflePlayerElement extends HTMLElement implements PlayerElement {
     #inner: InnerPlayer;
+    #legacyFSCommandHandler: ((command: string, args: string) => void) | null =
+        null;
 
-    get onFSCommand(): ((command: string, args: string) => boolean) | null {
-        return this.#inner.onFSCommand;
+    get onFSCommand(): ((command: string, args: string) => void) | null {
+        return this.#legacyFSCommandHandler;
     }
 
-    set onFSCommand(
-        value: ((command: string, args: string) => boolean) | null,
-    ) {
-        this.#inner.onFSCommand = value;
+    set onFSCommand(value: ((command: string, args: string) => void) | null) {
+        this.#legacyFSCommandHandler = value;
     }
 
     get readyState(): ReadyState {
@@ -54,6 +54,9 @@ export class RufflePlayerElement extends HTMLElement implements PlayerElement {
                 }
             },
         );
+        this.#inner.addFSCommandHandler((command, args) => {
+            this.#legacyFSCommandHandler?.(command, args);
+        });
     }
 
     ruffle<V extends keyof APIVersions = 1>(version?: V): APIVersions[V] {

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -1,6 +1,6 @@
 import type { DataLoadOptions, URLLoadOptions } from "../../public/config";
-import type { MovieMetadata, PlayerElement } from "../../public/player";
-import { InnerPlayer, ReadyState } from "./inner";
+import { MovieMetadata, PlayerElement, ReadyState } from "../../public/player";
+import { InnerPlayer } from "./inner";
 import { APIVersions } from "../../public/player";
 import { PlayerV1Impl } from "./impl_v1";
 

--- a/web/packages/core/src/public/player/index.ts
+++ b/web/packages/core/src/public/player/index.ts
@@ -8,3 +8,4 @@ export * from "./flash";
 export * from "./player-element";
 export * from "./movie-metadata";
 export * from "./legacy";
+export * from "./v1";

--- a/web/packages/core/src/public/player/index.ts
+++ b/web/packages/core/src/public/player/index.ts
@@ -9,3 +9,23 @@ export * from "./player-element";
 export * from "./movie-metadata";
 export * from "./legacy";
 export * from "./v1";
+
+/**
+ * Describes the loading state of an SWF movie.
+ */
+export enum ReadyState {
+    /**
+     * No movie is loaded, or no information is yet available about the movie.
+     */
+    HaveNothing = 0,
+
+    /**
+     * The movie is still loading, but it has started playback, and metadata is available.
+     */
+    Loading = 1,
+
+    /**
+     * The movie has completely loaded.
+     */
+    Loaded = 2,
+}

--- a/web/packages/core/src/public/player/legacy.ts
+++ b/web/packages/core/src/public/player/legacy.ts
@@ -181,7 +181,7 @@ export interface LegacyRuffleAPI {
      * @param isFull Whether to set to fullscreen or return to normal.
      * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
      * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.setFullscreen}
+     * A direct replacement is {@link PlayerV1.requestFullscreen} or {@link PlayerV1.exitFullscreen}.
      */
     setFullscreen(isFull: boolean): void;
 
@@ -192,7 +192,7 @@ export interface LegacyRuffleAPI {
      *
      * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
      * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.enterFullscreen}
+     * A direct replacement is {@link PlayerV1.requestFullscreen}
      */
     enterFullscreen(): void;
 

--- a/web/packages/core/src/public/player/legacy.ts
+++ b/web/packages/core/src/public/player/legacy.ts
@@ -97,21 +97,36 @@ export interface LegacyRuffleAPI {
     load(options: string | URLLoadOptions | DataLoadOptions): Promise<void>;
 
     /**
-     * Plays or resumes the movie.
+     * Resumes the movie from suspension.
+     *
+     * The movie will now resume executing any frames, scripts and sounds.
+     * If the movie is not suspended or no movie is loaded, this method will do nothing.
+     *
+     * @remarks
+     * This method was confusingly named and kept for legacy compatibility.
+     * "Playing" in this context referred to "not being suspended", and <b>not</b> the Flash concept of playing/paused.
      *
      * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
      * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.play}
+     * A direct replacement is {@link PlayerV1.resume}
      */
     play(): void;
 
     /**
-     * Whether this player is currently playing.
+     * Checks if this player is not suspended.
+     *
+     * A suspended movie will not execute any frames, scripts or sounds.
+     * This movie is considered inactive and will not wake up until resumed.
+     * If no movie is loaded, this method will return true.
+     *
+     * @remarks
+     * This method was confusingly named and kept for legacy compatibility.
+     * "Playing" in this context referred to "not being suspended", and <b>not</b> the Flash concept of playing/paused.
      *
      * @returns True if this player is playing, false if it's paused or hasn't started yet.
      * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
      * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.isPlaying}
+     * A direct replacement is {@link PlayerV1.suspended} (though inversed!)
      */
     get isPlaying(): boolean;
 
@@ -191,14 +206,19 @@ export interface LegacyRuffleAPI {
     exitFullscreen(): void;
 
     /**
-     * Pauses this player.
+     * Suspends the movie.
      *
-     * No more frames, scripts or sounds will be executed.
-     * This movie will be considered inactive and will not wake up until resumed.
+     * A suspended movie will not execute any frames, scripts or sounds.
+     * This movie is considered inactive and will not wake up until resumed.
+     * If the movie is already suspended or no movie is loaded, this method will do nothing.
+     *
+     * @remarks
+     * This method was confusingly named and kept for legacy compatibility.
+     * "Pause" in this context referred to "suspended", and <b>not</b> the Flash concept of playing/paused.
      *
      * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
      * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.pause}
+     * A direct replacement is {@link PlayerV1.suspend}
      */
     pause(): void;
 

--- a/web/packages/core/src/public/player/legacy.ts
+++ b/web/packages/core/src/public/player/legacy.ts
@@ -10,17 +10,25 @@ import { ReadyState } from "../../internal/player/inner";
  */
 export interface LegacyRuffleAPI {
     /**
-     * A movie can communicate with the hosting page using fscommand
-     * as long as script access is allowed.
+     * Adds a handler for arbitrary "fs commands" from a movie in this player.
      *
-     * @param command A string passed to the host application for any use.
-     * @param args A string passed to the host application for any use.
-     * @returns True if the command was handled.
+     * @remarks
+     * If script access is allowed, a movie may communicate to the page through the ActionScript method `fscommand(name, args)`.
+     *
+     * The exact commands and their arguments are more or less arbitrary and up to the movie.
+     * This is an incredibly deprecated way of communicating between Flash and JavaScript,
+     * and was deprecated in favor of `ExternalInterface` in Flash Player 8 (2005).
+     *
      * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
      * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.onFSCommand}
+     * A direct replacement is {@link PlayerV1.addFSCommandHandler}, which supports multiple handlers.
      */
-    onFSCommand: ((command: string, args: string) => boolean) | null;
+    onFSCommand:
+        | ((
+              /** An arbitrary name of a command. */ command: string,
+              /** An arbitrary argument to the command. */ args: string,
+          ) => void)
+        | null;
 
     /**
      * Any configuration that should apply to this specific player.

--- a/web/packages/core/src/public/player/legacy.ts
+++ b/web/packages/core/src/public/player/legacy.ts
@@ -1,6 +1,7 @@
 import { DataLoadOptions, URLLoadOptions } from "../config";
 import { MovieMetadata } from "./movie-metadata";
-import { ReadyState } from "../../internal/player/inner";
+
+import { ReadyState } from "./index";
 
 /**
  * Legacy interface to the Ruffle API.

--- a/web/packages/core/src/public/player/player-element.ts
+++ b/web/packages/core/src/public/player/player-element.ts
@@ -1,5 +1,13 @@
 import { LegacyRuffleAPI } from "./legacy";
 import { FlashAPI } from "./flash";
+import { PlayerV1 } from "./v1";
+
+/**
+ * A map of API version number, to API interface.
+ */
+export type APIVersions = {
+    1: PlayerV1;
+};
 
 /**
  * A Ruffle player's HTML element.
@@ -7,6 +15,15 @@ import { FlashAPI } from "./flash";
  * This is either created through `window.RufflePlayer.latest().createPlayer()`, or polyfilled from a `<embed>`/`<object>` tag.
  *
  * In addition to usual HTML attributes, this player contains methods and properties that belong to both
- * the **Flash JS API** and **legacy Ruffle API**s.
+ * the **Flash JS API** and **legacy Ruffle API**s. You are strongly discouraged from using them, and should instead
+ * use `.ruffle(version)` to access a versioned API interface.
  */
-export interface PlayerElement extends HTMLElement, LegacyRuffleAPI, FlashAPI {}
+export interface PlayerElement extends HTMLElement, LegacyRuffleAPI, FlashAPI {
+    /**
+     * Access a specific version of the Ruffle API.
+     * If the given version is not supported, an error is thrown.
+     *
+     * @param version Version of the API to access. Defaults to 1.
+     */
+    ruffle<V extends keyof APIVersions = 1>(version?: V): APIVersions[V];
+}

--- a/web/packages/core/src/public/player/v1.ts
+++ b/web/packages/core/src/public/player/v1.ts
@@ -67,18 +67,6 @@ export interface PlayerV1 {
     load(options: string | URLLoadOptions | DataLoadOptions): Promise<void>;
 
     /**
-     * Plays or resumes the movie.
-     */
-    play(): void;
-
-    /**
-     * Whether this player is currently playing.
-     *
-     * @returns True if this player is playing, false if it's paused or hasn't started yet.
-     */
-    get isPlaying(): boolean;
-
-    /**
      * Returns the master volume of the player.
      *
      * The volume is linear and not adapted for logarithmic hearing.
@@ -131,12 +119,40 @@ export interface PlayerV1 {
     exitFullscreen(): void;
 
     /**
-     * Pauses this player.
+     * Checks if this movie is suspended.
      *
-     * No more frames, scripts or sounds will be executed.
-     * This movie will be considered inactive and will not wake up until resumed.
+     * A suspended movie will not execute any frames, scripts or sounds.
+     * This movie is considered inactive and will not wake up until resumed.
+     * If no movie is loaded, this method will return true.
+     *
+     * @see {@link suspend} to suspend the player
+     * @see {@link resume} to resume the player from suspension
+     * @returns `true` if the movie is suspended or does not exist, `false` if the movie is playing
      */
-    pause(): void;
+    get suspended(): boolean;
+
+    /**
+     * Suspends the movie.
+     *
+     * A suspended movie will not execute any frames, scripts or sounds.
+     * This movie is considered inactive and will not wake up until resumed.
+     * If the movie is already suspended or no movie is loaded, this method will do nothing.
+     *
+     * @see {@link suspended} to check if the player is suspended
+     * @see {@link resume} to resume the player from suspension
+     */
+    suspend(): void;
+
+    /**
+     * Resumes the movie from suspension.
+     *
+     * The movie will now resume executing any frames, scripts and sounds.
+     * If the movie is not suspended or no movie is loaded, this method will do nothing.
+     *
+     * @see {@link suspended} to suspend the player
+     * @see {@link suspend} to check if the player is suspended
+     */
+    resume(): void;
 
     /**
      * Sets a trace observer on this flash player.

--- a/web/packages/core/src/public/player/v1.ts
+++ b/web/packages/core/src/public/player/v1.ts
@@ -87,7 +87,7 @@ export interface PlayerV1 {
     /**
      * Checks if this player is allowed to be fullscreen by the browser.
      *
-     * @returns True if you may call {@link enterFullscreen}.
+     * @returns True if you may call {@link requestFullscreen}.
      */
     get fullscreenEnabled(): boolean;
 
@@ -99,19 +99,11 @@ export interface PlayerV1 {
     get isFullscreen(): boolean;
 
     /**
-     * Exported function that requests the browser to change the fullscreen state if
-     * it is allowed.
-     *
-     * @param isFull Whether to set to fullscreen or return to normal.
-     */
-    setFullscreen(isFull: boolean): void;
-
-    /**
      * Requests the browser to make this player fullscreen.
      *
      * This is not guaranteed to succeed, please check {@link fullscreenEnabled} first.
      */
-    enterFullscreen(): void;
+    requestFullscreen(): void;
 
     /**
      * Requests the browser to no longer make this player fullscreen.

--- a/web/packages/core/src/public/player/v1.ts
+++ b/web/packages/core/src/public/player/v1.ts
@@ -158,4 +158,16 @@ export interface PlayerV1 {
      * @param message The message shown to the user.
      */
     displayMessage(message: string): void;
+
+    /**
+     * Calls an External Interface callback with the given name and arguments.
+     *
+     * This will call any ActionScript code assigned to the given name.
+     * If no such External Interface callback exists with the given name, this method silently fails and returns `undefined`.
+     *
+     * @param name Name of the callback to call.
+     * @param args Any arguments to pass to the callback.
+     * @returns Any value returned by the callback.
+     */
+    callExternalInterface(name: string, ...args: unknown[]): unknown;
 }

--- a/web/packages/core/src/public/player/v1.ts
+++ b/web/packages/core/src/public/player/v1.ts
@@ -1,14 +1,8 @@
-import { DataLoadOptions, URLLoadOptions } from "../config";
 import { MovieMetadata } from "./movie-metadata";
+import { DataLoadOptions, URLLoadOptions } from "../config";
 import { ReadyState } from "../../internal/player/inner";
 
-/**
- * Legacy interface to the Ruffle API.
- *
- * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
- * Any of these methods or properties may be replaced by Flash and are not guaranteed to exist.
- */
-export interface LegacyRuffleAPI {
+export interface PlayerV1 {
     /**
      * A movie can communicate with the hosting page using fscommand
      * as long as script access is allowed.
@@ -16,29 +10,18 @@ export interface LegacyRuffleAPI {
      * @param command A string passed to the host application for any use.
      * @param args A string passed to the host application for any use.
      * @returns True if the command was handled.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.onFSCommand}
      */
     onFSCommand: ((command: string, args: string) => boolean) | null;
 
     /**
      * Any configuration that should apply to this specific player.
      * This will be defaulted with any global configuration.
-     *
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.config}
      */
     config: URLLoadOptions | DataLoadOptions | object;
 
     /**
      * The effective config loaded with the last call to `load()`.
      * If no such call has been made, this will be `null`.
-     *
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.loadedConfig}
      */
     readonly loadedConfig: URLLoadOptions | DataLoadOptions | null;
 
@@ -46,9 +29,6 @@ export interface LegacyRuffleAPI {
      * Indicates the readiness of the playing movie.
      *
      * @returns The `ReadyState` of the player.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.readyState}
      */
     get readyState(): ReadyState;
 
@@ -58,9 +38,6 @@ export interface LegacyRuffleAPI {
      * For example, `metadata.width` is the width of the SWF file, and not the width of the Ruffle player.
      *
      * @returns The metadata of the movie, or `null` if the movie metadata has not yet loaded.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.metadata}
      */
     get metadata(): MovieMetadata | null;
 
@@ -68,10 +45,6 @@ export interface LegacyRuffleAPI {
      * Reloads the player, as if you called {@link load} with the same config as the last time it was called.
      *
      * If this player has never been loaded, this method will return an error.
-     *
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.reload}
      */
     reload(): Promise<void>;
 
@@ -90,18 +63,11 @@ export interface LegacyRuffleAPI {
      *
      * The options will be defaulted by the {@link config} field, which itself
      * is defaulted by a global `window.RufflePlayer.config`.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.load}
      */
     load(options: string | URLLoadOptions | DataLoadOptions): Promise<void>;
 
     /**
      * Plays or resumes the movie.
-     *
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.play}
      */
     play(): void;
 
@@ -109,9 +75,6 @@ export interface LegacyRuffleAPI {
      * Whether this player is currently playing.
      *
      * @returns True if this player is playing, false if it's paused or hasn't started yet.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.isPlaying}
      */
     get isPlaying(): boolean;
 
@@ -121,9 +84,6 @@ export interface LegacyRuffleAPI {
      * The volume is linear and not adapted for logarithmic hearing.
      *
      * @returns The volume. 1.0 is 100% volume.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.volume}
      */
     get volume(): number;
 
@@ -133,9 +93,6 @@ export interface LegacyRuffleAPI {
      * The volume should be linear and not adapted for logarithmic hearing.
      *
      * @param value The volume. 1.0 is 100% volume.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.volume}
      */
     set volume(value: number);
 
@@ -143,9 +100,6 @@ export interface LegacyRuffleAPI {
      * Checks if this player is allowed to be fullscreen by the browser.
      *
      * @returns True if you may call {@link enterFullscreen}.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.fullscreenEnabled}
      */
     get fullscreenEnabled(): boolean;
 
@@ -153,9 +107,6 @@ export interface LegacyRuffleAPI {
      * Checks if this player is currently fullscreen inside the browser.
      *
      * @returns True if it is fullscreen.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.isFullscreen}
      */
     get isFullscreen(): boolean;
 
@@ -164,9 +115,6 @@ export interface LegacyRuffleAPI {
      * it is allowed.
      *
      * @param isFull Whether to set to fullscreen or return to normal.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.setFullscreen}
      */
     setFullscreen(isFull: boolean): void;
 
@@ -174,19 +122,11 @@ export interface LegacyRuffleAPI {
      * Requests the browser to make this player fullscreen.
      *
      * This is not guaranteed to succeed, please check {@link fullscreenEnabled} first.
-     *
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.enterFullscreen}
      */
     enterFullscreen(): void;
 
     /**
      * Requests the browser to no longer make this player fullscreen.
-     *
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.exitFullscreen}
      */
     exitFullscreen(): void;
 
@@ -195,10 +135,6 @@ export interface LegacyRuffleAPI {
      *
      * No more frames, scripts or sounds will be executed.
      * This movie will be considered inactive and will not wake up until resumed.
-     *
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.pause}
      */
     pause(): void;
 
@@ -208,18 +144,11 @@ export interface LegacyRuffleAPI {
      * The observer will be called, as a function, for each message that the playing movie will "trace" (output).
      *
      * @param observer The observer that will be called for each trace.
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.traceObserver}
      */
     set traceObserver(observer: ((message: string) => void) | null);
 
     /**
      * Fetches the loaded SWF and downloads it.
-     *
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.downloadSwf}
      */
     downloadSwf(): Promise<void>;
 
@@ -227,10 +156,6 @@ export interface LegacyRuffleAPI {
      * Show a dismissible message in front of the player.
      *
      * @param message The message shown to the user.
-     *
-     * @deprecated Please use {@link PlayerElement.ruffle | ruffle()} to access a versioned API.
-     * This method may be replaced by Flash and is not guaranteed to exist.
-     * A direct replacement is {@link PlayerV1.displayMessage}
      */
     displayMessage(message: string): void;
 }

--- a/web/packages/core/src/public/player/v1.ts
+++ b/web/packages/core/src/public/player/v1.ts
@@ -4,14 +4,24 @@ import { ReadyState } from "../../internal/player/inner";
 
 export interface PlayerV1 {
     /**
-     * A movie can communicate with the hosting page using fscommand
-     * as long as script access is allowed.
+     * Adds a handler for arbitrary "fs commands" from a movie in this player.
      *
-     * @param command A string passed to the host application for any use.
-     * @param args A string passed to the host application for any use.
-     * @returns True if the command was handled.
+     * @remarks
+     * If script access is allowed, a movie may communicate to the page through the ActionScript method `fscommand(name, args)`.
+     *
+     * The exact commands and their arguments are more or less arbitrary and up to the movie.
+     * This is an incredibly deprecated way of communicating between Flash and JavaScript,
+     * and was deprecated in favor of `ExternalInterface` in Flash Player 8 (2005).
      */
-    onFSCommand: ((command: string, args: string) => boolean) | null;
+    addFSCommandHandler(
+        /**
+         * A command handler to receive `fscommand`s.
+         *
+         * @param command An arbitrary name of a command.
+         * @param args An arbitrary argument to the command.
+         */
+        handler: (command: string, args: string) => void,
+    ): void;
 
     /**
      * Any configuration that should apply to this specific player.

--- a/web/packages/core/src/public/player/v1.ts
+++ b/web/packages/core/src/public/player/v1.ts
@@ -1,6 +1,7 @@
 import { MovieMetadata } from "./movie-metadata";
 import { DataLoadOptions, URLLoadOptions } from "../config";
-import { ReadyState } from "../../internal/player/inner";
+
+import { ReadyState } from "./index";
 
 export interface PlayerV1 {
     /**

--- a/web/packages/demo/src/player.tsx
+++ b/web/packages/demo/src/player.tsx
@@ -34,7 +34,7 @@ export class Player extends React.Component<PlayerAttributes> {
         this.player.id = "player";
         this.player.addEventListener("loadedmetadata", () => {
             if (this.props.onLoadedMetadata) {
-                this.props.onLoadedMetadata(this.player!.metadata!);
+                this.props.onLoadedMetadata(this.player!.ruffle().metadata!);
             }
         });
         this.isLoading = false;
@@ -67,9 +67,12 @@ export class Player extends React.Component<PlayerAttributes> {
     reload() {
         if (!this.isLoading) {
             this.isLoading = true;
-            this.player?.reload().finally(() => {
-                this.isLoading = false;
-            });
+            this.player
+                ?.ruffle()
+                .reload()
+                .finally(() => {
+                    this.isLoading = false;
+                });
         }
     }
 
@@ -77,7 +80,8 @@ export class Player extends React.Component<PlayerAttributes> {
         if (!this.isLoading) {
             this.isLoading = true;
             this.player
-                ?.load({ url, ...this.props.baseConfig, ...options })
+                ?.ruffle()
+                .load({ url, ...this.props.baseConfig, ...options })
                 .finally(() => {
                     this.isLoading = false;
                 });
@@ -90,7 +94,7 @@ export class Player extends React.Component<PlayerAttributes> {
             new Response(file)
                 .arrayBuffer()
                 .then((data) => {
-                    return this.player?.load({
+                    return this.player?.ruffle().load({
                         data,
                         ...this.props.baseConfig,
                     });

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -130,10 +130,11 @@ async function load(
             return;
         }
     }
-    await player.load(options);
+    await player.ruffle().load(options);
     player.addEventListener("loadedmetadata", () => {
-        if (player.metadata) {
-            for (const [key, value] of Object.entries(player.metadata)) {
+        const metadata = player.ruffle().metadata;
+        if (metadata) {
+            for (const [key, value] of Object.entries(metadata)) {
                 const metadataElement = document.getElementById(key);
                 if (metadataElement) {
                     switch (key) {
@@ -244,7 +245,7 @@ reloadSwf.addEventListener("click", () => {
     if (player) {
         const confirmReload = confirm("Reload the current SWF?");
         if (confirmReload) {
-            player.reload();
+            player.ruffle().reload();
         }
     }
 });

--- a/web/packages/selfhosted/README.md
+++ b/web/packages/selfhosted/README.md
@@ -46,7 +46,7 @@ If you want to control the Ruffle player, you may use our Javascript API.
         let player = ruffle.createPlayer();
         let container = document.getElementById("container");
         container.appendChild(player);
-        player.load("movie.swf");
+        player.ruffle().load("movie.swf");
     });
 </script>
 <script src="path/to/ruffle/ruffle.js"></script>

--- a/web/packages/selfhosted/test/integration_tests/external_interface/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/external_interface/test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
+import { Player } from "ruffle-core";
 
 use(chaiHtml);
 
@@ -50,6 +51,10 @@ declare global {
 
             // Going to be redefined as part of a test
             redefinedMethod: () => string;
+
+            ruffle<V extends keyof Player.APIVersions = 1>(
+                version?: V,
+            ): Player.APIVersions[V];
         }
     }
 
@@ -135,10 +140,30 @@ ExternalInterface.objectID: "flash_name"
         );
     });
 
-    it("returns a value", async () => {
+    it("returns a value with legacy API", async () => {
         const player = await browser.$("<ruffle-object>");
         const returned = await browser.execute(
             (player) => player.returnAValue(123.4),
+            player,
+        );
+
+        expect(returned).to.eql(123.4);
+
+        const actualOutput = await getTraceOutput(browser, player);
+        expect(actualOutput).to.eql(
+            `returnAValue called with 123.4
+  [
+    123.4
+  ]
+`,
+        );
+    });
+
+    it("returns a value with V1 API", async () => {
+        const player = await browser.$("<ruffle-object>");
+        const returned = await browser.execute(
+            (player) =>
+                player.ruffle().callExternalInterface("returnAValue", 123.4),
             player,
         );
 

--- a/web/packages/selfhosted/test/js_api/exposed.ts
+++ b/web/packages/selfhosted/test/js_api/exposed.ts
@@ -37,6 +37,8 @@ describe("Exposed RufflePlayer methods/properties", () => {
             "traceObserver",
             "downloadSwf",
             "displayMessage",
+            // PlayerElement
+            "ruffle",
             // RufflePlayerElement
             "attributeChangedCallback",
             "connectedCallback",

--- a/web/packages/selfhosted/test/js_api/load.ts
+++ b/web/packages/selfhosted/test/js_api/load.ts
@@ -13,7 +13,7 @@ describe("RufflePlayer.load", () => {
         await browser.execute(async (playerElement) => {
             // https://github.com/webdriverio/webdriverio/issues/6486
             const player = playerElement as unknown as Player.PlayerElement;
-            await player.load("/test_assets/example.swf");
+            await player.ruffle().load("/test_assets/example.swf");
         }, player);
         await playAndMonitor(browser, player);
     });

--- a/web/packages/selfhosted/test/js_api/metadata.ts
+++ b/web/packages/selfhosted/test/js_api/metadata.ts
@@ -12,7 +12,8 @@ describe("RufflePlayer.metadata", () => {
         const player = await browser.$("<ruffle-player>");
         const metadata = await browser.execute(
             // https://github.com/webdriverio/webdriverio/issues/6486
-            (player) => (player as unknown as Player.PlayerElement).metadata,
+            (player) =>
+                (player as unknown as Player.PlayerElement).ruffle().metadata,
             player,
         );
         // [NA] Work around a chrome 87 bug where it's (somehow) adding extra data to this object

--- a/web/packages/selfhosted/test/utils.ts
+++ b/web/packages/selfhosted/test/utils.ts
@@ -109,7 +109,7 @@ export async function setupAndPlay(
             player.ruffle().traceObserver = (msg) => {
                 player.__ruffle_log__ += msg + "\n";
             };
-            player.ruffle().play();
+            player.ruffle().resume();
         },
         await player,
     );

--- a/web/packages/selfhosted/test/utils.ts
+++ b/web/packages/selfhosted/test/utils.ts
@@ -31,7 +31,7 @@ export async function isRufflePlayerLoaded(
             (player) =>
                 // https://github.com/webdriverio/webdriverio/issues/6486
                 // TODO: How can we import ReadyState enum?
-                (player as unknown as Player.PlayerElement).readyState,
+                (player as unknown as Player.PlayerElement).ruffle().readyState,
             await player,
         )) === 2
     );
@@ -106,10 +106,10 @@ export async function setupAndPlay(
             // https://github.com/webdriverio/webdriverio/issues/6486
             const player = playerElement as unknown as Player.PlayerElement;
             player.__ruffle_log__ = "";
-            player.traceObserver = (msg) => {
+            player.ruffle().traceObserver = (msg) => {
                 player.__ruffle_log__ += msg + "\n";
             };
-            player.play();
+            player.ruffle().play();
         },
         await player,
     );
@@ -197,7 +197,9 @@ export function loadJsAPI(swf?: string) {
             await browser.execute(
                 async (player, swf) => {
                     // https://github.com/webdriverio/webdriverio/issues/6486
-                    await (player as unknown as Player.PlayerElement).load(swf);
+                    await (player as unknown as Player.PlayerElement)
+                        .ruffle()
+                        .load(swf);
                 },
                 player,
                 swf,

--- a/web/src/external_interface.rs
+++ b/web/src/external_interface.rs
@@ -62,7 +62,7 @@ impl ExternalInterfaceProvider for JavascriptInterface {
 impl FsCommandProvider for JavascriptInterface {
     fn on_fs_command(&self, command: &str, args: &str) -> bool {
         self.js_player
-            .on_fs_command(command, args)
+            .call_fs_command(command, args)
             .unwrap_or_default()
     }
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -153,8 +153,9 @@ extern "C" {
     #[wasm_bindgen(method, js_name = "getObjectId")]
     fn get_object_id(this: &JavascriptPlayer) -> Option<String>;
 
-    #[wasm_bindgen(method, catch, js_name = "onFSCommand")]
-    fn on_fs_command(this: &JavascriptPlayer, command: &str, args: &str) -> Result<bool, JsValue>;
+    #[wasm_bindgen(method, catch, js_name = "callFSCommand")]
+    fn call_fs_command(this: &JavascriptPlayer, command: &str, args: &str)
+        -> Result<bool, JsValue>;
 
     #[wasm_bindgen(method)]
     fn panic(this: &JavascriptPlayer, error: &JsError);


### PR DESCRIPTION
Bikeshedding time, here's the chance to decide what the "v1 api" looks like before we lock it in.

The only change so far is that I've added a specific method for calling EI, vs the very easy-to-break and implicit "the method will exist, trust me". I'm awaiting feedback before touching anything else.

Whilst this is "version 1" (`PlayerV1` interface), if we never add a V2 that's totally fine. `ruffle()` is the same as `ruffle(1)`.

Things to consider for each existing member of the API:
- Is anything a property that should be a method?
- Is anything a method that should be a property?
- Should we rename anything, or change arguments?