### PR TITLE
ci: Commit translations and create PR manually

### DIFF
--- a/.github/workflows/download_translations.yml
+++ b/.github/workflows/download_translations.yml
@@ -16,23 +16,46 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Crowdin push
+      - name: Crowdin download
         uses: crowdin/github-action@v2
         with:
           config: 'crowdin.yml'
           upload_sources: false
           upload_translations: false
           download_translations: true
-          localization_branch_name: l10n_crowdin_translations
-
-          create_pull_request: true
-          pull_request_title: 'chore: Update translations'
-          pull_request_body: 'New Crowdin pull request with translations'
-          pull_request_labels: 'T-chore, A-i18n'
-          pull_request_base_branch_name: 'master'
-          commit_message: 'chore: Update translations from Crowdin'
+          push_translations: false
+          create_pull_request: false
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Commit
+        run: |
+          git config user.name "RuffleBuild"
+          git config user.email "ruffle@ruffle.rs"
+          git checkout -b l10n_crowdin_translations
+          git add -A
+          git commit -m 'chore: Update translations from Crowdin'
+
+      - name: Push
+        uses: ad-m/github-push-action@master
+        with:
+          branch: l10n_crowdin_translations
+          github_token: ${{ secrets.RUFFLE_BUILD_TOKEN }}
+          force: true
+
+      - name: Create a PR
+        run: |
+          prs=$(gh pr list --base master --head l10n_crowdin_translations --limit 1 --json id | jq length)
+          if [ "$prs" = 1 ]; then echo "PR already exists"; exit 0; fi
+
+          gh pr create \
+            --title 'chore: Update translations' \
+            --body 'New Crowdin pull request with translations 🎉' \
+            --head l10n_crowdin_translations \
+            --base master \
+            --label T-chore \
+            --label A-i18n
+        env:
           # Use a custom token rather than the automatic GITHUB_TOKEN, as the automatic one doesn't allow created PRs to trigger workflows
           # By using our own token (and thus own user), workflows will run, and the PR will be able to be merged.
           GITHUB_TOKEN: ${{ secrets.RUFFLE_BUILD_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,39 +1,32 @@
 # To use the crowdin-cli, set an access token in CROWDIN_PERSONAL_TOKEN or a ~/.crowdin.yml
 # File structure documentation can be found at: https://developer.crowdin.com/configuration-file/
-
-"api_token_env": "CROWDIN_PERSONAL_TOKEN"
-"project_id": 582621 # This is https://crowdin.com/project/ruffle
-"preserve_hierarchy": true # Keep the directory structure so that we know, for example, "messages.json" belongs to the extension
+api_token_env: CROWDIN_PERSONAL_TOKEN
+project_id: 582621 # This is https://crowdin.com/project/ruffle
+preserve_hierarchy: true # Keep the directory structure so that we know, for example, "messages.json" belongs to the extension
 
 # Files we want to translate
-"files": [
-  {
-    "source" : "/web/packages/extension/assets/_locales/en/messages.json",
-    "translation" : "/web/packages/extension/assets/_locales/%two_letters_code%/messages.json",
+files:
+  - source: /web/packages/extension/assets/_locales/en/messages.json
+    translation: /web/packages/extension/assets/_locales/%two_letters_code%/messages.json
 
     # The crowdin path doesn't actually matter, so let's make it slightly more intelligible than what we have
-    "dest": "/web/extension.json",
+    dest: /web/extension.json
 
     # Even though it's used by other browsers, the schema used is called "chrome" on crowdin
     # https://store.crowdin.com/chrome-json
-    "type": "chrome",
-  },
-  {
-    "source" : "/core/assets/texts/en-US/*.ftl",
-    "translation" : "/core/assets/texts/%locale%/%original_file_name%",
-    "dest": "/core/%original_file_name%",
-    "type": "ftl",
-  },
-  {
-    "source" : "/desktop/assets/texts/en-US/*.ftl",
-    "translation" : "/desktop/assets/texts/%locale%/%original_file_name%",
-    "dest": "/desktop/%original_file_name%",
-    "type": "ftl",
-  },
-  {
-    "source" : "/web/packages/core/texts/en-US/*.ftl",
-    "translation" : "/web/packages/core/texts/%locale%/%original_file_name%",
-    "dest": "/web/core/%original_file_name%",
-    "type": "ftl",
-  },
-]
+    type: chrome
+
+  - source: /core/assets/texts/en-US/*.ftl
+    translation: /core/assets/texts/%locale%/%original_file_name%
+    dest: /core/%original_file_name%
+    type: ftl
+
+  - source: /desktop/assets/texts/en-US/*.ftl
+    translation: /desktop/assets/texts/%locale%/%original_file_name%
+    dest: /desktop/%original_file_name%
+    type: ftl
+
+  - source: /web/packages/core/texts/en-US/*.ftl
+    translation: /web/packages/core/texts/%locale%/%original_file_name%
+    dest: /web/core/%original_file_name%
+    type: ftl


### PR DESCRIPTION
The Crowdin action does not allow adding custom modifications after downloading the translations and before creating the PR. Created the PR manually we can now modify files before creating the PR.

Additionally this PR reformats `crowdin.yml`.

This is a first step of automating localization of metainfo & .desktop file.