### PR TITLE
chore: Credit translators properly

### DIFF
--- a/TRANSLATORS
+++ b/TRANSLATORS
@@ -1,0 +1,233 @@
+# In general, Ruffle contributors are credited through the commit history.
+# However, in the case of translations, it is not always possible to identify or properly
+# attribute translators when synchronizing translation updates, especially when they
+# are contributed through third-party services or tools.
+#
+# This file ensures that all translators receive the proper recognition for
+# their valuable contributions to making Ruffle accessible in different languages.
+#
+# Thank you!
+
+# Languages are ordered alphabetically.
+# Contributors are ordered according to the number of words translated.
+
+# Arabic
+اياد (axui77)
+cmdocmd
+Attila Török (torokati44)
+Yasin Ahmed (Yasin_A)
+GD Alex (NumanTF2)
+Amr Shatnawi (WhiteCanvas)
+hussainxd824 (Hussainxd123)
+
+# Catalan
+Joel Puig Rubio (puigru)
+Ігнат Лостюк (Ignatlostuk)
+christopher414
+Attila Török (torokati44)
+FailedShack
+
+# Chinese Simplified
+yangyangdaji
+zjk261
+DemoJameson
+Nathan Adams (Dinnerbone)
+曾国立 (NotthingToSay)
+Kelvin Jia (Misty_Myto)
+Miaomiao Liushui (liushuimiaomiao)
+ZHY (anngg2008)
+SiQian Yao (YaoSiQian)
+Kishin Sagume (kishinsagi)
+i486-DX9
+
+# Chinese Traditional
+p0008874
+Nathan Adams (Dinnerbone)
+ktkk0924
+Miaomiao Liushui (liushuimiaomiao)
+yangyangdaji
+
+# Czech
+Marty_SVK
+FoltinV
+DejVIIK Bob (DejVIIK)
+Attila Török (torokati44)
+Kryštof Černý (panKrysha)
+Ігнат Лостюк (Ignatlostuk)
+christopher414
+Kamil Jarosz (kjarosh)
+
+# Dutch
+Thulinma
+stz33a
+Nathan Adams (Dinnerbone)
+Attila Török (torokati44)
+Flawake
+jonkoops
+
+# French
+Toad06 (Toad_06)
+Nathan Adams (Dinnerbone)
+Attila Török (torokati44)
+Ігнат Лостюк (Ignatlostuk)
+christopher414
+moulins
+gbetous
+Thibault Savenkoff (Thibault-Savenkoff)
+CreaZyp154
+lemangeurdep
+Polo (cy-polo)
+volcanofr
+R7LTIX
+
+# German
+marr killm (mlkkl)
+Valaphee
+Nathan Adams (Dinnerbone)
+raajun
+Attila Török (torokati44)
+Tom Schuster (evilpie)
+Ігнат Лостюк (Ignatlostuk)
+christopher414
+Korne127
+Nareshkumar Rao (naresh97)
+Dennis Paulus (OfficialCRUGG)
+Sven Vater (sevengoku)
+Marty_SVK
+
+# Hebrew
+milki (milki.SWF)
+Attila Török (torokati44)
+
+# Hungarian
+Attila Török (torokati44)
+Nathan Adams (Dinnerbone)
+Pacuka1
+Mózner Csanád (Csani10)
+
+# Indonesian
+AllinolCP
+Attila Török (torokati44)
+Ігнат Лостюк (Ignatlostuk)
+christopher414
+
+# Italian
+StarFang208
+Nathan Adams (Dinnerbone)
+Attila Török (torokati44)
+Ігнат Лостюк (Ignatlostuk)
+Larry84
+Flawake
+
+# Japanese
+稲凪咲 (creeper-0910)
+Re*Index.(ot_inc) (ot_inc)
+Nathan Adams (Dinnerbone)
+Attila Török (torokati44)
+Miaomiao Liushui (liushuimiaomiao)
+haruna (eggplants)
+ZHY (anngg2008)
+Kamil Jarosz (kjarosh)
+
+# Korean
+Jooy (jooy2)
+Nathan Adams (Dinnerbone)
+Attila Török (torokati44)
+여행족 (khdnms)
+
+# Polish
+Kamil Jarosz (kjarosh)
+Johnny (J0hny)
+Andrzej (brov123)
+Wilamaxin
+Attila Török (torokati44)
+Mateusz Naściszewski (Mateon1)
+christopher414
+Ігнат Лостюк (Ignatlostuk)
+
+# Portuguese
+João Frade (100Nome)
+Rage (tHzinnn)
+Fancy2209
+Attila Török (torokati44)
+André Botelho (keyoted)
+
+# Portuguese, Brazilian
+Eduardo Gimenez (Gamedroit)
+Attila Török (torokati44)
+Gabriel Lopes (hiperesp)
+Ігнат Лостюк (Ignatlostuk)
+christopher414
+YNPC 01 (yurrubelike)
+Leonardo Oliveira Reis (Kamina-sama)
+piratabrasileiro1
+
+# Romanian
+Cristian Silaghi (sno_w)
+Ant. Rares (Iepurooy)
+Nathan Adams (Dinnerbone)
+christopher414
+Attila Török (torokati44)
+mujkui
+
+# Russian
+Omegaplex
+Руслан Боровилов (Pycz)
+Nathan Adams (Dinnerbone)
+aivaz
+Attila Török (torokati44)
+makkoar
+saetgar
+DrMavrodi (Mavrodi)
+mtv king (mtv129jo)
+/////// (aeabobikus)
+mofeteus (mofet)
+Prosu Wanted (prosuWANTED) (prosuwanted)
+Anton (onkrot)
+Йцукен Фывин (kr0tek)
+
+# Slovak
+Marty_SVK
+Attila Török (torokati44)
+christopher414
+
+# Spanish
+Robert Setter (sombraguerrero)
+Kolozuz
+Nathan Adams (Dinnerbone)
+inventionpro
+BLUE UNITY SCRATCH (gomgounity)
+Attila Török (torokati44)
+Loader (Load3r)
+Alejandro Marin (alejandromcs61)
+Ander Aguinaga (Laquin)
+CCH (cch_crowdin)
+Kamil Jarosz (kjarosh)
+Joel Puig Rubio (puigru)
+Alfredo Soro (freddyncalm)
+Juan Pablosan (montoyaargudo1234)
+
+# Swedish
+Nathan Adams (Dinnerbone)
+Mx. Menacing (EfraimCreations)
+sunkenxn
+
+# Turkish
+HyDroN78
+Fatih Bakal (fatihbakal7)
+Nathan Adams (Dinnerbone)
+berkanx
+Attila Török (torokati44)
+Sib | Twig (SiB_Twig)
+Ömer Karayakalı (Krykl)
+YumiNee
+Telest
+JuanCaiza
+uqers
+Osman efe Erdoğan (M4kemebunny)
+
+# Ukrainian
+btncua (btnc_ua)
+Oleksandr Kalko (tsunami_state)
+Kamil Jarosz (kjarosh)
+Attila Török (torokati44)


### PR DESCRIPTION
This adds a TRANSLATORS file to acknowledge and credit contributors who provided translations for Ruffle.

Crowdin unfortunately does not allow crediting translators when synchronizing translations (https://github.com/crowdin/github-action/issues/35).