### PR TITLE
chore: Fix compilation warnings on non-Linux

### DIFF
--- a/desktop/src/gui/theme.rs
+++ b/desktop/src/gui/theme.rs
@@ -2,7 +2,6 @@
 use crate::dbus::{ColorScheme, FreedesktopSettings};
 use crate::preferences::GlobalPreferences;
 use egui::Context;
-use futures::StreamExt;
 use std::error::Error;
 use std::str::FromStr;
 use std::sync::{Arc, Weak};
@@ -68,6 +67,8 @@ impl ThemeController {
     #[cfg(target_os = "linux")]
     async fn start_dbus_theme_watcher_linux(&self) {
         async fn start_inner(this: &ThemeController) -> Result<(), Box<dyn Error>> {
+            use futures::StreamExt;
+
             let Some(ref connection) = this.data().zbus_connection else {
                 return Ok(());
             };


### PR DESCRIPTION
This fixes the following warning on macOS & Windows (and probably others that we do not build for here).

```
warning: unused import: `futures::StreamExt`
 --> desktop/src/gui/theme.rs:5:5
  |
5 | use futures::StreamExt;
  |     ^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `ruffle_desktop` (bin "ruffle_desktop" test) generated 1 warning (run `cargo fix --bin "ruffle_desktop" --tests` to apply 1 suggestion)
```