### PR TITLE
web: Use tsx for save manager rows and use more accurate check for SOL

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -2246,16 +2246,7 @@ function isSolData(data: string): boolean {
         if (data.charCodeAt(10 + i) !== markers[i]) return false;
     }
 
-    // Two bytes length of the object name
-    // First byte code * 256 + second byte code
-    const nameLength = data.charCodeAt(16) * 256 + data.charCodeAt(17);
-
-    // Three bytes of padding after the object name, always 0x00 0x00 0x00
-    if (data.slice(18 + nameLength, 18 + nameLength + 3) !== "\x00\x00\x00") {
-        return false;
-    }
-
-    // The structure makes this look like an SOL file up until the data
+    // This looks like an SOL file up until the end of the header
     return true;
 }
 

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -2229,10 +2229,7 @@ function isSolData(data: string): boolean {
     return (
        // First two bytes are a magic value (0x00 0xbf)
        data.charCodeAt(0) === 0x00 && data.charCodeAt(1) === 0xbf &&
-       // Next four bytes give the length of the LSO file excluding the first six bytes.
-       // First byte code * 256^3 + second byte code * 256^2 + third byte code * 256^1 + fourth byte code * 256^0 (1) + 6
-       [0, 1, 2, 3].reduce((acc, i) => acc + data.charCodeAt(i + 2) * (256 ** (3 - i)), 6) === data.length &&
-       // Next four bytes are another magic value (ASCII value of TCSO)
+       // Seventh through tenth bytes are another magic value (ASCII value of TCSO)
        data.slice(6, 10) === "TCSO" &&
        // Next six bytes are padding (0x00 0x04 0x00 0x00 0x00 0x00)
        [0x00, 0x04, 0x00, 0x00, 0x00, 0x00].every((v, i) => data.charCodeAt(10 + i) === v)


### PR DESCRIPTION
This includes a few vaguely related changes:

1) Many functions that relate to the save manager and don't rely on any parts of the `InnerPlayer` have been pulled out into external functions, taking a queue from already existing external functions like `parseBoolean` and `parseAllowScriptAccess`. These functions include `saveFile`, `base64ToArray` (which has also been slightly simplified), `base64ToBlob`, and `isB64SOL`.

2) `isB64SOL` has been changed to more accurately check for SOL data, using logic from https://www.sans.org/blog/local-shared-objects-aka-flash-cookies/

3) Each row of the save table has been changed to a tsx component called SaveRow, instead of using so much direct DOM manipulation.