### PR TITLE
core: Optimize BMD.fillRect()

### DIFF
--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -711,6 +711,19 @@ impl<'gc> BitmapData<'gc> {
     }
 
     #[inline]
+    pub fn set_pixel32_row_raw(&mut self, x1: u32, x2: u32, y: u32, color: Color) {
+        let p1 = (x1 + y * self.width) as usize;
+        let p2 = (x2 + y * self.width) as usize;
+        let slice = &mut self.pixels[p1..p2];
+        slice.fill(color);
+    }
+
+    #[inline]
+    pub fn fill(&mut self, color: Color) {
+        self.pixels.fill(color);
+    }
+
+    #[inline]
     pub fn get_pixel32_raw(&self, x: u32, y: u32) -> Color {
         self.pixels[(x + y * self.width()) as usize]
     }

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -45,7 +45,9 @@ pub fn fill_rect<'gc>(
         return;
     }
 
-    let target = if rect.width() == target.width() && rect.height() == target.height() {
+    let is_full = rect.width() == target.width() && rect.height() == target.height();
+
+    let target = if is_full {
         // If we're filling the whole region, we can discard the gpu data
         target.overwrite_cpu_pixels_from_gpu(mc).0
     } else {
@@ -55,9 +57,11 @@ pub fn fill_rect<'gc>(
     let mut write = target.write(mc);
     let color = Color::from(color).to_premultiplied_alpha(write.transparency());
 
-    for y in rect.y_min..rect.y_max {
-        for x in rect.x_min..rect.x_max {
-            write.set_pixel32_raw(x, y, color);
+    if is_full {
+        write.fill(color);
+    } else {
+        for y in rect.y_min..rect.y_max {
+            write.set_pixel32_row_raw(rect.x_min, rect.x_max, y, color);
         }
     }
     write.set_cpu_dirty(mc, rect);


### PR DESCRIPTION
This removed repeated range checks on each pixel, replacing them by possibly-memcpy.
I originally only added `set_pixel32_row_raw`, which improved 640x480 fills by 3x (FF) - 5x (desktop).
Then I tried adding a full-fill fast path, which (as expected) didn't do a noticeable difference on desktop, but somehow improved FF times by another 2x.

~~EDIT: I just remembered that I tested browser perf without wasm extensions, but bulk-memory might also do a difference here. Will check it soon.~~
With wasm-opt and bulk-memory enabled, the line-fill path and full-fill path are equally fast, and another 2x faster than the best result without extensions. Just slightly slower than desktop now (though weirdly, the FF profiler doesn't show `memory.fill` like it used to).

This only helps the CPU side, it won't help is most time is spent waiting for GPU.