### PR TITLE
web: Don't set the clipboard when notified about clipboard change

### DIFF
--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -32,6 +32,7 @@ use std::{cell::RefCell, error::Error, num::NonZeroI32};
 use tracing_subscriber::layer::{Layered, SubscriberExt};
 use tracing_subscriber::registry::Registry;
 use tracing_wasm::{WASMLayer, WASMLayerConfigBuilder};
+use ui::WebUiBackend;
 use url::Url;
 use wasm_bindgen::convert::FromWasmAbi;
 use wasm_bindgen::prelude::*;
@@ -379,7 +380,11 @@ impl RuffleHandle {
         if !clipboard.is_empty() {
             let _ = self.with_core_mut(|core| {
                 core.mutate_with_update_context(|context| {
-                    context.ui.set_clipboard_content(clipboard);
+                    context
+                        .ui
+                        .downcast_mut::<WebUiBackend>()
+                        .expect("Web UI backend")
+                        .set_clipboard_content_buffer(clipboard);
                 });
                 core.run_context_menu_callback(index);
             });
@@ -734,7 +739,10 @@ impl RuffleHandle {
                                     } else {
                                         "".into()
                                     };
-                                core.ui_mut().set_clipboard_content(clipboard_content);
+                                core.ui_mut()
+                                    .downcast_mut::<WebUiBackend>()
+                                    .expect("Web UI backend")
+                                    .set_clipboard_content_buffer(clipboard_content);
                                 core.handle_event(PlayerEvent::TextControl {
                                     code: TextControlCode::Paste,
                                 });

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -199,6 +199,10 @@ impl WebUiBackend {
             .set_property("cursor", cursor)
             .warn_on_error();
     }
+
+    pub fn set_clipboard_content_buffer(&mut self, content: String) {
+        self.clipboard_content = content;
+    }
 }
 
 impl UiBackend for WebUiBackend {
@@ -229,7 +233,8 @@ impl UiBackend for WebUiBackend {
     }
 
     fn set_clipboard_content(&mut self, content: String) {
-        self.clipboard_content = content.to_owned();
+        self.set_clipboard_content_buffer(content.to_owned());
+
         // We use `document.execCommand("copy")` as `navigator.clipboard.writeText("string")`
         // is available only in secure contexts (HTTPS).
         if let Some(element) = self.canvas.parent_element() {


### PR DESCRIPTION
This patch introduces `WebUiBackend::set_clipboard_content_buffer` which is able to set the clipboard buffer without also setting the clipboard. This method is then used in places where Ruffle is notified about a paste event, so that it doesn't have to set the clipboard to the same value.

This fixes a borrow checker error during pasting.

This does not (yet) fix the context menu pasting issue.