### PR TITLE
text: Return text width only in `Font::measure`

### DIFF
--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -9,7 +9,6 @@ use ruffle_render::shape_utils::{DrawCommand, FillRule};
 use ruffle_render::transform::Transform;
 use std::borrow::Cow;
 use std::cell::{OnceCell, RefCell};
-use std::cmp::max;
 use std::hash::{Hash, Hasher};
 use swf::FillStyle;
 
@@ -618,35 +617,20 @@ impl<'gc> Font<'gc> {
         }
     }
 
-    /// Measure a particular string's metrics (width and height).
-    pub fn measure(&self, text: &WStr, params: EvalParameters) -> (Twips, Twips) {
-        let round = false;
+    /// Measure a particular string's width.
+    pub fn measure(&self, text: &WStr, params: EvalParameters) -> Twips {
         let mut width = Twips::ZERO;
-        let mut height = Twips::ZERO;
 
         self.evaluate(
             text,
             Default::default(),
             params,
-            |_pos, transform, _glyph, advance, _x| {
-                let tx = transform.matrix.tx;
-                let ty = transform.matrix.ty;
-
-                if round {
-                    width = width.max((tx + advance).trunc_to_pixel());
-                    height = height.max(ty.trunc_to_pixel());
-                } else {
-                    width = width.max(tx + advance);
-                    height = height.max(ty);
-                }
+            |_pos, _transform, _glyph, advance, x| {
+                width = width.max(x + advance);
             },
         );
 
-        if text.is_empty() {
-            height = max(height, params.height);
-        }
-
-        (width, height)
+        width
     }
 
     /// Given a line of text, find the first breakpoint within the text.
@@ -690,9 +674,9 @@ impl<'gc> Font<'gc> {
                 params,
             );
 
-            if is_start_of_line && measure.0 > remaining_width {
+            if is_start_of_line && measure > remaining_width {
                 //Failsafe for if we get a word wider than the field.
-                let mut last_passing_breakpoint = (Twips::ZERO, Twips::ZERO);
+                let mut last_passing_breakpoint = Twips::ZERO;
 
                 let cur_slice = &text[word_start..];
                 let mut char_iter = cur_slice.char_indices();
@@ -700,7 +684,7 @@ impl<'gc> Font<'gc> {
                 let mut prev_frag_end = 0;
 
                 char_iter.next(); // No need to check cur_slice[0..0]
-                while last_passing_breakpoint.0 < remaining_width {
+                while last_passing_breakpoint < remaining_width {
                     prev_char_index = word_start + prev_frag_end;
 
                     if let Some((frag_end, _)) = char_iter.next() {
@@ -713,7 +697,7 @@ impl<'gc> Font<'gc> {
                 }
 
                 return Some(prev_char_index);
-            } else if measure.0 > remaining_width {
+            } else if measure > remaining_width {
                 //The word is wider than our remaining width, return the end of
                 //the line.
                 return Some(line_end);
@@ -724,7 +708,7 @@ impl<'gc> Font<'gc> {
 
                 //If the additional space were to cause an overflow, then
                 //return now.
-                remaining_width -= measure.0;
+                remaining_width -= measure;
                 if remaining_width < Twips::from_pixels(0.0) {
                     return Some(word_end);
                 }

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -274,7 +274,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
             if self.current_line_span.align != swf::TextAlign::Left {
                 linebox.bounds = linebox
                     .bounds
-                    .with_width(font.measure(text.trim_end(), params).0);
+                    .with_width(font.measure(text.trim_end(), params));
             }
 
             if let Some(line_bounds) = &mut line_bounds {
@@ -610,16 +610,16 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
             let params = EvalParameters::from_span(span);
             let ascent = font.get_baseline_for_height(params.height());
             let descent = font.get_descent_for_height(params.height());
-            let text_size = Size::from(font.measure(text, params));
+            let text_width = font.measure(text, params);
             let box_origin = self.cursor - (Twips::ZERO, ascent).into();
 
             let mut new_box = LayoutBox::from_text(text, start, end, font, span);
             new_box.bounds = BoxBounds::from_position_and_size(
                 box_origin,
-                Size::from((text_size.width(), ascent + descent)),
+                Size::from((text_width, ascent + descent)),
             );
 
-            self.cursor += (text_size.width(), Twips::ZERO).into();
+            self.cursor += (text_width, Twips::ZERO).into();
             self.append_box(new_box);
         }
     }
@@ -647,14 +647,14 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
             let ascent = bullet_font.get_baseline_for_height(params.height());
             let descent = bullet_font.get_descent_for_height(params.height());
             let bullet = WStr::from_units(&[0x2022u16]);
-            let text_size = Size::from(bullet_font.measure(bullet, params));
+            let text_width = bullet_font.measure(bullet, params);
             let box_origin = bullet_cursor - (Twips::ZERO, ascent).into();
 
             let pos = self.last_box_end_position();
             let mut new_bullet = LayoutBox::from_bullet(pos, bullet_font, span);
             new_bullet.bounds = BoxBounds::from_position_and_size(
                 box_origin,
-                Size::from((text_size.width(), ascent + descent)),
+                Size::from((text_width, ascent + descent)),
             );
 
             self.append_box(new_bullet);


### PR DESCRIPTION
This patch simplifies code, as text height is not needed anymore after recent text refactors.