### PR TITLE
desktop: Add `Controls > Step Once`, for frame-by-frame stepping 

### DIFF
--- a/desktop/assets/texts/en-US/main_menu.ftl
+++ b/desktop/assets/texts/en-US/main_menu.ftl
@@ -20,6 +20,7 @@ file-menu-exit = Exit
 controls-menu = Controls
 controls-menu-suspend = Suspend
 controls-menu-resume = Resume
+controls-menu-step-once = Step Once
 controls-menu-volume = Volume controls
 
 help-menu = Help


### PR DESCRIPTION
Fast-paced animations can be hard to investigate with the debug tools, as one needs to suspend the playback at exactly the right time.

To alleviate this, this PR adds the `Controls > Step Once` menu command (shortcut: Ctrl+Space), which allows advancing a suspended movie one frame at a time. Sounds are suppressed while stepping, to prevent unpleasant "sound bursts". 