### PR TITLE
chore: Use `ubuntu-24.04` for Crowdin actions

### DIFF
--- a/.github/workflows/download_translations.yml
+++ b/.github/workflows/download_translations.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   crowdin:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     if: github.repository == 'ruffle-rs/ruffle'
 

--- a/.github/workflows/upload_texts.yml
+++ b/.github/workflows/upload_texts.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   crowdin:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     if: github.repository == 'ruffle-rs/ruffle'
 


### PR DESCRIPTION
This stops GitHub from wasting our time by messing around with `ubuntu-latest`.