### PR TITLE
text: Remove layout line & layout box interior bounds

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -473,9 +473,7 @@ impl DisplayObjectWindow {
                         ("Text Exterior", LayoutDebugBoxesFlag::TEXT_EXTERIOR),
                         ("Text", LayoutDebugBoxesFlag::TEXT),
                         ("Line", LayoutDebugBoxesFlag::LINE),
-                        ("Line Interior", LayoutDebugBoxesFlag::LINE_INTERIOR),
                         ("Box", LayoutDebugBoxesFlag::BOX),
-                        ("Box Interior", LayoutDebugBoxesFlag::BOX_INTERIOR),
                         ("Character", LayoutDebugBoxesFlag::CHAR),
                     ] {
                         let old_value = object.layout_debug_boxes_flag(flag);

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -942,7 +942,7 @@ impl<'gc> EditText<'gc> {
 
     /// Render a layout box, plus its children.
     fn render_layout_box(self, context: &mut RenderContext<'_, 'gc>, lbox: &LayoutBox<'gc>) {
-        let origin = lbox.interior_bounds().origin();
+        let origin = lbox.bounds().origin();
 
         let edit_text = self.0.read();
 
@@ -1345,9 +1345,7 @@ impl<'gc> EditText<'gc> {
         let mut closest_layout_box: Option<&LayoutBox<'gc>> = None;
         for layout_box in line.boxes_iter() {
             if layout_box.is_text_box() {
-                if position.x >= layout_box.interior_bounds().offset_x()
-                    || closest_layout_box.is_none()
-                {
+                if position.x >= layout_box.bounds().offset_x() || closest_layout_box.is_none() {
                     closest_layout_box = Some(layout_box);
                 } else {
                     break;
@@ -1356,7 +1354,7 @@ impl<'gc> EditText<'gc> {
         }
 
         if let Some(layout_box) = closest_layout_box {
-            let origin = layout_box.interior_bounds().origin();
+            let origin = layout_box.bounds().origin();
             let mut matrix = Matrix::translate(origin.x(), origin.y());
             matrix = matrix.inverse().expect("Invertible layout matrix");
             let local_position = matrix * position;
@@ -2097,7 +2095,7 @@ impl<'gc> EditText<'gc> {
         text.layout.boxes_iter().any(|layout| {
             layout.is_link()
                 && layout
-                    .interior_bounds()
+                    .bounds()
                     .contains(Position::from((position.x, position.y)))
         })
     }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -906,19 +906,9 @@ impl<'gc> EditText<'gc> {
                 }
             }
         }
-        if flags.contains(LayoutDebugBoxesFlag::BOX_INTERIOR) {
-            for lbox in layout.boxes_iter() {
-                context.draw_rect_outline(Color::RED, lbox.interior_bounds().into(), Twips::ONE);
-            }
-        }
         if flags.contains(LayoutDebugBoxesFlag::BOX) {
             for lbox in layout.boxes_iter() {
                 context.draw_rect_outline(Color::RED, lbox.bounds().into(), Twips::ONE);
-            }
-        }
-        if flags.contains(LayoutDebugBoxesFlag::LINE_INTERIOR) {
-            for line in layout.lines() {
-                context.draw_rect_outline(Color::BLUE, line.interior_bounds().into(), Twips::ONE);
             }
         }
         if flags.contains(LayoutDebugBoxesFlag::LINE) {
@@ -2781,9 +2771,7 @@ bitflags::bitflags! {
         const TEXT_EXTERIOR = 1 << 1;
         const TEXT = 1 << 2;
         const LINE = 1 << 3;
-        const LINE_INTERIOR = 1 << 4;
         const BOX = 1 << 5;
-        const BOX_INTERIOR = 1 << 6;
         const CHAR = 1 << 7;
     }
 }

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -403,9 +403,9 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
 
         // Update layout bounds
         if let Some(lb) = &mut self.bounds {
-            *lb += interior_bounds;
+            *lb += bounds;
         } else {
-            self.bounds = Some(interior_bounds);
+            self.bounds = Some(bounds);
         }
     }
 

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -944,11 +944,11 @@ impl<'gc> LayoutLine<'gc> {
     }
 
     pub fn offset_y(&self) -> Twips {
-        self.interior_bounds().offset_y()
+        self.bounds().offset_y()
     }
 
     pub fn extent_y(&self) -> Twips {
-        self.interior_bounds().extent_y()
+        self.bounds().extent_y()
     }
 
     pub fn boxes_iter(&self) -> Iter<'_, LayoutBox<'gc>> {

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -185,13 +185,12 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
                         (starting_pos, underline_color)
                     {
                         if tf.underline.unwrap_or(false)
-                            && underline_baseline + linebox.interior_bounds().origin().y()
+                            && underline_baseline + linebox.bounds().origin().y()
                                 == starting_pos.y()
                             && underline_color == color
                         {
                             //Underline is at the same baseline, extend it
-                            current_width =
-                                Some(linebox.interior_bounds().extent_x() - starting_pos.x());
+                            current_width = Some(linebox.bounds().extent_x() - starting_pos.x());
 
                             line_extended = true;
                         }
@@ -213,10 +212,10 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
 
                         if tf.underline.unwrap_or(false) {
                             starting_pos = Some(
-                                linebox.interior_bounds().origin()
+                                linebox.bounds().origin()
                                     + Position::from((Twips::ZERO, underline_baseline)),
                             );
-                            current_width = Some(linebox.interior_bounds().width());
+                            current_width = Some(linebox.bounds().width());
                             underline_color = Some(color);
                         }
                     }


### PR DESCRIPTION
These were originally used for some calculations, but now they have been replaced by proper bounds.

When reworking the layout, I added proper bounds (named `bounds`), and renamed the original bounds to `interior_bounds` in order to preserve the old behavior in some places. As of now, we're ready to drop the interior bounds, as replacing them with proper bounds works and all tests pass.

Areas where this PR changes the calculated values (by a bit):

* layout metrics (getTextExtent),
* maxscroll,
* bottom scroll,
* positions of links in text.