### PR TITLE
web: Make npm run build:dual-wasm create an MVP vanilla WASM module and make the default WASM module be with extensions

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -336,6 +336,7 @@ jobs:
         with:
           toolchain: 1.81.0
           targets: wasm32-unknown-unknown
+          components: rust-src
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
+          components: rust-src
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -52,7 +52,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-          components: rust-src
 
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2
@@ -118,7 +117,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-          components: rust-src
 
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -52,6 +52,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: rust-src
 
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2
@@ -117,6 +118,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: rust-src
 
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2

--- a/web/README.md
+++ b/web/README.md
@@ -45,6 +45,7 @@ to update to the latest stable version of rust. You may run `rustup update` to d
 rust using the above instructions).
 
 For the compiler to be able to output WebAssembly, an additional target has to be added to it: `rustup target add wasm32-unknown-unknown`
+Because we use `RUSTC_BOOTSTRAP` in order to use certain Nightly flags with stable Rust you will also need to run `rustup component add rust-src`.
 
 #### Java
 
@@ -106,6 +107,7 @@ In this project, you may run the following commands to build all packages:
     -   There is `npm run build:dual-wasm` as well, to build a second WebAssembly module that makes use of some WebAssembly extensions,
         potentially resulting in better performance in browsers that support them, at the expense of longer build time.
     -   `npm run build:repro` enables reproducible builds. Note that this also requires a `version_seal.json`, which is not provided in the normal Git repository - only specially-marked reproducible source archives. Running this without a version seal will generate one based on the current state of your environment.
+    -   You will also need to run `rustup component add rust-src` with either of the previous two commands since we rebuild std for the vanilla WASM module.
 
 From here, you may follow the instructions to [use Ruffle on your website](packages/selfhosted/README.md),
 run a demo locally with `npm run demo`, or [install the extension in your browser](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#browser-extension).

--- a/web/README.md
+++ b/web/README.md
@@ -45,7 +45,6 @@ to update to the latest stable version of rust. You may run `rustup update` to d
 rust using the above instructions).
 
 For the compiler to be able to output WebAssembly, an additional target has to be added to it: `rustup target add wasm32-unknown-unknown`
-Because we use `RUSTC_BOOTSTRAP` in order to use certain Nightly flags with stable Rust you will also need to run `rustup component add rust-src`.
 
 #### Java
 
@@ -104,8 +103,8 @@ In this project, you may run the following commands to build all packages:
     -   This will build the wasm binary and every node package (notably selfhosted and extension).
     -   Output will be available in the `dist/` folder of each package (for example, `./packages/selfhosted/dist`).
     -   You may also use `npm run build:debug` to disable Webpack optimizations and activate the (extremely verbose) ActionScript debugging output.
-    -   There is `npm run build:dual-wasm` as well, to build a second WebAssembly module that makes use of some WebAssembly extensions,
-        potentially resulting in better performance in browsers that support them, at the expense of longer build time.
+    -   There is `npm run build:dual-wasm` as well, to build a second WebAssembly module that disables all supported WebAssembly extensions,
+        potentially resulting in support for more browsers, at the expense of longer build time.
     -   `npm run build:repro` enables reproducible builds. Note that this also requires a `version_seal.json`, which is not provided in the normal Git repository - only specially-marked reproducible source archives. Running this without a version seal will generate one based on the current state of your environment.
     -   You will also need to run `rustup component add rust-src` with either of the previous two commands since we rebuild std for the vanilla WASM module.
 

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN wget --progress=:giga https://github.com/WebAssembly/binaryen/releases/downl
     mv wasm-opt /usr/local/bin
 
 # Installing Rust using rustup:
-RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown
+RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown --component rust-src
 ENV PATH="/root/.cargo/bin:$PATH"
 # wasm-bindgen-cli version must match wasm-bindgen crate version.
 # Be sure to update in test_web.yml, release_nightly.yml, Cargo.toml, and web/README.md as well.

--- a/web/package.json
+++ b/web/package.json
@@ -45,8 +45,8 @@
     "scripts": {
         "build": "npm run build --workspace=ruffle-core && npm run build --workspace=ruffle-demo --workspace=ruffle-extension --workspace=ruffle-selfhosted",
         "build:debug": "cross-env NODE_ENV=development CARGO_FEATURES=avm_debug npm run build",
-        "build:dual-wasm": "cross-env ENABLE_WASM_EXTENSIONS=true npm run build",
-        "build:repro": "cross-env ENABLE_WASM_EXTENSIONS=true ENABLE_VERSION_SEAL=true npm run build",
+        "build:dual-wasm": "cross-env BUILD_WASM_MVP=true npm run build",
+        "build:repro": "cross-env BUILD_WASM_MVP=true ENABLE_VERSION_SEAL=true npm run build",
         "demo": "npm run preview --workspace ruffle-demo",
         "test": "npm test --workspaces --if-present",
         "wdio": "npm run wdio --workspaces --if-present --",

--- a/web/packages/core/tools/build_wasm.ts
+++ b/web/packages/core/tools/build_wasm.ts
@@ -155,7 +155,7 @@ function detectWasmOpt() {
         return false;
     }
 }
-const buildExtensions = !!process.env["ENABLE_WASM_EXTENSIONS"];
+const buildWasmMvp = !!process.env["BUILD_WASM_MVP"];
 const wasmSource = process.env["WASM_SOURCE"] || "cargo";
 const hasWasmOpt = detectWasmOpt();
 if (!hasWasmOpt) {
@@ -167,15 +167,15 @@ if (wasmSource === "cargo_and_store") {
     rmSync("../../dist", { recursive: true, force: true });
     mkdirSync("../../dist");
 }
-buildWasm("web-vanilla-wasm", "ruffle_web", hasWasmOpt, false, wasmSource);
-if (buildExtensions) {
-    buildWasm(
-        "web-wasm-extensions",
-        "ruffle_web-wasm_extensions",
-        hasWasmOpt,
-        true,
-        wasmSource,
-    );
+buildWasm(
+    "web-wasm-extensions",
+    "ruffle_web-wasm_extensions",
+    hasWasmOpt,
+    true,
+    wasmSource,
+);
+if (buildWasmMvp) {
+    buildWasm("web-vanilla-wasm", "ruffle_web", hasWasmOpt, false, wasmSource);
 } else {
-    copyStandIn("ruffle_web", "ruffle_web-wasm_extensions");
+    copyStandIn("ruffle_web-wasm_extensions", "ruffle_web");
 }


### PR DESCRIPTION
~~I'm not sure whether this itself will be controversial. By itself, this update changes nothing in the development or CI pipelines by default.~~

~~Instead, it adds an environment variable, `BUILD_WASM_MVP`, which when set will cause `npm run build:dual-wasm` and/or `npm run build:repro` to create a truly vanilla WASM module by using nightly Rust to disable all the WebAssembly extensions. With this set, the version of Ruffle that gets built can run on Pale Moon and Safari versions as old as 14.1.~~

~~What this doesn't do (yet) is use this environment variable on CI or in the Firefox Docker script. Doing that is a matter of debate. Once we unpin CI from Rust 1.81, if we don't use this environment variable on CI, Ruffle will stop working on those older browsers. We can use this on CI temporarily as long as we want to keep supporting those browsers.~~

Edit: New scope of this PR is to make `npm run build:dual-wasm` and `npm run build:repro` build the vanilla WASM modules as MVPs so they can support more browsers. It does this by building std, which it does stably by setting `RUSTC_BOOTSTRAP` to `1` to use Nightly features with stable Rust when building the vanilla module. Any CI scripts that use either of those commands (Nightly release, Dockerfile, dockerfile test) also now need to install the rust-src component. The environment variable used by those commands is now called BUILD_WASM_MVP=true instead of ENABLE_WASM_EXTENSIONS=true, to reflect the new purpose.

This also changes `npm run build` from building only the vanilla WASM module to building only the extensions WASM module.