### PR TITLE
chore: Bump `ashpd` to `0.9.2`, deduplicating it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,25 +242,9 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.9.0"
-source = "git+https://github.com/bilelmoussaoui/ashpd.git?rev=34c0ab8f83cd16c3190ecc4cc51021daa531d89b#34c0ab8f83cd16c3190ecc4cc51021daa531d89b"
-dependencies = [
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand",
- "serde",
- "serde_repr",
- "tokio",
- "url",
- "zbus",
-]
-
-[[package]]
-name = "ashpd"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe7e0dd0ac5a401dc116ed9f9119cf9decc625600474cb41f0fc0a0050abc9a"
+checksum = "4d43c03d9e36dd40cab48435be0b09646da362c278223ca535493877b2c1dee9"
 dependencies = [
  "async-fs",
  "async-net",
@@ -4249,7 +4233,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8af382a047821a08aa6bfc09ab0d80ff48d45d8726f7cd8e44891f7cb4a4278e"
 dependencies = [
- "ashpd 0.9.1",
+ "ashpd",
  "block2",
  "js-sys",
  "log",
@@ -4358,7 +4342,7 @@ name = "ruffle_desktop"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ashpd 0.9.0",
+ "ashpd",
  "bytemuck",
  "chrono",
  "clap",
@@ -5475,10 +5459,8 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -6860,7 +6842,6 @@ dependencies = [
  "serde_repr",
  "sha1",
  "static_assertions",
- "tokio",
  "tracing",
  "uds_windows",
  "windows-sys 0.52.0",

--- a/deny.toml
+++ b/deny.toml
@@ -77,8 +77,6 @@ unknown-git = "deny"
 # github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
-    # TODO: Remove once a release with https://github.com/bilelmoussaoui/ashpd/pull/234 in it is out.
-    "bilelmoussaoui",
 ]
 
 [advisories]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -52,7 +52,7 @@ rand = "0.8.5"
 thiserror.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-ashpd = { git = "https://github.com/bilelmoussaoui/ashpd.git", rev = "34c0ab8f83cd16c3190ecc4cc51021daa531d89b" }
+ashpd = "0.9.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"


### PR DESCRIPTION
See:

https://github.com/bilelmoussaoui/ashpd/pull/240
https://github.com/bilelmoussaoui/ashpd/releases/tag/0.9.2

Thanks for you patches, @kjarosh!