### PR TITLE
desktop: Move open URLs mode from launch options to preferences

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -56,24 +56,6 @@ pub enum SocketMode {
     Ask,
 }
 
-/// The handling mode of links opening a new website.
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum OpenURLMode {
-    /// Allow all links to open a new website.
-    #[cfg_attr(feature = "serde", serde(rename = "allow"))]
-    Allow,
-
-    /// A confirmation dialog opens with every link trying to open a new website.
-    #[cfg_attr(feature = "serde", serde(rename = "confirm"))]
-    Confirm,
-
-    /// Deny all links to open a new website.
-    #[cfg_attr(feature = "serde", serde(rename = "deny"))]
-    Deny,
-}
-
 impl NavigationMethod {
     /// Convert an SWF method enum into a NavigationMethod.
     pub fn from_send_vars_method(s: SendVarsMethod) -> Option<Self> {

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -192,8 +192,8 @@ pub struct Opt {
     pub frame_rate: Option<f64>,
 
     /// The handling mode of links opening a new website.
-    #[clap(long, default_value = "allow")]
-    pub open_url_mode: OpenURLMode,
+    #[clap(long)]
+    pub open_url_mode: Option<OpenUrlMode>,
 
     /// How to handle non-interactive filesystem access.
     #[clap(long, default_value = "ask")]
@@ -338,6 +338,46 @@ impl FromStr for GameModePreference {
             "on" => Ok(GameModePreference::On),
             "off" => Ok(GameModePreference::Off),
             _ => Err(()),
+        }
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, clap::ValueEnum)]
+pub enum OpenUrlMode {
+    #[default]
+    Confirm,
+    Allow,
+    Deny,
+}
+
+impl OpenUrlMode {
+    pub fn as_str(&self) -> Option<&'static str> {
+        match self {
+            OpenUrlMode::Confirm => None,
+            OpenUrlMode::Allow => Some("allow"),
+            OpenUrlMode::Deny => Some("deny"),
+        }
+    }
+}
+
+impl FromStr for OpenUrlMode {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allow" => Ok(OpenUrlMode::Allow),
+            "deny" => Ok(OpenUrlMode::Deny),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<OpenUrlMode> for OpenURLMode {
+    fn from(value: OpenUrlMode) -> Self {
+        match value {
+            OpenUrlMode::Confirm => OpenURLMode::Confirm,
+            OpenUrlMode::Allow => OpenURLMode::Allow,
+            OpenUrlMode::Deny => OpenURLMode::Deny,
         }
     }
 }

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -2,7 +2,7 @@ use crate::preferences::storage::StorageBackend;
 use crate::RUFFLE_VERSION;
 use anyhow::{anyhow, Error};
 use clap::{Parser, ValueEnum};
-use ruffle_core::backend::navigator::{OpenURLMode, SocketMode};
+use ruffle_core::backend::navigator::SocketMode;
 use ruffle_core::config::Letterbox;
 use ruffle_core::events::{GamepadButton, KeyCode};
 use ruffle_core::{LoadBehavior, PlayerRuntime, StageAlign, StageScaleMode};
@@ -368,16 +368,6 @@ impl FromStr for OpenUrlMode {
             "allow" => Ok(OpenUrlMode::Allow),
             "deny" => Ok(OpenUrlMode::Deny),
             _ => Err(()),
-        }
-    }
-}
-
-impl From<OpenUrlMode> for OpenURLMode {
-    fn from(value: OpenUrlMode) -> Self {
-        match value {
-            OpenUrlMode::Confirm => OpenURLMode::Confirm,
-            OpenUrlMode::Allow => OpenURLMode::Allow,
-            OpenUrlMode::Deny => OpenURLMode::Deny,
         }
     }
 }

--- a/desktop/src/gui/dialogs/open_dialog.rs
+++ b/desktop/src/gui/dialogs/open_dialog.rs
@@ -5,7 +5,7 @@ use crate::player::LaunchOptions;
 use egui::{
     emath, Align2, Button, Checkbox, ComboBox, Grid, Layout, Slider, TextEdit, Ui, Widget, Window,
 };
-use ruffle_core::backend::navigator::{OpenURLMode, SocketMode};
+use ruffle_core::backend::navigator::SocketMode;
 use ruffle_core::config::Letterbox;
 use ruffle_core::{LoadBehavior, PlayerRuntime, StageAlign, StageScaleMode};
 use ruffle_render::quality::StageQuality;
@@ -403,33 +403,6 @@ impl OpenDialog {
                 ui.label(text(locale, "tcp-connections"));
                 self.tcp_connections
                     .ui(ui, &mut self.options.tcp_connections, locale);
-                ui.end_row();
-
-                // TODO: This should probably be a global setting somewhere, not per load
-                ui.label(text(locale, "open-url-mode"));
-                ComboBox::from_id_salt("open-file-advanced-options-open-url-mode")
-                    .selected_text(match self.options.open_url_mode {
-                        OpenURLMode::Allow => text(locale, "open-url-mode-allow"),
-                        OpenURLMode::Confirm => text(locale, "open-url-mode-confirm"),
-                        OpenURLMode::Deny => text(locale, "open-url-mode-deny"),
-                    })
-                    .show_ui(ui, |ui| {
-                        ui.selectable_value(
-                            &mut self.options.open_url_mode,
-                            OpenURLMode::Allow,
-                            text(locale, "open-url-mode-allow"),
-                        );
-                        ui.selectable_value(
-                            &mut self.options.open_url_mode,
-                            OpenURLMode::Confirm,
-                            text(locale, "open-url-mode-confirm"),
-                        );
-                        ui.selectable_value(
-                            &mut self.options.open_url_mode,
-                            OpenURLMode::Deny,
-                            text(locale, "open-url-mode-deny"),
-                        );
-                    });
                 ui.end_row();
 
                 ui.label(text(locale, "load-behavior"));

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -9,7 +9,7 @@ use crate::gui::{FilePicker, MovieView};
 use crate::preferences::GlobalPreferences;
 use crate::{CALLSTACK, RENDER_INFO, SWF_INFO};
 use anyhow::anyhow;
-use ruffle_core::backend::navigator::{OpenURLMode, SocketMode};
+use ruffle_core::backend::navigator::SocketMode;
 use ruffle_core::config::Letterbox;
 use ruffle_core::events::{GamepadButton, KeyCode};
 use ruffle_core::{DefaultFont, LoadBehavior, Player, PlayerBuilder, PlayerEvent};
@@ -48,7 +48,6 @@ pub struct LaunchOptions {
     pub fullscreen: bool,
     pub save_directory: PathBuf,
     pub cache_directory: PathBuf,
-    pub open_url_mode: OpenURLMode,
     pub filesystem_access_mode: FilesystemAccessMode,
     pub gamepad_button_mapping: HashMap<GamepadButton, KeyCode>,
     pub avm2_optimizer_enabled: bool,
@@ -97,7 +96,6 @@ impl From<&GlobalPreferences> for LaunchOptions {
             fullscreen: value.cli.fullscreen,
             save_directory: value.cli.save_directory.clone(),
             cache_directory: value.cli.cache_directory.clone(),
-            open_url_mode: value.cli.open_url_mode.unwrap_or_default().into(),
             filesystem_access_mode: value.cli.filesystem_access_mode,
             socket_allowed: HashSet::from_iter(value.cli.socket_allow.iter().cloned()),
             tcp_connections: value.cli.tcp_connections,
@@ -206,7 +204,6 @@ impl ActivePlayer {
                     fullscreen: opt.fullscreen,
                     save_directory: opt.save_directory.clone(),
                     cache_directory: opt.cache_directory.clone(),
-                    open_url_mode: opt.open_url_mode,
                     filesystem_access_mode: opt.filesystem_access_mode,
                     gamepad_button_mapping: opt.gamepad_button_mapping.clone(),
                     avm2_optimizer_enabled: opt.avm2_optimizer_enabled,

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -231,10 +231,10 @@ impl ActivePlayer {
             opt.tcp_connections.unwrap_or(SocketMode::Ask),
             Rc::new(content),
             DesktopNavigatorInterface::new(
+                preferences.clone(),
                 event_loop.clone(),
                 movie_url.to_file_path().ok(),
                 opt.filesystem_access_mode,
-                opt.open_url_mode,
             ),
         );
 

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -227,7 +227,6 @@ impl ActivePlayer {
             future_spawner,
             opt.proxy.clone(),
             opt.player.upgrade_to_https.unwrap_or_default(),
-            opt.open_url_mode,
             opt.socket_allowed.clone(),
             opt.tcp_connections.unwrap_or(SocketMode::Ask),
             Rc::new(content),
@@ -235,6 +234,7 @@ impl ActivePlayer {
                 event_loop.clone(),
                 movie_url.to_file_path().ok(),
                 opt.filesystem_access_mode,
+                opt.open_url_mode,
             ),
         );
 

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -97,7 +97,7 @@ impl From<&GlobalPreferences> for LaunchOptions {
             fullscreen: value.cli.fullscreen,
             save_directory: value.cli.save_directory.clone(),
             cache_directory: value.cli.cache_directory.clone(),
-            open_url_mode: value.cli.open_url_mode,
+            open_url_mode: value.cli.open_url_mode.unwrap_or_default().into(),
             filesystem_access_mode: value.cli.filesystem_access_mode,
             socket_allowed: HashSet::from_iter(value.cli.socket_allow.iter().cloned()),
             tcp_connections: value.cli.tcp_connections,

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -304,7 +304,6 @@ impl ActivePlayer {
                 DesktopUiBackend::new(
                     window.clone(),
                     event_loop.clone(),
-                    opt.open_url_mode,
                     font_database,
                     preferences,
                     file_picker,

--- a/desktop/src/preferences.rs
+++ b/desktop/src/preferences.rs
@@ -213,6 +213,15 @@ impl GlobalPreferences {
         self.watchers.theme_preference_watcher.subscribe()
     }
 
+    pub fn open_url_mode(&self) -> OpenUrlMode {
+        self.cli.open_url_mode.unwrap_or_else(|| {
+            self.preferences
+                .lock()
+                .expect("Non-poisoned preferences")
+                .open_url_mode
+        })
+    }
+
     pub fn recents<R>(&self, fun: impl FnOnce(&Recents) -> R) -> R {
         fun(&self.recents.lock().expect("Recents is not reentrant"))
     }

--- a/desktop/src/preferences.rs
+++ b/desktop/src/preferences.rs
@@ -3,7 +3,7 @@ mod write;
 
 pub mod storage;
 
-use crate::cli::{GameModePreference, Opt};
+use crate::cli::{GameModePreference, OpenUrlMode, Opt};
 use crate::gui::ThemePreference;
 use crate::log::FilenamePattern;
 use crate::preferences::read::read_preferences;
@@ -269,6 +269,7 @@ pub struct SavedGlobalPreferences {
     pub log: LogPreferences,
     pub storage: StoragePreferences,
     pub theme_preference: ThemePreference,
+    pub open_url_mode: OpenUrlMode,
 }
 
 impl Default for SavedGlobalPreferences {
@@ -291,6 +292,7 @@ impl Default for SavedGlobalPreferences {
             log: Default::default(),
             storage: Default::default(),
             theme_preference: Default::default(),
+            open_url_mode: Default::default(),
         }
     }
 }

--- a/desktop/src/preferences/write.rs
+++ b/desktop/src/preferences/write.rs
@@ -1,4 +1,4 @@
-use crate::cli::GameModePreference;
+use crate::cli::{GameModePreference, OpenUrlMode};
 use crate::gui::ThemePreference;
 use crate::log::FilenamePattern;
 use crate::preferences::storage::StorageBackend;
@@ -118,6 +118,17 @@ impl<'a> PreferencesWriter<'a> {
                 toml_document.remove("gamemode");
             }
             values.gamemode_preference = gamemode_preference;
+        });
+    }
+
+    pub fn set_open_url_mode(&mut self, open_url_mode: OpenUrlMode) {
+        self.0.edit(|values, toml_document| {
+            if let Some(open_url_mode) = open_url_mode.as_str() {
+                toml_document["open_url_mode"] = value(open_url_mode);
+            } else {
+                toml_document.remove("open_url_mode");
+            }
+            values.open_url_mode = open_url_mode;
         });
     }
 }
@@ -299,6 +310,20 @@ mod tests {
         test(
             "gamemode = \"on\"",
             |writer| writer.set_gamemode_preference(GameModePreference::Default),
+            "",
+        );
+    }
+
+    #[test]
+    fn set_open_url_mode() {
+        test(
+            "open_url_mode = 6\n",
+            |writer| writer.set_open_url_mode(OpenUrlMode::Allow),
+            "open_url_mode = \"allow\"\n",
+        );
+        test(
+            "open_url_mode = \"deny\"",
+            |writer| writer.set_open_url_mode(OpenUrlMode::Confirm),
             "",
         );
     }

--- a/frontend-utils/src/backends/navigator.rs
+++ b/frontend-utils/src/backends/navigator.rs
@@ -9,7 +9,7 @@ use futures_lite::FutureExt;
 use reqwest::{cookie, header, Proxy};
 use ruffle_core::backend::navigator::{
     async_return, create_fetch_error, get_encoding, ErrorResponse, NavigationMethod,
-    NavigatorBackend, OpenURLMode, OwnedFuture, Request, SocketMode, SuccessResponse,
+    NavigatorBackend, OwnedFuture, Request, SocketMode, SuccessResponse,
 };
 use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
@@ -28,7 +28,7 @@ use tracing::warn;
 use url::{ParseError, Url};
 
 pub trait NavigatorInterface: Clone + Send + 'static {
-    fn navigate_to_website(&self, url: Url, ask: bool);
+    fn navigate_to_website(&self, url: Url);
 
     fn open_file(&self, path: &Path) -> impl std::future::Future<Output = io::Result<File>> + Send;
 
@@ -57,8 +57,6 @@ pub struct ExternalNavigatorBackend<F: FutureSpawner, I: NavigatorInterface> {
 
     upgrade_to_https: bool,
 
-    open_url_mode: OpenURLMode,
-
     content: Rc<PlayingContent>,
 
     interface: I,
@@ -74,7 +72,6 @@ impl<F: FutureSpawner, I: NavigatorInterface> ExternalNavigatorBackend<F, I> {
         future_spawner: F,
         proxy: Option<Url>,
         upgrade_to_https: bool,
-        open_url_mode: OpenURLMode,
         socket_allowed: HashSet<String>,
         socket_mode: SocketMode,
         content: Rc<PlayingContent>,
@@ -125,7 +122,6 @@ impl<F: FutureSpawner, I: NavigatorInterface> ExternalNavigatorBackend<F, I> {
             client,
             base_url,
             upgrade_to_https,
-            open_url_mode,
             socket_allowed,
             socket_mode,
             content,
@@ -182,13 +178,7 @@ impl<F: FutureSpawner + 'static, I: NavigatorInterface> NavigatorBackend
             return;
         }
 
-        if self.open_url_mode == OpenURLMode::Deny {
-            tracing::warn!("SWF tried to open a website, but opening a website is not allowed");
-            return;
-        }
-
-        let ask = self.open_url_mode == OpenURLMode::Confirm;
-        self.interface.navigate_to_website(modified_url, ask);
+        self.interface.navigate_to_website(modified_url);
     }
 
     fn fetch(&self, request: Request) -> OwnedFuture<Box<dyn SuccessResponse>, ErrorResponse> {
@@ -489,7 +479,7 @@ mod tests {
     use super::*;
 
     impl NavigatorInterface for () {
-        fn navigate_to_website(&self, _url: Url, _ask: bool) {}
+        fn navigate_to_website(&self, _url: Url) {}
 
         async fn open_file(&self, path: &Path) -> io::Result<File> {
             File::open(path)
@@ -558,7 +548,6 @@ mod tests {
             TestFutureSpawner,
             None,
             false,
-            OpenURLMode::Allow,
             Default::default(),
             if socket_allow {
                 SocketMode::Allow

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -1,12 +1,11 @@
 use crate::external_interface::JavascriptInterface;
-use crate::navigator::WebNavigatorBackend;
+use crate::navigator::{OpenUrlMode, WebNavigatorBackend};
 use crate::{
     audio, log_adapter, storage, ui, JavascriptPlayer, RuffleHandle, SocketProxy,
     RUFFLE_GLOBAL_PANIC,
 };
 use js_sys::Promise;
 use ruffle_core::backend::audio::{AudioBackend, NullAudioBackend};
-use ruffle_core::backend::navigator::OpenURLMode;
 use ruffle_core::backend::storage::{MemoryStorageBackend, StorageBackend};
 use ruffle_core::backend::ui::FontDefinition;
 use ruffle_core::compatibility_rules::CompatibilityRules;
@@ -54,7 +53,7 @@ pub struct RuffleInstanceBuilder {
     pub(crate) max_execution_duration: Duration,
     pub(crate) player_version: Option<u8>,
     pub(crate) preferred_renderer: Option<String>, // TODO: Enumify?
-    pub(crate) open_url_mode: OpenURLMode,
+    pub(crate) open_url_mode: OpenUrlMode,
     pub(crate) allow_networking: NetworkingAccessMode,
     pub(crate) socket_proxy: Vec<SocketProxy>,
     pub(crate) credential_allow_list: Vec<String>,
@@ -90,7 +89,7 @@ impl Default for RuffleInstanceBuilder {
             max_execution_duration: Duration::from_secs_f64(15.0),
             player_version: None,
             preferred_renderer: None,
-            open_url_mode: OpenURLMode::Allow,
+            open_url_mode: OpenUrlMode::Allow,
             allow_networking: NetworkingAccessMode::All,
             socket_proxy: vec![],
             credential_allow_list: vec![],
@@ -248,9 +247,9 @@ impl RuffleInstanceBuilder {
     #[wasm_bindgen(js_name = "setOpenUrlMode")]
     pub fn set_open_url_mode(&mut self, value: &str) {
         self.open_url_mode = match value {
-            "allow" => OpenURLMode::Allow,
-            "confirm" => OpenURLMode::Confirm,
-            "deny" => OpenURLMode::Deny,
+            "allow" => OpenUrlMode::Allow,
+            "confirm" => OpenUrlMode::Confirm,
+            "deny" => OpenUrlMode::Deny,
             _ => return,
         };
     }


### PR DESCRIPTION
This PR moves open links behavior preference from launch options (which was settable before running each SWF) to the preferences (which is settable at any point in time and is persistent).

Additionally, this PR changes the default to "confirm". Users who don't want the confirmation popup to be displayed all the time can disable it, and others will have an additional layer of security on by default.

Opening links without confirmation is unsafe because:

1. It shares your IP address and other information.

2. It might be used to leak sensitive information in the URL.

By having the confirmation dialog on by default, users will have a chance to check if the link is safe before opening it.

Fixes https://github.com/ruffle-rs/ruffle/issues/17432.

CC @n0samu

@torokati44 This PR changes a bit the frontend utils API which gives more control to the implementations over how links are opened, but requires adding a simple check by them to preserve the same behavior as before.