### PR TITLE
render: Skip blending if there's nothing to draw

### DIFF
--- a/render/src/commands.rs
+++ b/render/src/commands.rs
@@ -52,6 +52,11 @@ impl CommandList {
         Self::default()
     }
 
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+
     pub fn execute(self, handler: &mut impl CommandHandler) {
         for command in self.commands {
             match command {


### PR DESCRIPTION
Noticed on `The Last Stand: Union City` that it tries to draw out-of-frame street lights; the draw is culled, but the blending logic doesn't know that.
This won't improve max FPS if everything is in frame, but should save some GPU resources when there's blended stuff out of frame.

