### PR TITLE
desktop: Bump `egui` to latest `master` (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,7 +1430,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 [[package]]
 name = "ecolor"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1439,7 +1439,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
 dependencies = [
  "ahash",
  "emath",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1469,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
 dependencies = [
  "ahash",
  "arboard",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
 dependencies = [
  "ahash",
  "egui",
@@ -1503,7 +1503,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
 dependencies = [
  "bytemuck",
 ]
@@ -1632,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 naga = { version = "22.1.0", features = ["wgsl-out"] }
 wgpu = "22.1.0"
-egui = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e" }
+egui = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db" }
 clap = { version = "4.5.17", features = ["derive"] }
 cpal = "0.15.3"
 anyhow = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.10.1"
 egui = { workspace = true, optional = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e", default-features = false, optional = true }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db", default-features = false, optional = true }
 png = { version = "0.17.13", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 clap = { workspace = true }
 cpal = { workspace = true }
 egui = { workspace = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e", default-features = false, features = ["image"] }
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e", features = ["winit"] }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db", default-features = false, features = ["image"] }
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db", features = ["winit"] }
 image = { workspace = true, features = ["png"] }
-egui-winit = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e" }
+egui-winit = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db" }
 fontdb = "0.22"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }


### PR DESCRIPTION
Following https://github.com/ruffle-rs/ruffle/pull/17987, to pull in https://github.com/emilk/egui/pull/5133, fixing https://github.com/emilk/egui/issues/5132.

Cc: @kjarosh