### PR TITLE
chore: Switch to `rfd` release `v0.15.0` from git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4237,8 +4237,9 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.14.1"
-source = "git+https://github.com/PolyMeilex/rfd.git?rev=e0e725ec9a426acf7c93d9877c41e230fcee3fac#e0e725ec9a426acf7c93d9877c41e230fcee3fac"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af382a047821a08aa6bfc09ab0d80ff48d45d8726f7cd8e44891f7cb4a4278e"
 dependencies = [
  "ashpd",
  "block2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,8 @@ url = "2.5.2"
 # Make sure to match wasm-bindgen-cli version to this everywhere.
 wasm-bindgen = "=0.2.93"
 walkdir = "2.5.0"
-tokio = { version = "1.40.0" }
-rfd = { git = "https://github.com/PolyMeilex/rfd.git", rev = "e0e725ec9a426acf7c93d9877c41e230fcee3fac" }
+tokio = "1.40.0"
+rfd = "0.15.0"
 
 [workspace.lints.rust]
 # Clippy nightly often adds new/buggy lints that we want to ignore.

--- a/deny.toml
+++ b/deny.toml
@@ -79,8 +79,6 @@ github = [
     "ruffle-rs",
     # TODO: Remove once a release with https://github.com/emilk/egui/pull/4939 in it is out.
     "emilk",
-    # TODO: Remove once a release with https://github.com/PolyMeilex/rfd/pull/209 in it is out.
-    "PolyMeilex",
 ]
 
 [advisories]


### PR DESCRIPTION
Changelog: https://github.com/PolyMeilex/rfd/releases/tag/0.15.0