### PR TITLE
web: Support gamepad button input

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,4 +1,5 @@
 use crate::display_object::InteractiveObject;
+use std::str::FromStr;
 use swf::ClipEventFlag;
 
 #[derive(Debug, Clone, Copy)]
@@ -800,4 +801,30 @@ pub enum GamepadButton {
     DPadDown,
     DPadLeft,
     DPadRight,
+}
+
+pub struct ParseEnumError;
+
+impl FromStr for GamepadButton {
+    type Err = ParseEnumError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "south" => Self::South,
+            "east" => Self::East,
+            "north" => Self::North,
+            "west" => Self::West,
+            "left-trigger" => Self::LeftTrigger,
+            "left-trigger-2" => Self::LeftTrigger2,
+            "right-trigger" => Self::RightTrigger,
+            "right-trigger-2" => Self::RightTrigger2,
+            "select" => Self::Select,
+            "start" => Self::Start,
+            "dpad-up" => Self::DPadUp,
+            "dpad-down" => Self::DPadDown,
+            "dpad-left" => Self::DPadLeft,
+            "dpad-right" => Self::DPadRight,
+            _ => return Err(ParseEnumError),
+        })
+    }
 }

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -280,7 +280,7 @@ fn parse_gamepad_button(mapping: &str) -> Result<(GamepadButton, KeyCode), Error
         aliases.join(", ")
     }
 
-    let button = GamepadButton::from_str(&mapping[..pos], true).map_err(|err| {
+    let button = <GamepadButton as ValueEnum>::from_str(&mapping[..pos], true).map_err(|err| {
         anyhow!(
             "Could not parse <gamepad button>: {err}\n  The possible values are: {}",
             to_aliases(GamepadButton::value_variants())

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -74,7 +74,7 @@ features = [
     "EventTarget", "GainNode", "Headers", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement",
     "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent",
     "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "ReadableStream", "RequestCredentials",
-    "Url", "Clipboard", "FocusEvent", "ShadowRoot"
+    "Url", "Clipboard", "FocusEvent", "ShadowRoot", "Gamepad", "GamepadButton"
 ]
 
 [package.metadata.cargo-machete]

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -117,7 +117,7 @@ export default tseslint.config(
             ],
             "jsdoc/check-tag-names": [
                 "error",
-                { definedTags: ["privateRemarks", "remarks"] },
+                { definedTags: ["experimental", "privateRemarks", "remarks"] },
             ],
         },
         settings: {

--- a/web/packages/core/src/internal/builder.ts
+++ b/web/packages/core/src/internal/builder.ts
@@ -109,6 +109,14 @@ export function configureBuilder(
             builder.addSocketProxy(proxy.host, proxy.port, proxy.proxyUrl);
         }
     }
+
+    if (isExplicit(config.gamepadButtonMapping)) {
+        for (const [button, keyCode] of Object.entries(
+            config.gamepadButtonMapping,
+        )) {
+            builder.addGamepadButtonMapping(button, keyCode);
+        }
+    }
 }
 
 /**

--- a/web/packages/core/src/public/config/default.ts
+++ b/web/packages/core/src/public/config/default.ts
@@ -51,4 +51,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     defaultFonts: {},
     credentialAllowList: [],
     playerRuntime: PlayerRuntime.FlashPlayer,
+    gamepadButtonMapping: {},
 };

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -322,6 +322,26 @@ export interface DefaultFonts {
 }
 
 /**
+ * @experimental
+ */
+export enum GamepadButton {
+    South = "south",
+    East = "east",
+    North = "north",
+    West = "west",
+    LeftTrigger = "left-trigger",
+    LeftTrigger2 = "left-trigger-2",
+    RightTrigger = "right-trigger",
+    RightTrigger2 = "right-trigger-2",
+    Select = "select",
+    Start = "start",
+    DPadUp = "dpad-up",
+    DPadDown = "dpad-down",
+    DPadLeft = "dpad-left",
+    DPadRight = "dpad-right",
+}
+
+/**
  * Any options used for loading a movie.
  */
 export interface BaseLoadOptions {
@@ -667,6 +687,27 @@ export interface BaseLoadOptions {
      * This allows you to emulate Adobe AIR or Adobe Flash Player.
      */
     playerRuntime?: PlayerRuntime;
+
+    /**
+     * An object mapping gamepad button names to ActionScript key codes.
+     *
+     * With the appropriate mapping pressing a button on the gamepad will look like the corresponding key press to the loaded SWF.
+     * This can be used for adding gamepad support to games that don't support it otherwise.
+     *
+     * An example config for mapping the D-pad to the arrow keys would look like this:
+     * `
+     * {
+     *   "dpad-up": 38,
+     *   "dpad-down": 40,
+     *   "dpad-left": 37,
+     *   "dpad-right": 39,
+     * }
+     * `
+     *
+     * @experimental
+     * @default {}
+     */
+    gamepadButtonMapping?: Partial<Record<GamepadButton, number>>;
 }
 
 /**


### PR DESCRIPTION
Mostly just a proof of concept right now. This doesn't actually support defining the button to keycode mappings yet. I suspect we want to think a bit deeper about how that configuration would look like before adding it  to the Ruffle API.