### PR TITLE
extension: Set responseHeadersUnsupported to false explicitly

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -146,6 +146,7 @@ async function enableSWFTakeover() {
                 addRules: rules,
             });
         }
+        utils.storage.sync.set({ responseHeadersUnsupported: false });
     } else {
         utils.storage.sync.set({ responseHeadersUnsupported: true });
     }
@@ -156,6 +157,7 @@ async function disableSWFTakeover() {
         await utils.declarativeNetRequest.updateDynamicRules({
             removeRuleIds: [1, 2, 3],
         });
+        utils.storage.sync.set({ responseHeadersUnsupported: false });
     } else {
         utils.storage.sync.set({ responseHeadersUnsupported: true });
     }


### PR DESCRIPTION
I think this is the cause of the issue described here: https://github.com/ruffle-rs/ruffle/discussions/18161#discussioncomment-10846127

I mentioned this briefly on Discord: When you use Ruffle on a browser without support for a responseHeaders RuleCondition that later gets support, Ruffle has already set this value to true. I assumed that we could just default to false if it wasn't set and that would be fine, but then in this situation it just stays true indefinitely.