### PR TITLE
core: Stop sounds attached to an unloaded root movie

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -532,6 +532,26 @@ impl<'gc> AudioManager<'gc> {
         });
     }
 
+    /// Stops any sound associated with the given Display Object and its children. The DO must represent the parent.
+    /// Sounds associated with DOs are an AVM1/Timeline concept and should not be called from AVM2 scripts.
+    pub fn stop_sounds_on_parent_and_children(
+        &mut self,
+        audio: &mut dyn AudioBackend,
+        display_object: DisplayObject<'gc>,
+    ) {
+        self.sounds.retain(move |sound| {
+            let mut other = sound.display_object;
+            while let Some(other_do) = other {
+                if DisplayObject::ptr_eq(other_do, display_object) {
+                    audio.stop_sound(sound.instance);
+                    return false;
+                }
+                other = other_do.parent();
+            }
+            true
+        });
+    }
+
     pub fn stop_all_sounds(&mut self, audio: &mut dyn AudioBackend) {
         self.sounds.clear();
         audio.stop_all_sounds();

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -287,6 +287,11 @@ impl<'gc> UpdateContext<'gc> {
             .stop_sounds_with_display_object(self.audio, display_object)
     }
 
+    pub fn stop_sounds_on_parent_and_children(&mut self, display_object: DisplayObject<'gc>) {
+        self.audio_manager
+            .stop_sounds_on_parent_and_children(self.audio, display_object)
+    }
+
     pub fn stop_all_sounds(&mut self) {
         self.audio_manager.stop_all_sounds(self.audio)
     }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -2147,10 +2147,6 @@ pub trait TDisplayObject<'gc>:
             }
         }
 
-        context
-            .audio_manager
-            .stop_sounds_with_display_object(context.audio, (*self).into());
-
         self.set_avm1_removed(context.gc_context, true);
     }
 

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -404,9 +404,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         } else if let Some(node) = self.masker() {
             node.set_maskee(context.gc(), None, true);
         }
-        context
-            .audio_manager
-            .stop_sounds_with_display_object(context.audio, (*self).into());
+
         self.set_avm1_removed(context.gc(), true);
     }
 }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2413,10 +2413,6 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
                 .retain(|&text_field| !DisplayObject::ptr_eq(text_field.into(), (*self).into()));
         }
 
-        context
-            .audio_manager
-            .stop_sounds_with_display_object(context.audio, (*self).into());
-
         self.set_avm1_removed(context.gc_context, true);
     }
 }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2925,9 +2925,11 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             mc.stop_audio_stream(context);
         }
 
-        context
-            .audio_manager
-            .stop_sounds_with_display_object(context.audio, (*self).into());
+        if self.is_root() {
+            context
+                .audio_manager
+                .stop_sounds_on_parent_and_children(context.audio, (*self).into());
+        }
 
         // If this clip is currently pending removal, then it unload event will have already been dispatched
         if !self.avm1_pending_removal() {


### PR DESCRIPTION
... instead of doing this for each unloaded display object.

Fixes #18327.
Fixes #18181.
Fixes #18057.
Fixes #17718.
Fixes #17395.
This should fix #17059 as well... but I'm not sure where the issues are supposed to be. 😅

I also checked against the files mentioned in #17016 and can confirm that they continue to stop sounds as expected. However, I was unable to test #16947 due to the web server being down. For #963, I tested it on [FlashArch](https://flasharch.com/en/archive/play/2f4ee6ce445533f1f46a1ec8090e463f), since the file appears to be no longer accessible on the official site.

[Super Monkey Ball Mini](https://wondertrio.com/games/monkeyball/index.html) is an interesting test case, as it experienced both issues in sequence:
- Before [#17016](https://github.com/ruffle-rs/ruffle/pull/17016), the music from the title screen continued playing when entering a level instead of stopping.
- After [#17016](https://github.com/ruffle-rs/ruffle/pull/17016), while the title screen music did stop correctly, some sound effects unexpectedly stopped (for example, when clicking on a level index) or failed to play altogether (such as the "Go" sound when starting a level).