### PR TITLE
Revert "ci: Freeze rustc for nightly web builds to 1.81.0"

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -332,9 +332,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.81.0
+          toolchain: stable
           targets: wasm32-unknown-unknown
           components: rust-src
 


### PR DESCRIPTION
Reverts ruffle-rs/ruffle#18397.

To be merged once https://github.com/rustwasm/wasm-bindgen/pull/4213 is merged and released, so https://github.com/rustwasm/wasm-bindgen/issues/4227 can be fixed properly.

Also referencing https://github.com/rustwasm/wasm-bindgen/issues/4211.