### PR TITLE
desktop: Fix filesystem access dialog

### DIFF
--- a/desktop/src/backends.rs
+++ b/desktop/src/backends.rs
@@ -6,4 +6,5 @@ mod ui;
 pub use external_interface::DesktopExternalInterfaceProvider;
 pub use fscommand::DesktopFSCommandProvider;
 pub use navigator::DesktopNavigatorInterface;
+pub use navigator::PathAllowList;
 pub use ui::DesktopUiBackend;


### PR DESCRIPTION
This patch fixes the following two issues:

1. On Windows the allowed path check was not always working, due to Windows paths being Windows paths, now paths are canonicalized before comparison.

2. On some systems the dialog was not rendered when the main SWF wasn't loaded, and the dialog was not able to allow the main SWF. Now the dialog allows the SWF instantly when constructed.

That needs testing from @n0samu and @Lord-McSweeney, as I cannot reproduce these issues.

Fixes https://github.com/ruffle-rs/ruffle/issues/18141, fixes https://github.com/ruffle-rs/ruffle/issues/18142.