### PR TITLE
chore: Bump the `express` and `cookie` npm packages

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5526,9 +5526,9 @@
             "license": "MIT"
         },
         "node_modules/cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7258,17 +7258,18 @@
             }
         },
         "node_modules/express": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-            "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+            "version": "4.21.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+            "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.6.0",
+                "cookie": "0.7.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",


### PR DESCRIPTION
This should resolve https://github.com/advisories/GHSA-pxg6-pf52-xh8x (CVE-2024-47764 ).