### PR TITLE
core: Fix "Failed to get Object" panics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ RECOVER_*.fla
 
 # Jetbrains tools (CLion, IntelliJ, etc)
 /.idea
+
+# Mac junk
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "flash-lso"
 version = "0.6.0"
-source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=98679aa0cdcad5fecc5c7321b2eac35b69dbcd5f#98679aa0cdcad5fecc5c7321b2eac35b69dbcd5f"
+source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=cbd18e1a79cf902f8ff1d2bf551801c4021b3be6#cbd18e1a79cf902f8ff1d2bf551801c4021b3be6"
 dependencies = [
  "enumset",
  "nom",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,7 +43,7 @@ serde = { workspace = true }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "754b1184037aa9952a907107284fb73897e26adc", optional = true }
 regress = "0.10"
-flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "98679aa0cdcad5fecc5c7321b2eac35b69dbcd5f" }
+flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "cbd18e1a79cf902f8ff1d2bf551801c4021b3be6" }
 lzma-rs = {version = "0.3.0", optional = true }
 dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.4", default-features = false, features = ["mp3"], optional = true }

--- a/core/src/avm1/globals/netconnection.rs
+++ b/core/src/avm1/globals/netconnection.rs
@@ -11,6 +11,7 @@ use crate::context::UpdateContext;
 use crate::net_connection::{NetConnectionHandle, NetConnections, ResponderCallback};
 use crate::string::{AvmString, StringContext};
 use flash_lso::packet::Header;
+use flash_lso::types::ObjectId;
 use flash_lso::types::Value as AMFValue;
 use gc_arena::{Collect, Gc};
 use ruffle_wstr::WStr;
@@ -273,7 +274,7 @@ fn call<'gc>(
                 activation.context,
                 handle,
                 command.to_string(),
-                AMFValue::StrictArray(arguments),
+                AMFValue::StrictArray(ObjectId::INVALID, arguments),
                 responder,
             );
         } else {
@@ -281,7 +282,7 @@ fn call<'gc>(
                 activation.context,
                 handle,
                 command.to_string(),
-                AMFValue::StrictArray(arguments),
+                AMFValue::StrictArray(ObjectId::INVALID, arguments),
             );
         }
     }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -8,7 +8,7 @@ use crate::display_object::TDisplayObject;
 use crate::string::{AvmString, StringContext};
 use flash_lso::amf0::read::AMF0Decoder;
 use flash_lso::amf0::writer::{Amf0Writer, CacheKey, ObjWriter};
-use flash_lso::types::{Lso, Reference, Value as AmfValue};
+use flash_lso::types::{Lso, ObjectId, Reference, Value as AmfValue};
 use gc_arena::{Collect, GcCell};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -77,7 +77,7 @@ pub fn serialize<'gc>(activation: &mut Activation<'_, 'gc>, value: Value<'gc>) -
         Value::String(string) => AmfValue::String(string.to_string()),
         Value::Object(object) => {
             let lso = new_lso(activation, "root", object);
-            AmfValue::Object(lso.into_iter().collect(), None)
+            AmfValue::Object(ObjectId::INVALID, lso.into_iter().collect(), None)
         }
         Value::MovieClip(_) => AmfValue::Undefined,
     }
@@ -156,7 +156,7 @@ pub fn deserialize_value<'gc>(
         AmfValue::Number(f) => (*f).into(),
         AmfValue::String(s) => Value::String(AvmString::new_utf8(activation.context.gc_context, s)),
         AmfValue::Bool(b) => (*b).into(),
-        AmfValue::ECMAArray(_, associative, len) => {
+        AmfValue::ECMAArray(_, _, associative, len) => {
             let array_constructor = activation.context.avm1.prototypes().array_constructor;
             if let Ok(Value::Object(obj)) =
                 array_constructor.construct(activation, &[(*len).into()])
@@ -188,7 +188,7 @@ pub fn deserialize_value<'gc>(
                 Value::Undefined
             }
         }
-        AmfValue::Object(elements, _) => {
+        AmfValue::Object(_, elements, _) => {
             // Deserialize Object
             let obj = ScriptObject::new(
                 activation.context.gc_context,

--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -1,5 +1,7 @@
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use super::property::Property;
 use crate::avm2::bytearray::ByteArrayStorage;
 use crate::avm2::class::Class;
 use crate::avm2::object::{ByteArrayObject, ClassObject, TObject, VectorObject};
@@ -10,11 +12,9 @@ use crate::avm2::{Activation, Error, Object, Value};
 use crate::avm2_stub_method;
 use crate::string::AvmString;
 use enumset::EnumSet;
-use flash_lso::types::{AMFVersion, Element, Lso};
+use flash_lso::types::{AMFVersion, Element, Lso, ObjectId};
 use flash_lso::types::{Attribute, ClassDefinition, Value as AmfValue};
 use fnv::FnvHashMap;
-
-use super::property::Property;
 
 pub type ObjectTable<'gc> = FnvHashMap<Object<'gc>, Rc<AmfValue>>;
 
@@ -71,10 +71,10 @@ pub fn serialize_value<'gc>(
                         }
                     }
 
-                    Some(AmfValue::ECMAArray(dense, sparse, len))
+                    Some(AmfValue::ECMAArray(ObjectId::INVALID, dense, sparse, len))
                 } else {
                     // TODO: is this right?
-                    Some(AmfValue::ECMAArray(vec![], values, len))
+                    Some(AmfValue::ECMAArray(ObjectId::INVALID, vec![], values, len))
                 }
             } else if let Some(vec) = o.as_vector_storage() {
                 let val_type = vec.value_type();
@@ -99,7 +99,12 @@ pub fn serialize_value<'gc>(
                     let val_type = val_type.unwrap_or(activation.avm2().class_defs().object);
 
                     let name = class_to_alias(activation, val_type);
-                    Some(AmfValue::VectorObject(obj_vec, name, vec.is_fixed()))
+                    Some(AmfValue::VectorObject(
+                        ObjectId::INVALID,
+                        obj_vec,
+                        name,
+                        vec.is_fixed(),
+                    ))
                 }
             } else if let Some(date) = o.as_date_object() {
                 date.date_time()
@@ -133,6 +138,7 @@ pub fn serialize_value<'gc>(
                 )
                 .unwrap();
                 Some(AmfValue::Object(
+                    ObjectId::INVALID,
                     object_body,
                     if amf_version == AMFVersion::AMF3 {
                         Some(ClassDefinition {
@@ -271,6 +277,15 @@ pub fn deserialize_value<'gc>(
     activation: &mut Activation<'_, 'gc>,
     val: &AmfValue,
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let mut x = BTreeMap::new();
+    deserialize_value_impl(activation, val, &mut x)
+}
+
+pub fn deserialize_value_impl<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    val: &AmfValue,
+    object_map: &mut BTreeMap<ObjectId, Object<'gc>>,
+) -> Result<Value<'gc>, Error<'gc>> {
     Ok(match val {
         AmfValue::Null => Value::Null,
         AmfValue::Undefined => Value::Undefined,
@@ -283,14 +298,21 @@ pub fn deserialize_value<'gc>(
             let bytearray = ByteArrayObject::from_storage(activation, storage)?;
             bytearray.into()
         }
-        AmfValue::ECMAArray(values, elements, _) => {
+        AmfValue::ECMAArray(id, values, elements, _) => {
+            let empty_storage = ArrayStorage::new(0);
+            let array = ArrayObject::from_storage(activation, empty_storage)?;
+            object_map.insert(*id, array);
+
             // First let's create an array out of `values` (dense portion), then we add the elements onto it.
             let mut arr: Vec<Option<Value<'gc>>> = Vec::with_capacity(values.len());
             for value in values {
                 arr.push(Some(deserialize_value(activation, value)?));
             }
-            let storage = ArrayStorage::from_storage(arr);
-            let array = ArrayObject::from_storage(activation, storage)?;
+            array
+                .as_array_storage_mut(activation.context.gc_context)
+                .expect("Failed to get array storage from ArrayObject")
+                .replace_dense_storage(arr);
+
             // Now let's add each element as a property
             for element in elements {
                 array.set_public_property(
@@ -301,16 +323,24 @@ pub fn deserialize_value<'gc>(
             }
             array.into()
         }
-        AmfValue::StrictArray(values) => {
+        AmfValue::StrictArray(id, values) => {
+            let empty_storage = ArrayStorage::new(0);
+            let array = ArrayObject::from_storage(activation, empty_storage)?;
+            object_map.insert(*id, array);
+
             let mut arr: Vec<Option<Value<'gc>>> = Vec::with_capacity(values.len());
             for value in values {
                 arr.push(Some(deserialize_value(activation, value)?));
             }
-            let storage = ArrayStorage::from_storage(arr);
-            let array = ArrayObject::from_storage(activation, storage)?;
+
+            array
+                .as_array_storage_mut(activation.context.gc_context)
+                .expect("Failed to get array storage from ArrayObject")
+                .replace_dense_storage(arr);
+
             array.into()
         }
-        AmfValue::Object(elements, class) => {
+        AmfValue::Object(id, elements, class) => {
             let target_class = if let Some(class) = class {
                 let name = AvmString::new_utf8(activation.context.gc_context, &class.name);
                 alias_to_class(activation, name)?
@@ -318,6 +348,7 @@ pub fn deserialize_value<'gc>(
                 activation.avm2().classes().object
             };
             let obj = target_class.construct(activation, &[])?;
+            object_map.insert(*id, obj);
 
             for entry in elements {
                 let name = entry.name();
@@ -342,6 +373,7 @@ pub fn deserialize_value<'gc>(
                     }
                 }
             }
+
             obj.into()
         }
         AmfValue::Date(time, _) => activation
@@ -386,35 +418,52 @@ pub fn deserialize_value<'gc>(
             );
             VectorObject::from_vector(storage, activation)?.into()
         }
-        AmfValue::VectorObject(vec, ty_name, is_fixed) => {
+        AmfValue::VectorObject(id, vec, ty_name, is_fixed) => {
             let name = AvmString::new_utf8(activation.context.gc_context, ty_name);
             let class = alias_to_class(activation, name)?;
-            let storage = VectorStorage::from_values(
-                vec.iter()
-                    .map(|v| {
-                        deserialize_value(activation, v).map(|value| {
-                            // There's no Vector.<void>: convert any
-                            // Undefined items in the Vector to Null.
-                            if matches!(value, Value::Undefined) {
-                                Value::Null
-                            } else {
-                                value
-                            }
-                        })
-                    })
-                    .collect::<Result<Vec<_>, _>>()?,
+
+            // Create an empty vector, as it has to exist in the map before reading children, in case they reference it
+            let empty_storage = VectorStorage::new(
+                0,
                 *is_fixed,
                 Some(class.inner_class_definition()),
+                activation,
             );
-            VectorObject::from_vector(storage, activation)?.into()
+            let obj = VectorObject::from_vector(empty_storage, activation)?;
+            object_map.insert(*id, obj);
+
+            let new_values = vec
+                .iter()
+                .map(|v| {
+                    deserialize_value(activation, v).map(|value| {
+                        // There's no Vector.<void>: convert any
+                        // Undefined items in the Vector to Null.
+                        if matches!(value, Value::Undefined) {
+                            Value::Null
+                        } else {
+                            value
+                        }
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            // Swap in the actual values
+            obj.as_vector_storage_mut(activation.context.gc_context)
+                .expect("Failed to get vector storage from VectorObject")
+                .replace_storage(new_values);
+
+            obj.into()
         }
-        AmfValue::Dictionary(values, has_weak_keys) => {
+        AmfValue::Dictionary(id, values, has_weak_keys) => {
             let obj = activation
                 .avm2()
                 .classes()
                 .dictionary
                 .construct(activation, &[(*has_weak_keys).into()])?;
-            let dict_obj = obj.as_dictionary_object().unwrap();
+            object_map.insert(*id, obj);
+            let dict_obj = obj
+                .as_dictionary_object()
+                .expect("Failed to get dictionary from constructed object");
 
             for (key, value) in values {
                 let key = deserialize_value(activation, key)?;
@@ -442,6 +491,14 @@ pub fn deserialize_value<'gc>(
         }
         AmfValue::AMF3(val) => deserialize_value(activation, val)?,
         AmfValue::Unsupported => Value::Undefined,
+        AmfValue::Amf3ObjectReference(r) => {
+            if let Some(o) = object_map.get(r) {
+                (*o).into()
+            } else {
+                tracing::error!("AMF3 deserializer got an object reference {r:?} to an object we've not seen yet");
+                Value::Undefined
+            }
+        }
     })
 }
 

--- a/core/src/avm2/array.rs
+++ b/core/src/avm2/array.rs
@@ -114,6 +114,25 @@ impl<'gc> ArrayStorage<'gc> {
         }
     }
 
+    /// Replace the existing dense storage with a new dense storage.
+    /// Panics if this `ArrayStorage` is sparse.
+    pub fn replace_dense_storage(&mut self, new_storage: Vec<Option<Value<'gc>>>) {
+        let new_occupied_count = new_storage.iter().filter(|v| v.is_some()).count();
+
+        match self {
+            ArrayStorage::Dense {
+                storage,
+                occupied_count,
+            } => {
+                *occupied_count = new_occupied_count;
+                *storage = new_storage;
+            }
+            ArrayStorage::Sparse { .. } => {
+                panic!("Cannot replace dense storage on sparse ArrayStorage");
+            }
+        }
+    }
+
     /// Retrieve a value from array storage by index.
     ///
     /// Array holes and out of bounds values will be treated the same way, by

--- a/core/src/avm2/globals/flash/net/net_connection.rs
+++ b/core/src/avm2/globals/flash/net/net_connection.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use flash_lso::packet::Header;
 use flash_lso::types::AMFVersion;
+use flash_lso::types::ObjectId;
 use flash_lso::types::Value as AMFValue;
 use fnv::FnvHashMap;
 use ruffle_wstr::WStr;
@@ -266,7 +267,7 @@ pub fn call<'gc>(
                 activation.context,
                 handle,
                 command.to_string(),
-                AMFValue::StrictArray(arguments),
+                AMFValue::StrictArray(ObjectId::INVALID, arguments),
                 responder,
             );
         } else {
@@ -274,7 +275,7 @@ pub fn call<'gc>(
                 activation.context,
                 handle,
                 command.to_string(),
-                AMFValue::StrictArray(arguments),
+                AMFValue::StrictArray(ObjectId::INVALID, arguments),
             );
         }
 


### PR DESCRIPTION
This constitues the ruffle-side changes of https://github.com/ruffle-rs/rust-flash-lso/pull/67 and https://github.com/ruffle-rs/rust-flash-lso/pull/68. 

This fixes the following (previously would panic on load): 
https://github.com/ruffle-rs/ruffle/issues/17902 - loads
https://github.com/ruffle-rs/ruffle/issues/17709 - loads
https://github.com/ruffle-rs/ruffle/issues/13748 - loads
https://github.com/ruffle-rs/ruffle/issues/10520 - loads

This prevents panics on the following:
https://github.com/ruffle-rs/ruffle/issues/17782 - (and possible dupe https://github.com/ruffle-rs/ruffle/issues/17336 )
Now errors with "Property uploadFromBitmapData not found on flash.display3D.textures.RectangleTexture and there is no default value."

https://github.com/ruffle-rs/ruffle/issues/14329
Fails to load past 54%, some URL load failures might be related

https://github.com/ruffle-rs/ruffle/issues/10174
Same as 17782 above


These are not fixed, but one possible underlying issue is that a new `AMF3Decoder` is created for each call to `ByteArray.readObject` which could result in missing references that are replaced with `Undefined` when an element references a prior value in the stream. In the simple case, we could just cache the `AMF3Decoder` in the `ByteArray` object, but this won't handle more complex cases where the `ByteArray`s position is changed, so I'm leaving this for future work.
Update: I'm actually unsure if the above guess is true anymore, a missing change progressed the above and removed the invalid reference warnings but it still seems odd.