### PR TITLE
ci: Freeze rustc for nightly web builds to 1.81.0

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -332,9 +332,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.81.0
           targets: wasm32-unknown-unknown
 
       - name: Setup Node.js


### PR DESCRIPTION
***Note:** Tested locally, but not via CI.

Rust 1.82.0 enables the `reference-types` and `multivalue` target features for the WebAssembly target by default: https://releases.rs/docs/1.82.0/#compatibility-notes. wasm-bindgen 0.2.94+ enables reference type and multivalue transformations if the module already makes use of the corresponding target features.  The `reference-types` WebAssembly extension is not available in Safari 14.1, which we claim to support: https://caniuse.com/wasm-reference-types. It also, from testing, appears to not work in Pale Moon. Additionally, there seems to be some issues with support in Safari 15, which should support the reference-types extension but may have some bugs (which I don't expect will ever be fixed since Safari 15 isn't really supported anymore).

Hopefully, this can be reverted after a wasm-bindgen release with https://github.com/rustwasm/wasm-bindgen/pull/4213 is merged.