### PR TITLE
chore: Improve iOS support

### DIFF
--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -16,7 +16,7 @@ pub fn get_os<'gc>(
         PlayerRuntime::AIR => {
             if cfg!(windows) {
                 "Windows 10"
-            } else if cfg!(target_os = "macos") {
+            } else if cfg!(target_vendor = "apple") {
                 "Mac OS 10.5.2"
             } else {
                 "Linux 5.10.49"
@@ -37,7 +37,7 @@ pub fn get_version<'gc>(
         PlayerRuntime::AIR => {
             if cfg!(windows) {
                 "WIN"
-            } else if cfg!(target_os = "macos") {
+            } else if cfg!(target_vendor = "apple") {
                 "MAC"
             } else {
                 "LNX"

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -1105,8 +1105,8 @@ pub async fn request_adapter_and_device(
             let names = get_backend_names(backend);
             if names.is_empty() {
                 "Ruffle requires hardware acceleration, but no compatible graphics device was found (no backend provided?)".to_string()
-            } else if cfg!(target_os = "macos") {
-                "Ruffle does not support OpenGL on macOS.".to_string()
+            } else if cfg!(target_vendor = "apple") {
+                "Ruffle does not support OpenGL on macOS/iOS.".to_string()
             } else {
                 format!("Ruffle requires hardware acceleration, but no compatible graphics device was found supporting {}", format_list(&names, "or"))
             }


### PR DESCRIPTION
Fix a few instances of `target_os = "macos"`. Required for https://github.com/madsmtm/ruffle-ios.