### PR TITLE
core: Use the canonical empty `AvmString` instead of `"".into()`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -826,7 +826,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let object = object_val.coerce_to_object(self);
 
         let method_name = if method_name == Value::Undefined {
-            "".into()
+            self.strings().empty()
         } else {
             method_name.coerce_to_string(self)?
         };
@@ -1722,7 +1722,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let object = object_val.coerce_to_object(self);
 
         let method_name = if method_name == Value::Undefined {
-            "".into()
+            self.strings().empty()
         } else {
             method_name.coerce_to_string(self)?
         };

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -256,7 +256,7 @@ pub fn join<'gc>(
     };
 
     if length <= 0 {
-        return Ok("".into());
+        return Ok(activation.strings().empty().into());
     }
 
     let parts = (0..length)

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -158,7 +158,7 @@ fn send<'gc>(
 
     let window = match args.get(1) {
         Some(window) => window.coerce_to_string(activation)?,
-        None => "".into(),
+        None => activation.strings().empty(),
     };
 
     let method_name = args

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1544,7 +1544,7 @@ pub fn get_url<'gc>(
 
         let window = match args.get(1) {
             Some(window) => window.coerce_to_string(activation)?,
-            None => "".into(),
+            None => activation.strings().empty(),
         };
 
         let method = match args.get(2) {

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -116,7 +116,7 @@ fn char_at<'gc>(
         .and_then(|i| string.get(i))
         .map(WString::from_unit)
         .map(|ret| AvmString::new(activation.context.gc_context, ret))
-        .unwrap_or_else(|| "".into());
+        .unwrap_or_else(|| activation.strings().empty());
 
     Ok(ret.into())
 }
@@ -250,7 +250,7 @@ fn slice<'gc>(
         let ret = WString::from(&this[start_index..end_index]);
         Ok(AvmString::new(activation.context.gc_context, ret).into())
     } else {
-        Ok("".into())
+        Ok(activation.strings().empty().into())
     }
 }
 
@@ -332,7 +332,7 @@ fn substr<'gc>(
         let ret = WString::from(&this[start_index..end_index]);
         Ok(AvmString::new(activation.context.gc_context, ret).into())
     } else {
-        Ok("".into())
+        Ok(activation.strings().empty().into())
     }
 }
 

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -271,7 +271,7 @@ fn prefix<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
         .as_xml_node()
-        .and_then(|n| n.prefix(activation.context.gc_context))
+        .and_then(|n| n.prefix(activation.strings()))
         .map_or(Value::Null, Value::from))
 }
 
@@ -382,7 +382,7 @@ fn namespace_uri<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
-        if let Some(prefix) = node.prefix(activation.context.gc_context) {
+        if let Some(prefix) = node.prefix(activation.strings()) {
             return Ok(node
                 .lookup_namespace_uri(&prefix)
                 .unwrap_or_else(|| activation.strings().empty().into()));

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -37,15 +37,16 @@ pub fn constructor<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let mc = activation.gc();
     let mut node = if let [node_type, value, ..] = args {
         let node_type = node_type.coerce_to_u8(activation)?;
         let node_value = value.coerce_to_string(activation)?;
-        XmlNode::new(activation.context.gc_context, node_type, Some(node_value))
+        XmlNode::new(mc, node_type, Some(node_value))
     } else {
-        XmlNode::new(activation.context.gc_context, TEXT_NODE, Some("".into()))
+        XmlNode::new(mc, TEXT_NODE, Some(activation.strings().empty()))
     };
-    node.introduce_script_object(activation.context.gc_context, this);
-    this.set_native(activation.context.gc_context, NativeObject::XmlNode(node));
+    node.introduce_script_object(mc, this);
+    this.set_native(mc, NativeObject::XmlNode(node));
 
     Ok(this.into())
 }
@@ -145,7 +146,7 @@ fn get_prefix_for_namespace<'gc>(
                         if let Some(prefix) = prefix.strip_prefix(b':') {
                             return Ok(AvmString::new(activation.context.gc_context, prefix).into());
                         } else {
-                            return Ok("".into());
+                            return Ok(activation.strings().empty().into());
                         }
                     }
                 }
@@ -194,7 +195,7 @@ fn to_string<'gc>(
         return Ok(AvmString::new(activation.context.gc_context, string).into());
     }
 
-    Ok("".into())
+    Ok(activation.strings().empty().into())
 }
 
 fn local_name<'gc>(
@@ -384,7 +385,7 @@ fn namespace_uri<'gc>(
         if let Some(prefix) = node.prefix(activation.context.gc_context) {
             return Ok(node
                 .lookup_namespace_uri(&prefix)
-                .unwrap_or_else(|| "".into()));
+                .unwrap_or_else(|| activation.strings().empty().into()));
         }
 
         return Ok(Value::Null);

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -677,27 +677,18 @@ fn set_name<'gc>(
 }
 
 fn drop_target<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.as_movie_clip()
-        .and_then(|mc| mc.drop_target())
-        .map_or_else(
-            || {
-                if activation.swf_version() < 6 {
-                    Value::Undefined
-                } else {
-                    "".into()
-                }
-            },
-            |drop_target| {
-                AvmString::new(activation.context.gc_context, drop_target.slash_path()).into()
-            },
-        )
+    match this.as_movie_clip().and_then(|mc| mc.drop_target()) {
+        Some(target) => AvmString::new(activation.gc(), target.slash_path()).into(),
+        None if activation.swf_version() < 6 => Value::Undefined,
+        None => activation.strings().empty().into(),
+    }
 }
 
 fn url<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.as_movie_clip().map_or_else(
-        || "".into(),
-        |mc| AvmString::new_utf8(activation.context.gc_context, mc.movie().url()).into(),
-    )
+    match this.as_movie_clip() {
+        Some(mc) => AvmString::new_utf8(activation.gc(), mc.movie().url()).into(),
+        None => activation.strings().empty().into(),
+    }
 }
 
 fn high_quality<'gc>(

--- a/core/src/avm1/object_reference.rs
+++ b/core/src/avm1/object_reference.rs
@@ -188,7 +188,7 @@ impl<'gc> MovieClipReference<'gc> {
     pub fn coerce_to_string(&self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
         match self.resolve_reference(activation) {
             // Couldn't find the reference
-            None => "".into(),
+            None => activation.strings().empty(),
             // Found the reference, cached, we can't re-use `self.path` sadly, it would be quicker if we could
             // But if the clip has been re-named, since being created then `mc.path() != path`
             Some((true, _, dobj)) => AvmString::new(activation.gc(), dobj.path()),

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -410,7 +410,7 @@ impl<'gc> Value<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         Ok(match self {
-            Value::Undefined if activation.swf_version() < 7 => "".into(),
+            Value::Undefined if activation.swf_version() < 7 => activation.strings().empty(),
             Value::Bool(true) if activation.swf_version() < 5 => "1".into(),
             Value::Bool(false) if activation.swf_version() < 5 => "0".into(),
             Value::Object(object) => {

--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -82,7 +82,7 @@ pub fn serialize_value<'gc>(
                     let int_vec: Vec<_> = vec
                         .iter()
                         .map(|v| {
-                            v.as_integer(activation.context.gc_context)
+                            v.as_integer(activation.strings())
                                 .expect("Unexpected non-int value in int vector")
                         })
                         .collect();
@@ -91,7 +91,7 @@ pub fn serialize_value<'gc>(
                     let uint_vec: Vec<_> = vec
                         .iter()
                         .map(|v| {
-                            v.as_u32(activation.context.gc_context)
+                            v.as_u32(activation.strings())
                                 .expect("Unexpected non-uint value in int vector")
                         })
                         .collect();
@@ -100,7 +100,7 @@ pub fn serialize_value<'gc>(
                     let num_vec: Vec<_> = vec
                         .iter()
                         .map(|v| {
-                            v.as_number(activation.context.gc_context)
+                            v.as_number(activation.strings())
                                 .expect("Unexpected non-uint value in int vector")
                         })
                         .collect();

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1082,7 +1082,7 @@ impl<'gc> E4XNode<'gc> {
                     if &*name == b"xmlns" {
                         namespaces.push(E4XNamespace {
                             uri: value,
-                            prefix: Some("".into()),
+                            prefix: Some(activation.strings().empty()),
                         });
                         continue;
                     }
@@ -1328,7 +1328,9 @@ impl<'gc> E4XNode<'gc> {
             return self_ns.is_empty();
         }
 
-        name.namespace_set().iter().any(|ns| ns.as_uri() == self_ns)
+        name.namespace_set()
+            .iter()
+            .any(|ns| ns.as_uri_opt().expect("NS set cannot contain Any") == self_ns)
     }
 
     pub fn descendants(&self, name: &Multiname<'gc>, out: &mut Vec<E4XOrXml<'gc>>) {

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -91,7 +91,7 @@ pub fn make_reference_error<'gc>(
     multiname: &Multiname<'gc>,
     object_class: Class<'gc>,
 ) -> Error<'gc> {
-    let qualified_name = multiname.as_uri(activation.context.gc_context);
+    let qualified_name = multiname.as_uri(activation.strings());
     let class_name = object_class
         .name()
         .to_qualified_name_err_message(activation.context.gc_context);
@@ -283,7 +283,7 @@ pub fn make_error_1065<'gc>(
     activation: &mut Activation<'_, 'gc>,
     name: &Multiname<'gc>,
 ) -> Error<'gc> {
-    let qualified_name = name.as_uri(activation.context.gc_context);
+    let qualified_name = name.as_uri(activation.strings());
 
     let err = reference_error(
         activation,

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -253,7 +253,7 @@ where
             let item = resolve_array_hole(activation, this, i, item)?;
 
             if matches!(item, Value::Undefined) || matches!(item, Value::Null) {
-                accum.push("".into());
+                accum.push(activation.strings().empty());
             } else {
                 accum.push(conv(item, activation)?.coerce_to_string(activation)?);
             }

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -75,7 +75,7 @@ pub fn instance_init<'gc>(
         if args.len() == 1 {
             if let Some(expected_len) = args
                 .get(0)
-                .and_then(|v| v.as_number(activation.context.gc_context).ok())
+                .and_then(|v| v.as_number(activation.strings()).ok())
             {
                 if expected_len < 0.0 || expected_len.is_nan() || expected_len.fract() != 0.0 {
                     return Err(Error::AvmError(range_error(

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -262,7 +262,7 @@ fn describe_internal_body<'gc>(
     let mut skip_ns: Vec<Namespace<'_>> = Vec::new();
     if let Some(super_vtable) = super_vtable {
         for (_, ns, prop) in super_vtable.resolved_traits().iter() {
-            if !ns.as_uri().is_empty() {
+            if !ns.as_uri(activation.strings()).is_empty() {
                 if let Property::Method { .. } = prop {
                     if !skip_ns
                         .iter()
@@ -294,11 +294,7 @@ fn describe_internal_body<'gc>(
             continue;
         }
 
-        let uri = if ns.as_uri().is_empty() {
-            None
-        } else {
-            Some(ns.as_uri())
-        };
+        let uri = ns.as_uri_opt().filter(|uri| !uri.is_empty());
 
         match prop {
             Property::ConstSlot { slot_id } | Property::Slot { slot_id } => {
@@ -451,12 +447,7 @@ fn describe_internal_body<'gc>(
                     continue;
                 }
 
-                let uri = if ns.as_uri().is_empty() {
-                    None
-                } else {
-                    Some(ns.as_uri())
-                };
-
+                let uri = ns.as_uri_opt().filter(|uri| !uri.is_empty());
                 let accessor_type = display_name(activation.strings(), method_type);
                 let declared_by = defining_class.dollar_removed_name(mc).to_qualified_name(mc);
 

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -260,7 +260,7 @@ pub fn get_time<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_date_object().unwrap();
-    this.value_of(activation.context.gc_context)
+    this.value_of(activation.strings())
 }
 
 /// Implements `setTime` method.

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -1286,13 +1286,13 @@ fn read_point<'gc>(
     let x = data
         .get(*data_index, activation)
         .ok()?
-        .as_number(activation.context.gc_context)
+        .as_number(activation.strings())
         .expect("data is not a Vec.<Number>");
 
     let y = data
         .get(*data_index + 1, activation)
         .ok()?
-        .as_number(activation.context.gc_context)
+        .as_number(activation.strings())
         .expect("data is not a Vec.<Number>");
 
     *data_index += 2;
@@ -1395,7 +1395,7 @@ fn process_commands<'gc>(
         let command = commands
             .get(i, activation)
             .expect("missing command")
-            .as_integer(activation.context.gc_context)
+            .as_integer(activation.strings())
             .expect("commands is not a Vec.<int>");
 
         if process_command(activation, drawing, data, command, &mut data_index).is_none() {

--- a/core/src/avm2/globals/flash/display/shader_job.rs
+++ b/core/src/avm2/globals/flash/display/shader_job.rs
@@ -107,18 +107,18 @@ pub fn get_shader_args<'gc>(
                     let width = shader_input
                         .get_public_property("width", activation)
                         .unwrap()
-                        .as_u32(activation.context.gc_context)
+                        .as_u32(activation.strings())
                         .unwrap();
                     let height = shader_input
                         .get_public_property("height", activation)
                         .unwrap()
-                        .as_u32(activation.context.gc_context)
+                        .as_u32(activation.strings())
                         .unwrap();
 
                     let input_channels = shader_input
                         .get_public_property("channels", activation)
                         .unwrap()
-                        .as_u32(activation.context.gc_context)
+                        .as_u32(activation.strings())
                         .unwrap();
 
                     assert_eq!(*channels as u32, input_channels);
@@ -156,8 +156,7 @@ pub fn get_shader_args<'gc>(
                                 bytes: vector
                                     .iter()
                                     .flat_map(|val| {
-                                        (val.as_number(activation.context.gc_context).unwrap()
-                                            as f32)
+                                        (val.as_number(activation.strings()).unwrap() as f32)
                                             .to_le_bytes()
                                     })
                                     .collect(),
@@ -210,12 +209,12 @@ pub fn start<'gc>(
 
     let output_width = this
         .get_public_property("width", activation)?
-        .as_u32(activation.context.gc_context)
+        .as_u32(activation.strings())
         .expect("ShaderJob.width is not a number");
 
     let output_height = this
         .get_public_property("height", activation)?
-        .as_u32(activation.context.gc_context)
+        .as_u32(activation.strings())
         .expect("ShaderJob.height is not a number");
 
     let pixel_bender_target = if let Some(bitmap) = target.as_bitmap_data() {

--- a/core/src/avm2/globals/flash/display3D/context_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/context_3d.rs
@@ -365,10 +365,7 @@ pub fn set_program_constants_from_vector<'gc>(
 
         let raw_data = vector
             .iter()
-            .map(|val| {
-                val.as_number(activation.context.gc_context)
-                    .map(|val| val as f32)
-            })
+            .map(|val| val.as_number(activation.strings()).map(|val| val as f32))
             .take(to_take)
             .collect::<Result<Vec<f32>, _>>()?;
 
@@ -384,13 +381,13 @@ pub fn clear<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
-        let red = args[0].as_number(activation.context.gc_context)?;
-        let green = args[1].as_number(activation.context.gc_context)?;
-        let blue = args[2].as_number(activation.context.gc_context)?;
-        let alpha = args[3].as_number(activation.context.gc_context)?;
-        let depth = args[4].as_number(activation.context.gc_context)?;
-        let stencil = args[5].as_integer(activation.context.gc_context)? as u32;
-        let mask = args[6].as_integer(activation.context.gc_context)? as u32;
+        let red = args[0].as_number(activation.strings())?;
+        let green = args[1].as_number(activation.strings())?;
+        let blue = args[2].as_number(activation.strings())?;
+        let alpha = args[3].as_number(activation.strings())?;
+        let depth = args[4].as_number(activation.strings())?;
+        let stencil = args[5].as_integer(activation.strings())? as u32;
+        let mask = args[6].as_integer(activation.strings())? as u32;
         context.set_clear(red, green, blue, alpha, depth, stencil, mask);
     }
     Ok(Value::Undefined)
@@ -403,11 +400,11 @@ pub fn create_texture<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
-        let width = args[0].as_integer(activation.context.gc_context)? as u32;
-        let height = args[1].as_integer(activation.context.gc_context)? as u32;
+        let width = args[0].as_integer(activation.strings())? as u32;
+        let height = args[1].as_integer(activation.strings())? as u32;
         let format = args[2].coerce_to_string(activation)?;
         let optimize_for_render_to_texture = args[3].coerce_to_boolean();
-        let streaming_levels = args[4].as_integer(activation.context.gc_context)? as u32;
+        let streaming_levels = args[4].as_integer(activation.strings())? as u32;
         let format = Context3DTextureFormat::from_wstr(&format).ok_or_else(|| {
             Error::RustError(
                 format!("Unsupported texture format in createTexture: {:?}", format).into(),
@@ -436,8 +433,8 @@ pub fn create_rectangle_texture<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
-        let width = args[0].as_integer(activation.context.gc_context)? as u32;
-        let height = args[1].as_integer(activation.context.gc_context)? as u32;
+        let width = args[0].as_integer(activation.strings())? as u32;
+        let height = args[1].as_integer(activation.strings())? as u32;
         let format = args[2].coerce_to_string(activation)?;
         let optimize_for_render_to_texture = args[3].coerce_to_boolean();
         let format = Context3DTextureFormat::from_wstr(&format).ok_or_else(|| {
@@ -472,10 +469,10 @@ pub fn create_cube_texture<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
-        let size = args[0].as_integer(activation.context.gc_context)? as u32;
+        let size = args[0].as_integer(activation.strings())? as u32;
         let format = args[1].coerce_to_string(activation)?;
         let optimize_for_render_to_texture = args[2].coerce_to_boolean();
-        let streaming_levels = args[3].as_integer(activation.context.gc_context)? as u32;
+        let streaming_levels = args[3].as_integer(activation.strings())? as u32;
         let format = Context3DTextureFormat::from_wstr(&format).ok_or_else(|| {
             Error::RustError(
                 format!(
@@ -504,7 +501,7 @@ pub fn set_texture_at<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
-        let sampler = args[0].as_integer(activation.context.gc_context)? as u32;
+        let sampler = args[0].as_integer(activation.strings())? as u32;
         let mut cube = false;
         let texture = if matches!(args[1], Value::Null) {
             None
@@ -655,7 +652,7 @@ pub fn set_sampler_state_at<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
-        let sampler = args[0].as_integer(activation.context.gc_context)? as u32;
+        let sampler = args[0].as_integer(activation.strings())? as u32;
         let wrap = args[1].coerce_to_string(activation)?;
         let filter = args[2].coerce_to_string(activation)?;
         let mip_filter = args[3].coerce_to_string(activation)?;

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -67,11 +67,10 @@ pub fn get_definition<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(appdomain) = this.as_application_domain() {
-        let name = args
-            .get(0)
-            .cloned()
-            .unwrap_or_else(|| "".into())
-            .coerce_to_string(activation)?;
+        let name = match args.get(0) {
+            Some(arg) => arg.coerce_to_string(activation)?,
+            None => activation.strings().empty(),
+        };
         return appdomain.get_defined_value_handling_vector(activation, name);
     }
 
@@ -85,11 +84,10 @@ pub fn has_definition<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(appdomain) = this.as_application_domain() {
-        let name = args
-            .get(0)
-            .cloned()
-            .unwrap_or_else(|| "".into())
-            .coerce_to_string(activation)?;
+        let name = match args.get(0) {
+            Some(arg) => arg.coerce_to_string(activation)?,
+            None => activation.strings().empty(),
+        };
 
         return Ok(appdomain
             .get_defined_value_handling_vector(activation, name)

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -48,7 +48,7 @@ pub fn create_text_line<'gc>(
         None => {
             let txt = content
                 .get_public_property("text", activation)
-                .unwrap_or("".into());
+                .unwrap_or_else(|_| activation.strings().empty().into());
 
             if matches!(txt, Value::Null) {
                 // FP returns a null TextLine when `o` is null- note that

--- a/core/src/avm2/globals/flash/text/static_text.rs
+++ b/core/src/avm2/globals/flash/text/static_text.rs
@@ -20,5 +20,5 @@ pub fn get_text<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.text.StaticText", "text");
-    Ok("".into())
+    Ok(activation.strings().empty().into())
 }

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -1474,7 +1474,7 @@ pub fn get_selected_text<'gc>(
 
         return Ok(AvmString::new(activation.context.gc(), &text[start_index..end_index]).into());
     }
-    Ok("".into())
+    Ok(activation.strings().empty().into())
 }
 
 pub fn get_text_runs<'gc>(

--- a/core/src/avm2/globals/json.rs
+++ b/core/src/avm2/globals/json.rs
@@ -334,7 +334,7 @@ pub fn stringify<'gc>(
         }
     } else {
         let indent_size = spaces
-            .as_number(activation.context.gc_context)
+            .as_number(activation.strings())
             .unwrap_or(0.0)
             .clamp(0.0, 10.0) as u16;
         if indent_size == 0 {

--- a/core/src/avm2/globals/json.rs
+++ b/core/src/avm2/globals/json.rs
@@ -75,7 +75,10 @@ fn deserialize_json<'gc>(
     let val = deserialize_json_inner(activation, json, reviver)?;
     match reviver {
         None => Ok(val),
-        Some(reviver) => reviver.call(Value::Null, &["".into(), val], activation),
+        Some(reviver) => {
+            let args = [activation.strings().empty().into(), val];
+            reviver.call(Value::Null, &args, activation)
+        }
     }
 }
 
@@ -255,7 +258,8 @@ impl<'gc> AvmSerializer<'gc> {
         activation: &mut Activation<'_, 'gc>,
         value: Value<'gc>,
     ) -> Result<JsonValue, Error<'gc>> {
-        let mapped = self.map_value(activation, || "".into(), value)?;
+        let empty = activation.strings().empty();
+        let mapped = self.map_value(activation, || empty, value)?;
         self.serialize_value(activation, mapped)
     }
 }

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -31,7 +31,9 @@ pub fn init<'gc>(
     let (prefix, namespace) = match arguments_list.as_slice() {
         [prefix, uri] => {
             let namespace_uri = if let Value::Object(Object::QNameObject(qname)) = uri {
-                qname.uri().unwrap_or_else(|| activation.strings().empty())
+                qname
+                    .uri(activation.strings())
+                    .unwrap_or_else(|| activation.strings().empty())
             } else {
                 uri.coerce_to_string(activation)?
             };
@@ -54,7 +56,7 @@ pub fn init<'gc>(
             (resulting_prefix, namespace)
         }
         [Value::Object(Object::QNameObject(qname))] => {
-            let uri = qname.uri();
+            let uri = qname.uri(activation.strings());
             let ns = uri.map_or_else(Namespace::any, |uri| {
                 Namespace::package(uri, api_version, activation.strings())
             });
@@ -110,11 +112,11 @@ pub fn get_prefix<'gc>(
 
 /// Implements `Namespace.uri`'s getter
 pub fn get_uri<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_namespace_object().unwrap();
 
-    Ok(this.namespace().as_uri().into())
+    Ok(this.namespace().as_uri(activation.strings()).into())
 }

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -7,7 +7,6 @@ use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Namespace;
-use crate::string::AvmString;
 
 pub use crate::avm2::object::namespace_allocator;
 
@@ -32,7 +31,7 @@ pub fn init<'gc>(
     let (prefix, namespace) = match arguments_list.as_slice() {
         [prefix, uri] => {
             let namespace_uri = if let Value::Object(Object::QNameObject(qname)) = uri {
-                qname.uri().unwrap_or_else(|| AvmString::from(""))
+                qname.uri().unwrap_or_else(|| activation.strings().empty())
             } else {
                 uri.coerce_to_string(activation)?
             };
@@ -46,7 +45,7 @@ pub fn init<'gc>(
                 Some(prefix_str)
             };
             // The only allowed prefix if the uri is empty is the literal empty string
-            if namespace.as_uri().is_empty() && resulting_prefix != Some("".into()) {
+            if namespace_uri.is_empty() && !resulting_prefix.is_some_and(|s| s.is_empty()) {
                 return Err(make_error_1098(activation, &prefix_str));
             }
             if !prefix_str.is_empty() && !is_xml_name(prefix_str) {
@@ -55,30 +54,24 @@ pub fn init<'gc>(
             (resulting_prefix, namespace)
         }
         [Value::Object(Object::QNameObject(qname))] => {
-            let ns = qname
-                .uri()
-                .map(|uri| Namespace::package(uri, api_version, activation.strings()))
-                .unwrap_or_else(Namespace::any);
-            if ns.as_uri().is_empty() {
-                (Some("".into()), ns)
-            } else {
-                (None, ns)
-            }
+            let uri = qname.uri();
+            let ns = uri.map_or_else(Namespace::any, |uri| {
+                Namespace::package(uri, api_version, activation.strings())
+            });
+            let prefix = match uri {
+                Some(name) if !name.is_empty() => None,
+                _ => Some(activation.strings().empty()),
+            };
+            (prefix, ns)
         }
         [Value::Object(Object::NamespaceObject(ns))] => (ns.prefix(), ns.namespace()),
         [val] => {
-            let ns = Namespace::package(
-                val.coerce_to_string(activation)?,
-                api_version,
-                activation.strings(),
-            );
-            if ns.as_uri().is_empty() {
-                (Some("".into()), ns)
-            } else {
-                (None, ns)
-            }
+            let name = val.coerce_to_string(activation)?;
+            let ns = Namespace::package(name, api_version, activation.strings());
+            let prefix = name.is_empty().then(|| activation.strings().empty());
+            (prefix, ns)
         }
-        _ => (Some("".into()), namespaces.public_all()),
+        _ => (Some(activation.strings().empty()), namespaces.public_all()),
     };
 
     this.init_namespace(activation.context.gc_context, namespace);

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -181,7 +181,7 @@ fn value_of<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    this.value_of(activation.context.gc_context)
+    this.value_of(activation.strings())
 }
 
 /// `Object.prototype.hasOwnProperty`

--- a/core/src/avm2/globals/q_name.rs
+++ b/core/src/avm2/globals/q_name.rs
@@ -63,7 +63,7 @@ pub fn init<'gc>(
         let namespace = match ns_arg {
             Value::Object(Object::NamespaceObject(ns)) => Some(ns.namespace()),
             Value::Object(Object::QNameObject(qname)) => qname
-                .uri()
+                .uri(activation.strings())
                 .map(|uri| Namespace::package(uri, ApiVersion::AllVersions, activation.strings())),
             Value::Null => None,
             Value::Undefined => Some(Namespace::package("", api_version, activation.strings())),
@@ -128,12 +128,14 @@ pub fn get_local_name<'gc>(
 
 /// Implements `QName.uri`'s getter
 pub fn get_uri<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this.as_qname_object() {
-        return Ok(this.uri().map(Value::from).unwrap_or(Value::Null));
+        return Ok(this
+            .uri(activation.strings())
+            .map_or_else(|| Value::Null, Value::from));
     }
 
     Ok(Value::Undefined)
@@ -146,7 +148,7 @@ pub fn to_string<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this.as_qname_object() {
-        return Ok(this.name().as_uri(activation.context.gc_context).into());
+        return Ok(this.name().as_uri(activation.strings()).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/q_name.rs
+++ b/core/src/avm2/globals/q_name.rs
@@ -55,7 +55,7 @@ pub fn init<'gc>(
         let mut local_arg = arguments_list[1];
 
         if matches!(local_arg, Value::Undefined) {
-            local_arg = "".into();
+            local_arg = activation.strings().empty().into();
         }
 
         let api_version = activation.avm2().root_api_version;
@@ -92,7 +92,7 @@ pub fn init<'gc>(
         }
 
         let local = if qname_arg == Value::Undefined {
-            "".into()
+            activation.strings().empty()
         } else {
             qname_arg.coerce_to_string(activation)?
         };

--- a/core/src/avm2/globals/reg_exp.rs
+++ b/core/src/avm2/globals/reg_exp.rs
@@ -18,7 +18,7 @@ pub fn init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mut regexp) = this.as_regexp_mut(activation.context.gc_context) {
         let source: AvmString<'gc> = match args.get(0) {
-            Some(Value::Undefined) => "".into(),
+            Some(Value::Undefined) => activation.strings().empty(),
             Some(Value::Object(Object::RegExpObject(o))) => {
                 if !matches!(args.get(1), Some(Value::Undefined)) {
                     return Err(Error::AvmError(type_error(
@@ -32,18 +32,15 @@ pub fn init<'gc>(
                 regexp.set_flags(other.flags());
                 return Ok(Value::Undefined);
             }
-            arg => arg
-                .unwrap_or(&Value::String("".into()))
-                .coerce_to_string(activation)?,
+            Some(arg) => arg.coerce_to_string(activation)?,
+            None => activation.strings().empty(),
         };
 
         regexp.set_source(source);
 
         let flag_chars = match args.get(1) {
-            Some(Value::Undefined) => "".into(),
-            arg => arg
-                .unwrap_or(&Value::String("".into()))
-                .coerce_to_string(activation)?,
+            None | Some(Value::Undefined) => activation.strings().empty(),
+            Some(arg) => arg.coerce_to_string(activation)?,
         };
 
         let mut flags = RegExpFlags::empty();

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -103,7 +103,7 @@ fn length<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Value::String(s) = this.value_of(activation.context.gc_context)? {
+    if let Value::String(s) = this.value_of(activation.strings())? {
         return Ok(s.len().into());
     }
 
@@ -116,7 +116,7 @@ fn char_at<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Value::String(s) = this.value_of(activation.context.gc_context)? {
+    if let Value::String(s) = this.value_of(activation.strings())? {
         // This function takes Number, so if we use coerce_to_i32 instead of coerce_to_number, the value may overflow.
         let n = args
             .get(0)
@@ -144,7 +144,7 @@ fn char_code_at<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Value::String(s) = this.value_of(activation.context.gc_context)? {
+    if let Value::String(s) = this.value_of(activation.strings())? {
         // This function takes Number, so if we use coerce_to_i32 instead of coerce_to_number, the value may overflow.
         let n = args
             .get(0)
@@ -634,7 +634,7 @@ fn value_of<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    this.value_of(activation.context.gc_context)
+    this.value_of(activation.strings())
 }
 
 /// Implements `String.toUpperCase`

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -143,7 +143,7 @@ pub fn set_name<'gc>(
 
     let name = match args.get_value(0) {
         // 2. If (Type(name) is Object) and (name.[[Class]] == "QName") and (name.uri == null)
-        Value::Object(Object::QNameObject(qname)) if qname.uri().is_none() => {
+        Value::Object(Object::QNameObject(qname)) if qname.is_any_namespace() => {
             // a. Let name = name.localName
             qname.local_name().into()
         }
@@ -171,7 +171,7 @@ pub fn set_name<'gc>(
         None
     } else {
         new_name
-            .uri()
+            .uri(activation.strings())
             .filter(|uri| !uri.is_empty())
             .map(E4XNamespace::new_uri)
     };
@@ -272,7 +272,7 @@ pub fn add_namespace<'gc>(
         activation.gc(),
         E4XNamespace {
             prefix: ns.prefix(),
-            uri: ns.namespace().as_uri(),
+            uri: ns.namespace().as_uri(activation.strings()),
         },
     );
 
@@ -311,7 +311,7 @@ pub fn set_namespace<'gc>(
         .unwrap();
     let ns = E4XNamespace {
         prefix: ns.prefix(),
-        uri: ns.namespace().as_uri(),
+        uri: ns.namespace().as_uri(activation.strings()),
     };
 
     // 3. Let x.[[Name]] be a new QName created as if by calling the constructor new QName(ns2, x.[[Name]])
@@ -360,7 +360,7 @@ pub fn remove_namespace<'gc>(
         .unwrap();
     let ns = E4XNamespace {
         prefix: ns.prefix(),
-        uri: ns.namespace().as_uri(),
+        uri: ns.namespace().as_uri(activation.strings()),
     };
 
     // 3. Let thisNS be the result of calling [[GetNamespace]] on x.[[Name]] with argument x.[[InScopeNamespaces]]

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -405,7 +405,7 @@ impl<'gc> Multiname<'gc> {
 
     pub fn explicit_namespace(&self) -> Option<AvmString<'gc>> {
         match self.ns {
-            NamespaceSet::Single(ns) if ns.is_namespace() && !ns.is_public() => Some(ns.as_uri()),
+            NamespaceSet::Single(ns) if ns.is_namespace() && !ns.is_public() => ns.as_uri_opt(),
             _ => None,
         }
     }
@@ -444,9 +444,9 @@ impl<'gc> Multiname<'gc> {
     pub fn to_qualified_name(&self, mc: &Mutation<'gc>) -> AvmString<'gc> {
         let mut uri = WString::new();
         let ns = match self.ns.get(0).filter(|_| self.ns.len() == 1) {
-            Some(ns) if ns.is_any() => "*".into(),
-            Some(ns) => ns.as_uri(),
-            None => "".into(),
+            Some(ns) if ns.is_any() => WStr::from_units(b"*"),
+            Some(ns) => ns.as_uri_opt().map(|uri| uri.as_wstr()).unwrap_or_default(),
+            None => WStr::empty(),
         };
 
         uri.push_str(&ns);
@@ -454,6 +454,9 @@ impl<'gc> Multiname<'gc> {
         if let Some(name) = self.name {
             if !uri.is_empty() {
                 uri.push_str(WStr::from_units(b"::"));
+            } else if self.param.is_none() {
+                // Special-case this to avoid allocating.
+                return name;
             }
             uri.push_str(&name);
         } else {
@@ -485,26 +488,27 @@ impl<'gc> Multiname<'gc> {
 
     // note: I didn't look very deeply into how different exactly this should be
     // this is currently generally based on to_qualified_name, without params and leading ::
-    pub fn as_uri(&self, mc: &Mutation<'gc>) -> AvmString<'gc> {
-        let mut uri = WString::new();
+    pub fn as_uri(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         let ns = match self.ns.get(0).filter(|_| self.ns.len() == 1) {
-            Some(ns) if ns.is_any() => "*".into(),
-            Some(ns) => ns.as_uri(),
-            None => "".into(),
+            Some(ns) if ns.is_any() => WStr::from_units(b"*"),
+            Some(ns) => ns.as_uri(context).as_wstr(),
+            None => WStr::empty(),
         };
 
-        if !ns.is_empty() {
-            uri.push_str(&ns);
-            uri.push_str(WStr::from_units(b"::"));
-        }
-
-        if let Some(name) = self.name {
-            uri.push_str(&name);
+        if ns.is_empty() {
+            // Special-case this to avoid allocating.
+            self.name.unwrap_or_else(|| context.ascii_char(b'*'))
         } else {
-            uri.push_str(WStr::from_units(b"*"));
+            let mut uri = WString::new();
+            uri.push_str(ns);
+            uri.push_str(WStr::from_units(b"::"));
+            uri.push_str(
+                self.name
+                    .as_deref()
+                    .unwrap_or_else(|| WStr::from_units(b"*")),
+            );
+            AvmString::new(context.gc(), uri)
         }
-
-        AvmString::new(mc, uri)
     }
 
     pub fn set_ns(&mut self, ns: NamespaceSet<'gc>) {

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -449,7 +449,7 @@ impl<'gc> Multiname<'gc> {
             None => WStr::empty(),
         };
 
-        uri.push_str(&ns);
+        uri.push_str(ns);
 
         if let Some(name) = self.name {
             if !uri.is_empty() {

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -281,8 +281,8 @@ impl<'gc> Namespace<'gc> {
     /// Get the string value of this namespace, ignoring its type.
     ///
     /// TODO: Is this *actually* the namespace URI?
-    pub fn as_uri(&self) -> AvmString<'gc> {
-        self.as_uri_opt().unwrap_or_else(|| "".into())
+    pub fn as_uri(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
+        self.as_uri_opt().unwrap_or_else(|| context.empty())
     }
 
     /// Compares two namespaces, requiring that their versions match exactly.

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -20,7 +20,7 @@ use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::display_object::DisplayObject;
 use crate::html::TextFormat;
 use crate::streams::NetStream;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, Gc, Mutation};
 use ruffle_macros::enum_trait_object;
 use std::cell::{Ref, RefMut};
@@ -990,7 +990,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     ///
     /// The default implementation wraps the object in a `Value`, using the
     /// `Into<Object<'gc>>` implementation.
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
+    fn value_of(&self, _context: &mut StringContext<'gc>) -> Result<Value<'gc>, Error<'gc>> {
         Ok(Value::Object((*self).into()))
     }
 

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -987,7 +987,12 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     ///
     /// `valueOf` is a method used to request an object be coerced to a
     /// primitive value. Typically, this would be a number of some kind.
-    fn value_of(&self, mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>>;
+    ///
+    /// The default implementation wraps the object in a `Value`, using the
+    /// `Into<Object<'gc>>` implementation.
+    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
+        Ok(Value::Object((*self).into()))
+    }
 
     /// Determine if this object is an instance of a given type.
     ///

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -261,10 +261,6 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
             || self.base().property_is_enumerable(name)
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
-    }
-
     fn as_array_object(&self) -> Option<ArrayObject<'gc>> {
         Some(*self)
     }

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -3,7 +3,6 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use core::fmt;
@@ -113,10 +112,6 @@ impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_bitmap_data(&self) -> Option<BitmapDataWrapper<'gc>> {

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -7,7 +7,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::character::Character;
 use core::fmt;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use std::cell::{Ref, RefCell, RefMut};
 
 /// A class instance allocator that allocates ByteArray objects.
@@ -219,10 +219,6 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
         }
 
         self.base().has_own_property(name)
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_bytearray(&self) -> Option<Ref<ByteArrayStorage>> {

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -426,7 +426,7 @@ impl<'gc> ClassObject<'gc> {
     ) -> Result<Value<'gc>, Error<'gc>> {
         let property = self.instance_vtable().get_trait(multiname);
         if property.is_none() {
-            let qualified_multiname_name = multiname.as_uri(activation.context.gc_context);
+            let qualified_multiname_name = multiname.as_uri(activation.strings());
             let qualified_class_name = self
                 .inner_class_definition()
                 .name()

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -752,10 +752,6 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         self.to_string(activation)
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
-    }
-
     fn call(
         self,
         _receiver: Value<'gc>,

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -8,7 +8,7 @@ use crate::avm2::Error;
 use crate::avm2_stub_method;
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::context::RenderContext;
-use gc_arena::{Collect, Gc, GcCell, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcCell, GcWeak};
 use ruffle_render::backend::{
     BufferUsage, Context3D, Context3DBlendFactor, Context3DCommand, Context3DCompareMode,
     Context3DTextureFormat, Context3DTriangleFace, Context3DVertexBufferFormat, ProgramType,
@@ -505,10 +505,6 @@ impl<'gc> TObject<'gc> for Context3DObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_context_3d(&self) -> Option<Context3DObject<'gc>> {

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -3,9 +3,10 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::{Hint, Value};
 use crate::avm2::Error;
+use crate::string::StringContext;
 use chrono::{DateTime, Utc};
 use core::fmt;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use std::cell::Cell;
 
 /// A class instance allocator that allocates Date objects.
@@ -96,7 +97,7 @@ impl<'gc> TObject<'gc> for DateObject<'gc> {
         Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
+    fn value_of(&self, _context: &mut StringContext<'gc>) -> Result<Value<'gc>, Error<'gc>> {
         if let Some(date) = self.date_time() {
             Ok((date.timestamp_millis() as f64).into())
         } else {

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -104,10 +104,6 @@ impl<'gc> TObject<'gc> for DictionaryObject<'gc> {
         Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Object::from(*self).into())
-    }
-
     fn as_dictionary_object(self) -> Option<DictionaryObject<'gc>> {
         Some(self)
     }

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -6,6 +6,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::string::StringContext;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
@@ -104,7 +105,7 @@ impl<'gc> TObject<'gc> for DispatchObject<'gc> {
         Err("Cannot construct internal event dispatcher structures.".into())
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
+    fn value_of(&self, _context: &mut StringContext<'gc>) -> Result<Value<'gc>, Error<'gc>> {
         Err("Cannot subclass internal event dispatcher structures.".into())
     }
 

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -4,7 +4,6 @@ use crate::avm2::activation::Activation;
 use crate::avm2::domain::Domain;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
 use core::fmt;
 use gc_arena::barrier::unlock;
@@ -108,11 +107,5 @@ impl<'gc> TObject<'gc> for DomainObject<'gc> {
 
     fn init_application_domain(&self, mc: &Mutation<'gc>, domain: Domain<'gc>) {
         unlock!(Gc::write(mc, self.0), DomainObjectData, domain).set(domain);
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        let this: Object<'gc> = Object::DomainObject(*self);
-
-        Ok(this.into())
     }
 }

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -8,7 +8,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::WString;
 use core::fmt;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use std::fmt::Debug;
 use tracing::{enabled, Level};
 
@@ -127,10 +127,6 @@ impl<'gc> TObject<'gc> for ErrorObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_error_object(&self) -> Option<ErrorObject<'gc>> {

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -359,10 +359,6 @@ impl<'gc> TObject<'gc> for EventObject<'gc> {
         Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object((*self).into()))
-    }
-
     fn as_event(&self) -> Option<Ref<Event<'gc>>> {
         Some(self.0.event.borrow())
     }

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -27,7 +27,7 @@ pub fn event_allocator<'gc>(
         activation.context.gc_context,
         EventObjectData {
             base,
-            event: RefLock::new(Event::new("")),
+            event: RefLock::new(Event::new(activation.strings().empty())),
         },
     ))
     .into())

--- a/core/src/avm2/object/file_reference_object.rs
+++ b/core/src/avm2/object/file_reference_object.rs
@@ -1,10 +1,9 @@
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::{Activation, Error};
 use crate::backend::ui::FileDialogResult;
+use gc_arena::GcWeak;
 use gc_arena::{Collect, Gc};
-use gc_arena::{GcWeak, Mutation};
 use std::cell::{Cell, Ref, RefCell};
 use std::fmt;
 
@@ -44,10 +43,6 @@ impl<'gc> TObject<'gc> for FileReferenceObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_file_reference(&self) -> Option<FileReferenceObject<'gc>> {

--- a/core/src/avm2/object/font_object.rs
+++ b/core/src/avm2/object/font_object.rs
@@ -1,6 +1,5 @@
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::{Activation, ClassObject, Error};
 use crate::character::Character;
 use crate::font::Font;
@@ -73,10 +72,6 @@ impl<'gc> TObject<'gc> for FontObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_font(&self) -> Option<Font<'gc>> {

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -186,10 +186,6 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         self.to_string(activation)
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
-    }
-
     fn as_executable(&self) -> Option<Ref<BoundMethod<'gc>>> {
         Some(self.0.exec.borrow())
     }

--- a/core/src/avm2/object/index_buffer_3d_object.rs
+++ b/core/src/avm2/object/index_buffer_3d_object.rs
@@ -3,9 +3,8 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::backend::IndexBuffer;
 use std::cell::{Cell, RefCell, RefMut};
 
@@ -90,10 +89,6 @@ impl<'gc> TObject<'gc> for IndexBuffer3DObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_index_buffer(&self) -> Option<IndexBuffer3DObject<'gc>> {

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -4,7 +4,6 @@ use crate::avm2::activation::Activation;
 use crate::avm2::error::argument_error;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, StageObject, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Avm2;
 use crate::avm2::Error;
 use crate::avm2::EventObject;
@@ -409,10 +408,6 @@ impl<'gc> TObject<'gc> for LoaderInfoObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object((*self).into()))
     }
 
     fn as_loader_info_object(&self) -> Option<&LoaderInfoObject<'gc>> {

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -9,7 +9,7 @@ use crate::local_connection::{LocalConnectionHandle, LocalConnections};
 use crate::string::AvmString;
 use core::fmt;
 use flash_lso::types::Value as AmfValue;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use std::cell::RefCell;
 
 /// A class instance allocator that allocates LocalConnection objects.
@@ -159,10 +159,6 @@ impl<'gc> TObject<'gc> for LocalConnectionObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object((*self).into()))
     }
 
     fn as_local_connection_object(&self) -> Option<LocalConnectionObject<'gc>> {

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -6,7 +6,7 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Namespace;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::Lock, Collect, Gc, GcWeak, Mutation};
@@ -123,12 +123,8 @@ impl<'gc> TObject<'gc> for NamespaceObject<'gc> {
         Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        // TODO(moulins): pass in a StringContext so we can call .as_uri() directly.
-        match self.0.namespace.get().as_uri_opt() {
-            Some(uri) => Ok(uri.into()),
-            None => Ok("".into()),
-        }
+    fn value_of(&self, context: &mut StringContext<'gc>) -> Result<Value<'gc>, Error<'gc>> {
+        Ok(self.0.namespace.get().as_uri(context).into())
     }
 
     fn as_namespace(&self) -> Option<Namespace<'gc>> {

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -25,7 +25,7 @@ pub fn namespace_allocator<'gc>(
             base,
             namespace: Lock::new(namespace),
             prefix: Lock::new(if namespace.as_uri().is_empty() {
-                Some("".into())
+                Some(activation.strings().empty())
             } else {
                 None
             }),
@@ -85,7 +85,7 @@ impl<'gc> NamespaceObject<'gc> {
                 base,
                 namespace: Lock::new(namespace),
                 prefix: Lock::new(if namespace.as_uri().is_empty() {
-                    Some("".into())
+                    Some(activation.strings().empty())
                 } else {
                     None
                 }),

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -3,10 +3,9 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::net_connection::NetConnectionHandle;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use std::cell::Cell;
 use std::fmt;
 use std::fmt::Debug;
@@ -61,10 +60,6 @@ impl<'gc> TObject<'gc> for NetConnectionObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_net_connection(self) -> Option<NetConnectionObject<'gc>> {

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -3,10 +3,9 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::streams::NetStream;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use std::fmt::Debug;
 
 pub fn netstream_allocator<'gc>(
@@ -61,10 +60,6 @@ impl<'gc> TObject<'gc> for NetStreamObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object((*self).into()))
     }
 
     fn as_netstream(self) -> Option<NetStream<'gc>> {

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -8,7 +8,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::string::AvmString;
+use crate::string::{AvmString, StringContext};
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
 
@@ -142,7 +142,7 @@ impl<'gc> TObject<'gc> for PrimitiveObject<'gc> {
         }
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
+    fn value_of(&self, _context: &mut StringContext<'gc>) -> Result<Value<'gc>, Error<'gc>> {
         Ok(*self.0.primitive.borrow())
     }
 

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -3,9 +3,8 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::backend::ShaderModule;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -80,10 +79,6 @@ impl<'gc> TObject<'gc> for Program3DObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_program_3d(&self) -> Option<Program3DObject<'gc>> {

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -8,7 +8,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
 use core::fmt;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 
 /// A class instance allocator that allocates Proxy objects.
 pub fn proxy_allocator<'gc>(
@@ -63,10 +63,6 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Object::from(*self).into())
     }
 
     fn get_property_local(

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -151,10 +151,6 @@ impl<'gc> TObject<'gc> for QNameObject<'gc> {
         Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
-    }
-
     fn as_qname_object(self) -> Option<QNameObject<'gc>> {
         Some(self)
     }

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -171,12 +171,15 @@ impl<'gc> TObject<'gc> for QNameObject<'gc> {
     fn get_enumerant_value(
         self,
         index: u32,
-        _activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         // NOTE: Weird avmplus behavior, get_enumerant_name returns uri first, but get_enumerant_value returns localName first.
         Ok(match index {
             1 => self.local_name().into(),
-            2 => self.uri().map(Into::into).unwrap_or("".into()),
+            2 => self
+                .uri()
+                .unwrap_or_else(|| activation.strings().empty())
+                .into(),
             _ => Value::Undefined,
         })
     }

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -23,7 +23,7 @@ pub fn reg_exp_allocator<'gc>(
         activation.context.gc_context,
         RegExpObjectData {
             base,
-            regexp: RefLock::new(RegExp::new("")),
+            regexp: RefLock::new(RegExp::new(activation.strings().empty())),
         },
     ))
     .into())

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -6,7 +6,7 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::regexp::{RegExp, RegExpFlags};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::string::{AvmString, WString};
+use crate::string::{AvmString, StringContext, WString};
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
@@ -95,7 +95,7 @@ impl<'gc> TObject<'gc> for RegExpObject<'gc> {
         Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
-    fn value_of(&self, mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
+    fn value_of(&self, context: &mut StringContext<'gc>) -> Result<Value<'gc>, Error<'gc>> {
         let regexp = self.0.regexp.borrow();
         let mut s = WString::new();
         s.push_byte(b'/');
@@ -120,7 +120,7 @@ impl<'gc> TObject<'gc> for RegExpObject<'gc> {
             s.push_byte(b'x');
         }
 
-        Ok(AvmString::new(mc, s).into())
+        Ok(AvmString::new(context.gc(), s).into())
     }
 
     /// Unwrap this object as a regexp.

--- a/core/src/avm2/object/responder_object.rs
+++ b/core/src/avm2/object/responder_object.rs
@@ -1,6 +1,5 @@
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, FunctionObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::{Activation, Error};
 use crate::context::UpdateContext;
 use crate::net_connection::ResponderCallback;
@@ -46,10 +45,6 @@ impl<'gc> TObject<'gc> for ResponderObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object((*self).into()))
     }
 
     fn as_responder(self) -> Option<ResponderObject<'gc>> {

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -73,10 +73,6 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
     }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
-    }
 }
 
 fn maybe_int_property(name: AvmString<'_>) -> DynamicKey<'_> {

--- a/core/src/avm2/object/shader_data_object.rs
+++ b/core/src/avm2/object/shader_data_object.rs
@@ -3,10 +3,9 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
 use core::fmt;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::pixel_bender::PixelBenderShaderHandle;
 use std::cell::Cell;
 
@@ -79,10 +78,6 @@ impl<'gc> TObject<'gc> for ShaderDataObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_shader_data(&self) -> Option<ShaderDataObject<'gc>> {

--- a/core/src/avm2/object/socket_object.rs
+++ b/core/src/avm2/object/socket_object.rs
@@ -1,11 +1,10 @@
 use crate::avm2::bytearray::{ByteArrayError, Endian, ObjectEncoding};
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::{Activation, Error};
 use crate::socket::SocketHandle;
+use gc_arena::GcWeak;
 use gc_arena::{Collect, Gc};
-use gc_arena::{GcWeak, Mutation};
 use std::cell::{Cell, RefCell, RefMut};
 use std::fmt;
 
@@ -51,10 +50,6 @@ impl<'gc> TObject<'gc> for SocketObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_socket(&self) -> Option<SocketObject<'gc>> {

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -3,7 +3,6 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Avm2;
 use crate::avm2::Error;
 use crate::avm2::EventObject;
@@ -296,10 +295,6 @@ impl<'gc> TObject<'gc> for SoundObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Object::from(*self).into())
     }
 
     fn as_sound_object(self) -> Option<SoundObject<'gc>> {

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -9,7 +9,7 @@ use crate::backend::audio::SoundInstanceHandle;
 use crate::context::UpdateContext;
 use crate::display_object::SoundTransform;
 use core::fmt;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use std::cell::{Cell, RefCell};
 
 /// A class instance allocator that allocates SoundChannel objects.
@@ -215,10 +215,6 @@ impl<'gc> TObject<'gc> for SoundChannelObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Object::from(*self).into())
     }
 
     fn as_sound_channel(self) -> Option<SoundChannelObject<'gc>> {

--- a/core/src/avm2/object/stage3d_object.rs
+++ b/core/src/avm2/object/stage3d_object.rs
@@ -3,7 +3,6 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
 use core::fmt;
 use gc_arena::barrier::unlock;
@@ -89,10 +88,6 @@ impl<'gc> TObject<'gc> for Stage3DObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_stage_3d(&self) -> Option<Stage3DObject<'gc>> {

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -2,11 +2,11 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::DisplayObject;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use std::fmt::Debug;
 
 #[derive(Clone, Collect, Copy)]
@@ -126,10 +126,6 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
 
     fn as_display_object(&self) -> Option<DisplayObject<'gc>> {
         Some(self.0.display_object)
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 }
 

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -3,11 +3,10 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::html::{TextDisplay, TextFormat};
 use core::fmt;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use std::cell::{Ref, RefCell, RefMut};
 
 /// A class instance allocator that allocates TextFormat objects.
@@ -90,10 +89,6 @@ impl<'gc> TObject<'gc> for TextFormatObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     /// Unwrap this object as a text format.

--- a/core/src/avm2/object/texture_object.rs
+++ b/core/src/avm2/object/texture_object.rs
@@ -3,9 +3,8 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::backend::{Context3DTextureFormat, Texture};
 use std::rc::Rc;
 
@@ -87,10 +86,6 @@ impl<'gc> TObject<'gc> for TextureObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_texture(&self) -> Option<TextureObject<'gc>> {

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -239,10 +239,6 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         }
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
-    }
-
     fn as_vector_storage(&self) -> Option<Ref<VectorStorage<'gc>>> {
         Some(self.0.vector.borrow())
     }

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -3,9 +3,8 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::backend::VertexBuffer;
 use std::rc::Rc;
 
@@ -91,10 +90,6 @@ impl<'gc> TObject<'gc> for VertexBuffer3DObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
     }
 
     fn as_vertex_buffer(&self) -> Option<VertexBuffer3DObject<'gc>> {

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -290,8 +290,11 @@ impl<'gc> XmlListObject<'gc> {
                 }
 
                 // 2.e.ii. Call [[Put]] on base with arguments x.[[TargetProperty]] and the empty string
-                base.as_object()
-                    .set_property_local(&target_property, "".into(), activation)?;
+                base.as_object().set_property_local(
+                    &target_property,
+                    activation.strings().empty().into(),
+                    activation,
+                )?;
 
                 // 2.e.iii. Let target be the result of calling [[Get]] on base with argument x.[[TargetProperty]]
                 return base.get_property_local(&target_property, activation);
@@ -724,7 +727,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                                     activation.gc(),
                                     x.explicit_namespace().map(E4XNamespace::new_uri),
                                     x.local_name().unwrap(),
-                                    "".into(),
+                                    activation.strings().empty(),
                                     r,
                                 )
                             }
@@ -732,9 +735,9 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                             // 2.c.v.1. Let y.[[Name]] = null
                             // 2.c.v.2. Let y.[[Class]] = "text"
                             Some(x) if x.is_any_name() => {
-                                E4XNode::text(activation.gc(), "".into(), r)
+                                E4XNode::text(activation.gc(), activation.strings().empty(), r)
                             }
-                            None => E4XNode::text(activation.gc(), "".into(), r),
+                            None => E4XNode::text(activation.gc(), activation.strings().empty(), r),
                             // NOTE: avmplus edge case.
                             //       See https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/XMLListObject.cpp#L297-L300
                             _ if value
@@ -744,7 +747,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                                     x.node().is_text() || x.node().is_attribute()
                                 }) =>
                             {
-                                E4XNode::text(activation.gc(), "".into(), r)
+                                E4XNode::text(activation.gc(), activation.strings().empty(), r)
                             }
 
                             // 2.c.vi. Else let y.[[Class]] = "element"

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -487,10 +487,6 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
         Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
-    }
-
     fn as_xml_list_object(&self) -> Option<Self> {
         Some(*self)
     }

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -263,10 +263,6 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
         Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
-    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
-    }
-
     fn as_xml_object(&self) -> Option<Self> {
         Some(*self)
     }

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -228,7 +228,7 @@ impl<'gc> RegExp<'gc> {
                     Some(r) => {
                         AvmString::new(activation.context.gc_context, &txt[r.start..r.end]).into()
                     }
-                    None => "".into(),
+                    None => activation.strings().empty().into(),
                 })
                 .chain(std::iter::once(m.range.start.into()))
                 .chain(std::iter::once((*txt).into()))

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -482,6 +482,11 @@ pub fn capture_specification(context: &mut UpdateContext, output: &Path) {
             .playerglobals_domain
             .get_defined_value(&mut activation, QName::new(namespace, name))
             .expect("Builtins shouldn't error");
+
+        let namespace_uri = namespace.as_uri(activation.strings());
+        let namespace_uri = namespace_uri.to_utf8_lossy();
+        let name = name.to_utf8_lossy();
+
         if let Some(object) = value.as_object() {
             if let Some(class) = object.as_class_object() {
                 let class_name = class
@@ -495,31 +500,22 @@ pub fn capture_specification(context: &mut UpdateContext, output: &Path) {
                     Definition::from_class(class, &mut activation, &class_stubs),
                 );
             } else if let Some(executable) = object.as_executable() {
-                let namespace_stubs =
-                    ClassStubs::for_class(&namespace.as_uri().to_string(), &stubs);
-                let definition = definitions
-                    .entry(namespace.as_uri().to_string())
-                    .or_default();
+                let namespace_stubs = ClassStubs::for_class(&namespace_uri, &stubs);
+                let definition = definitions.entry(namespace_uri.into()).or_default();
                 let instance_traits = definition
                     .instance_traits
                     .get_or_insert_with(Default::default);
-                instance_traits.function.insert(
-                    name.to_string(),
-                    FunctionInfo::from_bound_method(
-                        &executable,
-                        namespace_stubs.has_method(&name.to_string()),
-                    ),
-                );
+                let fn_info =
+                    FunctionInfo::from_bound_method(&executable, namespace_stubs.has_method(&name));
+                instance_traits.function.insert(name.into(), fn_info);
             }
         } else {
-            let definition = definitions
-                .entry(namespace.as_uri().to_string())
-                .or_default();
+            let definition = definitions.entry(namespace_uri.into()).or_default();
             let instance_traits = definition
                 .instance_traits
                 .get_or_insert_with(Default::default);
             instance_traits.constants.insert(
-                name.to_string(),
+                name.into(),
                 VariableInfo::from_value(value, &mut activation),
             );
         }

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -1153,14 +1153,16 @@ impl<'gc> Value<'gc> {
 
             if let Some(self_qname) = obj.as_qname_object() {
                 if let Value::Object(Object::QNameObject(other_qname)) = other {
-                    return Ok(self_qname.uri() == other_qname.uri()
+                    return Ok(self_qname.uri(activation.strings())
+                        == other_qname.uri(activation.strings())
                         && self_qname.local_name() == other_qname.local_name());
                 }
             }
 
             if let Some(self_ns) = obj.as_namespace_object() {
                 if let Value::Object(Object::NamespaceObject(other_ns)) = other {
-                    return Ok(self_ns.namespace().as_uri() == other_ns.namespace().as_uri());
+                    return Ok(self_ns.namespace().as_uri(activation.strings())
+                        == other_ns.namespace().as_uri(activation.strings()));
                 }
             }
         }

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -1669,7 +1669,7 @@ pub fn set_vector<'gc>(
             let color = iter
                 .next()
                 .expect("BitmapData.setVector: Expected element")
-                .as_u32(activation.context.gc_context)
+                .as_u32(activation.strings())
                 .expect("BitmapData.setVector: Expected uint vector");
             bitmap_data.set_pixel32_raw(
                 x,

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -240,7 +240,8 @@ impl Avm2ObjectWindow {
                 let name = definition.name();
 
                 ui.label("Namespace");
-                ui.text_edit_singleline(&mut name.namespace().as_uri().to_string().as_str());
+                let namespace = name.namespace().as_uri(activation.strings());
+                ui.text_edit_singleline(&mut namespace.to_string().as_str());
                 ui.end_row();
 
                 ui.label("Name");
@@ -370,7 +371,10 @@ impl Avm2ObjectWindow {
                 });
             }
             Property::Virtual { get: Some(get), .. } => {
-                let key = (ns.as_uri().to_string(), name.to_string());
+                let key = (
+                    ns.as_uri(activation.strings()).to_string(),
+                    name.to_string(),
+                );
                 body.row(18.0, |mut row| {
                     label_col(&mut row);
                     row.col(|ui| {

--- a/core/src/string/avm_string.rs
+++ b/core/src/string/avm_string.rs
@@ -89,9 +89,9 @@ impl<'gc> AvmString<'gc> {
         }
     }
 
-    pub fn as_wstr(&self) -> &WStr {
-        match &self.source {
-            Source::Managed(s) => s,
+    pub fn as_wstr(&self) -> &'gc WStr {
+        match self.source {
+            Source::Managed(s) => Gc::as_ref(s).as_wstr(),
             Source::Static(s) => s,
         }
     }

--- a/core/src/xml/tree.rs
+++ b/core/src/xml/tree.rs
@@ -3,7 +3,7 @@
 use crate::avm1::Attribute;
 use crate::avm1::{Activation, NativeObject};
 use crate::avm1::{ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::string::{AvmString, WStr, WString};
+use crate::string::{AvmString, StringContext, WStr, WString};
 use crate::xml;
 use gc_arena::{Collect, GcCell, Mutation};
 use quick_xml::escape::escape;
@@ -282,10 +282,10 @@ impl<'gc> XmlNode<'gc> {
         })
     }
 
-    pub fn prefix(self, gc_context: &Mutation<'gc>) -> Option<AvmString<'gc>> {
+    pub fn prefix(self, context: &mut StringContext<'gc>) -> Option<AvmString<'gc>> {
         self.node_name().map(|name| match name.find(b':') {
-            Some(i) if i + 1 < name.len() => AvmString::new(gc_context, &name[..i]),
-            _ => "".into(),
+            Some(i) if i + 1 < name.len() => AvmString::new(context.gc(), &name[..i]),
+            _ => context.empty(),
         })
     }
 


### PR DESCRIPTION
Some more progress towards removing `'static` strings.

This mostly involves passing a `&StringContext` in a few more places, together with some local refactors to make the borrow-checker happy.

Notable changes:
- `avm2::TObject::value_of` now takes a `&StringContext`, and has a default impl that returns `self` as a `Value`;
- `Namespace::as_uri` takes a `&StringContext` too, in some cases I rewrote the calling logic to use `as_uri_opt` instead.