### PR TITLE
web: Make element selectors in browser tests valid for BiDi

### DIFF
--- a/web/packages/selfhosted/test/integration_tests/external_interface/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/external_interface/test.ts
@@ -69,7 +69,7 @@ describe("ExternalInterface", () => {
     it("loads the test", async () => {
         await openTest(browser, "integration_tests/external_interface");
         await injectRuffleAndWait(browser);
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         await playAndMonitor(
             browser,
             player,
@@ -108,7 +108,7 @@ ExternalInterface.objectID: "flash_name"
     });
 
     it("responds to 'log'", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         await browser.execute(
             (player) =>
                 player.log("Hello world!", {
@@ -136,7 +136,7 @@ ExternalInterface.objectID: "flash_name"
     });
 
     it("returns a value", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         const returned = await browser.execute(
             (player) => player.returnAValue(123.4),
             player,
@@ -155,7 +155,7 @@ ExternalInterface.objectID: "flash_name"
     });
 
     it("calls a method with delay", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         await browser.execute(
             (player) =>
                 player.callMethodWithDelay("window.RuffleTest.set", true),
@@ -179,7 +179,7 @@ ExternalInterface.objectID: "flash_name"
     // [NA] Broken on Ruffle at time of writing
     it.skip("calls a reentrant JS method", async () => {
         // JS -> Flash -> JS within one call
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         const actualValue = await browser.execute((player) => {
             player.callMethodImmediately("window.RuffleTest.set", {
                 nested: { object: { complex: true } },
@@ -211,7 +211,7 @@ ExternalInterface.objectID: "flash_name"
 
     it("calls a reentrant Flash method", async () => {
         // Flash -> JS -> Flash within one call
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         await browser.execute((player) => {
             player.callMethodWithDelay("window.RuffleTest.log", "Reentrant!");
         }, player);
@@ -236,7 +236,7 @@ log called with 1 argument
     });
 
     it("supports a JS function as name", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         await browser.execute((player) => {
             player.callMethodWithDelay(
                 "function(name){window.RuffleTest.set(name)}",
@@ -263,7 +263,7 @@ log called with 1 argument
     });
 
     it("supports calling a method that doesn't exist", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         await browser.execute((player) => {
             player.callMethodWithDelay("does.not.exist");
         }, player);
@@ -283,7 +283,7 @@ log called with 1 argument
     });
 
     it("doesn't enforce Strict Mode", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         await browser.execute((player) => {
             player.callMethodWithDelay(
                 "function(){return aPropertyThatDoesntExist = 'success!'}",
@@ -305,7 +305,7 @@ log called with 1 argument
     });
 
     it("allows overriding a Ruffle method", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
         await browser.execute((player) => {
             player.addAnotherCallback("isPlaying", "isPlaying from EI");
         }, player);
@@ -325,7 +325,7 @@ log called with 1 argument
     });
 
     it("allows redefining a method", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("ruffle-object");
 
         // First definition
         await browser.execute((player) => {

--- a/web/packages/selfhosted/test/integration_tests/keyboard_input/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/keyboard_input/test.ts
@@ -9,7 +9,7 @@ describe("Key up and down events work", () => {
     loadJsAPI("/test/integration_tests/keyboard_input/test.swf");
 
     it("'a' key is recognised", async () => {
-        const player = await browser.$("<ruffle-player>");
+        const player = await browser.$("ruffle-player");
         await player.click();
         // Extra safety click in case there's a modal
         await player.click();
@@ -30,7 +30,7 @@ event.keyCode = 65
     });
 
     it("enter key is recognised", async () => {
-        const player = await browser.$("<ruffle-player>");
+        const player = await browser.$("ruffle-player");
         await player.click();
 
         await browser.keys([Key.Enter]);

--- a/web/packages/selfhosted/test/js_api/exposed.ts
+++ b/web/packages/selfhosted/test/js_api/exposed.ts
@@ -8,7 +8,7 @@ describe("Exposed RufflePlayer methods/properties", () => {
     loadJsAPI();
 
     it("exposed API has not changed", async () => {
-        const player = await browser.$("<ruffle-player>");
+        const player = await browser.$("ruffle-player");
         const keys = await browser.execute(async (playerElement) => {
             // https://github.com/webdriverio/webdriverio/issues/6486
             const player = playerElement as unknown;

--- a/web/packages/selfhosted/test/js_api/load.ts
+++ b/web/packages/selfhosted/test/js_api/load.ts
@@ -9,7 +9,7 @@ describe("RufflePlayer.load", () => {
     loadJsAPI();
 
     it("loads and plays a URL", async () => {
-        const player = await browser.$("<ruffle-player>");
+        const player = await browser.$("ruffle-player");
         await browser.execute(async (playerElement) => {
             // https://github.com/webdriverio/webdriverio/issues/6486
             const player = playerElement as unknown as Player;

--- a/web/packages/selfhosted/test/js_api/metadata.ts
+++ b/web/packages/selfhosted/test/js_api/metadata.ts
@@ -9,7 +9,7 @@ describe("RufflePlayer.metadata", () => {
     loadJsAPI("/test_assets/example.swf");
 
     it("has metadata after load", async () => {
-        const player = await browser.$("<ruffle-player>");
+        const player = await browser.$("ruffle-player");
         const metadata = await browser.execute(
             // https://github.com/webdriverio/webdriverio/issues/6486
             (player) => (player as unknown as Player).metadata,

--- a/web/packages/selfhosted/test/polyfill/classic_frames_injected/test.ts
+++ b/web/packages/selfhosted/test/polyfill/classic_frames_injected/test.ts
@@ -13,7 +13,7 @@ describe("Flash inside frame with injected ruffle", () => {
     it("polyfills inside a frame", async () => {
         await injectRuffleAndWait(browser);
         await browser.switchToFrame(await browser.$("#test-frame"));
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -37,7 +37,7 @@ describe("Flash inside frame with injected ruffle", () => {
         // And finally, check
         await browser.switchToFrame(null);
         await browser.switchToFrame(await browser.$("#test-frame"));
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(

--- a/web/packages/selfhosted/test/polyfill/classic_frames_provided/test.ts
+++ b/web/packages/selfhosted/test/polyfill/classic_frames_provided/test.ts
@@ -12,7 +12,7 @@ describe("Flash inside frame with provided ruffle", () => {
 
     it("polyfills inside a frame", async () => {
         await browser.switchToFrame(await browser.$("#test-frame"));
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -36,7 +36,7 @@ describe("Flash inside frame with provided ruffle", () => {
         // And finally, check
         await browser.switchToFrame(null);
         await browser.switchToFrame(await browser.$("#test-frame"));
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(

--- a/web/packages/selfhosted/test/polyfill/embed_default/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_default/test.ts
@@ -23,7 +23,7 @@ describe("Embed tag", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_insensitive/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_insensitive/test.ts
@@ -12,7 +12,7 @@ describe("Embed with case-insensitive MIME type", () => {
 
     it("Polyfills", async () => {
         await injectRuffleAndWait(browser);
-        await browser.$("<ruffle-embed />").waitForExist();
+        await browser.$("ruffle-embed").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -25,7 +25,7 @@ describe("Embed with case-insensitive MIME type", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_missing_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_type/test.ts
@@ -23,7 +23,7 @@ describe("Embed without type attribute", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/iframes_injected/test.ts
+++ b/web/packages/selfhosted/test/polyfill/iframes_injected/test.ts
@@ -13,7 +13,7 @@ describe("Flash inside iframe with injected ruffle", () => {
     it("polyfills inside an iframe", async () => {
         await injectRuffleAndWait(browser);
         await browser.switchToFrame(await browser.$("#test-frame"));
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -36,7 +36,7 @@ describe("Flash inside iframe with injected ruffle", () => {
         // And finally, check
         await browser.switchToFrame(null);
         await browser.switchToFrame(await browser.$("#test-frame"));
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(

--- a/web/packages/selfhosted/test/polyfill/iframes_onload/test.ts
+++ b/web/packages/selfhosted/test/polyfill/iframes_onload/test.ts
@@ -12,7 +12,7 @@ describe("iframe onload", () => {
 
     it("runs the iframe onload event", async () => {
         await injectRuffleAndWait(browser);
-        await browser.$("<div />").waitForExist();
+        await browser.$("div").waitForExist();
 
         const actual = await browser.$("#container").getHTML(false);
         const expected = fs.readFileSync(

--- a/web/packages/selfhosted/test/polyfill/iframes_provided/test.ts
+++ b/web/packages/selfhosted/test/polyfill/iframes_provided/test.ts
@@ -12,7 +12,7 @@ describe("Flash inside iframe with provided ruffle", () => {
 
     it("polyfills inside an iframe", async () => {
         await browser.switchToFrame(await browser.$("#test-frame"));
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -35,7 +35,7 @@ describe("Flash inside iframe with provided ruffle", () => {
         // And finally, check
         await browser.switchToFrame(null);
         await browser.switchToFrame(await browser.$("#test-frame"));
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(

--- a/web/packages/selfhosted/test/polyfill/object_MIME_insensitive/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_MIME_insensitive/test.ts
@@ -12,7 +12,7 @@ describe("Object with case-insensitive MIME type", () => {
 
     it("Polyfills", async () => {
         await injectRuffleAndWait(browser);
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -25,7 +25,7 @@ describe("Object with case-insensitive MIME type", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_clsid_insensitive/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_insensitive/test.ts
@@ -12,7 +12,7 @@ describe("Object with case-insensitive clsid", () => {
 
     it("Polyfills", async () => {
         await injectRuffleAndWait(browser);
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -25,7 +25,7 @@ describe("Object with case-insensitive clsid", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.ts
@@ -23,7 +23,7 @@ describe("Object with clsid and embed", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_data/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_data/test.ts
@@ -12,7 +12,7 @@ describe("Object with only data attribute", () => {
 
     it("Polyfills", async () => {
         await injectRuffleAndWait(browser);
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -25,7 +25,7 @@ describe("Object with only data attribute", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_default/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_default/test.ts
@@ -23,7 +23,7 @@ describe("Object tag", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_double_object/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_double_object/test.ts
@@ -23,7 +23,7 @@ describe("Object with another object tag", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_double_object_classid/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_double_object_classid/test.ts
@@ -23,7 +23,7 @@ describe("Object using classid with another object tag without classid", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_flashvars/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars/test.ts
@@ -23,7 +23,7 @@ describe("Object tag", () => {
     it("Plays a movie with flashvars", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
             `// _level0.a
 1
 

--- a/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.ts
@@ -23,7 +23,7 @@ describe("Object tag", () => {
     it("Plays a movie with flashvars", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
             `// _level0.a
 1
 

--- a/web/packages/selfhosted/test/polyfill/object_ie_only/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_ie_only/test.ts
@@ -23,7 +23,7 @@ describe("Object for old IE must work everywhere", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type/test.ts
@@ -23,7 +23,7 @@ describe("Object without type attribute", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.ts
@@ -23,7 +23,7 @@ describe("Object without type and classid attributes", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.ts
@@ -23,7 +23,7 @@ describe("Object with unexpected string", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_wrong_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_wrong_type/test.ts
@@ -23,7 +23,7 @@ describe("Object with wrong type attribute value", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("ruffle-embed"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/swf_extension_insensitive/test.ts
+++ b/web/packages/selfhosted/test/polyfill/swf_extension_insensitive/test.ts
@@ -12,7 +12,7 @@ describe("SWF extension insensitive", () => {
 
     it("Polyfills", async () => {
         await injectRuffleAndWait(browser);
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -25,7 +25,7 @@ describe("SWF extension insensitive", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/swf_extension_with_fragment/test.ts
+++ b/web/packages/selfhosted/test/polyfill/swf_extension_with_fragment/test.ts
@@ -12,7 +12,7 @@ describe("SWF extension, file with fragment", () => {
 
     it("Polyfills", async () => {
         await injectRuffleAndWait(browser);
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -25,7 +25,7 @@ describe("SWF extension, file with fragment", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/swf_extension_with_get/test.ts
+++ b/web/packages/selfhosted/test/polyfill/swf_extension_with_get/test.ts
@@ -12,7 +12,7 @@ describe("SWF extension, file with GET parameter", () => {
 
     it("Polyfills", async () => {
         await injectRuffleAndWait(browser);
-        await browser.$("<ruffle-object />").waitForExist();
+        await browser.$("ruffle-object").waitForExist();
 
         const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(
@@ -25,7 +25,7 @@ describe("SWF extension, file with GET parameter", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser.$("#test-container").$("ruffle-object"),
         );
     });
 });


### PR DESCRIPTION
I've extracted these changes from https://github.com/ruffle-rs/ruffle/pull/17539 just to reduce the miscellaneous diff noise in there.