### PR TITLE
chore: Fix errors reported by clippy beta

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -45,7 +45,7 @@ macro_rules! avm_debug {
 #[derive(Clone)]
 pub struct RegisterSet<'gc>(SmallVec<[Value<'gc>; 8]>);
 
-unsafe impl<'gc> gc_arena::Collect for RegisterSet<'gc> {
+unsafe impl gc_arena::Collect for RegisterSet<'_> {
     #[inline]
     fn trace(&self, cc: &gc_arena::Collection) {
         for register in &self.0 {

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -457,7 +457,7 @@ impl<'gc> Executable<'gc> {
     }
 }
 
-impl<'gc> From<NativeFunction> for Executable<'gc> {
+impl From<NativeFunction> for Executable<'_> {
     fn from(nf: NativeFunction) -> Self {
         Executable::Native(nf)
     }

--- a/core/src/avm1/property_map.rs
+++ b/core/src/avm1/property_map.rs
@@ -108,7 +108,7 @@ impl<'gc, V> PropertyMap<'gc, V> {
     }
 }
 
-unsafe impl<'gc, V: Collect> Collect for PropertyMap<'gc, V> {
+unsafe impl<V: Collect> Collect for PropertyMap<'_, V> {
     fn trace(&self, cc: &gc_arena::Collection) {
         for (key, value) in &self.0 {
             key.0.trace(cc);
@@ -127,7 +127,7 @@ pub struct OccupiedEntry<'gc, 'a, V> {
     index: usize,
 }
 
-impl<'gc, 'a, V> OccupiedEntry<'gc, 'a, V> {
+impl<'gc, V> OccupiedEntry<'gc, '_, V> {
     pub fn remove_entry(&mut self) -> (AvmString<'gc>, V) {
         let (k, v) = self.map.shift_remove_index(self.index).unwrap();
         (k.0, v)
@@ -151,7 +151,7 @@ pub struct VacantEntry<'gc, 'a, V> {
     key: AvmString<'gc>,
 }
 
-impl<'gc, 'a, V> VacantEntry<'gc, 'a, V> {
+impl<V> VacantEntry<'_, '_, V> {
     pub fn insert(self, value: V) {
         self.map.insert(PropertyName(self.key), value);
     }
@@ -160,13 +160,13 @@ impl<'gc, 'a, V> VacantEntry<'gc, 'a, V> {
 /// Wraps a str-like type, causing the hash map to use a case insensitive hash and equality.
 struct CaseInsensitive<T>(T);
 
-impl<'a> Hash for CaseInsensitive<&'a WStr> {
+impl Hash for CaseInsensitive<&WStr> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         swf_hash_string_ignore_case(self.0, state);
     }
 }
 
-impl<'gc, 'a> Equivalent<PropertyName<'gc>> for CaseInsensitive<&'a WStr> {
+impl<'gc> Equivalent<PropertyName<'gc>> for CaseInsensitive<&WStr> {
     fn equivalent(&self, key: &PropertyName<'gc>) -> bool {
         key.0.eq_ignore_case(self.0)
     }
@@ -176,13 +176,13 @@ impl<'gc, 'a> Equivalent<PropertyName<'gc>> for CaseInsensitive<&'a WStr> {
 /// but case sensitive equality.
 struct CaseSensitive<T>(T);
 
-impl<'a> Hash for CaseSensitive<&'a WStr> {
+impl Hash for CaseSensitive<&WStr> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         swf_hash_string_ignore_case(self.0, state);
     }
 }
 
-impl<'gc, 'a> Equivalent<PropertyName<'gc>> for CaseSensitive<&'a WStr> {
+impl<'gc> Equivalent<PropertyName<'gc>> for CaseSensitive<&WStr> {
     fn equivalent(&self, key: &PropertyName<'gc>) -> bool {
         key.0 == self.0
     }
@@ -198,7 +198,7 @@ impl<'gc, 'a> Equivalent<PropertyName<'gc>> for CaseSensitive<&'a WStr> {
 struct PropertyName<'gc>(AvmString<'gc>);
 
 #[allow(clippy::derive_hash_xor_eq)]
-impl<'gc> Hash for PropertyName<'gc> {
+impl Hash for PropertyName<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         swf_hash_string_ignore_case(self.0.as_ref(), state);
     }

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -47,13 +47,13 @@ impl<'gc> From<AvmAtom<'gc>> for Value<'gc> {
     }
 }
 
-impl<'gc> From<&'static str> for Value<'gc> {
+impl From<&'static str> for Value<'_> {
     fn from(string: &'static str) -> Self {
         Value::String(string.into())
     }
 }
 
-impl<'gc> From<bool> for Value<'gc> {
+impl From<bool> for Value<'_> {
     fn from(value: bool) -> Self {
         Value::Bool(value)
     }
@@ -68,61 +68,61 @@ where
     }
 }
 
-impl<'gc> From<f64> for Value<'gc> {
+impl From<f64> for Value<'_> {
     fn from(value: f64) -> Self {
         Value::Number(value)
     }
 }
 
-impl<'gc> From<f32> for Value<'gc> {
+impl From<f32> for Value<'_> {
     fn from(value: f32) -> Self {
         Value::Number(f64::from(value))
     }
 }
 
-impl<'gc> From<i8> for Value<'gc> {
+impl From<i8> for Value<'_> {
     fn from(value: i8) -> Self {
         Value::Number(f64::from(value))
     }
 }
 
-impl<'gc> From<u8> for Value<'gc> {
+impl From<u8> for Value<'_> {
     fn from(value: u8) -> Self {
         Value::Number(f64::from(value))
     }
 }
 
-impl<'gc> From<i16> for Value<'gc> {
+impl From<i16> for Value<'_> {
     fn from(value: i16) -> Self {
         Value::Number(f64::from(value))
     }
 }
 
-impl<'gc> From<u16> for Value<'gc> {
+impl From<u16> for Value<'_> {
     fn from(value: u16) -> Self {
         Value::Number(f64::from(value))
     }
 }
 
-impl<'gc> From<i32> for Value<'gc> {
+impl From<i32> for Value<'_> {
     fn from(value: i32) -> Self {
         Value::Number(f64::from(value))
     }
 }
 
-impl<'gc> From<u32> for Value<'gc> {
+impl From<u32> for Value<'_> {
     fn from(value: u32) -> Self {
         Value::Number(f64::from(value))
     }
 }
 
-impl<'gc> From<u64> for Value<'gc> {
+impl From<u64> for Value<'_> {
     fn from(value: u64) -> Self {
         Value::Number(value as f64)
     }
 }
 
-impl<'gc> From<usize> for Value<'gc> {
+impl From<usize> for Value<'_> {
     fn from(value: usize) -> Self {
         Value::Number(value as f64)
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -36,10 +36,9 @@ use super::error::make_mismatch_error;
 /// Represents a particular register set.
 ///
 /// This type exists primarily because SmallVec isn't garbage-collectable.
-
 pub struct RegisterSet<'gc>(SmallVec<[Value<'gc>; 8]>);
 
-unsafe impl<'gc> gc_arena::Collect for RegisterSet<'gc> {
+unsafe impl gc_arena::Collect for RegisterSet<'_> {
     #[inline]
     fn trace(&self, cc: &gc_arena::Collection) {
         for register in &self.0 {

--- a/core/src/avm2/array.rs
+++ b/core/src/avm2/array.rs
@@ -34,7 +34,7 @@ struct ArrayStorageIterator<'a, 'gc> {
     index_back: usize,
 }
 
-impl<'a, 'gc> Iterator for ArrayStorageIterator<'a, 'gc> {
+impl<'gc> Iterator for ArrayStorageIterator<'_, 'gc> {
     type Item = Option<Value<'gc>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -51,7 +51,7 @@ impl<'a, 'gc> Iterator for ArrayStorageIterator<'a, 'gc> {
     }
 }
 
-impl<'a, 'gc> DoubleEndedIterator for ArrayStorageIterator<'a, 'gc> {
+impl DoubleEndedIterator for ArrayStorageIterator<'_, '_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.index >= self.index_back || self.index_back == 0 {
             None
@@ -66,7 +66,7 @@ impl<'a, 'gc> DoubleEndedIterator for ArrayStorageIterator<'a, 'gc> {
     }
 }
 
-impl<'a, 'gc> ExactSizeIterator for ArrayStorageIterator<'a, 'gc> {
+impl ExactSizeIterator for ArrayStorageIterator<'_, '_> {
     fn len(&self) -> usize {
         self.index_back - self.index
     }
@@ -139,9 +139,7 @@ impl<'gc> ArrayStorage<'gc> {
     /// yielding `None`.
     pub fn get(&self, item: usize) -> Option<Value<'gc>> {
         match &self {
-            ArrayStorage::Dense { storage, .. } => {
-                return storage.get(item).copied().unwrap_or(None);
-            }
+            ArrayStorage::Dense { storage, .. } => storage.get(item).copied().unwrap_or(None),
             ArrayStorage::Sparse { storage, .. } => storage.get(&item).copied(),
         }
     }

--- a/core/src/avm2/call_stack.rs
+++ b/core/src/avm2/call_stack.rs
@@ -69,13 +69,13 @@ impl<'gc> CallStack<'gc> {
     }
 }
 
-impl<'gc> Default for CallStack<'gc> {
+impl Default for CallStack<'_> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'gc> std::fmt::Display for CallStack<'gc> {
+impl std::fmt::Display for CallStack<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut output = WString::new();
         self.display(&mut output);

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -199,7 +199,7 @@ impl Hash for Class<'_> {
     }
 }
 
-impl<'gc> core::fmt::Debug for Class<'gc> {
+impl core::fmt::Debug for Class<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("Class").field("name", &self.name()).finish()
     }

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -427,10 +427,10 @@ impl<'gc> Domain<'gc> {
 
 pub enum DomainPtr {}
 
-impl<'gc> PartialEq for Domain<'gc> {
+impl PartialEq for Domain<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0.as_ptr() == other.0.as_ptr()
     }
 }
 
-impl<'gc> Eq for Domain<'gc> {}
+impl Eq for Domain<'_> {}

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -42,7 +42,7 @@ pub struct E4XNodeData<'gc> {
     notification: Option<FunctionObject<'gc>>,
 }
 
-impl<'gc> Debug for E4XNodeData<'gc> {
+impl Debug for E4XNodeData<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("E4XNodeData")
             // Don't print the actual parent, to avoid infinite recursion
@@ -1392,16 +1392,16 @@ impl<'gc> E4XNode<'gc> {
                     );
                 }
 
-                return to_xml_string(E4XOrXml::E4X(*self), activation);
+                to_xml_string(E4XOrXml::E4X(*self), activation)
             }
             E4XNodeKind::Comment(_) | E4XNodeKind::ProcessingInstruction(_) => {
-                return to_xml_string(E4XOrXml::E4X(*self), activation);
+                to_xml_string(E4XOrXml::E4X(*self), activation)
             }
         }
     }
 
     pub fn xml_to_xml_string(&self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        return to_xml_string(E4XOrXml::E4X(*self), activation);
+        to_xml_string(E4XOrXml::E4X(*self), activation)
     }
 
     pub fn kind(&self) -> Ref<'_, E4XNodeKind<'gc>> {

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -22,7 +22,7 @@ pub enum Error<'gc> {
     RustError(Box<dyn std::error::Error>),
 }
 
-impl<'gc> Debug for Error<'gc> {
+impl Debug for Error<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Error::AvmError(error) = self {
             if let Some(error) = error.as_object().and_then(|obj| obj.as_error_object()) {
@@ -836,7 +836,7 @@ fn error_constructor<'gc>(
         .into())
 }
 
-impl<'gc> std::fmt::Display for Error<'gc> {
+impl std::fmt::Display for Error<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")
     }

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -303,7 +303,7 @@ impl<'gc> DispatchList<'gc> {
     }
 }
 
-impl<'gc> Default for DispatchList<'gc> {
+impl Default for DispatchList<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -331,15 +331,15 @@ impl<'gc> EventHandler<'gc> {
     }
 }
 
-impl<'gc> PartialEq for EventHandler<'gc> {
+impl PartialEq for EventHandler<'_> {
     fn eq(&self, rhs: &Self) -> bool {
         self.use_capture == rhs.use_capture && Object::ptr_eq(self.handler, rhs.handler)
     }
 }
 
-impl<'gc> Eq for EventHandler<'gc> {}
+impl Eq for EventHandler<'_> {}
 
-impl<'gc> Hash for EventHandler<'gc> {
+impl Hash for EventHandler<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.use_capture.hash(state);
         self.handler.as_ptr().hash(state);

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -253,7 +253,7 @@ pub fn exec<'gc>(
     ret
 }
 
-impl<'gc> fmt::Debug for BoundMethod<'gc> {
+impl fmt::Debug for BoundMethod<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.method {
             Method::Bytecode(be) => fmt

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -416,58 +416,58 @@ pub fn draw_rect<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Length between two points on a unit circle that are 45 degrees apart from
-/// one another.
-///
-/// This constant is `H`, short for 'hypotenuse', because it is also the length
-/// of the hypotenuse formed from the control point triangle of any quadratic
-/// Bezier curve approximating a 45-degree unit circle arc.
-///
-/// The derivation of this constant - or a similar constant for any other arc
-/// angle hypotenuse - is as follows:
-///
-/// 1. Call the arc angle `alpha`. In this special case, `alpha` is 45 degrees,
-///    or one-quarter `PI`.
-/// 2. Consider the triangle formed by the center of the circle and the two
-///    points at the start and end of the arc. The two other angles will be
-///    equal, and it and `alpha` sum to 180 degrees. We'll call this angle
-///    `beta`, and it is equal to `alpha` minus 180 degrees, divided by 2.
-/// 3. Using the law of sines, we know that the sine of `alpha` divided by `H`
-///    is equal to the sine of `beta` divided by `r`, where `r` is the radius
-///    of the circle. We can solve for `H` to get the result. Note that since
-///    this is a unit circle, you won't see a radius term in this constant.
-//const H:f64 = (PI * 0.25).sin() / (PI * 0.375).sin();
+// /// Length between two points on a unit circle that are 45 degrees apart from
+// /// one another.
+// ///
+// /// This constant is `H`, short for 'hypotenuse', because it is also the length
+// /// of the hypotenuse formed from the control point triangle of any quadratic
+// /// Bezier curve approximating a 45-degree unit circle arc.
+// ///
+// /// The derivation of this constant - or a similar constant for any other arc
+// /// angle hypotenuse - is as follows:
+// ///
+// /// 1. Call the arc angle `alpha`. In this special case, `alpha` is 45 degrees,
+// ///    or one-quarter `PI`.
+// /// 2. Consider the triangle formed by the center of the circle and the two
+// ///    points at the start and end of the arc. The two other angles will be
+// ///    equal, and it and `alpha` sum to 180 degrees. We'll call this angle
+// ///    `beta`, and it is equal to `alpha` minus 180 degrees, divided by 2.
+// /// 3. Using the law of sines, we know that the sine of `alpha` divided by `H`
+// ///    is equal to the sine of `beta` divided by `r`, where `r` is the radius
+// ///    of the circle. We can solve for `H` to get the result. Note that since
+// ///    this is a unit circle, you won't see a radius term in this constant.
+// const H:f64 = (PI * 0.25).sin() / (PI * 0.375).sin();
 
-/// Length between two control points of a quadratic Bezier curve approximating
-/// a 45-degree arc of a unit circle.
-///
-/// This constant is critical to calculating the off-curve point of the control
-/// point triangle. We do so by taking the tangents at each on-curve point,
-/// which point in the direction of the off-curve points. Then, we scale one of
-/// those tangent vectors by `A_B` and add it to the on-curve point to get the
-/// off-curve point, constructing our Bezier.
-///
-/// The derivation of this constant - or a similar constant for any other arc
-/// angle Bezier - is as follows:
-///
-/// 1. Start with the value of `H` for the given arc angle `alpha`.
-/// 2. Consider the triangle formed by the three control points of our desired
-///    Bezier curve. We'll call the angle at the off-curve control point
-///    `delta`, and the two other angles of this triangle are `gamma`.
-/// 3. Because two of the lines of this triangle are tangent lines of the
-///    circle, they will form a right angle with the normal, which is the same
-///    as the line between the center of the circle and the point.
-///    Coincidentally, this right angle is shared between `beta`, meaning that
-///    we can subtract it from 90 degrees to obtain `gamma`. Or, after some
-///    elementary algebra, just take half of `alpha`.
-/// 4. We can then derive the value of `delta` by subtracting out the other two
-///    `gamma`s from 180 degrees. This, again, can be simplified to just
-///    180 degrees minus `alpha`.
-/// 5. By the law of sines, the sine of `delta` divided by `H` is equal to
-///    the sine of `gamma` divided by `A_B`. We can then rearrange this to get
-///    `H` times the sine of `gamma`, divided by the sine of `delta`; which is
-///    our `A_B` constant.
-//const A_B:f64 = H * (PI * 0.125).sin() / (PI * 0.75).sin();
+// /// Length between two control points of a quadratic Bezier curve approximating
+// /// a 45-degree arc of a unit circle.
+// ///
+// /// This constant is critical to calculating the off-curve point of the control
+// /// point triangle. We do so by taking the tangents at each on-curve point,
+// /// which point in the direction of the off-curve points. Then, we scale one of
+// /// those tangent vectors by `A_B` and add it to the on-curve point to get the
+// /// off-curve point, constructing our Bezier.
+// ///
+// /// The derivation of this constant - or a similar constant for any other arc
+// /// angle Bezier - is as follows:
+// ///
+// /// 1. Start with the value of `H` for the given arc angle `alpha`.
+// /// 2. Consider the triangle formed by the three control points of our desired
+// ///    Bezier curve. We'll call the angle at the off-curve control point
+// ///    `delta`, and the two other angles of this triangle are `gamma`.
+// /// 3. Because two of the lines of this triangle are tangent lines of the
+// ///    circle, they will form a right angle with the normal, which is the same
+// ///    as the line between the center of the circle and the point.
+// ///    Coincidentally, this right angle is shared between `beta`, meaning that
+// ///    we can subtract it from 90 degrees to obtain `gamma`. Or, after some
+// ///    elementary algebra, just take half of `alpha`.
+// /// 4. We can then derive the value of `delta` by subtracting out the other two
+// ///    `gamma`s from 180 degrees. This, again, can be simplified to just
+// ///    180 degrees minus `alpha`.
+// /// 5. By the law of sines, the sine of `delta` divided by `H` is equal to
+// ///    the sine of `gamma` divided by `A_B`. We can then rearrange this to get
+// ///    `H` times the sine of `gamma`, divided by the sine of `delta`; which is
+// ///    our `A_B` constant.
+// const A_B:f64 = H * (PI * 0.125).sin() / (PI * 0.75).sin();
 
 /// A list of five quadratic Bezier control points, intended to approximate the
 /// bottom-right quadrant of a unit circle.

--- a/core/src/avm2/globals/flash/system/security.rs
+++ b/core/src/avm2/globals/flash/system/security.rs
@@ -49,7 +49,7 @@ pub fn get_sandbox_type<'gc>(
         SandboxType::LocalTrusted => "localTrusted",
         SandboxType::Application => "application",
     };
-    return Ok(AvmString::new_utf8(activation.context.gc_context, sandbox_type).into());
+    Ok(AvmString::new_utf8(activation.context.gc_context, sandbox_type).into())
 }
 
 pub fn allow_domain<'gc>(

--- a/core/src/avm2/globals/reg_exp.rs
+++ b/core/src/avm2/globals/reg_exp.rs
@@ -74,7 +74,7 @@ pub fn call_handler<'gc>(
             return Ok(arg);
         }
     }
-    return this_class.construct(activation, args).map(|o| o.into());
+    this_class.construct(activation, args).map(|o| o.into())
 }
 
 /// Implements `RegExp.dotall`

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -210,11 +210,10 @@ fn index_of<'gc>(
         Some(n) => n.coerce_to_i32(activation)?.max(0) as usize,
     };
 
-    return this
-        .slice(start_index..)
+    this.slice(start_index..)
         .and_then(|s| s.find(&pattern))
         .map(|i| Ok((i + start_index).into()))
-        .unwrap_or_else(|| Ok((-1).into())); // Out of range or not found
+        .unwrap_or_else(|| Ok((-1).into())) // Out of range or not found
 }
 
 /// Implements `String.lastIndexOf`
@@ -237,12 +236,11 @@ fn last_index_of<'gc>(
         },
     };
 
-    return this
-        .slice(..start_index)
+    this.slice(..start_index)
         .unwrap_or(&this)
         .rfind(&pattern)
         .map(|i| Ok(i.into()))
-        .unwrap_or_else(|| Ok((-1).into())); // Not found
+        .unwrap_or_else(|| Ok((-1).into())) // Not found
 }
 
 /// Implements String.localeCompare
@@ -273,7 +271,7 @@ fn locale_compare<'gc>(
         return Ok(Value::Integer(1));
     }
 
-    return Ok(Value::Integer(0));
+    Ok(Value::Integer(0))
 }
 
 /// Implements `String.match`
@@ -493,9 +491,9 @@ fn split<'gc>(
             .collect()
     };
 
-    return Ok(ArrayObject::from_storage(activation, storage)
+    Ok(ArrayObject::from_storage(activation, storage)
         .unwrap()
-        .into());
+        .into())
 }
 
 /// Implements `String.substr`

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -356,7 +356,7 @@ impl<'gc> NativeMethod<'gc> {
     }
 }
 
-impl<'gc> fmt::Debug for NativeMethod<'gc> {
+impl fmt::Debug for NativeMethod<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NativeMethod")
             .field("method", &format!("{:p}", &self.method))

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -269,14 +269,12 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             Some(Property::Virtual { get: Some(get), .. }) => {
                 self.call_method(get, &[], activation)
             }
-            Some(Property::Virtual { get: None, .. }) => {
-                return Err(error::make_reference_error(
-                    activation,
-                    error::ReferenceErrorCode::ReadFromWriteOnly,
-                    multiname,
-                    self.instance_class(),
-                ));
-            }
+            Some(Property::Virtual { get: None, .. }) => Err(error::make_reference_error(
+                activation,
+                error::ReferenceErrorCode::ReadFromWriteOnly,
+                multiname,
+                self.instance_class(),
+            )),
             None => self.get_property_local(multiname, activation),
         }
     }
@@ -362,23 +360,23 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     return self.set_property_local(multiname, value, activation);
                 }
 
-                return Err(error::make_reference_error(
+                Err(error::make_reference_error(
                     activation,
                     error::ReferenceErrorCode::AssignToMethod,
                     multiname,
                     self.instance_class(),
-                ));
+                ))
             }
             Some(Property::Virtual { set: Some(set), .. }) => {
                 self.call_method(set, &[value], activation).map(|_| ())
             }
             Some(Property::ConstSlot { .. }) | Some(Property::Virtual { set: None, .. }) => {
-                return Err(error::make_reference_error(
+                Err(error::make_reference_error(
                     activation,
                     error::ReferenceErrorCode::WriteToReadOnly,
                     multiname,
                     self.instance_class(),
-                ));
+                ))
             }
             None => self.set_property_local(multiname, value, activation),
         }
@@ -437,25 +435,21 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
                 Ok(())
             }
-            Some(Property::Method { .. }) => {
-                return Err(error::make_reference_error(
-                    activation,
-                    error::ReferenceErrorCode::AssignToMethod,
-                    multiname,
-                    self.instance_class(),
-                ));
-            }
+            Some(Property::Method { .. }) => Err(error::make_reference_error(
+                activation,
+                error::ReferenceErrorCode::AssignToMethod,
+                multiname,
+                self.instance_class(),
+            )),
             Some(Property::Virtual { set: Some(set), .. }) => {
                 self.call_method(set, &[value], activation).map(|_| ())
             }
-            Some(Property::Virtual { set: None, .. }) => {
-                return Err(error::make_reference_error(
-                    activation,
-                    error::ReferenceErrorCode::WriteToReadOnly,
-                    multiname,
-                    self.instance_class(),
-                ));
-            }
+            Some(Property::Virtual { set: None, .. }) => Err(error::make_reference_error(
+                activation,
+                error::ReferenceErrorCode::WriteToReadOnly,
+                multiname,
+                self.instance_class(),
+            )),
             None => self.init_property_local(multiname, value, activation),
         }
     }
@@ -519,14 +513,12 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
                 obj.call(Value::from(self.into()), arguments, activation)
             }
-            Some(Property::Virtual { get: None, .. }) => {
-                return Err(error::make_reference_error(
-                    activation,
-                    error::ReferenceErrorCode::ReadFromWriteOnly,
-                    multiname,
-                    self.instance_class(),
-                ));
-            }
+            Some(Property::Virtual { get: None, .. }) => Err(error::make_reference_error(
+                activation,
+                error::ReferenceErrorCode::ReadFromWriteOnly,
+                multiname,
+                self.instance_class(),
+            )),
             None => self.call_property_local(multiname, arguments, activation),
         }
     }
@@ -1423,15 +1415,15 @@ impl<'gc> Object<'gc> {
     }
 }
 
-impl<'gc> PartialEq for Object<'gc> {
+impl PartialEq for Object<'_> {
     fn eq(&self, other: &Self) -> bool {
         Object::ptr_eq(*self, *other)
     }
 }
 
-impl<'gc> Eq for Object<'gc> {}
+impl Eq for Object<'_> {}
 
-impl<'gc> Hash for Object<'gc> {
+impl Hash for Object<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_ptr().hash(state);
     }

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -856,21 +856,21 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
     }
 }
 
-impl<'gc> PartialEq for ClassObject<'gc> {
+impl PartialEq for ClassObject<'_> {
     fn eq(&self, other: &Self) -> bool {
         Object::ptr_eq(*self, *other)
     }
 }
 
-impl<'gc> Eq for ClassObject<'gc> {}
+impl Eq for ClassObject<'_> {}
 
-impl<'gc> Hash for ClassObject<'gc> {
+impl Hash for ClassObject<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_ptr().hash(state);
     }
 }
 
-impl<'gc> Debug for ClassObject<'gc> {
+impl Debug for ClassObject<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("ClassObject")
             .field("name", &self.debug_class_name())

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -368,7 +368,7 @@ impl<'gc> TObject<'gc> for EventObject<'gc> {
     }
 }
 
-impl<'gc> Debug for EventObject<'gc> {
+impl Debug for EventObject<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("EventObject")
             .field("type", &self.0.event.borrow().event_type())

--- a/core/src/avm2/object/file_reference_object.rs
+++ b/core/src/avm2/object/file_reference_object.rs
@@ -50,7 +50,7 @@ impl<'gc> TObject<'gc> for FileReferenceObject<'gc> {
     }
 }
 
-impl<'gc> FileReferenceObject<'gc> {
+impl FileReferenceObject<'_> {
     pub fn init_from_dialog_result(&self, result: Box<dyn FileDialogResult>) -> FileReference {
         self.0
             .reference

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -60,7 +60,7 @@ pub enum LoaderStream<'gc> {
     Swf(Arc<SwfMovie>, DisplayObject<'gc>),
 }
 
-impl<'gc> LoaderStream<'gc> {
+impl LoaderStream<'_> {
     pub fn movie(&self) -> &Arc<SwfMovie> {
         match self {
             LoaderStream::NotYetLoaded(movie, _, _) => movie,

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -67,7 +67,7 @@ impl<'gc> TObject<'gc> for NetConnectionObject<'gc> {
     }
 }
 
-impl<'gc> NetConnectionObject<'gc> {
+impl NetConnectionObject<'_> {
     pub fn handle(&self) -> Option<NetConnectionHandle> {
         self.0.handle.get()
     }
@@ -77,7 +77,7 @@ impl<'gc> NetConnectionObject<'gc> {
     }
 }
 
-impl<'gc> Debug for NetConnectionObject<'gc> {
+impl Debug for NetConnectionObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "NetConnectionObject")
     }

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -67,7 +67,7 @@ impl<'gc> TObject<'gc> for NetStreamObject<'gc> {
     }
 }
 
-impl<'gc> Debug for NetStreamObject<'gc> {
+impl Debug for NetStreamObject<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("NetStreamObject")
             .field("ptr", &Gc::as_ptr(self.0))

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -243,12 +243,12 @@ impl<'gc> ScriptObjectWrapper<'gc> {
         // as dynamic properties that have not yet been set, and yield
         // `undefined`
         if self.is_sealed() {
-            return Err(error::make_reference_error(
+            Err(error::make_reference_error(
                 activation,
                 error::ReferenceErrorCode::InvalidRead,
                 multiname,
                 self.instance_class(),
-            ));
+            ))
         } else {
             Ok(Value::Undefined)
         }
@@ -444,7 +444,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
     }
 }
 
-impl<'gc> Debug for ScriptObject<'gc> {
+impl Debug for ScriptObject<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("ScriptObject")
             .field("name", &ScriptObjectWrapper(self.0).debug_class_name())

--- a/core/src/avm2/object/shader_data_object.rs
+++ b/core/src/avm2/object/shader_data_object.rs
@@ -40,7 +40,7 @@ impl fmt::Debug for ShaderDataObject<'_> {
     }
 }
 
-impl<'gc> ShaderDataObject<'gc> {
+impl ShaderDataObject<'_> {
     pub fn pixel_bender_shader(&self) -> Option<PixelBenderShaderHandle> {
         let shader = &self.0.shader;
         let guard = scopeguard::guard(shader.take(), |stolen| shader.set(stolen));

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -129,7 +129,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
     }
 }
 
-impl<'gc> Debug for StageObject<'gc> {
+impl Debug for StageObject<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("StageObject")
             .field("name", &self.base().debug_class_name())

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -48,7 +48,7 @@ pub struct XmlListObject<'gc>(pub Gc<'gc, XmlListObjectData<'gc>>);
 #[collect(no_drop)]
 pub struct XmlListObjectWeak<'gc>(pub GcWeak<'gc, XmlListObjectData<'gc>>);
 
-impl<'gc> Debug for XmlListObject<'gc> {
+impl Debug for XmlListObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("XmlListObject")
             .field("ptr", &Gc::as_ptr(self.0))

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -346,7 +346,7 @@ pub enum Op<'gc> {
     URShift,
 }
 
-impl<'gc> Op<'gc> {
+impl Op<'_> {
     pub fn is_block_terminating(&self) -> bool {
         matches!(
             self,

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -130,7 +130,7 @@ impl<'gc> OptValue<'gc> {
     }
 }
 
-impl<'gc> std::fmt::Debug for OptValue<'gc> {
+impl std::fmt::Debug for OptValue<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("OptValue")
             .field("class", &self.class)

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -29,7 +29,7 @@ pub struct PropertyMap<'gc, V>(
     HashMap<AvmString<'gc>, SmallVec<[(Namespace<'gc>, V); 2]>, FnvBuildHasher>,
 );
 
-unsafe impl<'gc, V> Collect for PropertyMap<'gc, V>
+unsafe impl<V> Collect for PropertyMap<'_, V>
 where
     V: Collect,
 {
@@ -45,7 +45,7 @@ where
     }
 }
 
-impl<'gc, V> Default for PropertyMap<'gc, V> {
+impl<V> Default for PropertyMap<'_, V> {
     fn default() -> Self {
         Self::new()
     }

--- a/core/src/avm2/qname.rs
+++ b/core/src/avm2/qname.rs
@@ -23,14 +23,14 @@ pub struct QName<'gc> {
     name: AvmString<'gc>,
 }
 
-impl<'gc> PartialEq for QName<'gc> {
+impl PartialEq for QName<'_> {
     fn eq(&self, other: &Self) -> bool {
         // Implemented by hand to enforce order of comparisons for perf
         self.name == other.name && self.ns.exact_version_match(other.ns)
     }
 }
 
-impl<'gc> Eq for QName<'gc> {}
+impl Eq for QName<'_> {}
 
 impl<'gc> QName<'gc> {
     pub fn new(ns: Namespace<'gc>, name: impl Into<AvmString<'gc>>) -> Self {
@@ -175,7 +175,7 @@ impl<'gc> QName<'gc> {
     }
 }
 
-impl<'gc> Debug for QName<'gc> {
+impl Debug for QName<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self.to_qualified_name_no_mc() {
             Either::Left(name) => write!(f, "{name}"),

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -28,7 +28,7 @@ pub struct RegExp<'gc> {
     cached_text: Option<CachedText<'gc>>,
 }
 
-impl<'gc> Clone for RegExp<'gc> {
+impl Clone for RegExp<'_> {
     fn clone(&self) -> Self {
         Self {
             source: self.source,

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -616,7 +616,7 @@ impl<'gc> Script<'gc> {
     }
 }
 
-impl<'gc> Debug for Script<'gc> {
+impl Debug for Script<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("Script")
             .field("ptr", &self.0.as_ptr())

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -67,13 +67,13 @@ impl<'gc> From<AvmAtom<'gc>> for Value<'gc> {
     }
 }
 
-impl<'gc> From<&'static str> for Value<'gc> {
+impl From<&'static str> for Value<'_> {
     fn from(string: &'static str) -> Self {
         Value::String(string.into())
     }
 }
 
-impl<'gc> From<bool> for Value<'gc> {
+impl From<bool> for Value<'_> {
     fn from(value: bool) -> Self {
         Value::Bool(value)
     }
@@ -88,43 +88,43 @@ where
     }
 }
 
-impl<'gc> From<f64> for Value<'gc> {
+impl From<f64> for Value<'_> {
     fn from(value: f64) -> Self {
         Value::Number(value)
     }
 }
 
-impl<'gc> From<f32> for Value<'gc> {
+impl From<f32> for Value<'_> {
     fn from(value: f32) -> Self {
         Value::Number(f64::from(value))
     }
 }
 
-impl<'gc> From<u8> for Value<'gc> {
+impl From<u8> for Value<'_> {
     fn from(value: u8) -> Self {
         Value::Integer(i32::from(value))
     }
 }
 
-impl<'gc> From<i8> for Value<'gc> {
+impl From<i8> for Value<'_> {
     fn from(value: i8) -> Self {
         Value::Integer(i32::from(value))
     }
 }
 
-impl<'gc> From<i16> for Value<'gc> {
+impl From<i16> for Value<'_> {
     fn from(value: i16) -> Self {
         Value::Integer(i32::from(value))
     }
 }
 
-impl<'gc> From<u16> for Value<'gc> {
+impl From<u16> for Value<'_> {
     fn from(value: u16) -> Self {
         Value::Integer(i32::from(value))
     }
 }
 
-impl<'gc> From<i32> for Value<'gc> {
+impl From<i32> for Value<'_> {
     fn from(value: i32) -> Self {
         if value >= (1 << 28) || value < -(1 << 28) {
             Value::Number(value as f64)
@@ -134,7 +134,7 @@ impl<'gc> From<i32> for Value<'gc> {
     }
 }
 
-impl<'gc> From<u32> for Value<'gc> {
+impl From<u32> for Value<'_> {
     fn from(value: u32) -> Self {
         if value >= (1 << 28) {
             Value::Number(value as f64)
@@ -144,7 +144,7 @@ impl<'gc> From<u32> for Value<'gc> {
     }
 }
 
-impl<'gc> From<usize> for Value<'gc> {
+impl From<usize> for Value<'_> {
     fn from(value: usize) -> Self {
         Value::Number(value as f64)
     }

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -767,7 +767,7 @@ impl<'gc> AudioManager<'gc> {
     }
 }
 
-impl<'gc> Default for AudioManager<'gc> {
+impl Default for AudioManager<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -27,7 +27,6 @@ use swf::{BlendMode, ColorTransform, Fixed8, Rectangle, Twips};
 /// This will allow us to be able to optimise the implementations and share the
 /// same code between VMs.
 #[allow(clippy::too_many_arguments)]
-
 pub fn fill_rect<'gc>(
     mc: &Mutation<'gc>,
     renderer: &mut dyn RenderBackend,

--- a/core/src/bitmap/turbulence.rs
+++ b/core/src/bitmap/turbulence.rs
@@ -1,7 +1,8 @@
-/// This file is a Rust port of the C reference implementation of the
-/// feTurbulence element in the SVG specification. It's the usual Perlin noise.
-/// See: https://www.w3.org/TR/SVG11/filters.html#feTurbulenceElement
-/// The `octave_offsets` parameter of `turbulence` was added after porting.
+//! This file is a Rust port of the C reference implementation of the
+//! feTurbulence element in the SVG specification. It's the usual Perlin noise.
+//!
+//! See: <https://www.w3.org/TR/SVG11/filters.html#feTurbulenceElement>.
+//! The `octave_offsets` parameter of `turbulence` was added after porting.
 
 // Copyright © 2015 W3C® (MIT, ERCIM, Keio, Beihang).
 // This software or document includes material copied from or derived
@@ -38,9 +39,13 @@ fn random(seed: i64) -> i64 {
 
 #[derive(Copy, Clone)]
 struct StitchInfo {
-    width: i32, // How much to subtract to wrap for stitching.
+    /// How much width to subtract to wrap for stitching.
+    width: i32,
+    /// How much height to subtract to wrap for stitching.
     height: i32,
-    wrap_x: i32, // Minimum value to wrap.
+    /// Minimum value of x to wrap.
+    wrap_x: i32,
+    /// Minimum value of y to wrap.
     wrap_y: i32,
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -508,7 +508,7 @@ impl<'gc> ActionQueue<'gc> {
     }
 }
 
-impl<'gc> Default for ActionQueue<'gc> {
+impl Default for ActionQueue<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -548,7 +548,7 @@ pub struct RenderContext<'a, 'gc> {
     pub stage: Stage<'gc>,
 }
 
-impl<'a, 'gc> RenderContext<'a, 'gc> {
+impl<'gc> RenderContext<'_, 'gc> {
     /// Convenience method to retrieve the current GC context. Note that explicitly writing
     /// `self.gc_context` can be sometimes necessary to satisfy the borrow checker.
     #[inline(always)]

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -270,7 +270,7 @@ pub struct DisplayObjectBase<'gc> {
     cache: Option<BitmapCache>,
 }
 
-impl<'gc> Default for DisplayObjectBase<'gc> {
+impl Default for DisplayObjectBase<'_> {
     fn default() -> Self {
         Self {
             parent: Default::default(),

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -859,10 +859,10 @@ impl<'gc> ChildContainer<'gc> {
             matching_render_children.sort_by_key(|&(depth, _child)| *depth);
 
             // First child will have the lowest depth
-            return matching_render_children
+            matching_render_children
                 .first()
                 .map(|&(_depth, child)| child)
-                .copied();
+                .copied()
         } else {
             // TODO: Make a HashMap from name -> child?
             // But need to handle conflicting names (lowest in depth order takes priority).
@@ -1157,4 +1157,4 @@ impl<'gc> DoubleEndedIterator for RenderIter<'gc> {
     }
 }
 
-impl<'gc> ExactSizeIterator for RenderIter<'gc> {}
+impl ExactSizeIterator for RenderIter<'_> {}

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -178,7 +178,7 @@ pub struct EditTextData<'gc> {
     last_click: Option<ClickEventData>,
 }
 
-impl<'gc> EditTextData<'gc> {
+impl EditTextData<'_> {
     fn vertical_scroll_offset(&self) -> Twips {
         if self.scroll > 1 {
             let lines = self.layout.lines();

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -733,12 +733,6 @@ impl<'gc> EditText<'gc> {
         self.try_bind_text_field_variable(activation, true);
     }
 
-    /// Construct a base text transform for this `EditText`, to be used for
-    /// evaluating fonts.
-    ///
-    /// The `text_transform` constitutes the base transform that all text is
-    /// written into.
-
     /// Internal padding between the bounds of the EditText and the text.
     /// Applies to each side.
     const INTERNAL_PADDING: f64 = 2.0;

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -96,7 +96,7 @@ pub struct InteractiveObjectBase<'gc> {
     focus_rect: Option<bool>,
 }
 
-impl<'gc> Default for InteractiveObjectBase<'gc> {
+impl Default for InteractiveObjectBase<'_> {
     fn default() -> Self {
         Self {
             base: Default::default(),
@@ -710,7 +710,7 @@ pub enum Avm2MousePick<'gc> {
     Miss,
 }
 
-impl<'gc> Debug for Avm2MousePick<'gc> {
+impl Debug for Avm2MousePick<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Avm2MousePick::Hit(target) => write!(f, "Hit({:?})", target.as_displayobject().name()),
@@ -781,10 +781,10 @@ impl<'gc> InteractiveObject<'gc> {
     }
 }
 
-impl<'gc> PartialEq for InteractiveObject<'gc> {
+impl PartialEq for InteractiveObject<'_> {
     fn eq(&self, other: &Self) -> bool {
         InteractiveObject::ptr_eq(*self, *other)
     }
 }
 
-impl<'gc> Eq for InteractiveObject<'gc> {}
+impl Eq for InteractiveObject<'_> {}

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -311,7 +311,7 @@ pub enum ClipEvent<'gc> {
     },
 }
 
-impl<'gc> ClipEvent<'gc> {
+impl ClipEvent<'_> {
     /// Method names for button event handles.
     pub const BUTTON_EVENT_METHODS: [&'static str; 7] = [
         "onDragOver",

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -90,7 +90,7 @@ struct GlyphToDrawing<'a>(&'a mut Drawing);
 /// Convert from a TTF outline, to a flash Drawing.
 ///
 /// Note that the Y axis is flipped. I do not know why, but Flash does this.
-impl<'a> ttf_parser::OutlineBuilder for GlyphToDrawing<'a> {
+impl ttf_parser::OutlineBuilder for GlyphToDrawing<'_> {
     fn move_to(&mut self, x: f32, y: f32) {
         self.0.draw_command(DrawCommand::MoveTo(Point::new(
             Twips::new(x as i32),

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -1055,7 +1055,7 @@ pub enum LayoutContent<'gc> {
     },
 }
 
-impl<'gc> Debug for LayoutContent<'gc> {
+impl Debug for LayoutContent<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             LayoutContent::Text { start, end, .. } => f

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -354,7 +354,7 @@ pub struct MovieLibrarySource<'a, 'gc> {
     pub library: &'a MovieLibrary<'gc>,
 }
 
-impl<'a, 'gc> ruffle_render::bitmap::BitmapSource for MovieLibrarySource<'a, 'gc> {
+impl ruffle_render::bitmap::BitmapSource for MovieLibrarySource<'_, '_> {
     fn bitmap_size(&self, id: u16) -> Option<ruffle_render::bitmap::BitmapSize> {
         if let Some(Character::Bitmap { compressed, .. }) = self.library.characters.get(&id) {
             Some(compressed.size())
@@ -424,7 +424,7 @@ pub struct Library<'gc> {
     avm2_class_registry: Avm2ClassRegistry<'gc>,
 }
 
-unsafe impl<'gc> gc_arena::Collect for Library<'gc> {
+unsafe impl gc_arena::Collect for Library<'_> {
     #[inline]
     fn trace(&self, cc: &gc_arena::Collection) {
         for (_, val) in self.movie_libraries.iter() {

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -240,7 +240,7 @@ impl From<crate::avm1::Error<'_>> for Error {
 /// Holds all in-progress loads for the player.
 pub struct LoadManager<'gc>(SlotMap<LoaderHandle, Loader<'gc>>);
 
-unsafe impl<'gc> Collect for LoadManager<'gc> {
+unsafe impl Collect for LoadManager<'_> {
     fn trace(&self, cc: &gc_arena::Collection) {
         for (_, loader) in self.0.iter() {
             loader.trace(cc)
@@ -719,7 +719,7 @@ impl<'gc> LoadManager<'gc> {
     }
 }
 
-impl<'gc> Default for LoadManager<'gc> {
+impl Default for LoadManager<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/core/src/local_connection.rs
+++ b/core/src/local_connection.rs
@@ -229,7 +229,7 @@ impl<'gc> LocalConnections<'gc> {
             }
         } else {
             tracing::error!("LocalConnection: Unable to parse movie URL: {url}");
-            return Cow::Borrowed("unknown"); // this is surely an error but it'll hopefully highlight this case in issues for us
+            Cow::Borrowed("unknown") // this is surely an error but it'll hopefully highlight this case in issues for us
         }
     }
 

--- a/core/src/net_connection.rs
+++ b/core/src/net_connection.rs
@@ -75,7 +75,7 @@ pub enum NetConnectionObject<'gc> {
     Avm1(Avm1Object<'gc>),
 }
 
-impl<'gc> NetConnectionObject<'gc> {
+impl NetConnectionObject<'_> {
     pub fn set_handle(&self, handle: Option<NetConnectionHandle>) -> Option<NetConnectionHandle> {
         match self {
             NetConnectionObject::Avm2(object) => object.set_handle(handle),
@@ -107,7 +107,7 @@ pub struct NetConnections<'gc> {
     connections: SlotMap<NetConnectionHandle, NetConnection<'gc>>,
 }
 
-unsafe impl<'gc> Collect for NetConnections<'gc> {
+unsafe impl Collect for NetConnections<'_> {
     fn trace(&self, cc: &gc_arena::Collection) {
         for (_, connection) in self.connections.iter() {
             connection.trace(cc)
@@ -115,7 +115,7 @@ unsafe impl<'gc> Collect for NetConnections<'gc> {
     }
 }
 
-impl<'gc> Default for NetConnections<'gc> {
+impl Default for NetConnections<'_> {
     fn default() -> Self {
         Self {
             connections: SlotMap::with_key(),
@@ -344,7 +344,7 @@ pub struct NetConnection<'gc> {
     protocol: NetConnectionProtocol,
 }
 
-impl<'gc> NetConnection<'gc> {
+impl NetConnection<'_> {
     pub fn is_connected(&self) -> bool {
         match self.protocol {
             NetConnectionProtocol::Local => true,

--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -70,7 +70,7 @@ pub struct Sockets<'gc> {
     sender: Sender<SocketAction>,
 }
 
-unsafe impl<'gc> Collect for Sockets<'gc> {
+unsafe impl Collect for Sockets<'_> {
     fn trace(&self, cc: &gc_arena::Collection) {
         for (_, socket) in self.sockets.iter() {
             socket.trace(cc)

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -79,7 +79,7 @@ pub struct StreamManager<'gc> {
     active_streams: Vec<NetStream<'gc>>,
 }
 
-impl<'gc> Default for StreamManager<'gc> {
+impl Default for StreamManager<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -151,13 +151,13 @@ impl<'gc> StreamManager<'gc> {
 #[collect(no_drop)]
 pub struct NetStream<'gc>(GcCell<'gc, NetStreamData<'gc>>);
 
-impl<'gc> PartialEq for NetStream<'gc> {
+impl PartialEq for NetStream<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0.as_ptr() == other.0.as_ptr()
     }
 }
 
-impl<'gc> Eq for NetStream<'gc> {}
+impl Eq for NetStream<'_> {}
 
 /// The current type of the data in the stream buffer.
 #[derive(Clone, Debug)]

--- a/core/src/string/avm_string.rs
+++ b/core/src/string/avm_string.rs
@@ -173,7 +173,7 @@ impl Default for AvmString<'_> {
     }
 }
 
-impl<'gc> From<&'static str> for AvmString<'gc> {
+impl From<&'static str> for AvmString<'_> {
     #[inline]
     fn from(str: &'static str) -> Self {
         // TODO(moulins): actually check that `str` is valid ASCII.
@@ -183,7 +183,7 @@ impl<'gc> From<&'static str> for AvmString<'gc> {
     }
 }
 
-impl<'gc> From<&'static WStr> for AvmString<'gc> {
+impl From<&'static WStr> for AvmString<'_> {
     #[inline]
     fn from(str: &'static WStr) -> Self {
         Self {
@@ -192,7 +192,7 @@ impl<'gc> From<&'static WStr> for AvmString<'gc> {
     }
 }
 
-impl<'gc> Deref for AvmString<'gc> {
+impl Deref for AvmString<'_> {
     type Target = WStr;
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -201,7 +201,7 @@ impl<'gc> Deref for AvmString<'gc> {
 }
 
 // Manual equality implementation with fast paths for owned strings.
-impl<'gc> PartialEq for AvmString<'gc> {
+impl PartialEq for AvmString<'_> {
     fn eq(&self, other: &Self) -> bool {
         if let (Source::Managed(left), Source::Managed(right)) = (self.source, other.source) {
             // Fast accept for identical strings.
@@ -235,6 +235,6 @@ impl<'gc> PartialEq<AvmAtom<'gc>> for AvmString<'gc> {
     }
 }
 
-impl<'gc> Eq for AvmString<'gc> {}
+impl Eq for AvmString<'_> {}
 
 wstr_impl_traits!(impl['gc] manual_eq for AvmString<'gc>);

--- a/core/src/string/interner.rs
+++ b/core/src/string/interner.rs
@@ -15,33 +15,33 @@ use crate::string::{AvmString, AvmStringRepr, WStr};
 #[collect(no_drop)]
 pub struct AvmAtom<'gc>(pub(super) Gc<'gc, AvmStringRepr<'gc>>);
 
-impl<'gc> PartialEq for AvmAtom<'gc> {
+impl PartialEq for AvmAtom<'_> {
     fn eq(&self, other: &Self) -> bool {
         Gc::ptr_eq(self.0, other.0)
     }
 }
 
-impl<'gc> Eq for AvmAtom<'gc> {}
+impl Eq for AvmAtom<'_> {}
 
-impl<'gc> Hash for AvmAtom<'gc> {
+impl Hash for AvmAtom<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         Gc::as_ptr(self.0).hash(state);
     }
 }
 
-impl<'gc> fmt::Debug for AvmAtom<'gc> {
+impl fmt::Debug for AvmAtom<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_wstr(), f)
     }
 }
 
-impl<'gc> fmt::Display for AvmAtom<'gc> {
+impl fmt::Display for AvmAtom<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_wstr(), f)
     }
 }
 
-impl<'gc> AvmAtom<'gc> {
+impl AvmAtom<'_> {
     pub fn as_wstr(&self) -> &WStr {
         &self.0
     }
@@ -252,7 +252,7 @@ impl<'gc, T: Hash + 'gc> WeakSet<'gc, T> {
     }
 }
 
-unsafe impl<'gc, T> Collect for WeakSet<'gc, T> {
+unsafe impl<T> Collect for WeakSet<'_, T> {
     fn trace(&self, cc: &gc_arena::Collection) {
         // Prune entries known to be dead.
         // Safe, as we never pick up new GC pointers from outside this allocation.

--- a/core/src/string/repr.rs
+++ b/core/src/string/repr.rs
@@ -180,7 +180,7 @@ impl<'gc> AvmStringRepr<'gc> {
     }
 }
 
-impl<'gc> Drop for AvmStringRepr<'gc> {
+impl Drop for AvmStringRepr<'_> {
     fn drop(&mut self) {
         let cap = self.capacity.get().len32();
         if cap > 0 {
@@ -195,7 +195,7 @@ impl<'gc> Drop for AvmStringRepr<'gc> {
     }
 }
 
-impl<'gc> Deref for AvmStringRepr<'gc> {
+impl Deref for AvmStringRepr<'_> {
     type Target = WStr;
     #[inline]
     fn deref(&self) -> &WStr {
@@ -203,7 +203,7 @@ impl<'gc> Deref for AvmStringRepr<'gc> {
     }
 }
 
-impl<'gc> Default for AvmStringRepr<'gc> {
+impl Default for AvmStringRepr<'_> {
     #[inline]
     fn default() -> Self {
         Self::from_raw(WString::new(), false)

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -304,7 +304,7 @@ impl Default for Timers<'_> {
     }
 }
 
-unsafe impl<'gc> Collect for Timers<'gc> {
+unsafe impl Collect for Timers<'_> {
     fn trace(&self, cc: &gc_arena::Collection) {
         for timer in &self.timers {
             timer.trace(cc);

--- a/core/src/xml/iterators.rs
+++ b/core/src/xml/iterators.rs
@@ -35,7 +35,7 @@ impl<'gc> Iterator for ChildIter<'gc> {
     }
 }
 
-impl<'gc> DoubleEndedIterator for ChildIter<'gc> {
+impl DoubleEndedIterator for ChildIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.index < self.back_index {
             self.back_index -= 1;

--- a/core/src/xml/tree.rs
+++ b/core/src/xml/tree.rs
@@ -527,7 +527,7 @@ impl<'gc> XmlNode<'gc> {
     }
 }
 
-impl<'gc> fmt::Debug for XmlNode<'gc> {
+impl fmt::Debug for XmlNode<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("XmlNodeData")
             .field("ptr", &self.0.as_ptr())

--- a/flv/src/reader.rs
+++ b/flv/src/reader.rs
@@ -113,7 +113,7 @@ impl<'a> FlvReader<'a> {
     }
 }
 
-impl<'a> Seek for FlvReader<'a> {
+impl Seek for FlvReader<'_> {
     fn seek(&mut self, pos: SeekFrom) -> IoResult<u64> {
         let newpos = match pos {
             SeekFrom::Start(pos) => pos,

--- a/render/naga-agal/src/varying.rs
+++ b/render/naga-agal/src/varying.rs
@@ -22,7 +22,7 @@ pub struct VaryingRegister {
     output_struct_index: Option<usize>,
 }
 
-impl<'a> NagaBuilder<'a> {
+impl NagaBuilder<'_> {
     pub fn get_varying_pointer(&mut self, index: usize) -> Result<Handle<Expression>> {
         if index >= self.varying_registers.varying_pointers.len() {
             self.varying_registers

--- a/render/naga-pixelbender/src/lib.rs
+++ b/render/naga-pixelbender/src/lib.rs
@@ -119,7 +119,7 @@ pub const ZEROED_OUT_OF_RANGE_MODE_INDEX: u32 = 5;
 
 pub const TEXTURE_START_BIND_INDEX: u32 = 6;
 
-impl<'a> ShaderBuilder<'a> {
+impl ShaderBuilder<'_> {
     pub fn build(shader: &PixelBenderShader) -> Result<NagaModules> {
         let mut module = Module::default();
 

--- a/render/src/filters.rs
+++ b/render/src/filters.rs
@@ -35,7 +35,7 @@ pub struct ShaderFilter<'a> {
     pub shader_args: Vec<PixelBenderShaderArgument<'a>>,
 }
 
-impl<'gc> PartialEq for ShaderFilter<'gc> {
+impl PartialEq for ShaderFilter<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.bottom_extension == other.bottom_extension
             && self.left_extension == other.left_extension

--- a/render/src/matrix.rs
+++ b/render/src/matrix.rs
@@ -1,6 +1,6 @@
 use swf::{Fixed16, Point, PointDelta, Rectangle, Twips};
 
-/// TODO: Consider using portable SIMD when it's stable (https://doc.rust-lang.org/std/simd/index.html).
+// TODO: Consider using portable SIMD when it's stable (https://doc.rust-lang.org/std/simd/index.html).
 
 /// The transformation matrix used by Flash display objects.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/render/wgpu/src/pixel_bender.rs
+++ b/render/wgpu/src/pixel_bender.rs
@@ -268,7 +268,7 @@ enum BorrowedOrOwnedTexture<'a> {
     Owned(wgpu::Texture),
 }
 
-impl<'a> std::ops::Deref for BorrowedOrOwnedTexture<'a> {
+impl std::ops::Deref for BorrowedOrOwnedTexture<'_> {
     type Target = wgpu::Texture;
 
     fn deref(&self) -> &Self::Target {

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -608,7 +608,7 @@ impl<'a> WgpuCommandHandler<'a> {
     }
 }
 
-impl<'a> CommandHandler for WgpuCommandHandler<'a> {
+impl CommandHandler for WgpuCommandHandler<'_> {
     fn blend(&mut self, commands: CommandList, blend_mode: RenderBlendMode) {
         let mut surface = Surface::new(
             self.descriptors,

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -1575,7 +1575,7 @@ impl<'a> EditText<'a> {
     }
 }
 
-impl<'a> Default for EditText<'a> {
+impl Default for EditText<'_> {
     fn default() -> Self {
         Self {
             id: Default::default(),

--- a/tests/framework/src/image_trigger.rs
+++ b/tests/framework/src/image_trigger.rs
@@ -21,7 +21,7 @@ impl<'de> Deserialize<'de> for ImageTrigger {
 
 struct ImageTriggerVisitor;
 
-impl<'de> Visitor<'de> for ImageTriggerVisitor {
+impl Visitor<'_> for ImageTriggerVisitor {
     type Value = ImageTrigger;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/tests/framework/src/runner.rs
+++ b/tests/framework/src/runner.rs
@@ -539,7 +539,7 @@ fn capture_and_compare_image(
 struct PrettyString<'a>(pub &'a str);
 
 /// Make diff to display string as multi-line string
-impl<'a> std::fmt::Debug for PrettyString<'a> {
+impl std::fmt::Debug for PrettyString<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.write_str(self.0)
     }

--- a/wstr/src/buf.rs
+++ b/wstr/src/buf.rs
@@ -306,7 +306,7 @@ impl WString {
             }
         }
 
-        impl<'a> Drop for Guard<'a> {
+        impl Drop for Guard<'_> {
             fn drop(&mut self) {
                 // SAFETY: something has gone wrong, replace the buffer with an empty one and drop it.
                 unsafe {

--- a/wstr/src/common.rs
+++ b/wstr/src/common.rs
@@ -473,14 +473,14 @@ impl WStr {
     }
 }
 
-impl<'a> Default for &'a WStr {
+impl Default for &WStr {
     #[inline]
     fn default() -> Self {
         WStr::empty()
     }
 }
 
-impl<'a> Default for &'a mut WStr {
+impl Default for &mut WStr {
     #[inline]
     fn default() -> Self {
         WStr::empty_mut()

--- a/wstr/src/ops.rs
+++ b/wstr/src/ops.rs
@@ -12,7 +12,7 @@ pub struct Iter<'a> {
     inner: Units<SliceIter<'a, u8>, SliceIter<'a, u16>>,
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = u16;
 
     #[inline]
@@ -24,7 +24,7 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Iter<'a> {
+impl DoubleEndedIterator for Iter<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         match &mut self.inner {
@@ -41,7 +41,7 @@ pub struct CharIndices<'a> {
     start: usize,
 }
 
-impl<'a> Iterator for CharIndices<'a> {
+impl Iterator for CharIndices<'_> {
     type Item = (usize, Result<char, core::char::DecodeUtf16Error>);
 
     #[inline]

--- a/wstr/src/pattern.rs
+++ b/wstr/src/pattern.rs
@@ -221,7 +221,7 @@ impl EmptySearcher {
     }
 }
 
-impl<'a> Searcher<'a> for EmptySearcher {
+impl Searcher<'_> for EmptySearcher {
     fn next(&mut self) -> SearchStep {
         match self.range.next() {
             Some(i) => SearchStep::Match(i, i),
@@ -255,7 +255,7 @@ impl<T: Copy + Eq> Predicate<T> for T {
 
 pub struct AnyOf<'a, T>(&'a [T]);
 
-impl<'a, T: Copy, U: Copy + Eq + TryFrom<T>> Predicate<T> for AnyOf<'a, U> {
+impl<T: Copy, U: Copy + Eq + TryFrom<T>> Predicate<T> for AnyOf<'_, U> {
     fn matches(&mut self, c: T) -> bool {
         self.0.iter().any(|m| U::try_from(c).ok() == Some(*m))
     }

--- a/wstr/src/utils.rs
+++ b/wstr/src/utils.rs
@@ -131,7 +131,7 @@ impl<'a> DecodeAvmUtf8<'a> {
     }
 }
 
-impl<'a> Iterator for DecodeAvmUtf8<'a> {
+impl Iterator for DecodeAvmUtf8<'_> {
     type Item = u32;
     fn next(&mut self) -> Option<Self::Item> {
         let first = *self.src.get(self.index)?;


### PR DESCRIPTION
This fixes errors like

    error: the following explicit lifetimes could be elided: 'a
    error: empty line after doc comment
    error: unneeded `return` statement

Plus others related to doc comments.