### PR TITLE
web: Show the original cause of the error when Ruffle fails to load

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -1835,6 +1835,7 @@ export class InnerPlayer {
         }
         this.panicked = true;
         this.hideSplashScreen();
+        const originalError = error;
 
         if (
             error instanceof Error &&
@@ -1854,6 +1855,7 @@ export class InnerPlayer {
                 this.addOpenInNewTabMessage(openInNewTab, swfUrl);
                 return;
             }
+            error = error.cause;
         }
 
         const errorArray: Array<string | null> & {
@@ -1892,7 +1894,7 @@ export class InnerPlayer {
         errorArray.push(this.getPanicData());
 
         // Clears out any existing content (ie play button or canvas) and replaces it with the error screen
-        showPanicScreen(this.container, error, errorArray, this.swfUrl);
+        showPanicScreen(this.container, originalError, errorArray, this.swfUrl);
 
         // Do this last, just in case it causes any cascading issues.
         this.destroy();


### PR DESCRIPTION
Before, the panic screen just said:

"Failed to load Ruffle WASM": https://github.com/ruffle-rs/ruffle/issues?q=is%3Aissue+is%3Aopen+%22Failed+to+load+Ruffle+WASM%22

The only LoadRuffleWasmError that should produce a report bug button is a TypeError I believe, but we can't really be sure that's working properly with this issue in place. Often when there's a TypeError it does mean the website is redefining a global so often there is nothing we can do, but sometimes we may be able to work around such instances if they are common enough and the workaround is simple enough, which is why the report button appears.

See the LoadRuffleWasmError constructor: it has a cause which is itself an error, so we should report on that: https://github.com/ruffle-rs/ruffle/blob/master/web/packages/core/src/internal/errors.tsx#L15