### PR TITLE
desktop: Use trash can emoji on remove buttons

### DIFF
--- a/desktop/src/gui/dialogs/open_dialog.rs
+++ b/desktop/src/gui/dialogs/open_dialog.rs
@@ -569,7 +569,7 @@ impl OpenDialog {
                     ui.horizontal(|ui| {
                         ui.text_edit_singleline(value);
                         if ui
-                            .button("x")
+                            .button("🗑")
                             .on_hover_text(text(locale, "open-dialog-remove-parameter"))
                             .clicked()
                         {


### PR DESCRIPTION
This replaces the letter x with the trash can emoji, which looks nicer (IMO) and has clearer semantics.

| Before | After |
| ------ | ----- |
| <image src="https://github.com/user-attachments/assets/e6d13f50-8394-40b7-89fd-84217742b6d2" width="300"/> | <image src="https://github.com/user-attachments/assets/5d4c34e8-8433-4f2c-b045-d2456e960a79" width="300"/> |
