### PR TITLE
build(deps): bump quick-xml in the cargo-minor group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "ffbfb3ddf5364c9cfcd65549a1e7b801d0e8d1b14c1a1590a6408aa93cfbfa84"
 dependencies = [
  "memchr",
 ]
@@ -6041,9 +6041,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
+checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
 dependencies = [
  "proc-macro2",
  "quick-xml",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,7 @@ bitflags = { workspace = true }
 smallvec = { version = "1.13.2", features = ["union"] }
 num-traits = { workspace = true }
 num-derive = { workspace = true }
-quick-xml = "0.36.2"
+quick-xml = "0.37.0"
 downcast-rs = "2.0.1"
 url = { workspace = true }
 weak-table = "0.3.2"

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -1759,7 +1759,7 @@ impl<'a> FormatState<'a> {
         }
 
         let encoded = line.to_utf8_lossy();
-        let escaped = escape(&encoded);
+        let escaped = escape(&*encoded);
 
         if let Cow::Borrowed(_) = &encoded {
             // Optimization: if the utf8 conversion was a no-op, we know the text is ASCII;

--- a/core/src/xml/tree.rs
+++ b/core/src/xml/tree.rs
@@ -482,7 +482,7 @@ impl<'gc> XmlNode<'gc> {
                 for (key, value) in self.attributes().own_properties() {
                     let value = value.coerce_to_string(activation)?;
                     let value = value.to_utf8_lossy();
-                    let value = escape(&value);
+                    let value = escape(&*value);
 
                     result.push_byte(b' ');
                     result.push_str(&key);
@@ -510,7 +510,7 @@ impl<'gc> XmlNode<'gc> {
         } else {
             let value = self.0.read().node_value.unwrap();
             let value = value.to_utf8_lossy();
-            let value = escape(&value);
+            let value = escape(&*value);
             result.push_utf8(&value);
         }
 


### PR DESCRIPTION
Replacing https://github.com/ruffle-rs/ruffle/pull/18406 with this, so Dependabot won't get confused...

Bumps the cargo-minor group with 1 update: [quick-xml](https://github.com/tafia/quick-xml).

Updates `quick-xml` from 0.36.2 to 0.37.0
- [Release notes](https://github.com/tafia/quick-xml/releases)
- [Changelog](https://github.com/tafia/quick-xml/blob/master/Changelog.md)
- [Commits](https://github.com/tafia/quick-xml/compare/v0.36.2...v0.37.0)