### PR TITLE
extension: Disable Ruffle on Duo Security

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -22,6 +22,7 @@
                 "https://*.time4learning.com/*",
                 "https://*.edgenuity.com/*",
                 "https://www.chewy.com/*",
+                "https://*.duosecurity.com/*",
             ],
             "js": ["dist/content.js"],
             "all_frames": true,

--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -14,15 +14,15 @@
         {
             "matches": ["<all_urls>"],
             "exclude_matches": [
-                "https://sso.godaddy.com/*",
-                "https://authentication.td.com/*",
-                "https://*.twitch.tv/*",
-                "https://www.tuxedocomputers.com/*",
-                "https://*.taobao.com/*",
-                "https://*.time4learning.com/*",
-                "https://*.edgenuity.com/*",
-                "https://www.chewy.com/*",
-                "https://*.duosecurity.com/*",
+                "https://sso.godaddy.com/*", // See https://github.com/ruffle-rs/ruffle/pull/7146
+                "https://authentication.td.com/*", // See https://github.com/ruffle-rs/ruffle/issues/2158
+                "https://*.twitch.tv/*", // See https://github.com/ruffle-rs/ruffle/pull/8150
+                "https://www.tuxedocomputers.com/*", // See https://github.com/ruffle-rs/ruffle/issues/11906
+                "https://*.taobao.com/*", // See https://github.com/ruffle-rs/ruffle/pull/12650
+                "https://*.time4learning.com/*", // See https://github.com/ruffle-rs/ruffle/pull/16186
+                "https://*.edgenuity.com/*", // See https://github.com/ruffle-rs/ruffle/pull/16186
+                "https://www.chewy.com/*", // See https://github.com/ruffle-rs/ruffle/issues/18265
+                "https://*.duosecurity.com/*", // See https://github.com/ruffle-rs/ruffle/pull/18299
             ],
             "js": ["dist/content.js"],
             "all_frames": true,

--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -182,15 +182,15 @@ async function enable() {
                 persistAcrossSessions: true,
                 matches: ["<all_urls>"],
                 excludeMatches: [
-                    "https://sso.godaddy.com/*",
-                    "https://authentication.td.com/*",
-                    "https://*.twitch.tv/*",
-                    "https://www.tuxedocomputers.com/*",
-                    "https://*.taobao.com/*",
-                    "https://*.time4learning.com/*",
-                    "https://*.edgenuity.com/*",
-                    "https://www.chewy.com/*",
-                    "https://*.duosecurity.com/*",
+                    "https://sso.godaddy.com/*", // See https://github.com/ruffle-rs/ruffle/pull/7146
+                    "https://authentication.td.com/*", // See https://github.com/ruffle-rs/ruffle/issues/2158
+                    "https://*.twitch.tv/*", // See https://github.com/ruffle-rs/ruffle/pull/8150
+                    "https://www.tuxedocomputers.com/*", // See https://github.com/ruffle-rs/ruffle/issues/11906
+                    "https://*.taobao.com/*", // See https://github.com/ruffle-rs/ruffle/pull/12650
+                    "https://*.time4learning.com/*", // See https://github.com/ruffle-rs/ruffle/pull/16186
+                    "https://*.edgenuity.com/*", // See https://github.com/ruffle-rs/ruffle/pull/16186
+                    "https://www.chewy.com/*", // See https://github.com/ruffle-rs/ruffle/issues/18265
+                    "https://*.duosecurity.com/*", // See https://github.com/ruffle-rs/ruffle/pull/18299
                 ],
                 runAt: "document_start",
                 allFrames: true,

--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -190,6 +190,7 @@ async function enable() {
                     "https://*.time4learning.com/*",
                     "https://*.edgenuity.com/*",
                     "https://www.chewy.com/*",
+                    "https://*.duosecurity.com/*",
                 ],
                 runAt: "document_start",
                 allFrames: true,


### PR DESCRIPTION
My organization uses https://outlook.office.com secured by Duo Security, and they use Duo Security's check for Flash installation to ensure you don't log in with Flash installed. Unfortunately or fortunately depending on how you look at it, Ruffle is detected as Flash. We can't avoid that without fooling fewer plugin detection scripts used to enable Flash content, so we instead have to disable Ruffle on this site.