### PR TITLE
core: Do not allocate or render empty `Drawing`s

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1001,7 +1001,9 @@ pub fn clone_sprite<'gc>(
 
     new_clip.set_clip_event_handlers(context.gc_context, movie_clip.clip_actions().to_vec());
 
-    *new_clip.drawing_mut(context.gc()) = movie_clip.drawing().clone();
+    if let Some(drawing) = movie_clip.drawing().as_deref().cloned() {
+        *new_clip.drawing_mut(context.gc()) = drawing;
+    }
     // TODO: Any other properties we should copy...?
     // Definitely not ScriptObject properties.
 

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -400,12 +400,10 @@ fn line_style<'gc>(
             .with_is_pixel_hinted(is_pixel_hinted)
             .with_allow_close(false);
         movie_clip
-            .drawing(activation.context.gc_context)
+            .drawing_mut(activation.gc())
             .set_line_style(Some(line_style));
     } else {
-        movie_clip
-            .drawing(activation.context.gc_context)
-            .set_line_style(None);
+        movie_clip.drawing_mut(activation.gc()).set_line_style(None);
     }
     Ok(Value::Undefined)
 }
@@ -486,7 +484,7 @@ fn line_gradient_style<'gc>(
             },
         };
         movie_clip
-            .drawing(activation.context.gc_context)
+            .drawing_mut(activation.gc())
             .set_line_fill_style(style);
     }
     Ok(Value::Undefined)
@@ -579,12 +577,10 @@ fn begin_fill<'gc>(
             / 100.0
             * 255.0;
         movie_clip
-            .drawing(activation.context.gc_context)
+            .drawing_mut(activation.gc())
             .set_fill_style(Some(FillStyle::Color(Color::from_rgb(rgb, alpha as u8))));
     } else {
-        movie_clip
-            .drawing(activation.context.gc_context)
-            .set_fill_style(None);
+        movie_clip.drawing_mut(activation.gc()).set_fill_style(None);
     }
     Ok(Value::Undefined)
 }
@@ -604,9 +600,7 @@ fn begin_bitmap_fill<'gc>(
                 width: bitmap_data.width() as u16,
                 height: bitmap_data.height() as u16,
             };
-            let id = movie_clip
-                .drawing(activation.context.gc_context)
-                .add_bitmap(bitmap);
+            let id = movie_clip.drawing_mut(activation.gc()).add_bitmap(bitmap);
 
             let mut matrix = avm1::globals::matrix::object_to_matrix_or_default(
                 args.get(1)
@@ -640,7 +634,7 @@ fn begin_bitmap_fill<'gc>(
         None
     };
     movie_clip
-        .drawing(activation.context.gc_context)
+        .drawing_mut(activation.gc())
         .set_fill_style(fill_style);
     Ok(Value::Undefined)
 }
@@ -652,9 +646,7 @@ fn begin_gradient_fill<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if Value::Undefined == *args.get(0).unwrap_or(&Value::Undefined) {
         // The path has no fill if the first parameter is `undefined`, or if no parameters are passed.
-        movie_clip
-            .drawing(activation.context.gc_context)
-            .set_fill_style(None);
+        movie_clip.drawing_mut(activation.gc()).set_fill_style(None);
     } else if let (Some(gradient_type), Some(colors), Some(alphas), Some(ratios), Some(matrix)) = (
         args.get(0),
         args.get(1),
@@ -718,7 +710,7 @@ fn begin_gradient_fill<'gc>(
             },
         };
         movie_clip
-            .drawing(activation.context.gc_context)
+            .drawing_mut(activation.gc())
             .set_fill_style(Some(style));
     }
     Ok(Value::Undefined)
@@ -733,7 +725,7 @@ fn move_to<'gc>(
         let x = x.coerce_to_f64(activation)?;
         let y = y.coerce_to_f64(activation)?;
         movie_clip
-            .drawing(activation.context.gc_context)
+            .drawing_mut(activation.gc())
             .draw_command(DrawCommand::MoveTo(Point::from_pixels(x, y)));
     }
     Ok(Value::Undefined)
@@ -748,7 +740,7 @@ fn line_to<'gc>(
         let x = x.coerce_to_f64(activation)?;
         let y = y.coerce_to_f64(activation)?;
         movie_clip
-            .drawing(activation.context.gc_context)
+            .drawing_mut(activation.gc())
             .draw_command(DrawCommand::LineTo(Point::from_pixels(x, y)));
     }
     Ok(Value::Undefined)
@@ -765,7 +757,7 @@ fn curve_to<'gc>(
         let anchor_x = anchor_x.coerce_to_f64(activation)?;
         let anchor_y = anchor_y.coerce_to_f64(activation)?;
         movie_clip
-            .drawing(activation.context.gc_context)
+            .drawing_mut(activation.gc())
             .draw_command(DrawCommand::QuadraticCurveTo {
                 control: Point::from_pixels(control_x, control_y),
                 anchor: Point::from_pixels(anchor_x, anchor_y),
@@ -779,9 +771,7 @@ fn end_fill<'gc>(
     activation: &mut Activation<'_, 'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    movie_clip
-        .drawing(activation.context.gc_context)
-        .set_fill_style(None);
+    movie_clip.drawing_mut(activation.gc()).set_fill_style(None);
     Ok(Value::Undefined)
 }
 
@@ -790,7 +780,7 @@ fn clear<'gc>(
     activation: &mut Activation<'_, 'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    movie_clip.drawing(activation.context.gc_context).clear();
+    movie_clip.drawing_mut(activation.gc()).clear();
     Ok(Value::Undefined)
 }
 
@@ -1011,7 +1001,7 @@ pub fn clone_sprite<'gc>(
 
     new_clip.set_clip_event_handlers(context.gc_context, movie_clip.clip_actions().to_vec());
 
-    *new_clip.drawing(context.gc_context) = movie_clip.drawing(context.gc_context).clone();
+    *new_clip.drawing_mut(context.gc()) = movie_clip.drawing().clone();
     // TODO: Any other properties we should copy...?
     // Definitely not ScriptObject properties.
 

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -102,7 +102,7 @@ impl<'gc> Graphic<'gc> {
         ))
     }
 
-    pub fn drawing(&self, gc_context: &Mutation<'gc>) -> RefMut<'_, Drawing> {
+    pub fn drawing_mut(&self, gc_context: &Mutation<'gc>) -> RefMut<'_, Drawing> {
         RefMut::map(self.0.write(gc_context), |w| {
             w.drawing.get_or_insert_with(Drawing::new)
         })
@@ -258,7 +258,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 
     fn as_drawing(&self, gc_context: &Mutation<'gc>) -> Option<RefMut<'_, Drawing>> {
-        Some(self.drawing(gc_context))
+        Some(self.drawing_mut(gc_context))
     }
 }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2350,10 +2350,14 @@ impl<'gc> MovieClip<'gc> {
         self.0.write(context.gc_context).button_mode = button_mode;
     }
 
-    pub fn drawing(&self, gc_context: &Mutation<'gc>) -> RefMut<'_, Drawing> {
+    pub fn drawing_mut(&self, gc_context: &Mutation<'gc>) -> RefMut<'_, Drawing> {
         // We're about to change graphics, so invalidate on the next frame
         self.invalidate_cached_bitmap(gc_context);
         RefMut::map(self.0.write(gc_context), |s| &mut s.drawing)
+    }
+
+    pub fn drawing(&self) -> Ref<'_, Drawing> {
+        Ref::map(self.0.read(), |s| &s.drawing)
     }
 
     pub fn is_button_mode(&self, context: &mut UpdateContext<'gc>) -> bool {
@@ -2818,7 +2822,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn as_drawing(&self, gc_context: &Mutation<'gc>) -> Option<RefMut<'_, Drawing>> {
-        Some(self.drawing(gc_context))
+        Some(self.drawing_mut(gc_context))
     }
 
     fn post_instantiation(

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -789,7 +789,7 @@ impl GlyphShape {
                 let mut glyph = glyph.borrow_mut();
                 Some(renderer.register_shape((&*glyph.shape()).into(), &NullBitmapSource))
             }
-            GlyphShape::Drawing(drawing) => Some(drawing.register_or_replace(renderer)),
+            GlyphShape::Drawing(drawing) => drawing.register_or_replace(renderer),
             GlyphShape::None => None,
         }
     }


### PR DESCRIPTION
All `MovieClip`s (and `Graphic`s) logically have a `Drawing` (that can be manipulated by ActionScript), but most of these stay empty.

This does two things:
- avoid registering `ShapeHandle`s for empty drawings;
- box and lazily allocate drawings inside `MovieClip`s and `Graphic`s.

Thanks to @adrian17 for notifying this inefficiency!