### PR TITLE
desktop: Close dialogs when the player is destroyed

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -555,7 +555,7 @@ impl ApplicationHandler<RuffleEvent> for App {
 
             (Some(main_window), RuffleEvent::CloseFile) => {
                 main_window.gui.window().set_title("Ruffle"); // Reset title since file has been closed.
-                main_window.player.destroy();
+                main_window.gui.close_movie(&mut main_window.player);
             }
 
             (Some(main_window), RuffleEvent::EnterFullScreen) => {

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -213,6 +213,11 @@ impl RuffleGui {
         self.context_menu.is_some()
     }
 
+    /// Notifies the GUI that the player has been destroyed.
+    fn on_player_destroyed(&mut self) {
+        self.dialogs.close_dialogs_with_notifiers();
+    }
+
     /// Notifies the GUI that a new player was created.
     fn on_player_created(
         &mut self,

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -227,12 +227,18 @@ impl GuiController {
         response.consumed
     }
 
+    pub fn close_movie(&mut self, player: &mut PlayerController) {
+        player.destroy();
+        self.gui.on_player_destroyed();
+    }
+
     pub fn create_movie(
         &mut self,
         player: &mut PlayerController,
         opt: LaunchOptions,
         movie_url: Url,
     ) {
+        self.close_movie(player);
         let movie_view = MovieView::new(
             self.movie_view_renderer.clone(),
             &self.descriptors.device,

--- a/desktop/src/gui/dialogs.rs
+++ b/desktop/src/gui/dialogs.rs
@@ -106,6 +106,16 @@ impl Dialogs {
         self.picker.clone()
     }
 
+    /// Close all dialogs that have someone waiting for an answer.
+    ///
+    /// This method may be used when the original receiver is closed,
+    /// e.g. by loading a new movie or destroying the existing one.
+    pub fn close_dialogs_with_notifiers(&mut self) {
+        self.network_access_dialog_queue.clear();
+        self.filesystem_access_dialog = None;
+        self.filesystem_access_dialog_queue.clear();
+    }
+
     pub fn recreate_open_dialog(
         &mut self,
         opt: LaunchOptions,


### PR DESCRIPTION
Fixes https://github.com/ruffle-rs/ruffle/issues/18236.

This consists of two main parts:

1. Handling failures when sending `SocketAction` properly instead of panicking
2. Closing the dialogs that require a notifier when player is destroyed