### PR TITLE
desktop: Move `cpal` audio backend to `frontend-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4397,6 +4397,8 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "async-io",
+ "bytemuck",
+ "cpal",
  "futures-lite",
  "macro_rules_attribute",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ naga = { version = "22.1.0", features = ["wgsl-out"] }
 wgpu = "22.1.0"
 egui = { git = "https://github.com/emilk/egui.git", rev = "f4697bc007447c6c2674beb4e25f599fb7afa093" }
 clap = { version = "4.5.17", features = ["derive"] }
+cpal = "0.15.3"
 anyhow = "1.0"
 slotmap = "1.0.7"
 async-channel = "2.3.1"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 clap = { workspace = true }
-cpal = "0.15.3"
+cpal = { workspace = true }
 egui = { workspace = true }
 egui_extras = { git = "https://github.com/emilk/egui.git", rev = "f4697bc007447c6c2674beb4e25f599fb7afa093", default-features = false, features = ["image"] }
 egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "f4697bc007447c6c2674beb4e25f599fb7afa093", features = ["winit"] }
@@ -24,7 +24,7 @@ ruffle_render = { path = "../render", features = ["clap"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }
 ruffle_video_external = { path = "../video/external", optional = true }
-ruffle_frontend_utils = { path = "../frontend-utils" }
+ruffle_frontend_utils = { path = "../frontend-utils", features = ["cpal"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = "0.2.3"

--- a/desktop/src/backends.rs
+++ b/desktop/src/backends.rs
@@ -1,10 +1,8 @@
-mod audio;
 mod external_interface;
 mod fscommand;
 mod navigator;
 mod ui;
 
-pub use audio::CpalAudioBackend;
 pub use external_interface::DesktopExternalInterfaceProvider;
 pub use fscommand::DesktopFSCommandProvider;
 pub use navigator::DesktopNavigatorInterface;

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -1,6 +1,6 @@
 use crate::backends::{
-    CpalAudioBackend, DesktopExternalInterfaceProvider, DesktopFSCommandProvider,
-    DesktopNavigatorInterface, DesktopUiBackend,
+    DesktopExternalInterfaceProvider, DesktopFSCommandProvider, DesktopNavigatorInterface,
+    DesktopUiBackend,
 };
 use crate::custom_event::RuffleEvent;
 use crate::gui::{FilePicker, MovieView};
@@ -11,6 +11,7 @@ use ruffle_core::backend::navigator::{OpenURLMode, SocketMode};
 use ruffle_core::config::Letterbox;
 use ruffle_core::events::{GamepadButton, KeyCode};
 use ruffle_core::{DefaultFont, LoadBehavior, Player, PlayerBuilder, PlayerEvent};
+use ruffle_frontend_utils::backends::audio::CpalAudioBackend;
 use ruffle_frontend_utils::backends::executor::{AsyncExecutor, PollRequester};
 use ruffle_frontend_utils::backends::navigator::ExternalNavigatorBackend;
 use ruffle_frontend_utils::bundle::source::BundleSourceError;
@@ -134,7 +135,7 @@ impl ActivePlayer {
     ) -> Self {
         let mut builder = PlayerBuilder::new();
 
-        match CpalAudioBackend::new(&preferences) {
+        match CpalAudioBackend::new(preferences.output_device_name().as_deref()) {
             Ok(audio) => {
                 builder = builder.with_audio(audio);
             }

--- a/frontend-utils/Cargo.toml
+++ b/frontend-utils/Cargo.toml
@@ -10,12 +10,15 @@ version.workspace = true
 [lints]
 workspace = true
 
+[features]
+cpal = ["dep:cpal", "dep:bytemuck"]
+
 [dependencies]
 toml_edit = { version = "0.22.20", features = ["parse"] }
 url = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-zip = { version = "2.2.0", default-features = false, features = ["deflate"]}
+zip = { version = "2.2.0", default-features = false, features = ["deflate"] }
 urlencoding = "2.1.3"
 ruffle_core = { path = "../core", default-features = false }
 ruffle_render = { path = "../render", default-features = false }
@@ -23,8 +26,16 @@ async-channel = { workspace = true }
 slotmap = { workspace = true }
 async-io = "2.3.4"
 futures-lite = "2.3.0"
-reqwest = { version = "0.12.7", default-features = false, features = ["rustls-tls", "cookies", "charset", "http2", "macos-system-configuration"] }
+reqwest = { version = "0.12.7", default-features = false, features = [
+    "rustls-tls",
+    "cookies",
+    "charset",
+    "http2",
+    "macos-system-configuration",
+] }
 tokio = { workspace = true, features = ["net"] }
+cpal = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/frontend-utils/src/backends.rs
+++ b/frontend-utils/src/backends.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "cpal")]
+pub mod audio;
 pub mod executor;
 pub mod navigator;
 pub mod storage;


### PR DESCRIPTION
Required for https://github.com/madsmtm/ruffle-ios.