### PR TITLE
core: Improve ergonomics by replacing `GcContext` by `StringContext`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -868,16 +868,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         &mut self,
         action: ConstantPool,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let encoding = self.encoding();
         let constants = action
             .strings
             .iter()
-            .map(|s| {
-                self.context
-                    .strings
-                    .interner
-                    .intern_wstr(self.context.gc_context, s.decode(self.encoding()))
-                    .into()
-            })
+            .map(|s| self.strings().intern_wstr(s.decode(encoding)).into())
             .collect();
 
         self.context

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -13,7 +13,7 @@ use crate::display_object::{
 };
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use crate::loader::MovieLoaderVMData;
-use crate::string::{AvmString, SwfStrExt as _, WStr, WString};
+use crate::string::{AvmString, StringContext, SwfStrExt as _, WStr, WString};
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
 use crate::{avm_error, avm_warn};
@@ -239,8 +239,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     /// Convenience method to retrieve the current GC context. Note that explicitly writing
     /// `self.context.gc_context` can be sometimes necessary to satisfy the borrow checker.
     #[inline(always)]
-    pub fn gc(&self) -> &'gc gc_arena::Mutation<'gc> {
+    pub fn gc(&self) -> &'gc Mutation<'gc> {
         self.context.gc_context
+    }
+
+    #[inline(always)]
+    pub fn strings(&mut self) -> &mut StringContext<'gc> {
+        &mut self.context.strings
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -868,6 +873,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .iter()
             .map(|s| {
                 self.context
+                    .strings
                     .interner
                     .intern_wstr(self.context.gc_context, s.decode(self.encoding()))
                     .into()

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -4,9 +4,8 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
 use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
-use crate::string::{AvmString, WStr, WString};
+use crate::string::{AvmString, StringContext, WStr, WString};
 use gc_arena::Collect;
 use std::str;
 
@@ -518,7 +517,7 @@ pub struct SystemPrototypes<'gc> {
 
 /// Initialize default global scope and builtins for an AVM1 instance.
 pub fn create_globals<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
 ) -> (
     SystemPrototypes<'gc>,
     Object<'gc>,
@@ -1207,7 +1206,7 @@ mod tests {
     use super::*;
 
     fn setup<'gc>(activation: &mut Activation<'_, 'gc>) -> Object<'gc> {
-        create_globals(&mut activation.context.borrow_gc()).1
+        create_globals(activation.strings()).1
     }
 
     test_method!(boolean_function, "Boolean", setup,

--- a/core/src/avm1/globals/accessibility.rs
+++ b/core/src/avm1/globals/accessibility.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
+use crate::string::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "isActive" => method(is_active; DONT_DELETE | READ_ONLY);
@@ -41,7 +41,7 @@ pub fn update_properties<'gc>(
 }
 
 pub fn create_accessibility_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -6,9 +6,8 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
-use crate::context::GcContext;
 use crate::ecma_conversions::f64_to_wrapping_i32;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use bitflags::bitflags;
 use std::cmp::Ordering;
 
@@ -62,7 +61,7 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create_array_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     array_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -743,7 +742,7 @@ fn qsort<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -7,8 +7,7 @@ use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::Declaration;
 use crate::avm1::{Activation, ArrayObject, Object, ScriptObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, Mutation};
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
@@ -19,7 +18,7 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> (BroadcasterFunctions<'gc>, Object<'gc>) {

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -4,8 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
-use crate::string::{AvmString, WStr};
+use crate::string::{AvmString, StringContext, WStr};
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{BevelFilterFlags, Color, Fixed16, Fixed8, GradientFilterFlags};
@@ -533,7 +532,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -543,7 +542,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -12,8 +12,8 @@ use crate::bitmap::bitmap_data::{BitmapDataDrawError, IBitmapDrawable};
 use crate::bitmap::bitmap_data::{ChannelOptions, ThresholdOperation};
 use crate::bitmap::{is_size_valid, operations};
 use crate::character::Character;
-use crate::context::GcContext;
 use crate::display_object::DisplayObject;
+use crate::string::StringContext;
 use crate::swf::BlendMode;
 use crate::{avm1_stub, avm_error};
 use gc_arena::{GcCell, Mutation};
@@ -1522,7 +1522,7 @@ fn load_bitmap<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: ScriptObject<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -13,7 +13,8 @@ use crate::avm1::globals::gradient_filter::GradientFilter;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Attribute, Object, ScriptObject, TObject, Value};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::UpdateContext;
+use crate::string::StringContext;
 use ruffle_render::filters::Filter;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -194,7 +195,7 @@ pub fn create_instance<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::string::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{BlurFilterFlags, Fixed16};
@@ -186,7 +186,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -196,7 +196,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -6,8 +6,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string; DONT_ENUM | DONT_DELETE);
@@ -46,7 +45,7 @@ pub fn boolean_function<'gc>(
 }
 
 pub fn create_boolean_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     boolean_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -61,7 +60,7 @@ pub fn create_boolean_object<'gc>(
 
 /// Creates `Boolean.prototype`.
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -8,9 +8,8 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::ArrayObject;
 use crate::avm1::{globals, Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
 use crate::display_object::{Avm1Button, TDisplayObject, TInteractiveObject};
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 macro_rules! button_getter {
     ($name:ident) => {
@@ -52,7 +51,7 @@ const PROTO_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -8,8 +8,8 @@ use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
 use crate::display_object::{DisplayObject, TDisplayObject};
+use crate::string::StringContext;
 
 use swf::Fixed8;
 
@@ -38,7 +38,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::string::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 
@@ -158,7 +158,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -168,7 +168,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -3,8 +3,7 @@
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, GcCell};
 use swf::{ColorTransform, Fixed8};
 
@@ -265,7 +264,7 @@ fn concat<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -4,9 +4,9 @@ use crate::avm1::object::TObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
 use crate::context_menu;
 use crate::display_object::DisplayObject;
+use crate::string::StringContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "copy" => method(copy; DONT_ENUM | DONT_DELETE);
@@ -142,7 +142,7 @@ pub fn hide_builtin_items<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -4,8 +4,7 @@ use crate::avm1::object::TObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "copy" => method(copy; DONT_ENUM | DONT_DELETE);
@@ -90,7 +89,7 @@ pub fn copy<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -5,7 +5,8 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::UpdateContext;
+use crate::string::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{Color, ConvolutionFilterFlags};
@@ -408,7 +409,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -418,7 +419,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -3,9 +3,8 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
 use crate::locale::{get_current_date_time, get_timezone};
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::Gc;
 use std::cell::Cell;
 use std::fmt;
@@ -567,7 +566,7 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -6,8 +6,8 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
 use crate::bitmap::bitmap_data::BitmapDataWrapper;
-use crate::context::{GcContext, UpdateContext};
-use crate::string::{AvmString, FromWStr, WStr};
+use crate::context::UpdateContext;
+use crate::string::{AvmString, FromWStr, StringContext, WStr};
 use gc_arena::{Collect, GcCell, Mutation};
 use ruffle_render::filters::DisplacementMapFilterMode;
 use std::convert::Infallible;
@@ -442,7 +442,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -457,7 +457,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::string::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{Color, DropShadowFilterFlags, Fixed16, Fixed8};
@@ -431,7 +431,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -441,7 +441,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::string::StringContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "message" => string("Error");
@@ -27,7 +27,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
 use crate::external::{Callback, Value as ExternalValue};
+use crate::string::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "available" => property(get_available; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -84,7 +84,7 @@ pub fn call<'gc>(
 }
 
 pub fn create_external_interface_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -93,7 +93,7 @@ pub fn create_external_interface_object<'gc>(
     object.into()
 }
 
-pub fn create_proto<'gc>(context: &mut GcContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
+pub fn create_proto<'gc>(context: &mut StringContext<'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
     ScriptObject::new(context.gc_context, Some(proto)).into()
 }

--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -6,8 +6,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Executable, NativeObject, Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
 use crate::backend::ui::{FileDialogResult, FileFilter};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, GcCell};
 use url::Url;
 
@@ -437,7 +436,7 @@ fn constructor<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     array_proto: Object<'gc>,

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -5,8 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{ExecutionName, ExecutionReason};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "call" => method(call; DONT_ENUM | DONT_DELETE);
@@ -117,7 +116,7 @@ pub fn apply<'gc>(
 /// them in order to obtain a valid ECMAScript `Function` prototype. The
 /// returned object is also a bare object, which will need to be linked into
 /// the prototype of `Object`.
-pub fn create_proto<'gc>(context: &mut GcContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
+pub fn create_proto<'gc>(context: &mut StringContext<'gc>, proto: Object<'gc>) -> Object<'gc> {
     let function_proto = ScriptObject::new(context.gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, context, function_proto, function_proto.into());
     function_proto.into()

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::string::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{Color, Fixed16, Fixed8, GlowFilterFlags};
@@ -344,7 +344,7 @@ fn method<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -354,7 +354,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/gradient_filter.rs
+++ b/core/src/avm1/globals/gradient_filter.rs
@@ -6,8 +6,8 @@ use crate::avm1::globals::bevel_filter::BevelFilterType;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::context::{GcContext, UpdateContext};
-use crate::string::{AvmString, WStr};
+use crate::context::UpdateContext;
+use crate::string::{AvmString, StringContext, WStr};
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
 use swf::{Color, Fixed16, Fixed8, GradientFilterFlags, GradientRecord};
@@ -520,7 +520,7 @@ fn method<'gc>(
 }
 
 pub fn create_bevel_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -530,7 +530,7 @@ pub fn create_bevel_proto<'gc>(
 }
 
 pub fn create_bevel_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -544,7 +544,7 @@ pub fn create_bevel_constructor<'gc>(
 }
 
 pub fn create_glow_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -554,7 +554,7 @@ pub fn create_glow_proto<'gc>(
 }
 
 pub fn create_glow_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -3,8 +3,8 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
 use crate::events::KeyCode;
+use crate::string::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "ALT" => int(KeyCode::ALT.value() as i32; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -82,7 +82,7 @@ pub fn get_code<'gc>(
 }
 
 pub fn create_key_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -9,8 +9,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
 use crate::backend::navigator::{NavigationMethod, Request};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "load" => method(load; DONT_ENUM | DONT_DELETE);
@@ -37,7 +36,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/local_connection.rs
+++ b/core/src/avm1/globals/local_connection.rs
@@ -8,10 +8,10 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{
     ActivationIdentifier, ExecutionReason, NativeObject, Object, ScriptObject, Value,
 };
-use crate::context::{GcContext, UpdateContext};
+use crate::context::UpdateContext;
 use crate::display_object::TDisplayObject;
 use crate::local_connection::{LocalConnectionHandle, LocalConnections};
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use flash_lso::types::Value as AmfValue;
 use gc_arena::{Collect, Gc};
 use std::cell::RefCell;
@@ -245,7 +245,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
+use crate::string::StringContext;
 
 use rand::Rng;
 use std::f64::consts;
@@ -162,7 +162,7 @@ pub fn random<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -179,11 +179,7 @@ mod tests {
     fn setup<'gc>(activation: &mut Activation<'_, 'gc>) -> Object<'gc> {
         let object_proto = activation.context.avm1.prototypes().object;
         let function_proto = activation.context.avm1.prototypes().function;
-        create(
-            &mut activation.context.borrow_gc(),
-            object_proto,
-            function_proto,
-        )
+        create(activation.strings(), object_proto, function_proto)
     }
 
     test_method!(test_abs, "abs", setup,

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -6,8 +6,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 use ruffle_render::matrix::Matrix;
 use swf::Twips;
@@ -455,7 +454,7 @@ fn to_string<'gc>(
 }
 
 pub fn create_matrix_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     matrix_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -469,7 +468,7 @@ pub fn create_matrix_object<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
+use crate::string::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "show" => method(show_mouse; DONT_DELETE | DONT_ENUM | READ_ONLY);
@@ -31,7 +31,7 @@ pub fn hide_mouse<'gc>(
 }
 
 pub fn create_mouse_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -8,11 +8,11 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{self, ArrayObject, Object, ScriptObject, TObject, Value};
 use crate::backend::navigator::NavigationMethod;
-use crate::context::{GcContext, UpdateContext};
+use crate::context::UpdateContext;
 use crate::display_object::{Bitmap, EditText, MovieClip, TInteractiveObject};
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::prelude::*;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use crate::vminterface::Instantiator;
 use crate::{avm1_stub, avm_error, avm_warn};
 use ruffle_render::shape_utils::{DrawCommand, GradientType};
@@ -261,7 +261,7 @@ pub fn hit_test<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -9,9 +9,9 @@ use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, Value};
 use crate::backend::navigator::Request;
-use crate::context::GcContext;
 use crate::display_object::TDisplayObject;
 use crate::loader::MovieLoaderVMData;
+use crate::string::StringContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "loadClip" => method(load_clip; DONT_ENUM | DONT_DELETE);
@@ -163,7 +163,7 @@ fn get_progress<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     array_proto: Object<'gc>,

--- a/core/src/avm1/globals/netconnection.rs
+++ b/core/src/avm1/globals/netconnection.rs
@@ -7,9 +7,9 @@ use crate::avm1::{
     Value,
 };
 use crate::avm1_stub;
-use crate::context::{GcContext, UpdateContext};
+use crate::context::UpdateContext;
 use crate::net_connection::{NetConnectionHandle, NetConnections, ResponderCallback};
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use flash_lso::packet::Header;
 use flash_lso::types::Value as AMFValue;
 use gc_arena::{Collect, Gc};
@@ -334,7 +334,7 @@ fn connect<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -344,7 +344,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_class<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     netconnection_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -3,8 +3,8 @@ use crate::avm1::object::{NativeObject, Object, TObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, ScriptObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
 use crate::streams::NetStream;
+use crate::string::StringContext;
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc>,
@@ -172,7 +172,7 @@ fn get_time<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -182,7 +182,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_class<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     netstream_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -7,8 +7,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string; DONT_ENUM | DONT_DELETE);
@@ -62,7 +61,7 @@ pub fn number_function<'gc>(
 }
 
 pub fn create_number_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     number_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -80,7 +79,7 @@ pub fn create_number_object<'gc>(
 
 /// Creates `Number.prototype`.
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -7,9 +7,8 @@ use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::avm_warn;
-use crate::context::GcContext;
 use crate::display_object::TDisplayObject;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "addProperty" => method(add_property; DONT_ENUM | DONT_DELETE | VERSION_6);
@@ -240,7 +239,7 @@ fn unwatch<'gc>(
 /// not allocate an object to store either proto. Instead, you must allocate
 /// bare objects for both and let this function fill Object for you.
 pub fn fill_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     object_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) {
@@ -317,7 +316,7 @@ pub fn as_set_prop_flags<'gc>(
 }
 
 pub fn create_object_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -5,8 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, ExecutionReason, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string);
@@ -284,7 +283,7 @@ fn offset<'gc>(
 }
 
 pub fn create_point_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     point_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -301,7 +300,7 @@ pub fn create_point_object<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -6,8 +6,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{construct_new_point, point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string);
@@ -94,7 +93,7 @@ fn to_string<'gc>(
 }
 
 pub fn create_rectangle_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     rectangle_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -704,7 +703,7 @@ fn set_bottom_right<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -3,8 +3,8 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
 use crate::display_object::{EditText, TDisplayObject, TInteractiveObject, TextSelection};
+use crate::string::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "getBeginIndex" => method(get_begin_index; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -138,7 +138,7 @@ pub fn set_focus<'gc>(
 }
 
 pub fn create_selection_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
@@ -150,7 +150,7 @@ pub fn create_selection_object<'gc>(
     object.into()
 }
 
-pub fn create_proto<'gc>(context: &mut GcContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
+pub fn create_proto<'gc>(context: &mut StringContext<'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
     ScriptObject::new(context.gc_context, Some(proto)).into()
 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -4,9 +4,8 @@ use crate::avm1::{
     Activation, Attribute, Error, Executable, NativeObject, Object, ScriptObject, TObject, Value,
 };
 use crate::avm1_stub;
-use crate::context::GcContext;
 use crate::display_object::TDisplayObject;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use flash_lso::amf0::read::AMF0Decoder;
 use flash_lso::amf0::writer::{Amf0Writer, CacheKey, ObjWriter};
 use flash_lso::types::{Lso, Reference, Value as AmfValue};
@@ -596,7 +595,7 @@ fn constructor<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -8,8 +8,8 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, SoundObject, TObject, Value};
 use crate::backend::navigator::Request;
 use crate::character::Character;
-use crate::context::GcContext;
 use crate::display_object::{SoundTransform, TDisplayObject};
+use crate::string::StringContext;
 use crate::{avm1_stub, avm_warn};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -57,7 +57,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -7,9 +7,8 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use crate::context::GcContext;
 use crate::display_object::StageDisplayState;
-use crate::string::{AvmString, WStr, WString};
+use crate::string::{AvmString, StringContext, WStr, WString};
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "align" => property(align, set_align);
@@ -21,7 +20,7 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create_stage_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     array_proto: Object<'gc>,
     fn_proto: Object<'gc>,

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -7,8 +7,7 @@ use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
-use crate::context::GcContext;
-use crate::string::{utils as string_utils, AvmString, WString};
+use crate::string::{utils as string_utils, AvmString, StringContext, WString};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string_value_of; DONT_ENUM | DONT_DELETE);
@@ -72,7 +71,7 @@ pub fn string_function<'gc>(
 }
 
 pub fn create_string_object<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     string_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -90,7 +89,7 @@ pub fn create_string_object<'gc>(
 
 /// Creates `String.prototype`.
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/style_sheet.rs
+++ b/core/src/avm1/globals/style_sheet.rs
@@ -6,9 +6,8 @@ use crate::avm1::{
 use crate::avm1::{Activation, Error, Value};
 use crate::avm1_stub;
 use crate::backend::navigator::Request;
-use crate::context::GcContext;
 use crate::html::{transform_dashes_to_camel_case, CssStream, TextFormat};
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::Gc;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -211,7 +210,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -6,7 +6,8 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::runtime::Avm1;
 use crate::avm1::{ScriptObject, TObject, Value};
 use crate::avm1_stub;
-use crate::context::{GcContext, UpdateContext};
+use crate::context::UpdateContext;
+use crate::string::StringContext;
 use bitflags::bitflags;
 use core::fmt;
 
@@ -500,7 +501,7 @@ pub fn on_status<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     security: Object<'gc>,

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -4,8 +4,7 @@ use crate::avm1::globals::system::SystemCapabilities;
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "supports64BitProcesses" => property(get_has_64_bit_support);
@@ -256,7 +255,7 @@ pub fn get_max_idc_level<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -4,7 +4,7 @@ use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
-use crate::context::GcContext;
+use crate::string::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "ALPHANUMERIC_FULL" => string("ALPHANUMERIC_FULL"; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -80,7 +80,7 @@ fn set_enabled<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -4,10 +4,9 @@ use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
 use crate::prelude::TDisplayObject;
 use crate::sandbox::SandboxType;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "PolicyFileResolver" => method(policy_file_resolver);
@@ -92,7 +91,7 @@ fn policy_file_resolver<'gc>(
 }
 
 pub fn create<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -4,12 +4,11 @@ use crate::avm1::globals::bitmap_filter;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{globals, ArrayObject, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
 use crate::display_object::{
     AutoSizeMode, EditText, TDisplayObject, TInteractiveObject, TextSelection,
 };
 use crate::html::TextFormat;
-use crate::string::{AvmString, WStr};
+use crate::string::{AvmString, StringContext, WStr};
 use gc_arena::Gc;
 use swf::Color;
 
@@ -109,7 +108,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -4,11 +4,10 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
-use crate::context::GcContext;
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject};
 use crate::ecma_conversions::round_to_even;
 use crate::html::TextFormat;
-use crate::string::{AvmString, WStr};
+use crate::string::{AvmString, StringContext, WStr};
 use gc_arena::Gc;
 
 macro_rules! getter {
@@ -612,7 +611,7 @@ pub fn constructor<'gc>(
 
 /// `TextFormat.prototype` constructor
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -7,8 +7,8 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::object_reference::MovieClipReference;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
 use crate::display_object::{DisplayObject, TDisplayObject};
+use crate::string::StringContext;
 use gc_arena::Collect;
 use swf::{Rectangle, Twips};
 
@@ -175,7 +175,7 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/video.rs
+++ b/core/src/avm1/globals/video.rs
@@ -6,8 +6,8 @@ use crate::avm1::object::{NativeObject, Object, TObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::value::Value;
 use crate::avm1::ScriptObject;
-use crate::context::GcContext;
 use crate::display_object::{TDisplayObject, Video};
+use crate::string::StringContext;
 
 macro_rules! video_method {
     ( $fn: expr ) => {
@@ -56,7 +56,7 @@ pub fn attach_video<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -7,8 +7,7 @@ use crate::avm1::{
 };
 use crate::avm_warn;
 use crate::backend::navigator::Request;
-use crate::context::GcContext;
-use crate::string::{AvmString, WStr, WString};
+use crate::string::{AvmString, StringContext, WStr, WString};
 use crate::xml::{custom_unescape, XmlNode, ELEMENT_NODE, TEXT_NODE};
 use gc_arena::{Collect, GcCell, Mutation};
 use quick_xml::errors::IllFormedError;
@@ -566,7 +565,7 @@ fn spawn_xml_fetch<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -4,8 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{NativeObject, Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
-use crate::string::{AvmString, WStr};
+use crate::string::{AvmString, StringContext, WStr};
 use crate::xml::{XmlNode, TEXT_NODE};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -396,7 +395,7 @@ fn namespace_uri<'gc>(
 
 /// Construct the prototype for `XMLNode`.
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/globals/xml_socket.rs
+++ b/core/src/avm1/globals/xml_socket.rs
@@ -3,10 +3,10 @@ use crate::avm1::object::{NativeObject, Object};
 use crate::avm1::property_decl::define_properties_on;
 use crate::avm1::{property_decl::Declaration, ScriptObject};
 use crate::avm1::{Activation, Error, Executable, ExecutionReason, TObject, Value};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::UpdateContext;
 use crate::display_object::TDisplayObject;
 use crate::socket::SocketHandle;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, Gc};
 use std::cell::{Cell, RefCell, RefMut};
 
@@ -247,7 +247,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
@@ -257,7 +257,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn create_class<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     xml_socket_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -5,13 +5,13 @@ use std::borrow::Cow;
 use crate::avm1::function::{Executable, FunctionObject, NativeFunction};
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::GcContext;
+use crate::string::StringContext;
 
 /// Defines a list of properties on a [`ScriptObject`].
 #[inline(never)]
 pub fn define_properties_on<'gc>(
     decls: &[Declaration],
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     this: ScriptObject<'gc>,
     fn_proto: Object<'gc>,
 ) {
@@ -63,7 +63,7 @@ impl Declaration {
     /// defined a property.
     pub fn define_on<'gc>(
         &self,
-        context: &mut GcContext<'_, 'gc>,
+        context: &mut StringContext<'gc>,
         this: ScriptObject<'gc>,
         fn_proto: Object<'gc>,
     ) -> Value<'gc> {

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use crate::avm1::function::{Executable, FunctionObject, NativeFunction};
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::string::StringContext;
+use crate::string::{AvmAtom, StringContext};
 
 /// Defines a list of properties on a [`ScriptObject`].
 #[inline(never)]
@@ -69,11 +69,14 @@ impl Declaration {
     ) -> Value<'gc> {
         let mc = context.gc_context;
 
-        let name = match ruffle_wstr::from_utf8(self.name) {
-            Cow::Borrowed(name) => context.interner.intern_static(mc, name),
-            Cow::Owned(name) => context.interner.intern_wstr(mc, name),
+        let mut intern_utf8 = |s: &'static str| -> AvmAtom<'gc> {
+            match ruffle_wstr::from_utf8(s) {
+                Cow::Borrowed(s) => context.intern_static(s),
+                Cow::Owned(s) => context.intern_wstr(s),
+            }
         };
 
+        let name = intern_utf8(self.name);
         let value = match self.kind {
             DeclKind::Property { getter, setter } => {
                 let getter =
@@ -91,10 +94,7 @@ impl Declaration {
             DeclKind::Function(func) => {
                 FunctionObject::function(mc, Executable::Native(func), fn_proto, fn_proto).into()
             }
-            DeclKind::String(s) => {
-                let s = ruffle_wstr::from_utf8(s);
-                context.interner.intern_wstr(mc, s).into()
-            }
+            DeclKind::String(s) => intern_utf8(s).into(),
             DeclKind::Bool(b) => b.into(),
             DeclKind::Int(i) => i.into(),
             DeclKind::Float(f) => f.into(),

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -6,10 +6,10 @@ use crate::avm1::object::TObject;
 use crate::avm1::property_map::PropertyMap;
 use crate::avm1::scope::Scope;
 use crate::avm1::{scope, Activation, ActivationIdentifier, Error, Object, Value};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::UpdateContext;
 use crate::frame_lifecycle::FramePhase;
 use crate::prelude::*;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use crate::tag_utils::SwfSlice;
 use crate::{avm1, avm_debug};
 use gc_arena::{Collect, Gc, Mutation};
@@ -90,7 +90,7 @@ pub struct Avm1<'gc> {
 }
 
 impl<'gc> Avm1<'gc> {
-    pub fn new(context: &mut GcContext<'_, 'gc>, player_version: u8) -> Self {
+    pub fn new(context: &mut StringContext<'gc>, player_version: u8) -> Self {
         let gc_context = context.gc_context;
         let (prototypes, globals, broadcaster_functions) = create_globals(context);
 

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -914,7 +914,7 @@ mod test {
             );
             assert_eq!(null.to_primitive_num(activation).unwrap(), null);
 
-            let (protos, global, _) = create_globals(&mut activation.context.borrow_gc());
+            let (protos, global, _) = create_globals(activation.strings());
             let vglobal = Value::Object(global);
 
             assert_eq!(vglobal.to_primitive_num(activation).unwrap(), undefined);

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -193,7 +193,7 @@ impl<'gc> Avm2<'gc> {
         player_version: u8,
         player_runtime: PlayerRuntime,
     ) -> Self {
-        let mc = context.gc_context;
+        let mc = context.gc();
 
         let playerglobals_domain = Domain::uninitialized_domain(mc, None);
         let stage_domain = Domain::uninitialized_domain(mc, Some(playerglobals_domain));

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -10,9 +10,9 @@ use crate::avm2::globals::{
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::scope::ScopeChain;
 use crate::avm2::script::{Script, TranslationUnit};
-use crate::context::{GcContext, UpdateContext};
+use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, DisplayObjectWeak, TDisplayObject};
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use crate::tag_utils::SwfMovie;
 use crate::PlayerRuntime;
 
@@ -189,7 +189,7 @@ pub struct Avm2<'gc> {
 impl<'gc> Avm2<'gc> {
     /// Construct a new AVM interpreter.
     pub fn new(
-        context: &mut GcContext<'_, 'gc>,
+        context: &mut StringContext<'gc>,
         player_version: u8,
         player_runtime: PlayerRuntime,
     ) -> Self {

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -20,8 +20,8 @@ use crate::avm2::value::Value;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::{Avm2, Error};
-use crate::context::{GcContext, UpdateContext};
-use crate::string::{AvmAtom, AvmString};
+use crate::context::UpdateContext;
+use crate::string::{AvmAtom, AvmString, StringContext};
 use crate::tag_utils::SwfMovie;
 use gc_arena::Gc;
 use smallvec::SmallVec;
@@ -150,6 +150,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     #[inline(always)]
     pub fn gc(&self) -> &'gc gc_arena::Mutation<'gc> {
         self.context.gc_context
+    }
+
+    #[inline(always)]
+    pub fn strings(&mut self) -> &mut StringContext<'gc> {
+        &mut self.context.strings
     }
 
     /// Construct an activation that does not represent any particular scope.
@@ -635,11 +640,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     pub fn avm2(&mut self) -> &mut Avm2<'gc> {
         self.context.avm2
-    }
-
-    #[inline]
-    pub fn borrow_gc(&mut self) -> GcContext<'_, 'gc> {
-        self.context.borrow_gc()
     }
 
     pub fn scope_frame(&self) -> &[Scope<'gc>] {

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -803,8 +803,7 @@ impl<'gc> Class<'gc> {
         method: &AbcMethod,
         body: &AbcMethodBody,
     ) -> Result<Class<'gc>, Error<'gc>> {
-        let name =
-            translation_unit.pool_string(method.name.as_u30(), &mut activation.borrow_gc())?;
+        let name = translation_unit.pool_string(method.name.as_u30(), activation.strings())?;
         let mut traits = Vec::with_capacity(body.traits.len());
 
         for trait_entry in body.traits.iter() {

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1057,12 +1057,7 @@ impl<'gc> E4XNode<'gc> {
             let (ns, local_name) = parser.resolve_attribute(attribute.key);
 
             let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
-            let name = activation
-                .context
-                .strings
-                .interner
-                .intern_wstr(activation.gc(), local_name)
-                .into();
+            let name = activation.strings().intern_wstr(local_name).into();
 
             let namespace = match ns {
                 ResolveResult::Bound(ns) if ns.into_inner() == b"http://www.w3.org/2000/xmlns/" => {
@@ -1109,12 +1104,7 @@ impl<'gc> E4XNode<'gc> {
         let (ns, local_name) = parser.resolve_element(bs.name());
 
         let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
-        let name = activation
-            .context
-            .strings
-            .interner
-            .intern_wstr(activation.gc(), local_name)
-            .into();
+        let name = activation.strings().intern_wstr(local_name).into();
 
         let namespace = match ns {
             ResolveResult::Bound(ns) => {

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1059,6 +1059,7 @@ impl<'gc> E4XNode<'gc> {
             let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
             let name = activation
                 .context
+                .strings
                 .interner
                 .intern_wstr(activation.gc(), local_name)
                 .into();
@@ -1110,6 +1111,7 @@ impl<'gc> E4XNode<'gc> {
         let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
         let name = activation
             .context
+            .strings
             .interner
             .intern_wstr(activation.gc(), local_name)
             .into();

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -783,7 +783,7 @@ macro_rules! avm2_system_classes_playerglobal {
         let activation = $activation;
         $(
             // Lookup with the highest version, so we we see all defined classes here
-            let ns = Namespace::package($package, ApiVersion::VM_INTERNAL, &mut activation.borrow_gc());
+            let ns = Namespace::package($package, ApiVersion::VM_INTERNAL, activation.strings());
             let name = QName::new(ns, $class_name);
             let class_object = activation.domain().get_defined_value(activation, name).unwrap_or_else(|e| panic!("Failed to lookup {name:?}: {e:?}"));
             let class_object = class_object.as_object().unwrap().as_class_object().unwrap();
@@ -798,7 +798,7 @@ macro_rules! avm2_system_class_defs_playerglobal {
         let activation = $activation;
         $(
             // Lookup with the highest version, so we we see all defined classes here
-            let ns = Namespace::package($package, ApiVersion::VM_INTERNAL, &mut activation.borrow_gc());
+            let ns = Namespace::package($package, ApiVersion::VM_INTERNAL, activation.strings());
             let name = QName::new(ns, $class_name);
             let class_object = activation.domain().get_defined_value(activation, name).unwrap_or_else(|e| panic!("Failed to lookup {name:?}: {e:?}"));
             let class_def = class_object.as_object().unwrap().as_class_object().unwrap().inner_class_definition();

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -541,7 +541,7 @@ fn display_name<'gc>(
     if let Some(name) = name {
         name.to_qualified_name_or_star(context)
     } else {
-        context.get_ascii_char('*')
+        context.ascii_char(b'*')
     }
 }
 

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -541,7 +541,7 @@ fn display_name<'gc>(
     if let Some(name) = name {
         name.to_qualified_name_or_star(context)
     } else {
-        context.interner.get_ascii_char('*')
+        context.get_ascii_char('*')
     }
 }
 

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -6,8 +6,7 @@ use crate::avm2::object::{ArrayObject, TObject};
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::property::Property;
 use crate::avm2::{Activation, Error, Multiname, Namespace, Object, Value};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 
 use crate::avm2_stub_method;
 
@@ -306,8 +305,7 @@ fn describe_internal_body<'gc>(
                 if !flags.contains(DescribeTypeFlags::INCLUDE_VARIABLES) {
                     continue;
                 }
-                let prop_class_name =
-                    vtable.slot_class_name(&mut activation.borrow_gc(), *slot_id)?;
+                let prop_class_name = vtable.slot_class_name(activation.strings(), *slot_id)?;
 
                 let access = match prop {
                     Property::ConstSlot { .. } => "readonly",
@@ -362,7 +360,7 @@ fn describe_internal_body<'gc>(
                 }
 
                 let return_type_name =
-                    display_name(&mut activation.borrow_gc(), method.method.return_type());
+                    display_name(activation.strings(), method.method.return_type());
                 let declared_by = method.class;
 
                 if flags.contains(DescribeTypeFlags::HIDE_OBJECT)
@@ -459,7 +457,7 @@ fn describe_internal_body<'gc>(
                     Some(ns.as_uri())
                 };
 
-                let accessor_type = display_name(&mut activation.borrow_gc(), method_type);
+                let accessor_type = display_name(activation.strings(), method_type);
                 let declared_by = defining_class.dollar_removed_name(mc).to_qualified_name(mc);
 
                 let accessor_obj = activation
@@ -537,7 +535,7 @@ fn describe_internal_body<'gc>(
 }
 
 fn display_name<'gc>(
-    context: &mut GcContext<'_, 'gc>,
+    context: &mut StringContext<'gc>,
     name: Option<Gc<'gc, Multiname<'gc>>>,
 ) -> AvmString<'gc> {
     if let Some(name) = name {
@@ -556,7 +554,7 @@ fn write_params<'gc>(
         .as_array_storage_mut(activation.context.gc_context)
         .unwrap();
     for param in method.signature() {
-        let param_type_name = display_name(&mut activation.borrow_gc(), param.param_type_name);
+        let param_type_name = display_name(activation.strings(), param.param_type_name);
         let optional = param.default_value.is_some();
         let param_obj = activation
             .avm2()

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -36,8 +36,7 @@ pub fn init<'gc>(
             } else {
                 uri.coerce_to_string(activation)?
             };
-            let namespace =
-                Namespace::package(namespace_uri, api_version, &mut activation.borrow_gc());
+            let namespace = Namespace::package(namespace_uri, api_version, activation.strings());
             let prefix_str = prefix.coerce_to_string(activation)?;
 
             // The order is important here to match Flash
@@ -58,7 +57,7 @@ pub fn init<'gc>(
         [Value::Object(Object::QNameObject(qname))] => {
             let ns = qname
                 .uri()
-                .map(|uri| Namespace::package(uri, api_version, &mut activation.borrow_gc()))
+                .map(|uri| Namespace::package(uri, api_version, activation.strings()))
                 .unwrap_or_else(Namespace::any);
             if ns.as_uri().is_empty() {
                 (Some("".into()), ns)
@@ -71,7 +70,7 @@ pub fn init<'gc>(
             let ns = Namespace::package(
                 val.coerce_to_string(activation)?,
                 api_version,
-                &mut activation.borrow_gc(),
+                activation.strings(),
             );
             if ns.as_uri().is_empty() {
                 (Some("".into()), ns)

--- a/core/src/avm2/globals/q_name.rs
+++ b/core/src/avm2/globals/q_name.rs
@@ -62,19 +62,15 @@ pub fn init<'gc>(
 
         let namespace = match ns_arg {
             Value::Object(Object::NamespaceObject(ns)) => Some(ns.namespace()),
-            Value::Object(Object::QNameObject(qname)) => qname.uri().map(|uri| {
-                Namespace::package(uri, ApiVersion::AllVersions, &mut activation.borrow_gc())
-            }),
+            Value::Object(Object::QNameObject(qname)) => qname
+                .uri()
+                .map(|uri| Namespace::package(uri, ApiVersion::AllVersions, activation.strings())),
             Value::Null => None,
-            Value::Undefined => Some(Namespace::package(
-                "",
-                api_version,
-                &mut activation.borrow_gc(),
-            )),
+            Value::Undefined => Some(Namespace::package("", api_version, activation.strings())),
             v => Some(Namespace::package(
                 v.coerce_to_string(activation)?,
                 api_version,
-                &mut activation.borrow_gc(),
+                activation.strings(),
             )),
         };
 

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -130,7 +130,7 @@ fn char_at<'gc>(
 
         let index = if !n.is_nan() { n as usize } else { 0 };
         let ret = if let Some(c) = s.get(index) {
-            activation.strings().get_char(c)
+            activation.strings().make_char(c)
         } else {
             activation.strings().empty()
         };
@@ -449,7 +449,7 @@ fn slice<'gc>(
     if start_index < end_index {
         Ok(activation
             .strings()
-            .substring(this, start_index, end_index)
+            .substring(this, start_index..end_index)
             .into())
     } else {
         Ok("".into())
@@ -486,7 +486,7 @@ fn split<'gc>(
         // Special case this to match Flash's behavior.
         this.iter()
             .take(limit)
-            .map(|c| Value::from(activation.strings().get_char(c)))
+            .map(|c| Value::from(activation.strings().make_char(c)))
             .collect()
     } else {
         this.split(&delimiter)
@@ -551,7 +551,7 @@ fn substr<'gc>(
 
     Ok(activation
         .strings()
-        .substring(this, start_index, end_index)
+        .substring(this, start_index..end_index)
         .into())
 }
 
@@ -588,7 +588,7 @@ fn substring<'gc>(
 
     Ok(activation
         .strings()
-        .substring(this, start_index, end_index)
+        .substring(this, start_index..end_index)
         .into())
 }
 

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -132,10 +132,11 @@ fn char_at<'gc>(
         let ret = if let Some(c) = s.get(index) {
             activation
                 .context
+                .strings
                 .interner
                 .get_char(activation.context.gc_context, c)
         } else {
-            activation.context.interner.empty()
+            activation.context.strings.interner.empty()
         };
         return Ok(ret.into());
     }
@@ -452,6 +453,7 @@ fn slice<'gc>(
     if start_index < end_index {
         Ok(activation
             .context
+            .strings
             .interner
             .substring(activation.context.gc_context, this, start_index, end_index)
             .into())
@@ -494,6 +496,7 @@ fn split<'gc>(
                 Value::from(
                     activation
                         .context
+                        .strings
                         .interner
                         .get_char(activation.context.gc_context, c),
                 )
@@ -562,6 +565,7 @@ fn substr<'gc>(
 
     Ok(activation
         .context
+        .strings
         .interner
         .substring(activation.context.gc_context, this, start_index, end_index)
         .into())
@@ -600,6 +604,7 @@ fn substring<'gc>(
 
     Ok(activation
         .context
+        .strings
         .interner
         .substring(activation.context.gc_context, this, start_index, end_index)
         .into())

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -130,13 +130,9 @@ fn char_at<'gc>(
 
         let index = if !n.is_nan() { n as usize } else { 0 };
         let ret = if let Some(c) = s.get(index) {
-            activation
-                .context
-                .strings
-                .interner
-                .get_char(activation.context.gc_context, c)
+            activation.strings().get_char(c)
         } else {
-            activation.context.strings.interner.empty()
+            activation.strings().empty()
         };
         return Ok(ret.into());
     }
@@ -452,10 +448,8 @@ fn slice<'gc>(
 
     if start_index < end_index {
         Ok(activation
-            .context
-            .strings
-            .interner
-            .substring(activation.context.gc_context, this, start_index, end_index)
+            .strings()
+            .substring(this, start_index, end_index)
             .into())
     } else {
         Ok("".into())
@@ -492,15 +486,7 @@ fn split<'gc>(
         // Special case this to match Flash's behavior.
         this.iter()
             .take(limit)
-            .map(|c| {
-                Value::from(
-                    activation
-                        .context
-                        .strings
-                        .interner
-                        .get_char(activation.context.gc_context, c),
-                )
-            })
+            .map(|c| Value::from(activation.strings().get_char(c)))
             .collect()
     } else {
         this.split(&delimiter)
@@ -564,10 +550,8 @@ fn substr<'gc>(
     let end_index = this.len().min(start_index + len as usize);
 
     Ok(activation
-        .context
-        .strings
-        .interner
-        .substring(activation.context.gc_context, this, start_index, end_index)
+        .strings()
+        .substring(this, start_index, end_index)
         .into())
 }
 
@@ -603,10 +587,8 @@ fn substring<'gc>(
     }
 
     Ok(activation
-        .context
-        .strings
-        .interner
-        .substring(activation.context.gc_context, this, start_index, end_index)
+        .strings()
+        .substring(this, start_index, end_index)
         .into())
 }
 

--- a/core/src/avm2/metadata.rs
+++ b/core/src/avm2/metadata.rs
@@ -43,16 +43,16 @@ impl<'gc> Metadata<'gc> {
                 .get(single_metadata.0 as usize)
                 .ok_or_else(|| format!("Unknown metadata {}", single_metadata.0))?;
 
-            let name = translation_unit
-                .pool_string(single_metadata.name.0, &mut activation.borrow_gc())?;
+            let name =
+                translation_unit.pool_string(single_metadata.name.0, activation.strings())?;
 
             let mut current_metadata_items = vec![];
             for metadata_item in single_metadata.items.iter() {
-                let key = translation_unit
-                    .pool_string(metadata_item.key.0, &mut activation.borrow_gc())?;
+                let key =
+                    translation_unit.pool_string(metadata_item.key.0, activation.strings())?;
 
-                let value = translation_unit
-                    .pool_string(metadata_item.value.0, &mut activation.borrow_gc())?;
+                let value =
+                    translation_unit.pool_string(metadata_item.value.0, activation.strings())?;
 
                 let item = MetadataItem {
                     key: key.into(),

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -73,9 +73,7 @@ impl<'gc> ParamConfig<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
         let param_name = if let Some(name) = &config.name {
-            txunit
-                .pool_string(name.0, &mut activation.borrow_gc())?
-                .into()
+            txunit.pool_string(name.0, activation.strings())?.into()
         } else {
             AvmString::from("<Unnamed Parameter>")
         };

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -477,7 +477,7 @@ impl<'gc> Multiname<'gc> {
     /// This is used by `describeType`
     pub fn to_qualified_name_or_star(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         if self.is_any_name() {
-            context.interner.get_ascii_char('*')
+            context.get_ascii_char('*')
         } else {
             self.to_qualified_name(context.gc_context)
         }
@@ -543,16 +543,12 @@ pub struct CommonMultinames<'gc> {
 
 impl<'gc> CommonMultinames<'gc> {
     pub fn new(context: &mut StringContext<'gc>, namespaces: &CommonNamespaces<'gc>) -> Self {
-        let mc = context.gc_context;
-
         let mut create_pub_multiname = |local_name: &'static [u8]| -> Gc<'gc, Multiname<'gc>> {
             Gc::new(
-                mc,
+                context.gc(),
                 Multiname::new(
                     namespaces.public_all(),
-                    context
-                        .interner
-                        .intern_static(context.gc_context, WStr::from_units(local_name)),
+                    context.intern_static(WStr::from_units(local_name)),
                 ),
             )
         };

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -477,7 +477,7 @@ impl<'gc> Multiname<'gc> {
     /// This is used by `describeType`
     pub fn to_qualified_name_or_star(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         if self.is_any_name() {
-            context.get_ascii_char('*')
+            context.ascii_char(b'*')
         } else {
             self.to_qualified_name(context.gc_context)
         }

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -167,12 +167,7 @@ impl<'gc> Namespace<'gc> {
             let stripped = strip_version_mark(namespace_name.as_wstr(), is_playerglobals);
             let has_version_mark = stripped.is_some();
             if let Some((stripped, version)) = stripped {
-                let stripped_string = AvmString::new(mc, stripped);
-                namespace_name = activation
-                    .context
-                    .strings
-                    .interner
-                    .intern(mc, stripped_string);
+                namespace_name = activation.strings().intern_wstr(stripped);
                 api_version = version;
             }
 
@@ -233,9 +228,7 @@ impl<'gc> Namespace<'gc> {
         api_version: ApiVersion,
         context: &mut StringContext<'gc>,
     ) -> Self {
-        let atom = context
-            .interner
-            .intern(context.gc_context, package_name.into());
+        let atom = context.intern(package_name.into());
         Self(Some(Gc::new(
             context.gc_context,
             NamespaceData::Namespace(atom, api_version),
@@ -247,9 +240,7 @@ impl<'gc> Namespace<'gc> {
         package_name: impl Into<AvmString<'gc>>,
         context: &mut StringContext<'gc>,
     ) -> Self {
-        let atom = context
-            .interner
-            .intern(context.gc_context, package_name.into());
+        let atom = context.intern(package_name.into());
         Self(Some(Gc::new(
             context.gc_context,
             NamespaceData::PackageInternal(atom),

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -194,7 +194,7 @@ impl<'gc> XmlListObject<'gc> {
                         Some(ns) => Namespace::package(
                             ns.uri,
                             ApiVersion::AllVersions,
-                            &mut activation.context.borrow_gc(),
+                            activation.strings(),
                         ),
                         None => activation.avm2().namespaces.public_all(),
                     };

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -116,7 +116,7 @@ impl<'gc> PropertyClass<'gc> {
         match self {
             PropertyClass::Class(class) => class.name().to_qualified_name(context.gc_context),
             PropertyClass::Name(name, _) => name.to_qualified_name_or_star(context),
-            PropertyClass::Any => context.interner.get_ascii_char('*'),
+            PropertyClass::Any => context.get_ascii_char('*'),
         }
     }
 }

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -116,7 +116,7 @@ impl<'gc> PropertyClass<'gc> {
         match self {
             PropertyClass::Class(class) => class.name().to_qualified_name(context.gc_context),
             PropertyClass::Name(name, _) => name.to_qualified_name_or_star(context),
-            PropertyClass::Any => context.get_ascii_char('*'),
+            PropertyClass::Any => context.ascii_char(b'*'),
         }
     }
 }

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -5,8 +5,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::TranslationUnit;
 use crate::avm2::Value;
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, Gc};
 
 use super::class::Class;
@@ -113,7 +112,7 @@ impl<'gc> PropertyClass<'gc> {
         }
     }
 
-    pub fn get_name(&self, context: &mut GcContext<'_, 'gc>) -> AvmString<'gc> {
+    pub fn get_name(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         match self {
             PropertyClass::Class(class) => class.name().to_qualified_name(context.gc_context),
             PropertyClass::Name(name, _) => name.to_qualified_name_or_star(context),

--- a/core/src/avm2/qname.rs
+++ b/core/src/avm2/qname.rs
@@ -93,10 +93,7 @@ impl<'gc> QName<'gc> {
             .or_else(|| name.rsplit_once(WStr::from_units(b".")));
 
         if let Some((package_name, local_name)) = parts {
-            let package_name = context
-                .strings
-                .interner
-                .intern_wstr(context.gc(), package_name);
+            let package_name = context.strings.intern_wstr(package_name);
 
             Self {
                 ns: Namespace::package(package_name, api_version, &mut context.strings),

--- a/core/src/avm2/qname.rs
+++ b/core/src/avm2/qname.rs
@@ -93,10 +93,13 @@ impl<'gc> QName<'gc> {
             .or_else(|| name.rsplit_once(WStr::from_units(b".")));
 
         if let Some((package_name, local_name)) = parts {
-            let package_name = context.interner.intern_wstr(context.gc(), package_name);
+            let package_name = context
+                .strings
+                .interner
+                .intern_wstr(context.gc(), package_name);
 
             Self {
-                ns: Namespace::package(package_name, api_version, &mut context.borrow_gc()),
+                ns: Namespace::package(package_name, api_version, &mut context.strings),
                 name: AvmString::new(context.gc(), local_name),
             }
         } else {

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -14,8 +14,8 @@ use crate::avm2::vtable::VTable;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::{Avm2, Error};
-use crate::context::{GcContext, UpdateContext};
-use crate::string::{AvmAtom, AvmString};
+use crate::context::UpdateContext;
+use crate::string::{AvmAtom, AvmString, StringContext};
 use crate::tag_utils::SwfMovie;
 use crate::PlayerRuntime;
 use gc_arena::{Collect, Gc, GcCell, Mutation};
@@ -276,7 +276,7 @@ impl<'gc> TranslationUnit<'gc> {
     pub fn pool_string_option(
         self,
         string_index: u32,
-        context: &mut GcContext<'_, 'gc>,
+        context: &mut StringContext<'gc>,
     ) -> Result<Option<AvmAtom<'gc>>, Error<'gc>> {
         if string_index == 0 {
             Ok(None)
@@ -294,7 +294,7 @@ impl<'gc> TranslationUnit<'gc> {
     pub fn pool_string(
         self,
         string_index: u32,
-        context: &mut GcContext<'_, 'gc>,
+        context: &mut StringContext<'gc>,
     ) -> Result<AvmAtom<'gc>, Error<'gc>> {
         let mut write = self.0.write(context.gc_context);
         if let Some(Some(atom)) = write.strings.get(string_index as usize) {

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -313,10 +313,7 @@ impl<'gc> TranslationUnit<'gc> {
                 .as_slice()
         };
 
-        let atom = context
-            .interner
-            .intern_wstr(context.gc_context, ruffle_wstr::from_utf8_bytes(raw));
-
+        let atom = context.intern_wstr(ruffle_wstr::from_utf8_bytes(raw));
         write.strings[string_index as usize] = Some(atom);
         Ok(atom)
     }

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -521,7 +521,7 @@ pub fn abc_default_value<'gc>(
         AbcDefaultValue::Uint(u) => abc_uint(translation_unit, *u).map(|v| v.into()),
         AbcDefaultValue::Double(d) => abc_double(translation_unit, *d).map(|v| v.into()),
         AbcDefaultValue::String(s) => translation_unit
-            .pool_string(s.0, &mut activation.borrow_gc())
+            .pool_string(s.0, activation.strings())
             .map(Into::into),
         AbcDefaultValue::True => Ok(true.into()),
         AbcDefaultValue::False => Ok(false.into()),
@@ -841,6 +841,7 @@ impl<'gc> Value<'gc> {
                 if *i >= 0 && *i < 10 {
                     activation
                         .context
+                        .strings
                         .interner
                         .get_char(activation.context.gc_context, '0' as u16 + *i as u16)
                 } else {

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -839,11 +839,7 @@ impl<'gc> Value<'gc> {
             }
             Value::Integer(i) => {
                 if *i >= 0 && *i < 10 {
-                    activation
-                        .context
-                        .strings
-                        .interner
-                        .get_char(activation.context.gc_context, '0' as u16 + *i as u16)
+                    activation.strings().get_char('0' as u16 + *i as u16)
                 } else {
                     AvmString::new_utf8(activation.context.gc_context, i.to_string())
                 }

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -839,7 +839,7 @@ impl<'gc> Value<'gc> {
             }
             Value::Integer(i) => {
                 if *i >= 0 && *i < 10 {
-                    activation.strings().get_char('0' as u16 + *i as u16)
+                    activation.strings().make_char('0' as u16 + *i as u16)
                 } else {
                     AvmString::new_utf8(activation.context.gc_context, i.to_string())
                 }

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -840,7 +840,7 @@ fn pool_string<'gc>(
         return Err(make_error_1032(activation, 0));
     }
 
-    translation_unit.pool_string(index.0, &mut activation.borrow_gc())
+    translation_unit.pool_string(index.0, activation.strings())
 }
 
 fn pool_class<'gc>(

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -8,8 +8,7 @@ use crate::avm2::scope::ScopeChain;
 use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::value::Value;
 use crate::avm2::{Class, Error, Multiname, Namespace, QName};
-use crate::context::GcContext;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, GcCell, Mutation};
 use std::cell::Ref;
 use std::collections::HashMap;
@@ -115,7 +114,7 @@ impl<'gc> VTable<'gc> {
 
     pub fn slot_class_name(
         &self,
-        context: &mut GcContext<'_, 'gc>,
+        context: &mut StringContext<'gc>,
         slot_id: u32,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         self.0

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2201,10 +2201,7 @@ impl Player {
                 ui: this.ui.deref_mut(),
                 action_queue,
                 gc_context,
-                strings: StringContext {
-                    gc_context,
-                    interner,
-                },
+                strings: StringContext::from_parts(gc_context, interner),
                 stage,
                 mouse_data,
                 input: &this.input,
@@ -2748,10 +2745,7 @@ impl PlayerBuilder {
             // SAFETY: Extending this borrow to `'gc` is sound, as the result of this
             // block implements `Collect`, preventing any `&'gc _` outliving it.
             let interner: &'gc mut _ = unsafe { &mut *(&mut interner as *mut _) };
-            let mut init = StringContext {
-                gc_context,
-                interner,
-            };
+            let mut init = StringContext::from_parts(gc_context, interner);
             (
                 Avm1::new(&mut init, player_version),
                 Avm2::new(&mut init, player_version, player_runtime),

--- a/core/src/string.rs
+++ b/core/src/string.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 mod avm_string;
+mod context;
 mod interner;
 mod repr;
 
@@ -9,6 +10,7 @@ use repr::AvmStringRepr;
 pub use ruffle_wstr::*;
 
 pub use avm_string::AvmString;
+pub use context::StringContext;
 pub use interner::{AvmAtom, AvmStringInterner};
 
 pub trait SwfStrExt {

--- a/core/src/string/context.rs
+++ b/core/src/string/context.rs
@@ -1,6 +1,8 @@
-use gc_arena::Mutation;
+use std::borrow::Cow;
 
-use crate::string::AvmStringInterner;
+use gc_arena::{Gc, Mutation};
+
+use super::{AvmAtom, AvmString, AvmStringInterner, AvmStringRepr, WStr, WString};
 
 /// Context for managing `AvmString`s: allocating them, interning them, etc...
 pub struct StringContext<'gc> {
@@ -8,12 +10,94 @@ pub struct StringContext<'gc> {
     pub gc_context: &'gc Mutation<'gc>,
 
     /// The global string interner.
-    pub interner: &'gc mut AvmStringInterner<'gc>,
+    interner: &'gc mut AvmStringInterner<'gc>,
 }
 
 impl<'gc> StringContext<'gc> {
+    pub fn from_parts(
+        gc_context: &'gc Mutation<'gc>,
+        interner: &'gc mut AvmStringInterner<'gc>,
+    ) -> Self {
+        Self {
+            gc_context,
+            interner,
+        }
+    }
+
     #[inline(always)]
     pub fn gc(&self) -> &'gc Mutation<'gc> {
         self.gc_context
+    }
+
+    #[must_use]
+    pub fn intern_wstr<'a, S>(&mut self, s: S) -> AvmAtom<'gc>
+    where
+        S: Into<Cow<'a, WStr>>,
+    {
+        let s = s.into();
+        let mc = self.gc();
+        self.interner.intern_inner(mc, s, |s| {
+            let repr = AvmStringRepr::from_raw(s.into_owned(), true);
+            Gc::new(mc, repr)
+        })
+    }
+
+    #[must_use]
+    pub fn intern_static(&mut self, s: &'static WStr) -> AvmAtom<'gc> {
+        let mc = self.gc();
+        self.interner.intern_inner(mc, s, |s| {
+            let repr = AvmStringRepr::from_raw_static(s, true);
+            Gc::new(mc, repr)
+        })
+    }
+
+    #[must_use]
+    pub fn intern(&mut self, s: AvmString<'gc>) -> AvmAtom<'gc> {
+        if let Some(atom) = s.as_interned() {
+            atom
+        } else {
+            let mc = self.gc();
+            self.interner.intern_inner(mc, s, |s| {
+                let repr = s.to_fully_owned(mc);
+                repr.mark_interned();
+                repr
+            })
+        }
+    }
+
+    #[must_use]
+    pub fn get_interned(&self, s: &WStr) -> Option<AvmAtom<'gc>> {
+        self.interner.get(self.gc(), s)
+    }
+
+    #[must_use]
+    pub fn empty(&self) -> AvmString<'gc> {
+        self.interner.empty.into()
+    }
+
+    #[must_use]
+    pub fn get_char(&self, c: u16) -> AvmString<'gc> {
+        if let Some(s) = self.interner.chars.get(c as usize) {
+            (*s).into()
+        } else {
+            AvmString::new(self.gc(), WString::from_unit(c))
+        }
+    }
+
+    // Like get_char, but panics if the passed char is not ASCII.
+    #[must_use]
+    pub fn get_ascii_char(&self, c: char) -> AvmString<'gc> {
+        self.interner.chars[c as usize].into()
+    }
+
+    #[must_use]
+    pub fn substring(
+        &self,
+        s: AvmString<'gc>,
+        start_index: usize,
+        end_index: usize,
+    ) -> AvmString<'gc> {
+        self.interner
+            .substring(self.gc(), s, start_index, end_index)
     }
 }

--- a/core/src/string/context.rs
+++ b/core/src/string/context.rs
@@ -1,0 +1,19 @@
+use gc_arena::Mutation;
+
+use crate::string::AvmStringInterner;
+
+/// Context for managing `AvmString`s: allocating them, interning them, etc...
+pub struct StringContext<'gc> {
+    /// The mutation context to allocate and mutate `Gc` pointers.
+    pub gc_context: &'gc Mutation<'gc>,
+
+    /// The global string interner.
+    pub interner: &'gc mut AvmStringInterner<'gc>,
+}
+
+impl<'gc> StringContext<'gc> {
+    #[inline(always)]
+    pub fn gc(&self) -> &'gc Mutation<'gc> {
+        self.gc_context
+    }
+}

--- a/core/src/string/context.rs
+++ b/core/src/string/context.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, ops::Range};
 
 use gc_arena::{Gc, Mutation};
 
@@ -76,7 +76,7 @@ impl<'gc> StringContext<'gc> {
     }
 
     #[must_use]
-    pub fn get_char(&self, c: u16) -> AvmString<'gc> {
+    pub fn make_char(&self, c: u16) -> AvmString<'gc> {
         if let Some(s) = self.interner.chars.get(c as usize) {
             (*s).into()
         } else {
@@ -84,20 +84,15 @@ impl<'gc> StringContext<'gc> {
         }
     }
 
-    // Like get_char, but panics if the passed char is not ASCII.
+    /// Like `make_char`, but panics if the passed char is not ASCII.
     #[must_use]
-    pub fn get_ascii_char(&self, c: char) -> AvmString<'gc> {
+    pub fn ascii_char(&self, c: u8) -> AvmString<'gc> {
         self.interner.chars[c as usize].into()
     }
 
     #[must_use]
-    pub fn substring(
-        &self,
-        s: AvmString<'gc>,
-        start_index: usize,
-        end_index: usize,
-    ) -> AvmString<'gc> {
+    pub fn substring(&self, s: AvmString<'gc>, range: Range<usize>) -> AvmString<'gc> {
         self.interner
-            .substring(self.gc(), s, start_index, end_index)
+            .substring(self.gc(), s, range.start, range.end)
     }
 }


### PR DESCRIPTION
Supercedes #18081.

Embeds a `&Mutation<'gc>` directly into the string interner context (which is renamed from `GcContext` to `StringContext`, for clarity), and makes it accessible in `UpdateContext` without the need for an explicit reborrow method.

This simplifies most usages, as we don't need to pass a `&Mutation<'gc>` separately.