### PR TITLE
core: Make applyFilter with zero-sized rects noops

### DIFF
--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -1210,6 +1210,17 @@ pub fn apply_filter<'gc>(
     dest_point: (u32, u32),
     filter: Filter,
 ) {
+    // Prevent creating 0x0 textures.
+    // FIXME: this is not correct.
+    // Currently at minimum, applyFilter(blur) is bugged in that
+    // it doesn't include the blur's dimensions (see calculate_dest_rect).
+    // In other words, blur with 0x0 source rect is not supposed to be a noop.
+    // Once it is fixed, this check should be removed or replaced by
+    // "if after including size adjustment the size is still 0, return".
+    if source_size.0 == 0 || source_size.1 == 0 {
+        return;
+    }
+
     if !context.renderer.is_filter_supported(&filter) {
         let mut source_region = PixelRegion::for_whole_size(source.width(), source.height());
         let mut dest_region = PixelRegion::for_whole_size(target.width(), target.height());


### PR DESCRIPTION
Verified that it fixes https://github.com/ruffle-rs/ruffle/issues/17964 . Hopefully should fix most/all of "dimension X is zero" in applyFilter.

I don't know whether this is the best place (it can be done a layer above and below, and after more clamping). @Dinnerbone can you please check it out?