### PR TITLE
desktop: Create the window after the event loop

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -8,6 +8,7 @@ use crate::util::{
 };
 use anyhow::{Context, Error};
 use gilrs::{Event, EventType, Gilrs};
+use ruffle_core::swf::HeaderExt;
 use ruffle_core::PlayerEvent;
 use ruffle_render::backend::ViewportDimensions;
 use std::sync::Arc;
@@ -20,10 +21,13 @@ use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy}
 use winit::keyboard::{Key, NamedKey};
 use winit::window::{Fullscreen, Icon, WindowAttributes, WindowId};
 
-pub struct App {
+struct MainWindow {
     preferences: GlobalPreferences,
     gui: GuiController,
     player: PlayerController,
+    minimized: bool,
+    mouse_pos: PhysicalPosition<f64>,
+    modifiers: Modifiers,
     min_window_size: LogicalSize<u32>,
     max_window_size: PhysicalSize<u32>,
     no_gui: bool,
@@ -31,290 +35,13 @@ pub struct App {
     preferred_height: Option<f64>,
     start_fullscreen: bool,
     loaded: LoadingState,
-    gilrs: Option<Gilrs>,
-    event_loop_proxy: EventLoopProxy<RuffleEvent>,
-    minimized: bool,
-    mouse_pos: PhysicalPosition<f64>,
-    modifiers: Modifiers,
     time: Instant,
     next_frame_time: Option<Instant>,
+    event_loop_proxy: EventLoopProxy<RuffleEvent>,
 }
 
-impl App {
-    pub async fn new(
-        preferences: GlobalPreferences,
-    ) -> Result<(Self, EventLoop<RuffleEvent>), Error> {
-        let movie_url = preferences.cli.movie_url.clone();
-        let icon_bytes = include_bytes!("../assets/favicon-32.rgba");
-        let icon =
-            Icon::from_rgba(icon_bytes.to_vec(), 32, 32).context("Couldn't load app icon")?;
-
-        let event_loop = EventLoop::with_user_event().build()?;
-
-        let no_gui = preferences.cli.no_gui;
-        let min_window_size = (16, if no_gui { 16 } else { MENU_HEIGHT + 16 }).into();
-        let preferred_width = preferences.cli.width;
-        let preferred_height = preferences.cli.height;
-        let start_fullscreen = preferences.cli.fullscreen;
-
-        let window_attributes = WindowAttributes::default()
-            .with_visible(false)
-            .with_title("Ruffle")
-            .with_window_icon(Some(icon))
-            .with_min_inner_size(min_window_size);
-
-        // TODO: Migrate to ActiveEventLoop::create_window, see:
-        // https://github.com/rust-windowing/winit/releases/tag/v0.30.0
-        #[allow(deprecated)]
-        let window = event_loop.create_window(window_attributes)?;
-        let max_window_size = get_screen_size(&window);
-        window.set_max_inner_size(Some(max_window_size));
-        let window = Arc::new(window);
-
-        let mut font_database = fontdb::Database::default();
-        font_database.load_system_fonts();
-
-        let mut gui = GuiController::new(
-            window.clone(),
-            &event_loop,
-            preferences.clone(),
-            &font_database,
-            movie_url.clone(),
-            no_gui,
-        )
-        .await?;
-
-        let mut player = PlayerController::new(
-            event_loop.create_proxy(),
-            window.clone(),
-            gui.descriptors().clone(),
-            font_database,
-            preferences.clone(),
-            gui.file_picker(),
-        );
-
-        if let Some(movie_url) = &movie_url {
-            gui.create_movie(
-                &mut player,
-                LaunchOptions::from(&preferences),
-                movie_url.clone(),
-            );
-        } else {
-            gui.show_open_dialog();
-        }
-
-        let mut loaded = LoadingState::Loading;
-
-        if movie_url.is_none() {
-            // No SWF provided on command line; show window with dummy movie immediately.
-            window.set_visible(true);
-            loaded = LoadingState::Loaded;
-        }
-
-        let gilrs = Gilrs::new()
-            .inspect_err(|err| {
-                tracing::warn!("Gamepad support could not be initialized: {err}");
-            })
-            .ok();
-        let event_loop_proxy = event_loop.create_proxy();
-
-        Ok((
-            Self {
-                preferences,
-                gui,
-                player,
-                min_window_size,
-                max_window_size,
-                no_gui,
-                preferred_width,
-                preferred_height,
-                start_fullscreen,
-                loaded,
-                gilrs,
-                event_loop_proxy,
-                minimized: false,
-                mouse_pos: PhysicalPosition::new(0.0, 0.0),
-                modifiers: Modifiers::default(),
-                time: Instant::now(),
-                next_frame_time: None,
-            },
-            event_loop,
-        ))
-    }
-
-    fn check_redraw(&self) {
-        let player = self.player.get();
-        if player.map(|p| p.needs_render()).unwrap_or_default() || self.gui.needs_render() {
-            self.gui.window().request_redraw();
-        }
-    }
-}
-
-impl ApplicationHandler<RuffleEvent> for App {
-    fn resumed(&mut self, _event_loop: &ActiveEventLoop) {}
-
-    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: RuffleEvent) {
-        match event {
-            RuffleEvent::TaskPoll => self.player.poll(),
-            RuffleEvent::OnMetadata(swf_header) => {
-                let height_offset = if self.gui.window().fullscreen().is_some() || self.no_gui {
-                    0.0
-                } else {
-                    MENU_HEIGHT as f64
-                };
-
-                // To prevent issues like waiting on resize indefinitely (#11364) or desyncing the window state on Windows,
-                // do not resize while window is maximized.
-                let should_resize = !self.gui.window().is_maximized();
-
-                let viewport_size = if should_resize {
-                    let movie_width = swf_header.stage_size().width().to_pixels();
-                    let movie_height = swf_header.stage_size().height().to_pixels();
-
-                    let window_size: Size = match (self.preferred_width, self.preferred_height) {
-                        (None, None) => {
-                            LogicalSize::new(movie_width, movie_height + height_offset).into()
-                        }
-                        (Some(width), None) => {
-                            let scale = width / movie_width;
-                            let height = movie_height * scale;
-                            PhysicalSize::new(
-                                width.max(1.0),
-                                height.max(1.0) + height_offset * self.gui.window().scale_factor(),
-                            )
-                            .into()
-                        }
-                        (None, Some(height)) => {
-                            let scale = height / movie_height;
-                            let width = movie_width * scale;
-                            PhysicalSize::new(
-                                width.max(1.0),
-                                height.max(1.0) + height_offset * self.gui.window().scale_factor(),
-                            )
-                            .into()
-                        }
-                        (Some(width), Some(height)) => PhysicalSize::new(
-                            width.max(1.0),
-                            height.max(1.0) + height_offset * self.gui.window().scale_factor(),
-                        )
-                        .into(),
-                    };
-
-                    let window_size = Size::clamp(
-                        window_size,
-                        self.min_window_size.into(),
-                        self.max_window_size.into(),
-                        self.gui.window().scale_factor(),
-                    );
-
-                    let viewport_size = self.gui.window().inner_size();
-                    let mut window_resize_denied = false;
-
-                    if let Some(new_viewport_size) =
-                        self.gui.window().request_inner_size(window_size)
-                    {
-                        if new_viewport_size != viewport_size {
-                            self.gui.resize(new_viewport_size);
-                        } else {
-                            tracing::warn!("Unable to resize window");
-                            window_resize_denied = true;
-                        }
-                    }
-
-                    let viewport_size = self.gui.window().inner_size();
-
-                    // On X11 (and possibly other platforms), the window size is not updated immediately.
-                    // On a successful resize request, wait for the window to be resized to the requested size
-                    // before we start running the SWF (which can observe the viewport size in "noScale" mode)
-                    if !window_resize_denied && window_size != viewport_size.into() {
-                        self.loaded = LoadingState::WaitingForResize;
-                    } else {
-                        self.loaded = LoadingState::Loaded;
-                    }
-
-                    viewport_size
-                } else {
-                    self.gui.window().inner_size()
-                };
-
-                self.gui.window().set_fullscreen(if self.start_fullscreen {
-                    Some(Fullscreen::Borderless(None))
-                } else {
-                    None
-                });
-                self.gui.window().set_visible(true);
-
-                let viewport_scale_factor = self.gui.window().scale_factor();
-                if let Some(mut player) = self.player.get() {
-                    player.set_viewport_dimensions(ViewportDimensions {
-                        width: viewport_size.width,
-                        height: viewport_size.height - height_offset as u32,
-                        scale_factor: viewport_scale_factor,
-                    });
-                }
-            }
-
-            RuffleEvent::ContextMenuItemClicked(index) => {
-                if let Some(mut player) = self.player.get() {
-                    player.run_context_menu_callback(index);
-                }
-            }
-
-            RuffleEvent::BrowseAndOpen(options) => {
-                let event_loop = self.event_loop_proxy.clone();
-                let picker = self.gui.file_picker();
-                tokio::spawn(async move {
-                    if let Some(url) = picker
-                        .pick_ruffle_file(None)
-                        .await
-                        .and_then(|p| Url::from_file_path(p).ok())
-                    {
-                        let _ = event_loop.send_event(RuffleEvent::Open(url, options));
-                    }
-                });
-            }
-
-            RuffleEvent::Open(url, options) => {
-                self.gui.create_movie(&mut self.player, *options, url);
-            }
-
-            RuffleEvent::OpenDialog(descriptor) => {
-                self.gui.open_dialog(descriptor);
-            }
-
-            RuffleEvent::CloseFile => {
-                self.gui.window().set_title("Ruffle"); // Reset title since file has been closed.
-                self.player.destroy();
-            }
-
-            RuffleEvent::EnterFullScreen => {
-                if let Some(mut player) = self.player.get() {
-                    if player.is_playing() {
-                        player.set_fullscreen(true);
-                    }
-                }
-            }
-
-            RuffleEvent::ExitFullScreen => {
-                if let Some(mut player) = self.player.get() {
-                    if player.is_playing() {
-                        player.set_fullscreen(false);
-                    }
-                }
-            }
-
-            RuffleEvent::ExitRequested => {
-                event_loop.exit();
-            }
-        }
-    }
-
-    fn window_event(
-        &mut self,
-        event_loop: &ActiveEventLoop,
-        _window_id: WindowId,
-        event: WindowEvent,
-    ) {
+impl MainWindow {
+    pub fn window_event(&mut self, event_loop: &ActiveEventLoop, event: WindowEvent) {
         if matches!(event, WindowEvent::RedrawRequested) {
             // Don't render when minimized to avoid potential swap chain errors in `wgpu`.
             if !self.minimized {
@@ -519,9 +246,102 @@ impl ApplicationHandler<RuffleEvent> for App {
         }
     }
 
-    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        if let Some(Event { event, .. }) = self.gilrs.as_mut().and_then(|gilrs| gilrs.next_event())
-        {
+    fn on_metadata(&mut self, swf_header: HeaderExt) {
+        let height_offset = if self.gui.window().fullscreen().is_some() || self.no_gui {
+            0.0
+        } else {
+            MENU_HEIGHT as f64
+        };
+
+        // To prevent issues like waiting on resize indefinitely (#11364) or desyncing the window state on Windows,
+        // do not resize while window is maximized.
+        let should_resize = !self.gui.window().is_maximized();
+
+        let viewport_size = if should_resize {
+            let movie_width = swf_header.stage_size().width().to_pixels();
+            let movie_height = swf_header.stage_size().height().to_pixels();
+
+            let window_size: Size = match (self.preferred_width, self.preferred_height) {
+                (None, None) => LogicalSize::new(movie_width, movie_height + height_offset).into(),
+                (Some(width), None) => {
+                    let scale = width / movie_width;
+                    let height = movie_height * scale;
+                    PhysicalSize::new(
+                        width.max(1.0),
+                        height.max(1.0) + height_offset * self.gui.window().scale_factor(),
+                    )
+                    .into()
+                }
+                (None, Some(height)) => {
+                    let scale = height / movie_height;
+                    let width = movie_width * scale;
+                    PhysicalSize::new(
+                        width.max(1.0),
+                        height.max(1.0) + height_offset * self.gui.window().scale_factor(),
+                    )
+                    .into()
+                }
+                (Some(width), Some(height)) => PhysicalSize::new(
+                    width.max(1.0),
+                    height.max(1.0) + height_offset * self.gui.window().scale_factor(),
+                )
+                .into(),
+            };
+
+            let window_size = Size::clamp(
+                window_size,
+                self.min_window_size.into(),
+                self.max_window_size.into(),
+                self.gui.window().scale_factor(),
+            );
+
+            let viewport_size = self.gui.window().inner_size();
+            let mut window_resize_denied = false;
+
+            if let Some(new_viewport_size) = self.gui.window().request_inner_size(window_size) {
+                if new_viewport_size != viewport_size {
+                    self.gui.resize(new_viewport_size);
+                } else {
+                    tracing::warn!("Unable to resize window");
+                    window_resize_denied = true;
+                }
+            }
+
+            let viewport_size = self.gui.window().inner_size();
+
+            // On X11 (and possibly other platforms), the window size is not updated immediately.
+            // On a successful resize request, wait for the window to be resized to the requested size
+            // before we start running the SWF (which can observe the viewport size in "noScale" mode)
+            if !window_resize_denied && window_size != viewport_size.into() {
+                self.loaded = LoadingState::WaitingForResize;
+            } else {
+                self.loaded = LoadingState::Loaded;
+            }
+
+            viewport_size
+        } else {
+            self.gui.window().inner_size()
+        };
+
+        self.gui.window().set_fullscreen(if self.start_fullscreen {
+            Some(Fullscreen::Borderless(None))
+        } else {
+            None
+        });
+        self.gui.window().set_visible(true);
+
+        let viewport_scale_factor = self.gui.window().scale_factor();
+        if let Some(mut player) = self.player.get() {
+            player.set_viewport_dimensions(ViewportDimensions {
+                width: viewport_size.width,
+                height: viewport_size.height - height_offset as u32,
+                scale_factor: viewport_scale_factor,
+            });
+        }
+    }
+
+    fn about_to_wait(&mut self, gilrs: Option<&mut Gilrs>) {
+        if let Some(Event { event, .. }) = gilrs.and_then(|gilrs| gilrs.next_event()) {
             match event {
                 EventType::ButtonPressed(button, _) => {
                     if let Some(button) = gilrs_button_to_gamepad_button(button) {
@@ -558,10 +378,207 @@ impl ApplicationHandler<RuffleEvent> for App {
                 self.check_redraw();
             }
         }
+    }
+
+    fn check_redraw(&self) {
+        let player = self.player.get();
+        if player.map(|p| p.needs_render()).unwrap_or_default() || self.gui.needs_render() {
+            self.gui.window().request_redraw();
+        }
+    }
+}
+
+pub struct App {
+    main_window: MainWindow,
+    gilrs: Option<Gilrs>,
+}
+
+impl App {
+    pub async fn new(
+        preferences: GlobalPreferences,
+    ) -> Result<(Self, EventLoop<RuffleEvent>), Error> {
+        let movie_url = preferences.cli.movie_url.clone();
+        let icon_bytes = include_bytes!("../assets/favicon-32.rgba");
+        let icon =
+            Icon::from_rgba(icon_bytes.to_vec(), 32, 32).context("Couldn't load app icon")?;
+
+        let event_loop = EventLoop::with_user_event().build()?;
+
+        let no_gui = preferences.cli.no_gui;
+        let min_window_size = (16, if no_gui { 16 } else { MENU_HEIGHT + 16 }).into();
+        let preferred_width = preferences.cli.width;
+        let preferred_height = preferences.cli.height;
+        let start_fullscreen = preferences.cli.fullscreen;
+
+        let window_attributes = WindowAttributes::default()
+            .with_visible(false)
+            .with_title("Ruffle")
+            .with_window_icon(Some(icon))
+            .with_min_inner_size(min_window_size);
+
+        // TODO: Migrate to ActiveEventLoop::create_window, see:
+        // https://github.com/rust-windowing/winit/releases/tag/v0.30.0
+        #[allow(deprecated)]
+        let window = event_loop.create_window(window_attributes)?;
+        let max_window_size = get_screen_size(&window);
+        window.set_max_inner_size(Some(max_window_size));
+        let window = Arc::new(window);
+
+        let mut font_database = fontdb::Database::default();
+        font_database.load_system_fonts();
+
+        let mut gui = GuiController::new(
+            window.clone(),
+            &event_loop,
+            preferences.clone(),
+            &font_database,
+            movie_url.clone(),
+            no_gui,
+        )
+        .await?;
+
+        let mut player = PlayerController::new(
+            event_loop.create_proxy(),
+            window.clone(),
+            gui.descriptors().clone(),
+            font_database,
+            preferences.clone(),
+            gui.file_picker(),
+        );
+
+        if let Some(movie_url) = &movie_url {
+            gui.create_movie(
+                &mut player,
+                LaunchOptions::from(&preferences),
+                movie_url.clone(),
+            );
+        } else {
+            gui.show_open_dialog();
+        }
+
+        let mut loaded = LoadingState::Loading;
+
+        if movie_url.is_none() {
+            // No SWF provided on command line; show window with dummy movie immediately.
+            window.set_visible(true);
+            loaded = LoadingState::Loaded;
+        }
+
+        let gilrs = Gilrs::new()
+            .inspect_err(|err| {
+                tracing::warn!("Gamepad support could not be initialized: {err}");
+            })
+            .ok();
+        let event_loop_proxy = event_loop.create_proxy();
+
+        Ok((
+            Self {
+                main_window: MainWindow {
+                    preferences,
+                    gui,
+                    player,
+                    min_window_size,
+                    max_window_size,
+                    no_gui,
+                    preferred_width,
+                    preferred_height,
+                    start_fullscreen,
+                    loaded,
+                    minimized: false,
+                    mouse_pos: PhysicalPosition::new(0.0, 0.0),
+                    modifiers: Modifiers::default(),
+                    time: Instant::now(),
+                    next_frame_time: None,
+                    event_loop_proxy,
+                },
+                gilrs,
+            },
+            event_loop,
+        ))
+    }
+}
+
+impl ApplicationHandler<RuffleEvent> for App {
+    fn resumed(&mut self, _event_loop: &ActiveEventLoop) {}
+
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: RuffleEvent) {
+        match event {
+            RuffleEvent::TaskPoll => self.main_window.player.poll(),
+
+            RuffleEvent::OnMetadata(swf_header) => self.main_window.on_metadata(swf_header),
+
+            RuffleEvent::ContextMenuItemClicked(index) => {
+                if let Some(mut player) = self.main_window.player.get() {
+                    player.run_context_menu_callback(index);
+                }
+            }
+
+            RuffleEvent::BrowseAndOpen(options) => {
+                let event_loop = self.main_window.event_loop_proxy.clone();
+                let picker = self.main_window.gui.file_picker();
+                tokio::spawn(async move {
+                    if let Some(url) = picker
+                        .pick_ruffle_file(None)
+                        .await
+                        .and_then(|p| Url::from_file_path(p).ok())
+                    {
+                        let _ = event_loop.send_event(RuffleEvent::Open(url, options));
+                    }
+                });
+            }
+
+            RuffleEvent::Open(url, options) => {
+                self.main_window
+                    .gui
+                    .create_movie(&mut self.main_window.player, *options, url);
+            }
+
+            RuffleEvent::OpenDialog(descriptor) => {
+                self.main_window.gui.open_dialog(descriptor);
+            }
+
+            RuffleEvent::CloseFile => {
+                self.main_window.gui.window().set_title("Ruffle"); // Reset title since file has been closed.
+                self.main_window.player.destroy();
+            }
+
+            RuffleEvent::EnterFullScreen => {
+                if let Some(mut player) = self.main_window.player.get() {
+                    if player.is_playing() {
+                        player.set_fullscreen(true);
+                    }
+                }
+            }
+
+            RuffleEvent::ExitFullScreen => {
+                if let Some(mut player) = self.main_window.player.get() {
+                    if player.is_playing() {
+                        player.set_fullscreen(false);
+                    }
+                }
+            }
+
+            RuffleEvent::ExitRequested => {
+                event_loop.exit();
+            }
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        self.main_window.window_event(event_loop, event);
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        self.main_window.about_to_wait(self.gilrs.as_mut());
 
         // The event loop is finished; let's find out how long we need to wait for
         // (but don't change something that's already requesting a sooner update, or we'll delay it)
-        if let Some(next_frame_time) = self.next_frame_time {
+        if let Some(next_frame_time) = self.main_window.next_frame_time {
             match event_loop.control_flow() {
                 // A "Wait" has no time limit, set ours
                 ControlFlow::Wait => {

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -161,6 +161,10 @@ impl GuiController {
         self.gui.dialogs.file_picker()
     }
 
+    pub fn window(&self) -> &Arc<Window> {
+        &self.window
+    }
+
     pub fn resize(&mut self, size: PhysicalSize<u32>) {
         if size.width > 0 && size.height > 0 {
             self.size = size;


### PR DESCRIPTION
This resolves the remaining TODO from #17401

Winit wants us to create the window after the event loop starts, and that wasn't very easy - but here we are.

Kindly requesting that someone tests on Wayland & X11 to make sure it's fine still :D