### PR TITLE
core: Improve string interner ergonomics

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -7,13 +7,13 @@ use crate::avm1::runtime::skip_actions;
 use crate::avm1::scope::{Scope, ScopeClass};
 use crate::avm1::{fscommand, globals, scope, ArrayObject, ScriptObject, Value};
 use crate::backend::navigator::{NavigationMethod, Request};
-use crate::context::UpdateContext;
+use crate::context::{StringContext, UpdateContext};
 use crate::display_object::{
     DisplayObject, DisplayObjectContainer, MovieClip, TDisplayObject, TDisplayObjectContainer,
 };
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use crate::loader::MovieLoaderVMData;
-use crate::string::{AvmString, SwfStrExt as _, WStr, WString};
+use crate::string::{AvmString, AvmStringInterner, SwfStrExt as _, WStr, WString};
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
 use crate::{avm_error, avm_warn};
@@ -241,6 +241,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     #[inline(always)]
     pub fn gc(&self) -> &'gc gc_arena::Mutation<'gc> {
         self.context.gc_context
+    }
+
+    pub fn strings(&self) -> &AvmStringInterner<'gc> {
+        self.context.strings
+    }
+
+    pub fn strings_mut(&mut self) -> StringContext<'_, 'gc> {
+        self.context.strings_mut()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -868,7 +876,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .iter()
             .map(|s| {
                 self.context
-                    .interner
+                    .strings
                     .intern_wstr(self.context.gc_context, s.decode(self.encoding()))
                     .into()
             })

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
 use crate::string::{AvmString, WStr, WString};
 use gc_arena::Collect;
@@ -518,7 +518,7 @@ pub struct SystemPrototypes<'gc> {
 
 /// Initialize default global scope and builtins for an AVM1 instance.
 pub fn create_globals<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
 ) -> (
     SystemPrototypes<'gc>,
     Object<'gc>,
@@ -1207,7 +1207,7 @@ mod tests {
     use super::*;
 
     fn setup<'gc>(activation: &mut Activation<'_, 'gc>) -> Object<'gc> {
-        create_globals(&mut activation.context.borrow_gc()).1
+        create_globals(&mut activation.strings_mut()).1
     }
 
     test_method!(boolean_function, "Boolean", setup,

--- a/core/src/avm1/globals/accessibility.rs
+++ b/core/src/avm1/globals/accessibility.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
+use crate::context::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "isActive" => method(is_active; DONT_DELETE | READ_ONLY);
@@ -41,7 +41,7 @@ pub fn update_properties<'gc>(
 }
 
 pub fn create_accessibility_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -6,7 +6,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::string::AvmString;
 use bitflags::bitflags;
@@ -62,7 +62,7 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create_array_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     array_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -743,7 +743,7 @@ fn qsort<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -7,7 +7,7 @@ use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::Declaration;
 use crate::avm1::{Activation, ArrayObject, Object, ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 use gc_arena::{Collect, Mutation};
 
@@ -19,7 +19,7 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> (BroadcasterFunctions<'gc>, Object<'gc>) {

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::{AvmString, WStr};
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
@@ -533,7 +533,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -543,7 +543,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -12,7 +12,7 @@ use crate::bitmap::bitmap_data::{BitmapDataDrawError, IBitmapDrawable};
 use crate::bitmap::bitmap_data::{ChannelOptions, ThresholdOperation};
 use crate::bitmap::{is_size_valid, operations};
 use crate::character::Character;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::DisplayObject;
 use crate::swf::BlendMode;
 use crate::{avm1_stub, avm_error};
@@ -1522,7 +1522,7 @@ fn load_bitmap<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: ScriptObject<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -13,7 +13,7 @@ use crate::avm1::globals::gradient_filter::GradientFilter;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Attribute, Object, ScriptObject, TObject, Value};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use ruffle_render::filters::Filter;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -194,7 +194,7 @@ pub fn create_instance<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{BlurFilterFlags, Fixed16};
@@ -186,7 +186,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -196,7 +196,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -6,7 +6,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -46,7 +46,7 @@ pub fn boolean_function<'gc>(
 }
 
 pub fn create_boolean_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     boolean_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -61,7 +61,7 @@ pub fn create_boolean_object<'gc>(
 
 /// Creates `Boolean.prototype`.
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -8,7 +8,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::ArrayObject;
 use crate::avm1::{globals, Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::{Avm1Button, TDisplayObject, TInteractiveObject};
 use crate::string::AvmString;
 
@@ -52,7 +52,7 @@ const PROTO_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -8,7 +8,7 @@ use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::{DisplayObject, TDisplayObject};
 
 use swf::Fixed8;
@@ -38,7 +38,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 
@@ -158,7 +158,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -168,7 +168,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -3,7 +3,7 @@
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell};
 use swf::{ColorTransform, Fixed8};
@@ -265,7 +265,7 @@ fn concat<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -4,7 +4,7 @@ use crate::avm1::object::TObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::context_menu;
 use crate::display_object::DisplayObject;
 
@@ -142,7 +142,7 @@ pub fn hide_builtin_items<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -4,7 +4,7 @@ use crate::avm1::object::TObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -90,7 +90,7 @@ pub fn copy<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -5,7 +5,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{Color, ConvolutionFilterFlags};
@@ -408,7 +408,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -418,7 +418,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -3,7 +3,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::locale::{get_current_date_time, get_timezone};
 use crate::string::AvmString;
 use gc_arena::Gc;
@@ -567,7 +567,7 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -6,7 +6,7 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
 use crate::bitmap::bitmap_data::BitmapDataWrapper;
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use crate::string::{AvmString, FromWStr, WStr};
 use gc_arena::{Collect, GcCell, Mutation};
 use ruffle_render::filters::DisplacementMapFilterMode;
@@ -442,7 +442,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -457,7 +457,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{Color, DropShadowFilterFlags, Fixed16, Fixed8};
@@ -431,7 +431,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -441,7 +441,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "message" => string("Error");
@@ -27,7 +27,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::external::{Callback, Value as ExternalValue};
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
@@ -84,7 +84,7 @@ pub fn call<'gc>(
 }
 
 pub fn create_external_interface_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -93,7 +93,7 @@ pub fn create_external_interface_object<'gc>(
     object.into()
 }
 
-pub fn create_proto<'gc>(context: &mut GcContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
+pub fn create_proto<'gc>(context: &mut StringContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
     ScriptObject::new(context.gc_context, Some(proto)).into()
 }

--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -6,7 +6,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Executable, NativeObject, Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
 use crate::backend::ui::{FileDialogResult, FileFilter};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell};
 use url::Url;
@@ -437,7 +437,7 @@ fn constructor<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     array_proto: Object<'gc>,

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{ExecutionName, ExecutionReason};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -117,7 +117,7 @@ pub fn apply<'gc>(
 /// them in order to obtain a valid ECMAScript `Function` prototype. The
 /// returned object is also a bare object, which will need to be linked into
 /// the prototype of `Object`.
-pub fn create_proto<'gc>(context: &mut GcContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
+pub fn create_proto<'gc>(context: &mut StringContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
     let function_proto = ScriptObject::new(context.gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, context, function_proto, function_proto.into());
     function_proto.into()

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{Color, Fixed16, Fixed8, GlowFilterFlags};
@@ -344,7 +344,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -354,7 +354,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/gradient_filter.rs
+++ b/core/src/avm1/globals/gradient_filter.rs
@@ -6,7 +6,7 @@ use crate::avm1::globals::bevel_filter::BevelFilterType;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use crate::string::{AvmString, WStr};
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
@@ -520,7 +520,7 @@ fn method<'gc>(
 }
 
 pub fn create_bevel_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -530,7 +530,7 @@ pub fn create_bevel_proto<'gc>(
 }
 
 pub fn create_bevel_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -544,7 +544,7 @@ pub fn create_bevel_constructor<'gc>(
 }
 
 pub fn create_glow_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -554,7 +554,7 @@ pub fn create_glow_proto<'gc>(
 }
 
 pub fn create_glow_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::events::KeyCode;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
@@ -82,7 +82,7 @@ pub fn get_code<'gc>(
 }
 
 pub fn create_key_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -9,7 +9,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
 use crate::backend::navigator::{NavigationMethod, Request};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -37,7 +37,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/local_connection.rs
+++ b/core/src/avm1/globals/local_connection.rs
@@ -8,7 +8,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{
     ActivationIdentifier, ExecutionReason, NativeObject, Object, ScriptObject, Value,
 };
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use crate::display_object::TDisplayObject;
 use crate::local_connection::{LocalConnectionHandle, LocalConnections};
 use crate::string::AvmString;
@@ -245,7 +245,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 
 use rand::Rng;
 use std::f64::consts;
@@ -162,7 +162,7 @@ pub fn random<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -179,11 +179,7 @@ mod tests {
     fn setup<'gc>(activation: &mut Activation<'_, 'gc>) -> Object<'gc> {
         let object_proto = activation.context.avm1.prototypes().object;
         let function_proto = activation.context.avm1.prototypes().function;
-        create(
-            &mut activation.context.borrow_gc(),
-            object_proto,
-            function_proto,
-        )
+        create(&mut activation.strings_mut(), object_proto, function_proto)
     }
 
     test_method!(test_abs, "abs", setup,

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -6,7 +6,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 
 use ruffle_render::matrix::Matrix;
@@ -455,7 +455,7 @@ fn to_string<'gc>(
 }
 
 pub fn create_matrix_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     matrix_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -469,7 +469,7 @@ pub fn create_matrix_object<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "show" => method(show_mouse; DONT_DELETE | DONT_ENUM | READ_ONLY);
@@ -31,7 +31,7 @@ pub fn hide_mouse<'gc>(
 }
 
 pub fn create_mouse_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -8,7 +8,7 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{self, ArrayObject, Object, ScriptObject, TObject, Value};
 use crate::backend::navigator::NavigationMethod;
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use crate::display_object::{Bitmap, EditText, MovieClip, TInteractiveObject};
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::prelude::*;
@@ -261,7 +261,7 @@ pub fn hit_test<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -9,7 +9,7 @@ use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, Value};
 use crate::backend::navigator::Request;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::TDisplayObject;
 use crate::loader::MovieLoaderVMData;
 
@@ -163,7 +163,7 @@ fn get_progress<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     array_proto: Object<'gc>,

--- a/core/src/avm1/globals/netconnection.rs
+++ b/core/src/avm1/globals/netconnection.rs
@@ -7,7 +7,7 @@ use crate::avm1::{
     Value,
 };
 use crate::avm1_stub;
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use crate::net_connection::{NetConnectionHandle, NetConnections, ResponderCallback};
 use crate::string::AvmString;
 use flash_lso::packet::Header;
@@ -334,7 +334,7 @@ fn connect<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -344,7 +344,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_class<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     netconnection_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -3,7 +3,7 @@ use crate::avm1::object::{NativeObject, Object, TObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, ScriptObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::streams::NetStream;
 
 pub fn constructor<'gc>(
@@ -172,7 +172,7 @@ fn get_time<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -182,7 +182,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_class<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     netstream_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -7,7 +7,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -62,7 +62,7 @@ pub fn number_function<'gc>(
 }
 
 pub fn create_number_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     number_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -80,7 +80,7 @@ pub fn create_number_object<'gc>(
 
 /// Creates `Number.prototype`.
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -7,7 +7,7 @@ use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::avm_warn;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
 
@@ -240,7 +240,7 @@ fn unwatch<'gc>(
 /// not allocate an object to store either proto. Instead, you must allocate
 /// bare objects for both and let this function fill Object for you.
 pub fn fill_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     object_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) {
@@ -317,7 +317,7 @@ pub fn as_set_prop_flags<'gc>(
 }
 
 pub fn create_object_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, ExecutionReason, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -284,7 +284,7 @@ fn offset<'gc>(
 }
 
 pub fn create_point_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     point_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -301,7 +301,7 @@ pub fn create_point_object<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -6,7 +6,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{construct_new_point, point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -94,7 +94,7 @@ fn to_string<'gc>(
 }
 
 pub fn create_rectangle_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     rectangle_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -704,7 +704,7 @@ fn set_bottom_right<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::{EditText, TDisplayObject, TInteractiveObject, TextSelection};
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
@@ -138,7 +138,7 @@ pub fn set_focus<'gc>(
 }
 
 pub fn create_selection_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
@@ -150,7 +150,7 @@ pub fn create_selection_object<'gc>(
     object.into()
 }
 
-pub fn create_proto<'gc>(context: &mut GcContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
+pub fn create_proto<'gc>(context: &mut StringContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
     ScriptObject::new(context.gc_context, Some(proto)).into()
 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -4,7 +4,7 @@ use crate::avm1::{
     Activation, Attribute, Error, Executable, NativeObject, Object, ScriptObject, TObject, Value,
 };
 use crate::avm1_stub;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
 use flash_lso::amf0::read::AMF0Decoder;
@@ -596,7 +596,7 @@ fn constructor<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -8,7 +8,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, SoundObject, TObject, Value};
 use crate::backend::navigator::Request;
 use crate::character::Character;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::{SoundTransform, TDisplayObject};
 use crate::{avm1_stub, avm_warn};
 
@@ -57,7 +57,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -7,7 +7,7 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::StageDisplayState;
 use crate::string::{AvmString, WStr, WString};
 
@@ -21,7 +21,7 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create_stage_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     array_proto: Object<'gc>,
     fn_proto: Object<'gc>,

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -7,7 +7,7 @@ use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::{utils as string_utils, AvmString, WString};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -72,7 +72,7 @@ pub fn string_function<'gc>(
 }
 
 pub fn create_string_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     string_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -90,7 +90,7 @@ pub fn create_string_object<'gc>(
 
 /// Creates `String.prototype`.
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/style_sheet.rs
+++ b/core/src/avm1/globals/style_sheet.rs
@@ -6,7 +6,7 @@ use crate::avm1::{
 use crate::avm1::{Activation, Error, Value};
 use crate::avm1_stub;
 use crate::backend::navigator::Request;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::html::{transform_dashes_to_camel_case, CssStream, TextFormat};
 use crate::string::AvmString;
 use gc_arena::Gc;
@@ -211,7 +211,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -6,7 +6,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::runtime::Avm1;
 use crate::avm1::{ScriptObject, TObject, Value};
 use crate::avm1_stub;
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use bitflags::bitflags;
 use core::fmt;
 
@@ -500,7 +500,7 @@ pub fn on_status<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     security: Object<'gc>,

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -4,7 +4,7 @@ use crate::avm1::globals::system::SystemCapabilities;
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
@@ -256,7 +256,7 @@ pub fn get_max_idc_level<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -4,7 +4,7 @@ use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "ALPHANUMERIC_FULL" => string("ALPHANUMERIC_FULL"; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -80,7 +80,7 @@ fn set_enabled<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -4,7 +4,7 @@ use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::prelude::TDisplayObject;
 use crate::sandbox::SandboxType;
 use crate::string::AvmString;
@@ -92,7 +92,7 @@ fn policy_file_resolver<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -4,7 +4,7 @@ use crate::avm1::globals::bitmap_filter;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{globals, ArrayObject, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::{
     AutoSizeMode, EditText, TDisplayObject, TInteractiveObject, TextSelection,
 };
@@ -109,7 +109,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -4,7 +4,7 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject};
 use crate::ecma_conversions::round_to_even;
 use crate::html::TextFormat;
@@ -612,7 +612,7 @@ pub fn constructor<'gc>(
 
 /// `TextFormat.prototype` constructor
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -7,7 +7,7 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::object_reference::MovieClipReference;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::{DisplayObject, TDisplayObject};
 use gc_arena::Collect;
 use swf::{Rectangle, Twips};
@@ -175,7 +175,7 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/video.rs
+++ b/core/src/avm1/globals/video.rs
@@ -6,7 +6,7 @@ use crate::avm1::object::{NativeObject, Object, TObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::value::Value;
 use crate::avm1::ScriptObject;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::display_object::{TDisplayObject, Video};
 
 macro_rules! video_method {
@@ -56,7 +56,7 @@ pub fn attach_video<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -7,7 +7,7 @@ use crate::avm1::{
 };
 use crate::avm_warn;
 use crate::backend::navigator::Request;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::{AvmString, WStr, WString};
 use crate::xml::{custom_unescape, XmlNode, ELEMENT_NODE, TEXT_NODE};
 use gc_arena::{Collect, GcCell, Mutation};
@@ -566,7 +566,7 @@ fn spawn_xml_fetch<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{NativeObject, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::{AvmString, WStr};
 use crate::xml::{XmlNode, TEXT_NODE};
 
@@ -396,7 +396,7 @@ fn namespace_uri<'gc>(
 
 /// Construct the prototype for `XMLNode`.
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/xml_socket.rs
+++ b/core/src/avm1/globals/xml_socket.rs
@@ -3,7 +3,7 @@ use crate::avm1::object::{NativeObject, Object};
 use crate::avm1::property_decl::define_properties_on;
 use crate::avm1::{property_decl::Declaration, ScriptObject};
 use crate::avm1::{Activation, Error, Executable, ExecutionReason, TObject, Value};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use crate::display_object::TDisplayObject;
 use crate::socket::SocketHandle;
 use crate::string::AvmString;
@@ -247,7 +247,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -257,7 +257,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_class<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     xml_socket_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -5,13 +5,13 @@ use std::borrow::Cow;
 use crate::avm1::function::{Executable, FunctionObject, NativeFunction};
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::context::StringContext;
 
 /// Defines a list of properties on a [`ScriptObject`].
 #[inline(never)]
 pub fn define_properties_on<'gc>(
     decls: &[Declaration],
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'_, 'gc>,
     this: ScriptObject<'gc>,
     fn_proto: Object<'gc>,
 ) {
@@ -63,15 +63,15 @@ impl Declaration {
     /// defined a property.
     pub fn define_on<'gc>(
         &self,
-        context: &mut GcContext<'_, 'gc>,
+        context: &mut StringContext<'_, 'gc>,
         this: ScriptObject<'gc>,
         fn_proto: Object<'gc>,
     ) -> Value<'gc> {
         let mc = context.gc_context;
 
         let name = match ruffle_wstr::from_utf8(self.name) {
-            Cow::Borrowed(name) => context.interner.intern_static(mc, name),
-            Cow::Owned(name) => context.interner.intern_wstr(mc, name),
+            Cow::Borrowed(name) => context.strings.intern_static(mc, name),
+            Cow::Owned(name) => context.strings.intern_wstr(mc, name),
         };
 
         let value = match self.kind {
@@ -93,7 +93,7 @@ impl Declaration {
             }
             DeclKind::String(s) => {
                 let s = ruffle_wstr::from_utf8(s);
-                context.interner.intern_wstr(mc, s).into()
+                context.strings.intern_wstr(mc, s).into()
             }
             DeclKind::Bool(b) => b.into(),
             DeclKind::Int(i) => i.into(),

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -6,7 +6,7 @@ use crate::avm1::object::TObject;
 use crate::avm1::property_map::PropertyMap;
 use crate::avm1::scope::Scope;
 use crate::avm1::{scope, Activation, ActivationIdentifier, Error, Object, Value};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use crate::frame_lifecycle::FramePhase;
 use crate::prelude::*;
 use crate::string::AvmString;
@@ -90,7 +90,7 @@ pub struct Avm1<'gc> {
 }
 
 impl<'gc> Avm1<'gc> {
-    pub fn new(context: &mut GcContext<'_, 'gc>, player_version: u8) -> Self {
+    pub fn new(context: &mut StringContext<'_, 'gc>, player_version: u8) -> Self {
         let gc_context = context.gc_context;
         let (prototypes, globals, broadcaster_functions) = create_globals(context);
 

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -914,7 +914,7 @@ mod test {
             );
             assert_eq!(null.to_primitive_num(activation).unwrap(), null);
 
-            let (protos, global, _) = create_globals(&mut activation.context.borrow_gc());
+            let (protos, global, _) = create_globals(&mut activation.strings_mut());
             let vglobal = Value::Object(global);
 
             assert_eq!(vglobal.to_primitive_num(activation).unwrap(), undefined);

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -10,7 +10,7 @@ use crate::avm2::globals::{
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::scope::ScopeChain;
 use crate::avm2::script::{Script, TranslationUnit};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use crate::display_object::{DisplayObject, DisplayObjectWeak, TDisplayObject};
 use crate::string::AvmString;
 use crate::tag_utils::SwfMovie;
@@ -189,7 +189,7 @@ pub struct Avm2<'gc> {
 impl<'gc> Avm2<'gc> {
     /// Construct a new AVM interpreter.
     pub fn new(
-        context: &mut GcContext<'_, 'gc>,
+        context: &mut StringContext<'_, 'gc>,
         player_version: u8,
         player_runtime: PlayerRuntime,
     ) -> Self {

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -20,8 +20,8 @@ use crate::avm2::value::Value;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::{Avm2, Error};
-use crate::context::{GcContext, UpdateContext};
-use crate::string::{AvmAtom, AvmString};
+use crate::context::{StringContext, UpdateContext};
+use crate::string::{AvmAtom, AvmString, AvmStringInterner};
 use crate::tag_utils::SwfMovie;
 use gc_arena::Gc;
 use smallvec::SmallVec;
@@ -637,9 +637,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.context.avm2
     }
 
-    #[inline]
-    pub fn borrow_gc(&mut self) -> GcContext<'_, 'gc> {
-        self.context.borrow_gc()
+    pub fn strings(&self) -> &AvmStringInterner<'gc> {
+        self.context.strings
+    }
+
+    pub fn strings_mut(&mut self) -> StringContext<'_, 'gc> {
+        self.context.strings_mut()
     }
 
     pub fn scope_frame(&self) -> &[Scope<'gc>] {

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -803,8 +803,7 @@ impl<'gc> Class<'gc> {
         method: &AbcMethod,
         body: &AbcMethodBody,
     ) -> Result<Class<'gc>, Error<'gc>> {
-        let name =
-            translation_unit.pool_string(method.name.as_u30(), &mut activation.borrow_gc())?;
+        let name = translation_unit.pool_string(method.name.as_u30(), activation.strings_mut())?;
         let mut traits = Vec::with_capacity(body.traits.len());
 
         for trait_entry in body.traits.iter() {

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1059,7 +1059,7 @@ impl<'gc> E4XNode<'gc> {
             let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
             let name = activation
                 .context
-                .interner
+                .strings
                 .intern_wstr(activation.gc(), local_name)
                 .into();
 
@@ -1110,7 +1110,7 @@ impl<'gc> E4XNode<'gc> {
         let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
         let name = activation
             .context
-            .interner
+            .strings
             .intern_wstr(activation.gc(), local_name)
             .into();
 

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -783,7 +783,7 @@ macro_rules! avm2_system_classes_playerglobal {
         let activation = $activation;
         $(
             // Lookup with the highest version, so we we see all defined classes here
-            let ns = Namespace::package($package, ApiVersion::VM_INTERNAL, &mut activation.borrow_gc());
+            let ns = Namespace::package($package, ApiVersion::VM_INTERNAL, activation.strings_mut());
             let name = QName::new(ns, $class_name);
             let class_object = activation.domain().get_defined_value(activation, name).unwrap_or_else(|e| panic!("Failed to lookup {name:?}: {e:?}"));
             let class_object = class_object.as_object().unwrap().as_class_object().unwrap();
@@ -798,7 +798,7 @@ macro_rules! avm2_system_class_defs_playerglobal {
         let activation = $activation;
         $(
             // Lookup with the highest version, so we we see all defined classes here
-            let ns = Namespace::package($package, ApiVersion::VM_INTERNAL, &mut activation.borrow_gc());
+            let ns = Namespace::package($package, ApiVersion::VM_INTERNAL, activation.strings_mut());
             let name = QName::new(ns, $class_name);
             let class_object = activation.domain().get_defined_value(activation, name).unwrap_or_else(|e| panic!("Failed to lookup {name:?}: {e:?}"));
             let class_def = class_object.as_object().unwrap().as_class_object().unwrap().inner_class_definition();

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -37,7 +37,7 @@ pub fn init<'gc>(
                 uri.coerce_to_string(activation)?
             };
             let namespace =
-                Namespace::package(namespace_uri, api_version, &mut activation.borrow_gc());
+                Namespace::package(namespace_uri, api_version, activation.strings_mut());
             let prefix_str = prefix.coerce_to_string(activation)?;
 
             // The order is important here to match Flash
@@ -58,7 +58,7 @@ pub fn init<'gc>(
         [Value::Object(Object::QNameObject(qname))] => {
             let ns = qname
                 .uri()
-                .map(|uri| Namespace::package(uri, api_version, &mut activation.borrow_gc()))
+                .map(|uri| Namespace::package(uri, api_version, activation.strings_mut()))
                 .unwrap_or_else(Namespace::any);
             if ns.as_uri().is_empty() {
                 (Some("".into()), ns)
@@ -68,11 +68,8 @@ pub fn init<'gc>(
         }
         [Value::Object(Object::NamespaceObject(ns))] => (ns.prefix(), ns.namespace()),
         [val] => {
-            let ns = Namespace::package(
-                val.coerce_to_string(activation)?,
-                api_version,
-                &mut activation.borrow_gc(),
-            );
+            let name = val.coerce_to_string(activation)?;
+            let ns = Namespace::package(name, api_version, activation.strings_mut());
             if ns.as_uri().is_empty() {
                 (Some("".into()), ns)
             } else {

--- a/core/src/avm2/globals/q_name.rs
+++ b/core/src/avm2/globals/q_name.rs
@@ -63,18 +63,18 @@ pub fn init<'gc>(
         let namespace = match ns_arg {
             Value::Object(Object::NamespaceObject(ns)) => Some(ns.namespace()),
             Value::Object(Object::QNameObject(qname)) => qname.uri().map(|uri| {
-                Namespace::package(uri, ApiVersion::AllVersions, &mut activation.borrow_gc())
+                Namespace::package(uri, ApiVersion::AllVersions, activation.strings_mut())
             }),
             Value::Null => None,
             Value::Undefined => Some(Namespace::package(
                 "",
                 api_version,
-                &mut activation.borrow_gc(),
+                activation.strings_mut(),
             )),
             v => Some(Namespace::package(
                 v.coerce_to_string(activation)?,
                 api_version,
-                &mut activation.borrow_gc(),
+                activation.strings_mut(),
             )),
         };
 

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -131,11 +131,10 @@ fn char_at<'gc>(
         let index = if !n.is_nan() { n as usize } else { 0 };
         let ret = if let Some(c) = s.get(index) {
             activation
-                .context
-                .interner
+                .strings()
                 .get_char(activation.context.gc_context, c)
         } else {
-            activation.context.interner.empty()
+            activation.strings().empty()
         };
         return Ok(ret.into());
     }
@@ -451,8 +450,7 @@ fn slice<'gc>(
 
     if start_index < end_index {
         Ok(activation
-            .context
-            .interner
+            .strings()
             .substring(activation.context.gc_context, this, start_index, end_index)
             .into())
     } else {
@@ -493,8 +491,7 @@ fn split<'gc>(
             .map(|c| {
                 Value::from(
                     activation
-                        .context
-                        .interner
+                        .strings()
                         .get_char(activation.context.gc_context, c),
                 )
             })
@@ -561,8 +558,7 @@ fn substr<'gc>(
     let end_index = this.len().min(start_index + len as usize);
 
     Ok(activation
-        .context
-        .interner
+        .strings()
         .substring(activation.context.gc_context, this, start_index, end_index)
         .into())
 }
@@ -599,8 +595,7 @@ fn substring<'gc>(
     }
 
     Ok(activation
-        .context
-        .interner
+        .strings()
         .substring(activation.context.gc_context, this, start_index, end_index)
         .into())
 }

--- a/core/src/avm2/metadata.rs
+++ b/core/src/avm2/metadata.rs
@@ -43,16 +43,16 @@ impl<'gc> Metadata<'gc> {
                 .get(single_metadata.0 as usize)
                 .ok_or_else(|| format!("Unknown metadata {}", single_metadata.0))?;
 
-            let name = translation_unit
-                .pool_string(single_metadata.name.0, &mut activation.borrow_gc())?;
+            let name =
+                translation_unit.pool_string(single_metadata.name.0, activation.strings_mut())?;
 
             let mut current_metadata_items = vec![];
             for metadata_item in single_metadata.items.iter() {
-                let key = translation_unit
-                    .pool_string(metadata_item.key.0, &mut activation.borrow_gc())?;
+                let key =
+                    translation_unit.pool_string(metadata_item.key.0, activation.strings_mut())?;
 
                 let value = translation_unit
-                    .pool_string(metadata_item.value.0, &mut activation.borrow_gc())?;
+                    .pool_string(metadata_item.value.0, activation.strings_mut())?;
 
                 let item = MetadataItem {
                     key: key.into(),

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -73,9 +73,7 @@ impl<'gc> ParamConfig<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
         let param_name = if let Some(name) = &config.name {
-            txunit
-                .pool_string(name.0, &mut activation.borrow_gc())?
-                .into()
+            txunit.pool_string(name.0, activation.strings_mut())?.into()
         } else {
             AvmString::from("<Unnamed Parameter>")
         };

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -194,7 +194,7 @@ impl<'gc> XmlListObject<'gc> {
                         Some(ns) => Namespace::package(
                             ns.uri,
                             ApiVersion::AllVersions,
-                            &mut activation.context.borrow_gc(),
+                            activation.strings_mut(),
                         ),
                         None => activation.avm2().namespaces.public_all(),
                     };

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -5,7 +5,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::TranslationUnit;
 use crate::avm2::Value;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 use gc_arena::{Collect, Gc};
 
@@ -113,11 +113,11 @@ impl<'gc> PropertyClass<'gc> {
         }
     }
 
-    pub fn get_name(&self, context: &mut GcContext<'_, 'gc>) -> AvmString<'gc> {
+    pub fn get_name(&self, context: StringContext<'_, 'gc>) -> AvmString<'gc> {
         match self {
             PropertyClass::Class(class) => class.name().to_qualified_name(context.gc_context),
             PropertyClass::Name(name, _) => name.to_qualified_name_or_star(context),
-            PropertyClass::Any => context.interner.get_ascii_char('*'),
+            PropertyClass::Any => context.strings.get_ascii_char('*'),
         }
     }
 }

--- a/core/src/avm2/qname.rs
+++ b/core/src/avm2/qname.rs
@@ -93,10 +93,10 @@ impl<'gc> QName<'gc> {
             .or_else(|| name.rsplit_once(WStr::from_units(b".")));
 
         if let Some((package_name, local_name)) = parts {
-            let package_name = context.interner.intern_wstr(context.gc(), package_name);
+            let package_name = context.strings.intern_wstr(context.gc(), package_name);
 
             Self {
-                ns: Namespace::package(package_name, api_version, &mut context.borrow_gc()),
+                ns: Namespace::package(package_name, api_version, context.strings_mut()),
                 name: AvmString::new(context.gc(), local_name),
             }
         } else {

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -14,7 +14,7 @@ use crate::avm2::vtable::VTable;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::{Avm2, Error};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::{StringContext, UpdateContext};
 use crate::string::{AvmAtom, AvmString};
 use crate::tag_utils::SwfMovie;
 use crate::PlayerRuntime;
@@ -276,7 +276,7 @@ impl<'gc> TranslationUnit<'gc> {
     pub fn pool_string_option(
         self,
         string_index: u32,
-        context: &mut GcContext<'_, 'gc>,
+        context: StringContext<'_, 'gc>,
     ) -> Result<Option<AvmAtom<'gc>>, Error<'gc>> {
         if string_index == 0 {
             Ok(None)
@@ -294,7 +294,7 @@ impl<'gc> TranslationUnit<'gc> {
     pub fn pool_string(
         self,
         string_index: u32,
-        context: &mut GcContext<'_, 'gc>,
+        context: StringContext<'_, 'gc>,
     ) -> Result<AvmAtom<'gc>, Error<'gc>> {
         let mut write = self.0.write(context.gc_context);
         if let Some(Some(atom)) = write.strings.get(string_index as usize) {
@@ -314,7 +314,7 @@ impl<'gc> TranslationUnit<'gc> {
         };
 
         let atom = context
-            .interner
+            .strings
             .intern_wstr(context.gc_context, ruffle_wstr::from_utf8_bytes(raw));
 
         write.strings[string_index as usize] = Some(atom);

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -521,7 +521,7 @@ pub fn abc_default_value<'gc>(
         AbcDefaultValue::Uint(u) => abc_uint(translation_unit, *u).map(|v| v.into()),
         AbcDefaultValue::Double(d) => abc_double(translation_unit, *d).map(|v| v.into()),
         AbcDefaultValue::String(s) => translation_unit
-            .pool_string(s.0, &mut activation.borrow_gc())
+            .pool_string(s.0, activation.strings_mut())
             .map(Into::into),
         AbcDefaultValue::True => Ok(true.into()),
         AbcDefaultValue::False => Ok(false.into()),
@@ -840,8 +840,7 @@ impl<'gc> Value<'gc> {
             Value::Integer(i) => {
                 if *i >= 0 && *i < 10 {
                     activation
-                        .context
-                        .interner
+                        .strings()
                         .get_char(activation.context.gc_context, '0' as u16 + *i as u16)
                 } else {
                     AvmString::new_utf8(activation.context.gc_context, i.to_string())

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -840,7 +840,7 @@ fn pool_string<'gc>(
         return Err(make_error_1032(activation, 0));
     }
 
-    translation_unit.pool_string(index.0, &mut activation.borrow_gc())
+    translation_unit.pool_string(index.0, activation.strings_mut())
 }
 
 fn pool_class<'gc>(

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -8,7 +8,7 @@ use crate::avm2::scope::ScopeChain;
 use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::value::Value;
 use crate::avm2::{Class, Error, Multiname, Namespace, QName};
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::cell::Ref;
@@ -115,7 +115,7 @@ impl<'gc> VTable<'gc> {
 
     pub fn slot_class_name(
         &self,
-        context: &mut GcContext<'_, 'gc>,
+        context: StringContext<'_, 'gc>,
         slot_id: u32,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         self.0

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -52,24 +52,24 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 use web_time::Instant;
 
-/// Minimal context, useful for manipulating the GC heap.
-pub struct GcContext<'a, 'gc> {
+/// Minimal context, useful for allocating GC'd strings.
+pub struct StringContext<'a, 'gc> {
     /// The mutation context to allocate and mutate `Gc` pointers.
     pub gc_context: &'gc Mutation<'gc>,
 
     /// The global string interner.
-    pub interner: &'a mut AvmStringInterner<'gc>,
+    pub strings: &'a mut AvmStringInterner<'gc>,
 }
 
-impl<'a, 'gc> GcContext<'a, 'gc> {
+impl<'a, 'gc> StringContext<'a, 'gc> {
     #[inline(always)]
-    pub fn reborrow<'b>(&'b mut self) -> GcContext<'b, 'gc>
+    pub fn reborrow<'b>(&'b mut self) -> StringContext<'b, 'gc>
     where
         'a: 'b,
     {
-        GcContext {
+        StringContext {
             gc_context: self.gc_context,
-            interner: self.interner,
+            strings: self.strings,
         }
     }
 
@@ -93,7 +93,7 @@ pub struct UpdateContext<'gc> {
     pub gc_context: &'gc Mutation<'gc>,
 
     /// The global string interner.
-    pub interner: &'gc mut AvmStringInterner<'gc>,
+    pub strings: &'gc mut AvmStringInterner<'gc>,
 
     /// A collection of stubs encountered during this movie.
     pub stub_tracker: &'gc mut StubCollection,
@@ -469,13 +469,13 @@ impl<'a, 'gc> UpdateContext<'gc> {
     }
 
     #[inline]
-    pub fn borrow_gc<'b>(&'b mut self) -> GcContext<'b, 'gc>
+    pub fn strings_mut<'b>(&'b mut self) -> StringContext<'b, 'gc>
     where
         'a: 'b,
     {
-        GcContext {
+        StringContext {
             gc_context: self.gc_context,
-            interner: self.interner,
+            strings: self.strings,
         }
     }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -18,7 +18,7 @@ use crate::backend::{
 };
 use crate::compatibility_rules::CompatibilityRules;
 use crate::config::Letterbox;
-use crate::context::GcContext;
+use crate::context::StringContext;
 use crate::context::{ActionQueue, ActionType, RenderContext, UpdateContext};
 use crate::context_menu::{
     BuiltInItemFlags, ContextMenuCallback, ContextMenuItem, ContextMenuState,
@@ -156,7 +156,7 @@ struct GcRootData<'gc> {
     avm2: Avm2<'gc>,
 
     action_queue: ActionQueue<'gc>,
-    interner: AvmStringInterner<'gc>,
+    strings: AvmStringInterner<'gc>,
 
     /// Object which manages asynchronous processes that need to interact with
     /// data in the GC arena.
@@ -239,7 +239,7 @@ impl<'gc> GcRootData<'gc> {
             self.stage,
             &mut self.library,
             &mut self.action_queue,
-            &mut self.interner,
+            &mut self.strings,
             &mut self.avm1,
             &mut self.avm2,
             &mut self.drag_object,
@@ -2201,7 +2201,7 @@ impl Player {
                 ui: this.ui.deref_mut(),
                 action_queue,
                 gc_context,
-                interner,
+                strings: interner,
                 stage,
                 mouse_data,
                 input: &this.input,
@@ -2740,10 +2740,10 @@ impl PlayerBuilder {
         external_interface_providers: Vec<Box<dyn ExternalInterfaceProvider>>,
         fs_command_provider: Box<dyn FsCommandProvider>,
     ) -> GcRoot<'gc> {
-        let mut interner = AvmStringInterner::new(gc_context);
-        let mut init = GcContext {
+        let mut strings = AvmStringInterner::new(gc_context);
+        let mut init = StringContext {
             gc_context,
-            interner: &mut interner,
+            strings: &mut strings,
         };
 
         let data = GcRootData {
@@ -2751,7 +2751,7 @@ impl PlayerBuilder {
             action_queue: ActionQueue::new(),
             avm1: Avm1::new(&mut init, player_version),
             avm2: Avm2::new(&mut init, player_version, player_runtime),
-            interner,
+            strings,
             current_context_menu: None,
             drag_object: None,
             external_interface: ExternalInterface::new(


### PR DESCRIPTION
Preparatory work for future PRs introducing the interner in more places.

This tries to make using the interner slightly less verbose, by:
- Renaming `GcContext` to `StringContext`.
- Renaming `context.interner` to `context.strings`.
- Renaming `borrow_gc()` methods to `strings_mut()`.
- Adding `Activation::strings()` convenience method.
- Taking a `StringContext` instead of a `&mut StringContext` in most methods.