### PR TITLE
core: Clean up ExternalInterface a little

### DIFF
--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -57,19 +57,17 @@ pub fn call<'gc>(
         return Ok(Value::Null);
     }
 
-    let (name, external_args_len) = if let Some(method_name) = args.get(0) {
-        (*method_name, args.len() - 1)
-    } else {
-        (Value::Undefined, 0)
-    };
-    let name = name.coerce_to_string(activation)?;
+    let name = args
+        .get(0)
+        .unwrap_or(&Value::Undefined)
+        .coerce_to_string(activation)?;
 
-    let mut external_args = Vec::with_capacity(external_args_len);
-    if external_args_len > 0 {
-        for arg in &args[1..] {
-            external_args.push(ExternalValue::from_avm1(activation, arg.to_owned())?);
-        }
-    }
+    let external_args = args
+        .iter()
+        .skip(1)
+        .map(|arg| ExternalValue::from_avm1(activation, arg.to_owned()))
+        .collect::<Result<Vec<ExternalValue>, Error<'gc>>>()?;
+
     Ok(
         ExternalInterface::call_method(activation.context, &name.to_utf8_lossy(), &external_args)
             .into_avm1(activation),

--- a/core/src/avm2/globals/flash/external/external_interface.rs
+++ b/core/src/avm2/globals/flash/external/external_interface.rs
@@ -12,10 +12,12 @@ pub fn call<'gc>(
     let name = args.get_string(activation, 0)?;
     check_available(activation)?;
 
-    let mut external_args = Vec::with_capacity(args.len() - 1);
-    for arg in &args[1..] {
-        external_args.push(ExternalValue::from_avm2(arg.to_owned()));
-    }
+    let external_args = args
+        .iter()
+        .skip(1)
+        .map(|arg| ExternalValue::from_avm2(arg.to_owned()))
+        .collect::<Vec<ExternalValue>>();
+
     Ok(
         ExternalInterface::call_method(activation.context, &name.to_utf8_lossy(), &external_args)
             .into_avm2(activation),

--- a/core/src/avm2/globals/flash/external/external_interface.rs
+++ b/core/src/avm2/globals/flash/external/external_interface.rs
@@ -65,7 +65,7 @@ pub fn get_object_id<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(id) = activation.context.external_interface.any_id() {
+    if let Some(id) = activation.context.external_interface.get_id() {
         Ok(AvmString::new_utf8(activation.gc(), id).into())
     } else {
         Ok(Value::Null)

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -393,7 +393,7 @@ impl<'gc> ExternalInterface<'gc> {
         self.provider.is_some()
     }
 
-    pub fn any_id(&self) -> Option<String> {
+    pub fn get_id(&self) -> Option<String> {
         self.provider.as_ref().and_then(|p| p.get_id())
     }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2325,9 +2325,12 @@ impl Player {
         self.mutate_with_update_context(|context| context.avm1.has_mouse_listener())
     }
 
-    pub fn add_external_interface(&mut self, provider: Box<dyn ExternalInterfaceProvider>) {
+    pub fn set_external_interface_provider(
+        &mut self,
+        provider: Option<Box<dyn ExternalInterfaceProvider>>,
+    ) {
         self.mutate_with_update_context(|context| {
-            context.external_interface.add_provider(provider)
+            context.external_interface.set_provider(provider)
         });
     }
 
@@ -2424,7 +2427,7 @@ pub struct PlayerBuilder {
     quality: StageQuality,
     page_url: Option<String>,
     frame_rate: Option<f64>,
-    external_interface_providers: Vec<Box<dyn ExternalInterfaceProvider>>,
+    external_interface_provider: Option<Box<dyn ExternalInterfaceProvider>>,
     fs_command_provider: Box<dyn FsCommandProvider>,
     #[cfg(feature = "known_stubs")]
     stub_report_output: Option<std::path::PathBuf>,
@@ -2475,7 +2478,7 @@ impl PlayerBuilder {
             quality: StageQuality::High,
             page_url: None,
             frame_rate: None,
-            external_interface_providers: vec![],
+            external_interface_provider: None,
             fs_command_provider: Box::new(NullFsCommandProvider),
             #[cfg(feature = "known_stubs")]
             stub_report_output: None,
@@ -2660,7 +2663,7 @@ impl PlayerBuilder {
 
     /// Adds an External Interface provider for movies to communicate with
     pub fn with_external_interface(mut self, provider: Box<dyn ExternalInterfaceProvider>) -> Self {
-        self.external_interface_providers.push(provider);
+        self.external_interface_provider = Some(provider);
         self
     }
 
@@ -2694,7 +2697,7 @@ impl PlayerBuilder {
         player_runtime: PlayerRuntime,
         fullscreen: bool,
         fake_movie: Arc<SwfMovie>,
-        external_interface_providers: Vec<Box<dyn ExternalInterfaceProvider>>,
+        external_interface_provider: Option<Box<dyn ExternalInterfaceProvider>>,
         fs_command_provider: Box<dyn FsCommandProvider>,
     ) -> GcRoot<'gc> {
         let mut interner = AvmStringInterner::new(gc_context);
@@ -2718,7 +2721,7 @@ impl PlayerBuilder {
             current_context_menu: None,
             drag_object: None,
             external_interface: ExternalInterface::new(
-                external_interface_providers,
+                external_interface_provider,
                 fs_command_provider,
             ),
             library: Library::empty(),
@@ -2844,7 +2847,7 @@ impl PlayerBuilder {
                         self.player_runtime,
                         self.fullscreen,
                         fake_movie.clone(),
-                        self.external_interface_providers,
+                        self.external_interface_provider,
                         self.fs_command_provider,
                     )
                 }))),

--- a/desktop/src/backends/external_interface.rs
+++ b/desktop/src/backends/external_interface.rs
@@ -1,19 +1,9 @@
 use ruffle_core::context::UpdateContext;
-use ruffle_core::external::{
-    ExternalInterfaceMethod, ExternalInterfaceProvider, Value as ExternalValue,
-};
+use ruffle_core::external::{ExternalInterfaceProvider, Value as ExternalValue};
 use url::Url;
 
 pub struct DesktopExternalInterfaceProvider {
     pub spoof_url: Option<Url>,
-}
-
-struct FakeLocationHrefToString(Url);
-
-impl ExternalInterfaceMethod for FakeLocationHrefToString {
-    fn call(&self, _context: &mut UpdateContext<'_>, _args: &[ExternalValue]) -> ExternalValue {
-        ExternalValue::String(self.0.to_string())
-    }
 }
 
 fn is_location_href(code: &str) -> bool {
@@ -23,40 +13,37 @@ fn is_location_href(code: &str) -> bool {
     )
 }
 
-struct FakeEval(Option<Url>);
-
-impl ExternalInterfaceMethod for FakeEval {
-    fn call(&self, _context: &mut UpdateContext<'_>, args: &[ExternalValue]) -> ExternalValue {
-        if let Some(ref url) = self.0 {
-            if let [ExternalValue::String(ref code)] = args {
-                if is_location_href(code) {
-                    return ExternalValue::String(url.to_string());
-                }
-            }
-        }
-
-        tracing::warn!("Trying to call eval with ExternalInterface: {args:?}");
-        ExternalValue::Undefined
-    }
-}
-
 impl ExternalInterfaceProvider for DesktopExternalInterfaceProvider {
-    fn get_method(&self, name: &str) -> Option<Box<dyn ExternalInterfaceMethod>> {
+    fn call_method(
+        &self,
+        _context: &mut UpdateContext<'_>,
+        name: &str,
+        args: &[ExternalValue],
+    ) -> ExternalValue {
         if let Some(ref url) = self.spoof_url {
             // Check for e.g. "window.location.href.toString"
             if let Some(name) = name.strip_suffix(".toString") {
                 if is_location_href(name) {
-                    return Some(Box::new(FakeLocationHrefToString(url.clone())));
+                    return url.to_string().into();
                 }
             }
         }
 
         if name == "eval" {
-            return Some(Box::new(FakeEval(self.spoof_url.clone())));
+            if let Some(ref url) = self.spoof_url {
+                if let [ExternalValue::String(ref code)] = args {
+                    if is_location_href(code) {
+                        return ExternalValue::String(url.to_string());
+                    }
+                }
+            }
+
+            tracing::warn!("Trying to call eval with ExternalInterface: {args:?}");
+            return ExternalValue::Undefined;
         }
 
         tracing::warn!("Trying to call unknown ExternalInterface method: {name}");
-        None
+        ExternalValue::Undefined
     }
 
     fn on_callback_available(&self, _name: &str) {}

--- a/tests/tests/external_interface/mod.rs
+++ b/tests/tests/external_interface/mod.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::needless_pass_by_ref_mut)]
 
 use ruffle_core::context::UpdateContext;
-use ruffle_core::external::Value as ExternalValue;
-use ruffle_core::external::{ExternalInterfaceMethod, ExternalInterfaceProvider};
+use ruffle_core::external::ExternalInterfaceProvider;
+use ruffle_core::external::{Value as ExternalValue, Value};
 
 pub mod tests;
 
@@ -41,12 +41,17 @@ fn do_reentry(context: &mut UpdateContext<'_>, _args: &[ExternalValue]) -> Exter
 }
 
 impl ExternalInterfaceProvider for ExternalInterfaceTestProvider {
-    fn get_method(&self, name: &str) -> Option<Box<dyn ExternalInterfaceMethod>> {
+    fn call_method(
+        &self,
+        context: &mut UpdateContext<'_>,
+        name: &str,
+        args: &[ExternalValue],
+    ) -> ExternalValue {
         match name {
-            "trace" => Some(Box::new(do_trace)),
-            "ping" => Some(Box::new(do_ping)),
-            "reentry" => Some(Box::new(do_reentry)),
-            _ => None,
+            "trace" => do_trace(context, args),
+            "ping" => do_ping(context, args),
+            "reentry" => do_reentry(context, args),
+            _ => Value::Null,
         }
     }
 

--- a/tests/tests/external_interface/tests.rs
+++ b/tests/tests/external_interface/tests.rs
@@ -25,7 +25,7 @@ pub fn external_interface_avm1(
         .player()
         .lock()
         .unwrap()
-        .add_external_interface(Box::new(ExternalInterfaceTestProvider::new()));
+        .set_external_interface_provider(Some(Box::new(ExternalInterfaceTestProvider::new())));
 
     let mut first = true;
 
@@ -93,7 +93,7 @@ pub fn external_interface_avm2(
         .player()
         .lock()
         .unwrap()
-        .add_external_interface(Box::new(ExternalInterfaceTestProvider::new()));
+        .set_external_interface_provider(Some(Box::new(ExternalInterfaceTestProvider::new())));
 
     let mut first = true;
 


### PR DESCRIPTION
Instead of getting a method then calling it, we just call things directly now. We also can now only have one Provider instead of many, but realistically there's no case in which multiple providers can peacefully coexist as they'll be conflicting with methods.