### PR TITLE
AVM2: move cached namespaces to a new `CommonNamespaces` struct

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -778,13 +778,11 @@ impl<'gc> Class<'gc> {
         // interfaces (i.e. those that were not already implemented by the superclass)
         // Otherwise, our behavior diverges from Flash Player in certain cases.
         // See the ignored test 'tests/tests/swfs/avm2/weird_superinterface_properties/'
+        let ns = context.avm2.namespaces.public_vm_internal();
         for interface in &interfaces {
             for interface_trait in &*interface.traits() {
                 if !interface_trait.name().namespace().is_public() {
-                    let public_name = QName::new(
-                        context.avm2.public_namespace_vm_internal,
-                        interface_trait.name().local_name(),
-                    );
+                    let public_name = QName::new(ns, interface_trait.name().local_name());
                     self.0.read().vtable.copy_property_for_interface(
                         context.gc_context,
                         public_name,
@@ -817,7 +815,7 @@ impl<'gc> Class<'gc> {
             )?);
         }
 
-        let name = QName::new(activation.avm2().public_namespace_base_version, name);
+        let name = QName::new(activation.avm2().namespaces.public_all(), name);
 
         let i_class = Class(GcCell::new(
             activation.context.gc_context,

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1710,11 +1710,11 @@ pub fn string_to_multiname<'gc>(
         }
 
         let name = AvmString::new(activation.context.gc_context, name);
-        Multiname::attribute(activation.avm2().public_namespace_base_version, name)
+        Multiname::attribute(activation.avm2().namespaces.public_all(), name)
     } else if &*name == b"*" {
         Multiname::any()
     } else {
-        Multiname::new(activation.avm2().public_namespace_base_version, name)
+        Multiname::new(activation.avm2().namespaces.public_all(), name)
     }
 }
 

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -382,11 +382,10 @@ fn dispatch_event_to_target<'gc>(
         "Event dispatch: {} to {target:?}",
         event.as_event().unwrap().event_type(),
     );
+
+    let internal_ns = activation.avm2().namespaces.flash_events_internal;
     let dispatch_list = dispatcher
-        .get_property(
-            &Multiname::new(activation.avm2().flash_events_internal, "_dispatchList"),
-            activation,
-        )?
+        .get_property(&Multiname::new(internal_ns, "_dispatchList"), activation)?
         .as_object();
 
     if dispatch_list.is_none() {
@@ -448,11 +447,9 @@ pub fn dispatch_event<'gc>(
     event: Object<'gc>,
     simulate_dispatch: bool,
 ) -> Result<bool, Error<'gc>> {
+    let internal_ns = activation.avm2().namespaces.flash_events_internal;
     let target = this
-        .get_property(
-            &Multiname::new(activation.avm2().flash_events_internal, "_target"),
-            activation,
-        )?
+        .get_property(&Multiname::new(internal_ns, "_target"), activation)?
         .as_object()
         .unwrap_or(this);
 

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -1335,7 +1335,7 @@ pub fn remove_at<'gc>(
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(activation.avm2().public_namespace_base_version, "Array"),
+        QName::new(activation.avm2().namespaces.public_all(), "Array"),
         Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<Array instance initializer>", mc),
         Method::from_builtin(class_init, "<Array class initializer>", mc),
@@ -1356,13 +1356,13 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     )] = &[("length", Some(length), Some(set_length))];
     class.define_builtin_instance_properties(
         mc,
-        activation.avm2().public_namespace_base_version,
+        activation.avm2().namespaces.public_all(),
         PUBLIC_INSTANCE_PROPERTIES,
     );
 
     class.define_builtin_instance_methods(
         mc,
-        activation.avm2().as3_namespace,
+        activation.avm2().namespaces.as3,
         PUBLIC_AS3_INSTANCE_METHODS,
     );
 
@@ -1380,14 +1380,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         ("UNIQUESORT", SortOptions::UNIQUE_SORT.bits() as u32),
     ];
     class.define_constant_uint_class_traits(
-        activation.avm2().public_namespace_base_version,
+        activation.avm2().namespaces.public_all(),
         CONSTANTS_UINT,
         activation,
     );
 
     const CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
     class.define_constant_int_class_traits(
-        activation.avm2().public_namespace_base_version,
+        activation.avm2().namespaces.public_all(),
         CONSTANTS_INT,
         activation,
     );

--- a/core/src/avm2/globals/boolean.rs
+++ b/core/src/avm2/globals/boolean.rs
@@ -133,9 +133,11 @@ fn value_of<'gc>(
 
 /// Construct `Boolean`'s class.
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let class = Class::new(
-        QName::new(activation.avm2().public_namespace_base_version, "Boolean"),
+        QName::new(namespaces.public_all(), "Boolean"),
         Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<Boolean instance initializer>", mc),
         Method::from_builtin(class_init, "<Boolean class initializer>", mc),
@@ -156,18 +158,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
 
     const AS3_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] =
         &[("toString", to_string), ("valueOf", value_of)];
-    class.define_builtin_instance_methods(
-        mc,
-        activation.avm2().as3_namespace,
-        AS3_INSTANCE_METHODS,
-    );
+    class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
     const CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
-    class.define_constant_int_class_traits(
-        activation.avm2().public_namespace_base_version,
-        CONSTANTS_INT,
-        activation,
-    );
+    class.define_constant_int_class_traits(namespaces.public_all(), CONSTANTS_INT, activation);
 
     class.mark_traits_loaded(activation.context.gc_context);
     class

--- a/core/src/avm2/globals/class.rs
+++ b/core/src/avm2/globals/class.rs
@@ -57,9 +57,11 @@ pub fn create_i_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
     object_i_class: Class<'gc>,
 ) -> Class<'gc> {
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let class_i_class = Class::custom_new(
-        QName::new(activation.avm2().public_namespace_base_version, "Class"),
+        QName::new(namespaces.public_all(), "Class"),
         Some(object_i_class),
         Method::from_builtin(instance_init, "<Class instance initializer>", gc_context),
         gc_context,
@@ -84,7 +86,7 @@ pub fn create_i_class<'gc>(
     )] = &[("prototype", Some(prototype), None)];
     class_i_class.define_builtin_instance_properties(
         gc_context,
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         PUBLIC_INSTANCE_PROPERTIES,
     );
 
@@ -101,9 +103,11 @@ pub fn create_c_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
     class_i_class: Class<'gc>,
 ) -> Class<'gc> {
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let class_c_class = Class::custom_new(
-        QName::new(activation.avm2().public_namespace_base_version, "Class$"),
+        QName::new(namespaces.public_all(), "Class$"),
         Some(class_i_class),
         Method::from_builtin(class_init, "<Class class initializer>", gc_context),
         gc_context,
@@ -114,7 +118,7 @@ pub fn create_c_class<'gc>(
     // We need to define it, since it shows up in 'describeType'
     const CLASS_CONSTANTS: &[(&str, i32)] = &[("length", 1)];
     class_c_class.define_constant_int_instance_traits(
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         CLASS_CONSTANTS,
         activation,
     );

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -26,6 +26,8 @@ pub fn loader_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     // Loader does not have an associated `Character` variant, and can never be
     // instantiated from the timeline.
     let display_object = LoaderDisplay::empty(activation, activation.context.swf.clone()).into();
@@ -46,10 +48,7 @@ pub fn loader_allocator<'gc>(
         false,
     )?;
     loader.set_property(
-        &Multiname::new(
-            activation.avm2().flash_display_internal,
-            "_contentLoaderInfo",
-        ),
+        &Multiname::new(namespaces.flash_display_internal, "_contentLoaderInfo"),
         loader_info.into(),
         activation,
     )?;
@@ -61,15 +60,14 @@ pub fn load<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     let url_request = args.get_object(activation, 0, "request")?;
     let context = args.try_get_object(activation, 1);
 
     let loader_info = this
         .get_property(
-            &Multiname::new(
-                activation.avm2().flash_display_internal,
-                "_contentLoaderInfo",
-            ),
+            &Multiname::new(namespaces.flash_display_internal, "_contentLoaderInfo"),
             activation,
         )?
         .as_object()
@@ -223,16 +221,15 @@ pub fn load_bytes<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     let arg0 = args.get_object(activation, 0, "data")?;
     let bytes = arg0.as_bytearray().unwrap().bytes().to_vec();
     let context = args.try_get_object(activation, 1);
 
     let loader_info = this
         .get_property(
-            &Multiname::new(
-                activation.avm2().flash_display_internal,
-                "_contentLoaderInfo",
-            ),
+            &Multiname::new(namespaces.flash_display_internal, "_contentLoaderInfo"),
             activation,
         )?
         .as_object()
@@ -287,15 +284,14 @@ pub fn unload<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     // TODO: Broadcast an "unload" event on the LoaderInfo
     avm2_stub_method!(activation, "flash.display.Loader", "unload");
 
     let loader_info = this
         .get_property(
-            &Multiname::new(
-                activation.avm2().flash_display_internal,
-                "_contentLoaderInfo",
-            ),
+            &Multiname::new(namespaces.flash_display_internal, "_contentLoaderInfo"),
             activation,
         )?
         .as_object()

--- a/core/src/avm2/globals/flash/display/shader_parameter.rs
+++ b/core/src/avm2/globals/flash/display/shader_parameter.rs
@@ -10,7 +10,7 @@ pub fn make_shader_parameter<'gc>(
     param: &PixelBenderParam,
     index: usize,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let ns = activation.avm2().flash_display_internal;
+    let ns = activation.avm2().namespaces.flash_display_internal;
 
     match param {
         PixelBenderParam::Normal {

--- a/core/src/avm2/globals/flash/display/shape.rs
+++ b/core/src/avm2/globals/flash/display/shape.rs
@@ -47,16 +47,18 @@ pub fn get_graphics<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     if let Some(dobj) = this.as_display_object() {
         // Lazily initialize the `Graphics` object in a hidden property.
         let graphics = match this.get_property(
-            &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
+            &Multiname::new(namespaces.flash_display_internal, "_graphics"),
             activation,
         )? {
             Value::Undefined | Value::Null => {
                 let graphics = Value::from(StageObject::graphics(activation, dobj)?);
                 this.set_property(
-                    &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
+                    &Multiname::new(namespaces.flash_display_internal, "_graphics"),
                     graphics,
                     activation,
                 )?;

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -67,16 +67,18 @@ pub fn get_graphics<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     if let Some(dobj) = this.as_display_object() {
         // Lazily initialize the `Graphics` object in a hidden property.
         let graphics = match this.get_property(
-            &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
+            &Multiname::new(namespaces.flash_display_internal, "_graphics"),
             activation,
         )? {
             Value::Undefined | Value::Null => {
                 let graphics = Value::from(StageObject::graphics(activation, dobj)?);
                 this.set_property(
-                    &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
+                    &Multiname::new(namespaces.flash_display_internal, "_graphics"),
                     graphics,
                     activation,
                 )?;

--- a/core/src/avm2/globals/flash/events/event_dispatcher.rs
+++ b/core/src/avm2/globals/flash/events/event_dispatcher.rs
@@ -13,15 +13,17 @@ fn dispatch_list<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     match this.get_property(
-        &Multiname::new(activation.avm2().flash_events_internal, "_dispatchList"),
+        &Multiname::new(namespaces.flash_events_internal, "_dispatchList"),
         activation,
     )? {
         Value::Object(o) => Ok(o),
         _ => {
             let dispatch_list = DispatchObject::empty_list(activation);
             this.init_property(
-                &Multiname::new(activation.avm2().flash_events_internal, "_dispatchList"),
+                &Multiname::new(namespaces.flash_events_internal, "_dispatchList"),
                 dispatch_list.into(),
                 activation,
             )?;
@@ -101,6 +103,8 @@ pub fn will_trigger<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     let dispatch_list = dispatch_list(activation, this)?;
     let event_type = args.get_string(activation, 0)?;
 
@@ -114,7 +118,7 @@ pub fn will_trigger<'gc>(
 
     let target = this
         .get_property(
-            &Multiname::new(activation.avm2().flash_events_internal, "_target"),
+            &Multiname::new(namespaces.flash_events_internal, "_target"),
             activation,
         )?
         .as_object()
@@ -154,7 +158,7 @@ pub fn to_string<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let object_proto = activation.avm2().classes().object.prototype();
-    let name = Multiname::new(activation.avm2().public_namespace_base_version, "toString");
+    let name = Multiname::new(activation.avm2().namespaces.public_all(), "toString");
 
     object_proto
         .get_property(&name, activation)?

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -11,9 +11,11 @@ fn get_display_object<'gc>(
     this: Object<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<DisplayObject<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     Ok(this
         .get_property(
-            &Multiname::new(activation.avm2().flash_geom_internal, "_displayObject"),
+            &Multiname::new(namespaces.flash_geom_internal, "_displayObject"),
             activation,
         )?
         .as_object()
@@ -27,8 +29,10 @@ pub fn init<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     this.set_property(
-        &Multiname::new(activation.avm2().flash_geom_internal, "_displayObject"),
+        &Multiname::new(namespaces.flash_geom_internal, "_displayObject"),
         args.get_value(0),
         activation,
     )?;

--- a/core/src/avm2/globals/flash/net/shared_object.rs
+++ b/core/src/avm2/globals/flash/net/shared_object.rs
@@ -1,11 +1,10 @@
 //! `flash.net.SharedObject` builtin/prototype
 
-use crate::avm2::api_version::ApiVersion;
 use crate::avm2::error::error;
 use crate::avm2::object::TObject;
 use crate::avm2::Error::AvmError;
 use crate::avm2::Multiname;
-use crate::avm2::{Activation, Error, Namespace, Object, Value};
+use crate::avm2::{Activation, Error, Object, Value};
 use crate::string::AvmString;
 use crate::{avm2_stub_getter, avm2_stub_method, avm2_stub_setter};
 use flash_lso::types::{AMFVersion, Lso};
@@ -154,14 +153,7 @@ pub fn get_local<'gc>(
     let this = sharedobject_cls.construct(activation, &[])?;
 
     // Set the internal name
-    let ruffle_name = Multiname::new(
-        Namespace::package(
-            "__ruffle__",
-            ApiVersion::AllVersions,
-            &mut activation.borrow_gc(),
-        ),
-        "_ruffleName",
-    );
+    let ruffle_name = Multiname::new(activation.avm2().namespaces.__ruffle__, "_ruffleName");
     this.set_property(
         &ruffle_name,
         AvmString::new_utf8(activation.context.gc_context, &full_name).into(),
@@ -205,14 +197,7 @@ pub fn flush<'gc>(
         .get_public_property("data", activation)?
         .coerce_to_object(activation)?;
 
-    let ruffle_name = Multiname::new(
-        Namespace::package(
-            "__ruffle__",
-            ApiVersion::AllVersions,
-            &mut activation.borrow_gc(),
-        ),
-        "_ruffleName",
-    );
+    let ruffle_name = Multiname::new(activation.avm2().namespaces.__ruffle__, "_ruffleName");
     let name = this
         .get_property(&ruffle_name, activation)?
         .coerce_to_string(activation)?;
@@ -246,14 +231,7 @@ pub fn get_size<'gc>(
         .get_public_property("data", activation)?
         .coerce_to_object(activation)?;
 
-    let ruffle_name = Multiname::new(
-        Namespace::package(
-            "__ruffle__",
-            ApiVersion::AllVersions,
-            &mut activation.borrow_gc(),
-        ),
-        "_ruffleName",
-    );
+    let ruffle_name = Multiname::new(activation.avm2().namespaces.__ruffle__, "_ruffleName");
     let name = this
         .get_property(&ruffle_name, activation)?
         .coerce_to_string(activation)?;
@@ -293,14 +271,7 @@ pub fn clear<'gc>(
     this.set_public_property("data", data, activation)?;
 
     // Delete data from storage backend.
-    let ruffle_name = Multiname::new(
-        Namespace::package(
-            "__ruffle__",
-            ApiVersion::AllVersions,
-            &mut activation.borrow_gc(),
-        ),
-        "_ruffleName",
-    );
+    let ruffle_name = Multiname::new(activation.avm2().namespaces.__ruffle__, "_ruffleName");
     let name = this
         .get_property(&ruffle_name, activation)?
         .coerce_to_string(activation)?;

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -15,6 +15,7 @@ pub fn create_text_line<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
     avm2_stub_method!(activation, "flash.text.TextBlock", "createTextLine");
 
     let previous_text_line = args.try_get_object(activation, 0);
@@ -34,7 +35,7 @@ pub fn create_text_line<'gc>(
             // TODO: Support multiple lines
             this.set_property(
                 &Multiname::new(
-                    activation.avm2().flash_text_engine_internal,
+                    namespaces.flash_text_engine_internal,
                     "_textLineCreationResult",
                 ),
                 "complete".into(),
@@ -83,32 +84,26 @@ pub fn create_text_line<'gc>(
     class.call_super_init(instance.into(), &[], activation)?;
 
     instance.set_property(
-        &Multiname::new(activation.avm2().flash_text_engine_internal, "_textBlock"),
+        &Multiname::new(namespaces.flash_text_engine_internal, "_textBlock"),
         this.into(),
         activation,
     )?;
 
     instance.set_property(
-        &Multiname::new(
-            activation.avm2().flash_text_engine_internal,
-            "_specifiedWidth",
-        ),
+        &Multiname::new(namespaces.flash_text_engine_internal, "_specifiedWidth"),
         args.get_value(1),
         activation,
     )?;
 
     instance.set_property(
-        &Multiname::new(
-            activation.avm2().flash_text_engine_internal,
-            "_rawTextLength",
-        ),
+        &Multiname::new(namespaces.flash_text_engine_internal, "_rawTextLength"),
         text.len().into(),
         activation,
     )?;
 
     this.set_property(
         &Multiname::new(
-            activation.avm2().flash_text_engine_internal,
+            namespaces.flash_text_engine_internal,
             "_textLineCreationResult",
         ),
         "success".into(),
@@ -116,7 +111,7 @@ pub fn create_text_line<'gc>(
     )?;
 
     this.set_property(
-        &Multiname::new(activation.avm2().flash_text_engine_internal, "_firstLine"),
+        &Multiname::new(namespaces.flash_text_engine_internal, "_firstLine"),
         instance.into(),
         activation,
     )?;

--- a/core/src/avm2/globals/flash/utils/timer.rs
+++ b/core/src/avm2/globals/flash/utils/timer.rs
@@ -13,9 +13,11 @@ pub fn stop<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     let id = this
         .get_property(
-            &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
+            &Multiname::new(namespaces.flash_utils_internal, "_timerId"),
             activation,
         )
         .unwrap()
@@ -24,7 +26,7 @@ pub fn stop<'gc>(
     if id != -1 {
         activation.context.timers.remove(id);
         this.set_property(
-            &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
+            &Multiname::new(namespaces.flash_utils_internal, "_timerId"),
             (-1).into(),
             activation,
         )?;
@@ -39,9 +41,11 @@ pub fn start<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     let id = this
         .get_property(
-            &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
+            &Multiname::new(namespaces.flash_utils_internal, "_timerId"),
             activation,
         )
         .unwrap()
@@ -49,7 +53,7 @@ pub fn start<'gc>(
 
     let delay = this
         .get_property(
-            &Multiname::new(activation.avm2().flash_utils_internal, "_delay"),
+            &Multiname::new(namespaces.flash_utils_internal, "_delay"),
             activation,
         )
         .unwrap()
@@ -58,7 +62,7 @@ pub fn start<'gc>(
     if id == -1 {
         let on_update = this
             .get_property(
-                &Multiname::new(activation.avm2().flash_utils_internal, "onUpdate"),
+                &Multiname::new(namespaces.flash_utils_internal, "onUpdate"),
                 activation,
             )?
             .coerce_to_object(activation)?;
@@ -74,7 +78,7 @@ pub fn start<'gc>(
             false,
         );
         this.set_property(
-            &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
+            &Multiname::new(namespaces.flash_utils_internal, "_timerId"),
             id.into(),
             activation,
         )?;
@@ -88,9 +92,11 @@ pub fn update_delay<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     let id = this
         .get_property(
-            &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
+            &Multiname::new(namespaces.flash_utils_internal, "_timerId"),
             activation,
         )
         .unwrap()
@@ -98,7 +104,7 @@ pub fn update_delay<'gc>(
 
     let delay = this
         .get_property(
-            &Multiname::new(activation.avm2().flash_utils_internal, "_delay"),
+            &Multiname::new(namespaces.flash_utils_internal, "_delay"),
             activation,
         )
         .unwrap()
@@ -107,6 +113,5 @@ pub fn update_delay<'gc>(
     if id != -1 {
         activation.context.timers.set_delay(id, delay);
     }
-
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -229,16 +229,18 @@ pub fn create_class<'gc>(
     object_i_class: Class<'gc>,
     class_i_class: Class<'gc>,
 ) -> Class<'gc> {
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let function_i_class = Class::custom_new(
-        QName::new(activation.avm2().public_namespace_base_version, "Function"),
+        QName::new(namespaces.public_all(), "Function"),
         Some(object_i_class),
         Method::from_builtin(instance_init, "<Function instance initializer>", gc_context),
         gc_context,
     );
 
     let function_c_class = Class::custom_new(
-        QName::new(activation.avm2().public_namespace_base_version, "Function$"),
+        QName::new(namespaces.public_all(), "Function$"),
         Some(class_i_class),
         Method::from_builtin(class_init, "<Function class initializer>", gc_context),
         gc_context,
@@ -252,7 +254,7 @@ pub fn create_class<'gc>(
     const AS3_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[("call", call), ("apply", apply)];
     function_i_class.define_builtin_instance_methods(
         gc_context,
-        activation.avm2().as3_namespace,
+        namespaces.as3,
         AS3_INSTANCE_METHODS,
     );
 
@@ -266,13 +268,13 @@ pub fn create_class<'gc>(
     ];
     function_i_class.define_builtin_instance_properties(
         gc_context,
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         PUBLIC_INSTANCE_PROPERTIES,
     );
 
     const CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
     function_c_class.define_constant_int_instance_traits(
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         CONSTANTS_INT,
         activation,
     );

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -29,7 +29,7 @@ pub fn create_class<'gc>(
 ) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::custom_new(
-        QName::new(activation.avm2().public_namespace_base_version, "global"),
+        QName::new(activation.avm2().namespaces.public_all(), "global"),
         Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<global instance initializer>", mc),
         mc,

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -218,9 +218,11 @@ fn value_of<'gc>(
 
 /// Construct `int`'s class.
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let class = Class::new(
-        QName::new(activation.avm2().public_namespace_base_version, "int"),
+        QName::new(namespaces.public_all(), "int"),
         Some(activation.avm2().class_defs().object),
         Method::from_builtin_and_params(
             instance_init,
@@ -257,11 +259,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         ("MIN_VALUE", i32::MIN),
         ("length", 1),
     ];
-    class.define_constant_int_class_traits(
-        activation.avm2().public_namespace_base_version,
-        CLASS_CONSTANTS,
-        activation,
-    );
+    class.define_constant_int_class_traits(namespaces.public_all(), CLASS_CONSTANTS, activation);
 
     const AS3_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[
         ("toExponential", to_exponential),
@@ -270,11 +268,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         ("toString", to_string),
         ("valueOf", value_of),
     ];
-    class.define_builtin_instance_methods(
-        mc,
-        activation.avm2().as3_namespace,
-        AS3_INSTANCE_METHODS,
-    );
+    class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
     class.mark_traits_loaded(activation.context.gc_context);
     class

--- a/core/src/avm2/globals/number.rs
+++ b/core/src/avm2/globals/number.rs
@@ -373,9 +373,11 @@ fn value_of<'gc>(
 
 /// Construct `Number`'s class.
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let class = Class::new(
-        QName::new(activation.avm2().public_namespace_base_version, "Number"),
+        QName::new(namespaces.public_all(), "Number"),
         Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<Number instance initializer>", mc),
         Method::from_builtin(class_init, "<Number class initializer>", mc),
@@ -410,14 +412,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         ("LOG10E", std::f64::consts::LOG10_E),
     ];
     class.define_constant_number_class_traits(
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         CLASS_CONSTANTS_NUMBER,
         activation,
     );
 
     const CLASS_CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
     class.define_constant_int_class_traits(
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         CLASS_CONSTANTS_INT,
         activation,
     );
@@ -429,11 +431,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         ("toString", to_string),
         ("valueOf", value_of),
     ];
-    class.define_builtin_instance_methods(
-        mc,
-        activation.avm2().as3_namespace,
-        AS3_INSTANCE_METHODS,
-    );
+    class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
     class.mark_traits_loaded(activation.context.gc_context);
     class

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -257,9 +257,11 @@ pub fn init<'gc>(
 
 /// Construct `Object`'s i_class.
 pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let object_i_class = Class::custom_new(
-        QName::new(activation.avm2().public_namespace_base_version, "Object"),
+        QName::new(namespaces.public_all(), "Object"),
         None,
         Method::from_builtin(instance_init, "<Object instance initializer>", gc_context),
         gc_context,
@@ -294,7 +296,7 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     ];
     object_i_class.define_builtin_instance_methods_with_sig(
         gc_context,
-        activation.avm2().as3_namespace,
+        namespaces.as3,
         as3_instance_methods,
     );
 
@@ -311,9 +313,11 @@ pub fn create_c_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
     class_i_class: Class<'gc>,
 ) -> Class<'gc> {
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let object_c_class = Class::custom_new(
-        QName::new(activation.avm2().public_namespace_base_version, "Object$"),
+        QName::new(namespaces.public_all(), "Object$"),
         Some(class_i_class),
         Method::from_builtin(class_init, "<Object class initializer>", gc_context),
         gc_context,
@@ -323,7 +327,7 @@ pub fn create_c_class<'gc>(
     object_c_class.define_instance_trait(
         gc_context,
         Trait::from_const(
-            QName::new(activation.avm2().public_namespace_base_version, "length"),
+            QName::new(activation.avm2().namespaces.public_all(), "length"),
             Some(activation.avm2().multinames.int),
             Some(1.into()),
         ),
@@ -332,7 +336,7 @@ pub fn create_c_class<'gc>(
     const INTERNAL_INIT_METHOD: &[(&str, NativeMethodImpl)] = &[("init", init)];
     object_c_class.define_builtin_instance_methods(
         gc_context,
-        activation.avm2().internal_namespace,
+        namespaces.internal,
         INTERNAL_INIT_METHOD,
     );
 

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -686,9 +686,11 @@ fn is_dependent<'gc>(
 
 /// Construct `String`'s class.
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let class = Class::new(
-        QName::new(activation.avm2().public_namespace_base_version, "String"),
+        QName::new(namespaces.public_all(), "String"),
         Some(activation.avm2().class_defs().object),
         Method::from_builtin(instance_init, "<String instance initializer>", mc),
         Method::from_builtin(class_init, "<String class initializer>", mc),
@@ -710,14 +712,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     )] = &[("length", Some(length), None)];
     class.define_builtin_instance_properties(
         mc,
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         PUBLIC_INSTANCE_PROPERTIES,
     );
-    class.define_builtin_instance_methods(
-        mc,
-        activation.avm2().as3_namespace,
-        PUBLIC_INSTANCE_AND_PROTO_METHODS,
-    );
+    class.define_builtin_instance_methods(mc, namespaces.as3, PUBLIC_INSTANCE_AND_PROTO_METHODS);
 
     #[cfg(feature = "test_only_as3")]
     {
@@ -737,20 +735,12 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     }
 
     const CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
-    class.define_constant_int_class_traits(
-        activation.avm2().public_namespace_base_version,
-        CONSTANTS_INT,
-        activation,
-    );
+    class.define_constant_int_class_traits(namespaces.public_all(), CONSTANTS_INT, activation);
 
     const AS3_CLASS_METHODS: &[(&str, NativeMethodImpl)] = &[("fromCharCode", from_char_code)];
     const PUBLIC_CLASS_METHODS: &[(&str, NativeMethodImpl)] = &[("fromCharCode", from_char_code)];
-    class.define_builtin_class_methods(mc, activation.avm2().as3_namespace, AS3_CLASS_METHODS);
-    class.define_builtin_class_methods(
-        mc,
-        activation.avm2().public_namespace_base_version,
-        PUBLIC_CLASS_METHODS,
-    );
+    class.define_builtin_class_methods(mc, namespaces.as3, AS3_CLASS_METHODS);
+    class.define_builtin_class_methods(mc, namespaces.public_all(), PUBLIC_CLASS_METHODS);
 
     class.mark_traits_loaded(activation.context.gc_context);
     class

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -719,19 +719,8 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
 
     #[cfg(feature = "test_only_as3")]
     {
-        use crate::avm2::api_version::ApiVersion;
-        use crate::avm2::namespace::Namespace;
-
         const TEST_METHODS: &[(&str, NativeMethodImpl)] = &[("isDependent", is_dependent)];
-        class.define_builtin_instance_methods(
-            mc,
-            Namespace::package(
-                "__ruffle__",
-                ApiVersion::AllVersions,
-                &mut activation.borrow_gc(),
-            ),
-            TEST_METHODS,
-        );
+        class.define_builtin_instance_methods(mc, namespaces.__ruffle__, TEST_METHODS);
     }
 
     const CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -219,9 +219,11 @@ fn value_of<'gc>(
 
 /// Construct `uint`'s class.
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.gc();
+    let namespaces = activation.avm2().namespaces;
+
     let class = Class::new(
-        QName::new(activation.avm2().public_namespace_base_version, "uint"),
+        QName::new(namespaces.public_all(), "uint"),
         Some(activation.avm2().class_defs().object),
         Method::from_builtin_and_params(
             instance_init,
@@ -254,14 +256,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     const CLASS_CONSTANTS_UINT: &[(&str, u32)] =
         &[("MAX_VALUE", u32::MAX), ("MIN_VALUE", u32::MIN)];
     class.define_constant_uint_class_traits(
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         CLASS_CONSTANTS_UINT,
         activation,
     );
 
     const CLASS_CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
     class.define_constant_int_class_traits(
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         CLASS_CONSTANTS_INT,
         activation,
     );
@@ -273,11 +275,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         ("toString", to_string),
         ("valueOf", value_of),
     ];
-    class.define_builtin_instance_methods(
-        mc,
-        activation.avm2().as3_namespace,
-        AS3_INSTANCE_METHODS,
-    );
+    class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
     class.mark_traits_loaded(activation.context.gc_context);
     class

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -899,7 +899,7 @@ pub fn splice<'gc>(
 pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(activation.avm2().vector_public_namespace, "Vector"),
+        QName::new(activation.avm2().namespaces.vector_public, "Vector"),
         Some(activation.avm2().class_defs().object),
         Method::from_builtin(generic_init, "<Vector instance initializer>", mc),
         Method::from_builtin(generic_init, "<Vector class initializer>", mc),
@@ -930,18 +930,16 @@ pub fn create_builtin_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
     param: Option<Class<'gc>>,
 ) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.gc();
+    let namespaces = activation.avm2().namespaces;
 
     // FIXME - we should store a `Multiname` instead of a `QName`, and use the
     // `params` field. For now, this is good enough to get tests passing
     let name = if let Some(param) = param {
         let name = format!("Vector.<{}>", param.name().to_qualified_name(mc));
-        QName::new(
-            activation.avm2().vector_public_namespace,
-            AvmString::new_utf8(mc, name),
-        )
+        QName::new(namespaces.vector_public, AvmString::new_utf8(mc, name))
     } else {
-        QName::new(activation.avm2().vector_public_namespace, "Vector.<*>")
+        QName::new(namespaces.vector_public, "Vector.<*>")
     };
 
     let class = Class::new(
@@ -975,7 +973,7 @@ pub fn create_builtin_class<'gc>(
     ];
     class.define_builtin_instance_properties(
         mc,
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         PUBLIC_INSTANCE_PROPERTIES,
     );
 
@@ -1002,11 +1000,7 @@ pub fn create_builtin_class<'gc>(
         ("sort", sort),
         ("splice", splice),
     ];
-    class.define_builtin_instance_methods(
-        mc,
-        activation.avm2().as3_namespace,
-        AS3_INSTANCE_METHODS,
-    );
+    class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
     class.mark_traits_loaded(activation.context.gc_context);
     class

--- a/core/src/avm2/globals/void.rs
+++ b/core/src/avm2/globals/void.rs
@@ -17,7 +17,7 @@ fn void_init<'gc>(
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::custom_new(
-        QName::new(activation.avm2().public_namespace_base_version, "void"),
+        QName::new(activation.avm2().namespaces.public_all(), "void"),
         None,
         Method::from_builtin(void_init, "", mc),
         mc,

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -728,6 +728,8 @@ pub fn append_child<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
+
     let xml = this.as_xml_object().unwrap();
     let child = args.get_value(0);
     let child = crate::avm2::e4x::maybe_escape_child(activation, child)?;
@@ -743,7 +745,7 @@ pub fn append_child<'gc>(
         .expect("Should have an XMLList");
     let length = xml_list.length();
     let name = Multiname::new(
-        activation.avm2().public_namespace_base_version,
+        namespaces.public_all(),
         AvmString::new_utf8(activation.context.gc_context, length.to_string()),
     );
     xml_list.set_property_local(&name, child, activation)?;

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -453,8 +453,8 @@ pub fn normalize<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let namespaces = activation.avm2().namespaces;
     let list = this.as_xml_list_object().unwrap();
-    let public_namespace = activation.avm2().public_namespace_base_version;
 
     // 1. Let i = 0
     let mut index = 0;
@@ -504,7 +504,7 @@ pub fn normalize<'gc>(
                     list.delete_property_local(
                         activation,
                         &Multiname::new(
-                            public_namespace,
+                            namespaces.public_all(),
                             AvmString::new_utf8(activation.gc(), (index + 1).to_string()),
                         ),
                     )?;
@@ -519,7 +519,7 @@ pub fn normalize<'gc>(
                 list.delete_property_local(
                     activation,
                     &Multiname::new(
-                        public_namespace,
+                        namespaces.public_all(),
                         AvmString::new_utf8(activation.gc(), index.to_string()),
                     ),
                 )?;
@@ -547,6 +547,7 @@ macro_rules! define_xml_proxy {
                 this: Object<'gc>,
                 args: &[Value<'gc>],
             ) -> Result<Value<'gc>, Error<'gc>> {
+                let namespaces = activation.avm2().namespaces;
                 let list = this.as_xml_list_object().unwrap();
 
                 let mut children = list.children_mut(activation.context.gc_context);
@@ -554,7 +555,7 @@ macro_rules! define_xml_proxy {
                     [child] => {
                         child
                             .get_or_create_xml(activation)
-                            .call_property(&Multiname::new(activation.avm2().as3_namespace, $as_name), args, activation)
+                            .call_property(&Multiname::new(namespaces.as3, $as_name), args, activation)
                     }
                     _ => Err(make_error_1086(activation, $as_name)),
                 }
@@ -591,6 +592,7 @@ pub fn namespace_internal_impl<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let list = this.as_xml_list_object().unwrap();
+    let namespaces = activation.avm2().namespaces;
     let mut children = list.children_mut(activation.context.gc_context);
 
     let args = if args[0] == Value::Bool(true) {
@@ -601,7 +603,7 @@ pub fn namespace_internal_impl<'gc>(
 
     match &mut children[..] {
         [child] => child.get_or_create_xml(activation).call_property(
-            &Multiname::new(activation.avm2().as3_namespace, "namespace"),
+            &Multiname::new(namespaces.as3, "namespace"),
             args,
             activation,
         ),

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -1,8 +1,8 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::error::{make_error_1032, make_error_1080};
+use crate::avm2::namespace::{CommonNamespaces, Namespace};
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::Error;
-use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::avm2::{Object, Value};
 use crate::context::GcContext;
@@ -543,17 +543,14 @@ pub struct CommonMultinames<'gc> {
 }
 
 impl<'gc> CommonMultinames<'gc> {
-    pub fn new(
-        context: &mut GcContext<'_, 'gc>,
-        public_namespace_base_version: Namespace<'gc>,
-    ) -> Self {
+    pub fn new(context: &mut GcContext<'_, 'gc>, namespaces: &CommonNamespaces<'gc>) -> Self {
         let mc = context.gc_context;
 
         let mut create_pub_multiname = |local_name: &'static [u8]| -> Gc<'gc, Multiname<'gc>> {
             Gc::new(
                 mc,
                 Multiname::new(
-                    public_namespace_base_version,
+                    namespaces.public_all(),
                     context
                         .interner
                         .intern_static(context.gc_context, WStr::from_units(local_name)),

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -356,6 +356,8 @@ pub struct CommonNamespaces<'gc> {
     pub(super) flash_events_internal: Namespace<'gc>,
     pub(super) flash_text_engine_internal: Namespace<'gc>,
     pub(super) flash_net_internal: Namespace<'gc>,
+
+    pub(super) __ruffle__: Namespace<'gc>,
 }
 
 impl<'gc> CommonNamespaces<'gc> {
@@ -385,6 +387,8 @@ impl<'gc> CommonNamespaces<'gc> {
             flash_events_internal: Namespace::internal("flash.events", context),
             flash_text_engine_internal: Namespace::internal("flash.text.engine", context),
             flash_net_internal: Namespace::internal("flash.net", context),
+
+            __ruffle__: Namespace::package("__ruffle__", ApiVersion::AllVersions, context),
         }
     }
 

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -325,7 +325,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let name = Multiname::new(activation.avm2().public_namespace_vm_internal, name);
+        let name = Multiname::new(activation.avm2().namespaces.public_vm_internal(), name);
         self.set_property_local(&name, value, activation)
     }
 
@@ -392,11 +392,8 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        self.set_property(
-            &Multiname::new(activation.avm2().public_namespace_vm_internal, name),
-            value,
-            activation,
-        )
+        let name = Multiname::new(activation.avm2().namespaces.public_vm_internal(), name);
+        self.set_property(&name, value, activation)
     }
 
     /// Init a local property of the object. The Multiname should always be public.
@@ -748,7 +745,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         activation: &mut Activation<'_, 'gc>,
         name: impl Into<AvmString<'gc>>,
     ) -> Result<bool, Error<'gc>> {
-        let name = Multiname::new(activation.avm2().public_namespace_base_version, name);
+        let name = Multiname::new(activation.avm2().namespaces.public_all(), name);
         self.delete_property(activation, &name)
     }
 

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -292,13 +292,11 @@ impl<'gc> ClassObject<'gc> {
         // interfaces (i.e. those that were not already implemented by the superclass)
         // Otherwise, our behavior diverges from Flash Player in certain cases.
         // See the ignored test 'tests/tests/swfs/avm2/weird_superinterface_properties/'
+        let internal_ns = activation.avm2().namespaces.public_vm_internal();
         for interface in &*class.all_interfaces() {
             for interface_trait in &*interface.traits() {
                 if !interface_trait.name().namespace().is_public() {
-                    let public_name = QName::new(
-                        activation.context.avm2.public_namespace_vm_internal,
-                        interface_trait.name().local_name(),
-                    );
+                    let public_name = QName::new(internal_ns, interface_trait.name().local_name());
                     self.instance_vtable().copy_property_for_interface(
                         activation.context.gc_context,
                         public_name,

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -18,7 +18,7 @@ pub fn namespace_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    let namespace = activation.context.avm2.public_namespace_base_version;
+    let namespace = activation.avm2().namespaces.public_all();
     Ok(NamespaceObject(Gc::new(
         activation.context.gc_context,
         NamespaceObjectData {

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -75,12 +75,8 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let qname = QNameObject::from_name(activation, multiname.clone())?;
-
-        self.call_property(
-            &Multiname::new(activation.avm2().proxy_namespace, "getProperty"),
-            &[qname.into()],
-            activation,
-        )
+        let prop = Multiname::new(activation.avm2().namespaces.proxy, "getProperty");
+        self.call_property(&prop, &[qname.into()], activation)
     }
 
     fn set_property_local(
@@ -90,12 +86,8 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
         let qname = QNameObject::from_name(activation, multiname.clone())?;
-
-        self.call_property(
-            &Multiname::new(activation.avm2().proxy_namespace, "setProperty"),
-            &[qname.into(), value],
-            activation,
-        )?;
+        let prop = Multiname::new(activation.avm2().namespaces.proxy, "setProperty");
+        self.call_property(&prop, &[qname.into(), value], activation)?;
 
         Ok(())
     }
@@ -107,14 +99,11 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let qname = QNameObject::from_name(activation, multiname.clone())?;
+        let prop = Multiname::new(activation.avm2().namespaces.proxy, "callProperty");
+
         let mut args = vec![qname.into()];
         args.extend_from_slice(arguments);
-
-        self.call_property(
-            &Multiname::new(activation.avm2().proxy_namespace, "callProperty"),
-            &args,
-            activation,
-        )
+        self.call_property(&prop, &args, activation)
     }
 
     fn delete_property_local(
@@ -123,13 +112,10 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         multiname: &Multiname<'gc>,
     ) -> Result<bool, Error<'gc>> {
         let qname = QNameObject::from_name(activation, multiname.clone())?;
+        let prop = Multiname::new(activation.avm2().namespaces.proxy, "deleteProperty");
 
         Ok(self
-            .call_property(
-                &Multiname::new(activation.avm2().proxy_namespace, "deleteProperty"),
-                &[qname.into()],
-                activation,
-            )?
+            .call_property(&prop, &[qname.into()], activation)?
             .coerce_to_boolean())
     }
 
@@ -138,9 +124,10 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         name: &Multiname<'gc>,
     ) -> Result<bool, Error<'gc>> {
+        let prop = Multiname::new(activation.avm2().namespaces.proxy, "hasProperty");
         Ok(self
             .call_property(
-                &Multiname::new(activation.avm2().proxy_namespace, "hasProperty"),
+                &prop,
                 &[name
                     .local_name()
                     .map(Value::from)
@@ -156,12 +143,9 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<bool, Error<'gc>> {
         let name = name.into();
+        let prop = Multiname::new(activation.avm2().namespaces.proxy, "hasProperty");
         Ok(self
-            .call_property(
-                &Multiname::new(activation.avm2().proxy_namespace, "hasProperty"),
-                &[name.into()],
-                activation,
-            )?
+            .call_property(&prop, &[name.into()], activation)?
             .coerce_to_boolean())
     }
 
@@ -170,13 +154,10 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         last_index: u32,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Option<u32>, Error<'gc>> {
+        let prop = Multiname::new(activation.avm2().namespaces.proxy, "nextNameIndex");
         Ok(Some(
-            self.call_property(
-                &Multiname::new(activation.avm2().proxy_namespace, "nextNameIndex"),
-                &[last_index.into()],
-                activation,
-            )?
-            .coerce_to_u32(activation)?,
+            self.call_property(&prop, &[last_index.into()], activation)?
+                .coerce_to_u32(activation)?,
         ))
     }
 
@@ -185,11 +166,8 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         index: u32,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        self.call_property(
-            &Multiname::new(activation.avm2().proxy_namespace, "nextName"),
-            &[index.into()],
-            activation,
-        )
+        let prop = Multiname::new(activation.avm2().namespaces.proxy, "nextName");
+        self.call_property(&prop, &[index.into()], activation)
     }
 
     fn get_enumerant_value(
@@ -197,10 +175,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         index: u32,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        self.call_property(
-            &Multiname::new(activation.avm2().proxy_namespace, "nextValue"),
-            &[index.into()],
-            activation,
-        )
+        let prop = Multiname::new(activation.avm2().namespaces.proxy, "nextValue");
+        self.call_property(&prop, &[index.into()], activation)
     }
 }

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -196,7 +196,7 @@ impl<'gc> XmlListObject<'gc> {
                             ApiVersion::AllVersions,
                             &mut activation.context.borrow_gc(),
                         ),
-                        None => activation.avm2().public_namespace_base_version,
+                        None => activation.avm2().namespaces.public_all(),
                     };
 
                     *unlock!(
@@ -870,7 +870,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                         // FIXME: We probably need to take the namespace too.
                         // 2.e.i. Let z = ToAttributeName(x[i].[[Name]])
                         let z = Multiname::attribute(
-                            activation.avm2().public_namespace_base_version,
+                            activation.avm2().namespaces.public_all(),
                             child.local_name().expect("Attribute should have a name"),
                         );
                         // 2.e.ii. Call the [[Put]] method of x[i].[[Parent]] with arguments z and V

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -738,7 +738,7 @@ fn handle_input_multiname<'gc>(
                 let mut ns = Vec::new();
                 ns.extend(name.namespace_set());
                 if !name.contains_public_namespace() {
-                    ns.push(activation.avm2().public_namespace_base_version);
+                    ns.push(activation.avm2().namespaces.public_all());
                 }
                 new_name.set_ns(NamespaceSet::new(ns, activation.gc()));
             }

--- a/core/src/avm2/qname.rs
+++ b/core/src/avm2/qname.rs
@@ -92,19 +92,16 @@ impl<'gc> QName<'gc> {
             .rsplit_once(WStr::from_units(b"::"))
             .or_else(|| name.rsplit_once(WStr::from_units(b".")));
 
-        let mut context = context.borrow_gc();
         if let Some((package_name, local_name)) = parts {
-            let package_name = context
-                .interner
-                .intern_wstr(context.gc_context, package_name);
+            let package_name = context.interner.intern_wstr(context.gc(), package_name);
 
             Self {
-                ns: Namespace::package(package_name, api_version, &mut context),
-                name: AvmString::new(context.gc_context, local_name),
+                ns: Namespace::package(package_name, api_version, &mut context.borrow_gc()),
+                name: AvmString::new(context.gc(), local_name),
             }
         } else {
             Self {
-                ns: Namespace::package("", api_version, &mut context),
+                ns: context.avm2.namespaces.public_for(api_version),
                 name,
             }
         }

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -373,7 +373,7 @@ impl Definition {
                 && !class_trait
                     .name()
                     .namespace()
-                    .exact_version_match(avm2.as3_namespace)
+                    .exact_version_match(avm2.namespaces.as3)
             {
                 continue;
             }


### PR DESCRIPTION
Extracted from #17876; this mirrors #17842.