### PR TITLE
text: Introduce layout coordinate space and transforms

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -969,15 +969,9 @@ pub fn render_base<'gc>(this: DisplayObject<'gc>, context: &mut RenderContext<'_
                 true,
                 &context.stage.view_matrix(),
             );
-            context.commands.draw_rect(
-                background,
-                Matrix::create_box(
-                    bounds.width().to_pixels() as f32,
-                    bounds.height().to_pixels() as f32,
-                    bounds.x_min,
-                    bounds.y_min,
-                ),
-            );
+            context
+                .commands
+                .draw_rect(background, Matrix::create_box_from_rectangle(&bounds));
         }
         apply_standard_mask_and_scroll(this, context, |context| this.render_self(context));
     }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1338,11 +1338,8 @@ impl<'gc> EditText<'gc> {
 
     pub fn screen_position_to_index(self, position: Point<Twips>) -> Option<usize> {
         let text = self.0.read();
-        let mut position = self.global_to_local(position)?;
-        position.x += Twips::from_pixels(text.hscroll) - Self::GUTTER;
-        position.y += text.vertical_scroll_offset() - Self::GUTTER;
-        position.x -= text.bounds.x_min;
-        position.y -= text.bounds.y_min;
+        let position = self.global_to_local(position)?;
+        let position = self.local_to_layout(&text, position);
 
         // TODO We can use binary search for both y and x here
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -647,6 +647,28 @@ impl<'gc> EditText<'gc> {
             .set(flag, value);
     }
 
+    /// Returns the matrix for transforming from layout
+    /// coordinate space into this object's local space.
+    fn layout_to_local_matrix(self, data: &EditTextData) -> Matrix {
+        Matrix::translate(
+            data.bounds.x_min + Self::GUTTER - Twips::from_pixels(data.hscroll),
+            data.bounds.y_min + Self::GUTTER - data.vertical_scroll_offset(),
+        )
+    }
+
+    /// Returns the matrix for transforming from this object's
+    /// local space into its layout coordinate space.
+    fn local_to_layout_matrix(self, data: &EditTextData) -> Matrix {
+        // layout_to_local contains only a translation,
+        // no need to inverse the matrix generically.
+        let Matrix { tx, ty, .. } = self.layout_to_local_matrix(data);
+        Matrix::translate(-tx, -ty)
+    }
+
+    fn local_to_layout(&self, data: &EditTextData, local: Point<Twips>) -> Point<Twips> {
+        self.local_to_layout_matrix(data) * local
+    }
+
     pub fn replace_text(
         self,
         from: usize,

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2357,18 +2357,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         context.commands.activate_mask();
 
         context.transform_stack.push(&Transform {
-            matrix: Matrix::translate(edit_text.bounds.x_min, edit_text.bounds.y_min),
-            ..Default::default()
-        });
-
-        let scroll_offset = edit_text.vertical_scroll_offset();
-        // TODO: Where does this come from? How is this different than INTERNAL_PADDING? Does this apply to y as well?
-        // If this is actually right, offset the border in `redraw_border` instead of doing an extra push.
-        context.transform_stack.push(&Transform {
-            matrix: Matrix::translate(
-                Self::GUTTER - Twips::from_pixels(edit_text.hscroll),
-                Self::GUTTER - scroll_offset,
-            ),
+            matrix: self.layout_to_local_matrix(&edit_text),
             ..Default::default()
         });
 
@@ -2383,8 +2372,6 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             edit_text.layout_debug_boxes_flags,
             &edit_text.layout,
         );
-
-        context.transform_stack.pop();
 
         context.transform_stack.pop();
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2330,12 +2330,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         }
 
         context.commands.push_mask();
-        let mask = Matrix::create_box(
-            edit_text.bounds.width().to_pixels() as f32,
-            edit_text.bounds.height().to_pixels() as f32,
-            edit_text.bounds.x_min,
-            edit_text.bounds.y_min,
-        );
+        let mask = Matrix::create_box_from_rectangle(&edit_text.bounds);
         context.commands.draw_rect(
             Color::WHITE,
             context.transform_stack.transform().matrix * mask,

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2329,23 +2329,23 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             }
         }
 
-        context.transform_stack.push(&Transform {
-            matrix: Matrix::translate(edit_text.bounds.x_min, edit_text.bounds.y_min),
-            ..Default::default()
-        });
-
         context.commands.push_mask();
         let mask = Matrix::create_box(
             edit_text.bounds.width().to_pixels() as f32,
             edit_text.bounds.height().to_pixels() as f32,
-            Twips::ZERO,
-            Twips::ZERO,
+            edit_text.bounds.x_min,
+            edit_text.bounds.y_min,
         );
         context.commands.draw_rect(
             Color::WHITE,
             context.transform_stack.transform().matrix * mask,
         );
         context.commands.activate_mask();
+
+        context.transform_stack.push(&Transform {
+            matrix: Matrix::translate(edit_text.bounds.x_min, edit_text.bounds.y_min),
+            ..Default::default()
+        });
 
         let scroll_offset = edit_text.vertical_scroll_offset();
         // TODO: Where does this come from? How is this different than INTERNAL_PADDING? Does this apply to y as well?
@@ -2372,14 +2372,14 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
 
         context.transform_stack.pop();
 
+        context.transform_stack.pop();
+
         context.commands.deactivate_mask();
         context.commands.draw_rect(
             Color::WHITE,
             context.transform_stack.transform().matrix * mask,
         );
         context.commands.pop_mask();
-
-        context.transform_stack.pop();
     }
 
     fn allow_as_mask(&self) -> bool {

--- a/render/src/matrix.rs
+++ b/render/src/matrix.rs
@@ -122,6 +122,15 @@ impl Matrix {
         }
     }
 
+    pub fn create_box_from_rectangle(rect: &Rectangle<Twips>) -> Self {
+        Self::create_box(
+            rect.width().to_pixels() as f32,
+            rect.height().to_pixels() as f32,
+            rect.x_min,
+            rect.y_min,
+        )
+    }
+
     pub fn create_gradient_box(
         width: f32,
         height: f32,


### PR DESCRIPTION
This is a refactor that aims at code simplification and deduplication of logic. Specifically, it introduces the idea of layout coordinate space and implements transforms from local coordinate space to layout coordinate space and vice-versa.

By using these transforms it's easier and less error-prone to get coordinates within text.

This also simplifies text field rendering, pushing only one transform onto the stack instead of two.

After implementing this, I'm fairly certain that `is_link_at` is also broken, as it doesn't take into account translation resulting from bounds and it incorrectly compensates for the gutter. I'll leave this however for a future fix with tests.