### PR TITLE
ci: Run regression tests in random order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5312,6 +5312,7 @@ dependencies = [
  "futures",
  "image",
  "libtest-mimic",
+ "rand",
  "regex",
  "ruffle_core",
  "ruffle_render_wgpu",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -30,6 +30,7 @@ regex = "1.10.6"
 ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "default_font", "test_only_as3"] }
 ruffle_test_framework = { path = "framework" }
 libtest-mimic = "0.7.3"
+rand = "0.8.5"
 walkdir = { workspace = true }
 anyhow = { workspace = true }
 image = { workspace = true, features  = ["png"] }

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -126,7 +126,8 @@ fn main() {
         external_interface_avm2(&NativeEnvironment)
     }));
 
-    tests.sort_unstable_by(|a, b| a.name().cmp(b.name()));
+    use rand::seq::SliceRandom;
+    tests.shuffle(&mut rand::thread_rng());
 
     libtest_mimic::run(&args, tests).exit()
 }


### PR DESCRIPTION
This is the primitive, _chaotic neutral_ "little brother" of https://github.com/ruffle-rs/ruffle/pull/15950, with the same motivation - to make Rust CI runs faster on average.

I do think that it would still make sense to sort the tests after shuffling, to bring the known slow ones forward - so, sorting only by kind, not by name.

To explain it by sticking to the packing problem analogy: this is basically shaking up (shuffling) the big bag (campaign) of little boxes (test cases), before packing (executing) them one by one into smaller backpacks (threads); this way, reducing the chance that some bigger boxes (slow tests) end up being packed too late, making all the backpacks too tall (waiting to finish), leaving some of them empty at the top (threads idling).