### PR TITLE
text: Calculate character positions during relayout

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -909,9 +909,8 @@ impl<'gc> EditText<'gc> {
         layout: &Layout<'gc>,
     ) {
         if flags.contains(LayoutDebugBoxesFlag::CHAR) {
-            let text = &self.text();
-            for i in 0..text.len() {
-                if let Some(bounds) = layout.char_bounds(i, text) {
+            for i in 0..self.text().len() {
+                if let Some(bounds) = layout.char_bounds(i) {
                     context.draw_rect_outline(Color::MAGENTA, bounds, Twips::ONE);
                 }
             }
@@ -2030,13 +2029,7 @@ impl<'gc> EditText<'gc> {
 
     pub fn char_bounds(self, index: usize) -> Option<Rectangle<Twips>> {
         let edit_text = self.0.read();
-        let text = edit_text.text_spans.text();
-
-        if index >= text.len() {
-            return None;
-        }
-
-        let bounds = edit_text.layout.char_bounds(index, text)?;
+        let bounds = edit_text.layout.char_bounds(index)?;
         let padding = Twips::from_pixels(Self::INTERNAL_PADDING);
         let bounds = Matrix::translate(padding, padding) * bounds;
         Some(bounds)

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -1358,21 +1358,18 @@ impl<'gc> LayoutBox<'gc> {
     pub fn char_x_bounds(&self, position: usize, text: &WStr) -> Option<(Twips, Twips)> {
         let relative_position = position.checked_sub(self.start())?;
 
-        let mut x_bounds = None;
-        if let Some((text, _tf, font, params, _color)) = self.as_renderable_text(text) {
-            font.evaluate(
-                text,
-                Default::default(),
-                params,
-                |pos, _transform, _glyph: &Glyph, advance, x| {
-                    if pos == relative_position {
-                        x_bounds = Some((x, x + advance));
-                    }
-                },
-            );
-        }
+        let LayoutContent::Text { char_end_pos, .. } = &self.content else {
+            return None;
+        };
 
-        x_bounds
+        Some(if relative_position == 0 {
+            (Twips::ZERO, *char_end_pos.get(0)?)
+        } else {
+            (
+                *char_end_pos.get(relative_position - 1)?,
+                *char_end_pos.get(relative_position)?,
+            )
+        })
     }
 }
 

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -2,7 +2,7 @@
 
 use crate::context::UpdateContext;
 use crate::drawing::Drawing;
-use crate::font::{EvalParameters, Font, FontType, Glyph};
+use crate::font::{EvalParameters, Font, FontType};
 use crate::html::dimensions::{BoxBounds, Position, Size};
 use crate::html::text_format::{FormatSpans, TextFormat, TextSpan};
 use crate::string::{utils as string_utils, WStr};
@@ -823,10 +823,10 @@ impl<'gc> Layout<'gc> {
     }
 
     /// Returns char bounds of the given char relative to this layout.
-    pub fn char_bounds(&self, position: usize, text: &WStr) -> Option<Rectangle<Twips>> {
+    pub fn char_bounds(&self, position: usize) -> Option<Rectangle<Twips>> {
         let line_index = self.find_line_index_by_position(position)?;
         let line = self.lines.get(line_index)?;
-        line.char_bounds(position, text)
+        line.char_bounds(position)
     }
 }
 
@@ -923,13 +923,13 @@ impl<'gc> LayoutLine<'gc> {
     }
 
     /// Returns char bounds of the given char relative to the whole layout.
-    pub fn char_bounds(&self, position: usize, text: &WStr) -> Option<Rectangle<Twips>> {
+    pub fn char_bounds(&self, position: usize) -> Option<Rectangle<Twips>> {
         let box_index = self.find_box_index_by_position(position)?;
         let layout_box = self.boxes.get(box_index)?;
 
         let line_bounds = self.bounds();
         let origin_x = layout_box.bounds().origin().x();
-        let x_bounds = layout_box.char_x_bounds(position, text)?;
+        let x_bounds = layout_box.char_x_bounds(position)?;
 
         Some(Rectangle {
             x_min: origin_x + x_bounds.0,
@@ -1355,7 +1355,7 @@ impl<'gc> LayoutBox<'gc> {
     }
 
     /// Return x-axis char bounds of the given char relative to this layout box.
-    pub fn char_x_bounds(&self, position: usize, text: &WStr) -> Option<(Twips, Twips)> {
+    pub fn char_x_bounds(&self, position: usize) -> Option<(Twips, Twips)> {
         let relative_position = position.checked_sub(self.start())?;
 
         let LayoutContent::Text { char_end_pos, .. } = &self.content else {


### PR DESCRIPTION
This refactor simplifies existing code and makes it easier to write code related to character positions (evaluating a font each time is not needed anymore).