### PR TITLE
chore: Switch `egui` back to release `0.29.0` from git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,8 +1428,9 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "ecolor"
-version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5629649a8ae57c73f175f4a96419905a8102cfbfcbce96ea25a826bbf468e990"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1437,8 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bab3b3572566257a497b5f87d2cccaf7f7f122d4b8b620cba0493becc7955e"
 dependencies = [
  "ahash",
  "emath",
@@ -1449,8 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba69456826abf572ed95b658b265c01f07a23d615d6f029eedc9ee5f13ddf788"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1467,8 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642c749bf221b5a3ecae3144c98b837729d87b9fde6c39a6ad00f07b71dbee94"
 dependencies = [
  "ahash",
  "arboard",
@@ -1483,8 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1beb57a3c942fac2f058655188c79ac1cd200555e4f3684cd0c965ceb3a67"
 dependencies = [
  "ahash",
  "egui",
@@ -1501,8 +1506,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "emath"
-version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af86c4efae11da2a3dcbb4afebd0e9ed1916345e8d187b4051d443c8bd79af93"
 dependencies = [
  "bytemuck",
 ]
@@ -1630,8 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e11ec86a4d85e1350578ba20b2d89977ed937f3faab32e1c3ec81d20c1842"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1646,8 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=06f709481a4e5e74bec961544c77e9afcae265db#06f709481a4e5e74bec961544c77e9afcae265db"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5202b64bef2b2c42a7f6e2e5b40fa83dd04aa61fdb08bfd116553adc149fe47a"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 naga = { version = "22.1.0", features = ["wgsl-out"] }
 wgpu = "22.1.0"
-egui = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db" }
+egui = "0.29.0"
 clap = { version = "4.5.18", features = ["derive"] }
 cpal = "0.15.3"
 anyhow = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.11.0"
 egui = { workspace = true, optional = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db", default-features = false, optional = true }
+egui_extras = { version = "0.29.0", default-features = false, optional = true }
 png = { version = "0.17.13", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -74,11 +74,9 @@ unknown-registry = "deny"
 unknown-git = "deny"
 
 [sources.allow-org]
-#  github.com organizations to allow git sources for
+# github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
-    # TODO: Remove once a release with https://github.com/emilk/egui/pull/4939 in it is out.
-    "emilk",
 ]
 
 [advisories]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 clap = { workspace = true }
 cpal = { workspace = true }
 egui = { workspace = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db", default-features = false, features = ["image"] }
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db", features = ["winit"] }
+egui_extras = { version = "0.29.0", default-features = false, features = ["image"] }
+egui-wgpu = { version = "0.29.0", features = ["winit"] }
 image = { workspace = true, features = ["png"] }
-egui-winit = { git = "https://github.com/emilk/egui.git", rev = "06f709481a4e5e74bec961544c77e9afcae265db" }
+egui-winit = "0.29.0"
 fontdb = "0.22"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -353,18 +353,20 @@ impl GuiController {
         {
             let surface_view = surface_texture.texture.create_view(&Default::default());
 
-            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: &surface_view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
-                label: Some("egui_render"),
-                ..Default::default()
-            });
+            let mut render_pass = encoder
+                .begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &surface_view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    label: Some("egui_render"),
+                    ..Default::default()
+                })
+                .forget_lifetime();
 
             if let Some(movie_view) = movie_view {
                 movie_view.render(&self.movie_view_renderer, &mut render_pass);

--- a/desktop/src/gui/movie.rs
+++ b/desktop/src/gui/movie.rs
@@ -201,10 +201,10 @@ impl MovieView {
         }
     }
 
-    pub fn render<'pass, 'global: 'pass>(
-        &'pass self,
-        renderer: &'global MovieViewRenderer,
-        render_pass: &mut wgpu::RenderPass<'pass>,
+    pub fn render(
+        &self,
+        renderer: &MovieViewRenderer,
+        render_pass: &mut wgpu::RenderPass<'static>,
     ) {
         render_pass.set_pipeline(&renderer.pipeline);
         render_pass.set_bind_group(0, &self.bind_group, &[]);


### PR DESCRIPTION
Fresh out of the oven: https://github.com/emilk/egui/releases/tag/0.29.0 :bread:

~~We weren't that far behind already, so no significant changes expected.~~ EDIT: Spoke too soon...