### PR TITLE
wgpu: Perform blends as-needed, instead of ahead of time. Reduces memory usage for multiple blends significantly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5538,9 +5538,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.17.1"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63de1e1d4115534008d8fd5788b39324d6f58fc707849090533828619351d855"
+checksum = "746b078c6a09ebfd5594609049e07116735c304671eaab06ce749854d23435bc"
 dependencies = [
  "loom",
  "once_cell",
@@ -5550,11 +5550,12 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.23.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b98232a2447ce0a58f9a0bfb5f5e39647b5c597c994b63945fcccd1306fafb"
+checksum = "3637e734239e12ab152cd269302500bd063f37624ee210cd04b4936ed671f3b1"
 dependencies = [
  "cc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/render/wgpu/src/buffer_builder.rs
+++ b/render/wgpu/src/buffer_builder.rs
@@ -3,6 +3,7 @@ use std::ops::Range;
 use wgpu::util::DeviceExt;
 use wgpu::BufferAddress;
 
+#[derive(Debug)]
 pub struct BufferBuilder {
     inner: Vec<u8>,
     align_mask: usize,

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -2,27 +2,26 @@ mod commands;
 pub mod target;
 
 use crate::backend::RenderTargetMode;
-use crate::blend::ComplexBlend;
+use crate::blend::{BlendType, ComplexBlend};
 use crate::buffer_pool::TexturePool;
 use crate::dynamic_transforms::DynamicTransforms;
 use crate::filters::FilterSource;
 use crate::mesh::Mesh;
 use crate::pixel_bender::{run_pixelbender_shader_impl, ShaderMode};
+pub use crate::surface::commands::LayerRef;
 use crate::surface::commands::{chunk_blends, Chunk, CommandRenderer};
+use crate::utils::run_copy_pipeline;
 use crate::utils::{remove_srgb, supported_sample_count};
-use crate::{Descriptors, MaskState, Pipelines};
-use ruffle_render::commands::CommandList;
+use crate::{Descriptors, MaskState, Pipelines, Transforms};
+use ruffle_render::commands::{CommandList, RenderBlendMode};
+use ruffle_render::matrix::Matrix;
 use ruffle_render::pixel_bender::{ImageInputTexture, PixelBenderShaderArgument};
 use ruffle_render::quality::StageQuality;
 use std::sync::Arc;
+use swf::BlendMode;
 use target::CommandTarget;
 use tracing::instrument;
-
-use crate::utils::run_copy_pipeline;
-
-pub use crate::surface::commands::LayerRef;
-
-use self::commands::ChunkBlendMode;
+use wgpu::BufferAddress;
 
 #[derive(Debug)]
 pub struct Surface {
@@ -131,22 +130,7 @@ impl Surface {
 
         let mut num_masks = 0;
         let mut mask_state = MaskState::NoMask;
-        let chunks = chunk_blends(
-            commands,
-            descriptors,
-            staging_belt,
-            dynamic_transforms,
-            draw_encoder,
-            meshes,
-            self.quality,
-            target.width(),
-            target.height(),
-            match nearest_layer {
-                LayerRef::Current => LayerRef::Parent(&target),
-                layer => layer,
-            },
-            texture_pool,
-        );
+        let chunks = chunk_blends(commands, descriptors, dynamic_transforms);
 
         for chunk in chunks {
             match chunk {
@@ -194,44 +178,18 @@ impl Surface {
                     num_masks = renderer.num_masks();
                     mask_state = renderer.mask_state();
                 }
-                Chunk::Blend(texture, ChunkBlendMode::Shader(shader), needs_stencil) => {
-                    assert!(
-                        !needs_stencil,
-                        "Shader blend should not need stencil buffer"
-                    );
-                    let parent_blend_buffer =
-                        target.update_blend_buffer(descriptors, texture_pool, draw_encoder);
-                    run_pixelbender_shader_impl(
+                Chunk::Blend(chunk, needs_stencil, blend_mode) => {
+                    let is_layer = matches!(blend_mode, RenderBlendMode::Builtin(BlendMode::Layer));
+                    let blend_type = BlendType::from(blend_mode);
+                    let mut child = Surface::new(
                         descriptors,
-                        shader,
-                        ShaderMode::Filter,
-                        &[
-                            PixelBenderShaderArgument::ImageInput {
-                                index: 0,
-                                channels: 0xFF,
-                                name: "background".to_string(),
-                                texture: Some(ImageInputTexture::TextureRef(
-                                    parent_blend_buffer.texture(),
-                                )),
-                            },
-                            PixelBenderShaderArgument::ImageInput {
-                                index: 1,
-                                channels: 0xff,
-                                name: "foreground".to_string(),
-                                texture: Some(ImageInputTexture::TextureRef(texture.texture())),
-                            },
-                        ],
-                        parent_blend_buffer.texture(),
-                        draw_encoder,
-                        target.color_attachments(),
-                        target.sample_count(),
-                        &FilterSource::for_entire_texture(texture.texture()),
-                    )
-                    .expect("Failed to run PixelBender blend mode");
-                }
-                Chunk::Blend(texture, ChunkBlendMode::Complex(blend_mode), needs_stencil) => {
-                    let parent = match blend_mode {
-                        ComplexBlend::Alpha | ComplexBlend::Erase => {
+                        self.quality,
+                        target.width(),
+                        target.height(),
+                        wgpu::TextureFormat::Rgba8Unorm,
+                    );
+                    let parent = match blend_type {
+                        BlendType::Complex(ComplexBlend::Alpha | ComplexBlend::Erase) => {
                             match nearest_layer {
                                 LayerRef::None => {
                                     // An Alpha or Erase with no Layer above it should be ignored
@@ -243,102 +201,252 @@ impl Surface {
                         }
                         _ => &target,
                     };
-
                     let parent_blend_buffer =
                         parent.update_blend_buffer(descriptors, texture_pool, draw_encoder);
 
-                    let blend_bind_group =
-                        descriptors
-                            .device
-                            .create_bind_group(&wgpu::BindGroupDescriptor {
-                                label: create_debug_label!(
-                                    "Complex blend binds {:?} {}",
-                                    blend_mode,
-                                    if needs_stencil {
-                                        "(with stencil)"
-                                    } else {
-                                        "(Stencilless)"
-                                    }
+                    let child_target = child.draw_commands(
+                        RenderTargetMode::FreshWithColor(blend_type.default_color()),
+                        descriptors,
+                        meshes,
+                        chunk,
+                        staging_belt,
+                        dynamic_transforms,
+                        draw_encoder,
+                        match (is_layer, nearest_layer) {
+                            (true, _) => LayerRef::Current,
+                            (false, LayerRef::Current) => LayerRef::Parent(&target),
+                            (false, layer) => layer,
+                        },
+                        texture_pool,
+                    );
+                    child_target.ensure_cleared(draw_encoder);
+                    let child_texture = child_target.take_color_texture();
+
+                    match blend_type {
+                        BlendType::Trivial(blend_mode) => {
+                            let matrix =
+                                Matrix::scale(parent.width() as f32, parent.height() as f32);
+                            let transform = [Transforms {
+                                world_matrix: [
+                                    [matrix.a, matrix.b, 0.0, 0.0],
+                                    [matrix.c, matrix.d, 0.0, 0.0],
+                                    [0.0, 0.0, 1.0, 0.0],
+                                    [
+                                        matrix.tx.to_pixels() as f32,
+                                        matrix.ty.to_pixels() as f32,
+                                        0.0,
+                                        1.0,
+                                    ],
+                                ],
+                                mult_color: [1.0, 1.0, 1.0, 1.0],
+                                add_color: [0.0, 0.0, 0.0, 0.0],
+                            }];
+                            let transform_bytes: &[u8] = bytemuck::cast_slice(&transform);
+                            staging_belt
+                                .write_buffer(
+                                    draw_encoder,
+                                    &dynamic_transforms.buffer,
+                                    BufferAddress::default(),
+                                    wgpu::BufferSize::new(transform_bytes.len() as u64).unwrap(),
+                                    &descriptors.device,
                                 )
-                                .as_deref(),
-                                layout: &descriptors.bind_layouts.blend,
-                                entries: &[
-                                    wgpu::BindGroupEntry {
-                                        binding: 0,
-                                        resource: wgpu::BindingResource::TextureView(
-                                            parent_blend_buffer.view(),
-                                        ),
+                                .copy_from_slice(transform_bytes);
+                            let mut render_pass =
+                                draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                    label: create_debug_label!(
+                                        "Apply trivial blend {blend_mode:?} {}",
+                                        if needs_stencil {
+                                            "(with stencil)"
+                                        } else {
+                                            "(Stencilless)"
+                                        }
+                                    )
+                                    .as_deref(),
+                                    color_attachments: &[target.color_attachments()],
+                                    depth_stencil_attachment: if needs_stencil {
+                                        target.stencil_attachment(descriptors, texture_pool)
+                                    } else {
+                                        None
                                     },
-                                    wgpu::BindGroupEntry {
-                                        binding: 1,
-                                        resource: wgpu::BindingResource::TextureView(
-                                            texture.view(),
-                                        ),
+                                    ..Default::default()
+                                });
+                            render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
+                            let mut renderer = CommandRenderer::new(
+                                &self.pipelines,
+                                descriptors,
+                                dynamic_transforms,
+                                render_pass,
+                                num_masks,
+                                mask_state,
+                                needs_stencil,
+                            );
+                            let bind_group =
+                                descriptors
+                                    .device
+                                    .create_bind_group(&wgpu::BindGroupDescriptor {
+                                        layout: &descriptors.bind_layouts.bitmap,
+                                        entries: &[
+                                            wgpu::BindGroupEntry {
+                                                binding: 0,
+                                                resource: descriptors
+                                                    .quad
+                                                    .texture_transforms
+                                                    .as_entire_binding(),
+                                            },
+                                            wgpu::BindGroupEntry {
+                                                binding: 1,
+                                                resource: wgpu::BindingResource::TextureView(
+                                                    child_texture.view(),
+                                                ),
+                                            },
+                                            wgpu::BindGroupEntry {
+                                                binding: 2,
+                                                resource: wgpu::BindingResource::Sampler(
+                                                    descriptors
+                                                        .bitmap_samplers
+                                                        .get_sampler(false, false),
+                                                ),
+                                            },
+                                        ],
+                                        label: None,
+                                    });
+                            renderer.render_texture(0, &bind_group, blend_mode);
+                        }
+                        BlendType::Complex(blend_mode) => {
+                            let blend_bind_group =
+                                descriptors
+                                    .device
+                                    .create_bind_group(&wgpu::BindGroupDescriptor {
+                                        label: create_debug_label!(
+                                            "Complex blend binds {:?} {}",
+                                            blend_mode,
+                                            if needs_stencil {
+                                                "(with stencil)"
+                                            } else {
+                                                "(Stencilless)"
+                                            }
+                                        )
+                                        .as_deref(),
+                                        layout: &descriptors.bind_layouts.blend,
+                                        entries: &[
+                                            wgpu::BindGroupEntry {
+                                                binding: 0,
+                                                resource: wgpu::BindingResource::TextureView(
+                                                    parent_blend_buffer.view(),
+                                                ),
+                                            },
+                                            wgpu::BindGroupEntry {
+                                                binding: 1,
+                                                resource: wgpu::BindingResource::TextureView(
+                                                    child_texture.view(),
+                                                ),
+                                            },
+                                            wgpu::BindGroupEntry {
+                                                binding: 2,
+                                                resource: wgpu::BindingResource::Sampler(
+                                                    descriptors
+                                                        .bitmap_samplers
+                                                        .get_sampler(false, false),
+                                                ),
+                                            },
+                                        ],
+                                    });
+
+                            let mut render_pass =
+                                draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                    label: create_debug_label!(
+                                        "Apply complex blend {:?} {}",
+                                        blend_mode,
+                                        if needs_stencil {
+                                            "(with stencil)"
+                                        } else {
+                                            "(Stencilless)"
+                                        }
+                                    )
+                                    .as_deref(),
+                                    color_attachments: &[target.color_attachments()],
+                                    depth_stencil_attachment: if needs_stencil {
+                                        target.stencil_attachment(descriptors, texture_pool)
+                                    } else {
+                                        None
                                     },
-                                    wgpu::BindGroupEntry {
-                                        binding: 2,
-                                        resource: wgpu::BindingResource::Sampler(
-                                            descriptors.bitmap_samplers.get_sampler(false, false),
-                                        ),
+                                    ..Default::default()
+                                });
+                            render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
+
+                            if needs_stencil {
+                                match mask_state {
+                                    MaskState::NoMask => {}
+                                    MaskState::DrawMaskStencil => {
+                                        render_pass.set_stencil_reference(num_masks - 1);
+                                    }
+                                    MaskState::DrawMaskedContent => {
+                                        render_pass.set_stencil_reference(num_masks);
+                                    }
+                                    MaskState::ClearMaskStencil => {
+                                        render_pass.set_stencil_reference(num_masks);
+                                    }
+                                }
+                                render_pass.set_pipeline(
+                                    self.pipelines.complex_blends[blend_mode]
+                                        .pipeline_for(mask_state),
+                                );
+                            } else {
+                                render_pass.set_pipeline(
+                                    self.pipelines.complex_blends[blend_mode]
+                                        .stencilless_pipeline(),
+                                );
+                            }
+
+                            render_pass.set_bind_group(
+                                1,
+                                target.whole_frame_bind_group(descriptors),
+                                &[0],
+                            );
+                            render_pass.set_bind_group(2, &blend_bind_group, &[]);
+
+                            render_pass
+                                .set_vertex_buffer(0, descriptors.quad.vertices_pos.slice(..));
+                            render_pass.set_index_buffer(
+                                descriptors.quad.indices.slice(..),
+                                wgpu::IndexFormat::Uint32,
+                            );
+
+                            render_pass.draw_indexed(0..6, 0, 0..1);
+                        }
+                        BlendType::Shader(shader) => {
+                            run_pixelbender_shader_impl(
+                                descriptors,
+                                shader,
+                                ShaderMode::Filter,
+                                &[
+                                    PixelBenderShaderArgument::ImageInput {
+                                        index: 0,
+                                        channels: 0xFF,
+                                        name: "background".to_string(),
+                                        texture: Some(ImageInputTexture::TextureRef(
+                                            parent_blend_buffer.texture(),
+                                        )),
+                                    },
+                                    PixelBenderShaderArgument::ImageInput {
+                                        index: 1,
+                                        channels: 0xff,
+                                        name: "foreground".to_string(),
+                                        texture: Some(ImageInputTexture::TextureRef(
+                                            child_texture.texture(),
+                                        )),
                                     },
                                 ],
-                            });
-
-                    let mut render_pass =
-                        draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                            label: create_debug_label!(
-                                "Complex blend {:?} {}",
-                                blend_mode,
-                                if needs_stencil {
-                                    "(with stencil)"
-                                } else {
-                                    "(Stencilless)"
-                                }
+                                parent_blend_buffer.texture(),
+                                draw_encoder,
+                                target.color_attachments(),
+                                target.sample_count(),
+                                &FilterSource::for_entire_texture(child_texture.texture()),
                             )
-                            .as_deref(),
-                            color_attachments: &[target.color_attachments()],
-                            depth_stencil_attachment: if needs_stencil {
-                                target.stencil_attachment(descriptors, texture_pool)
-                            } else {
-                                None
-                            },
-                            ..Default::default()
-                        });
-                    render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
-
-                    if needs_stencil {
-                        match mask_state {
-                            MaskState::NoMask => {}
-                            MaskState::DrawMaskStencil => {
-                                render_pass.set_stencil_reference(num_masks - 1);
-                            }
-                            MaskState::DrawMaskedContent => {
-                                render_pass.set_stencil_reference(num_masks);
-                            }
-                            MaskState::ClearMaskStencil => {
-                                render_pass.set_stencil_reference(num_masks);
-                            }
+                            .expect("Failed to run PixelBender blend mode");
                         }
-                        render_pass.set_pipeline(
-                            self.pipelines.complex_blends[blend_mode].pipeline_for(mask_state),
-                        );
-                    } else {
-                        render_pass.set_pipeline(
-                            self.pipelines.complex_blends[blend_mode].stencilless_pipeline(),
-                        );
                     }
-
-                    render_pass.set_bind_group(1, target.whole_frame_bind_group(descriptors), &[0]);
-                    render_pass.set_bind_group(2, &blend_bind_group, &[]);
-
-                    render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos.slice(..));
-                    render_pass.set_index_buffer(
-                        descriptors.quad.indices.slice(..),
-                        wgpu::IndexFormat::Uint32,
-                    );
-
-                    render_pass.draw_indexed(0..6, 0, 0..1);
-                    drop(render_pass);
+                    drop(child_texture);
                 }
             }
         }


### PR DESCRIPTION
This fixes #18317 and should help a lot with any movie that does multiple blends on the same frame (unless they're nested). For me, it reduces VRAM of that game during loading down from **13 GB** to just shy of **500 MB**.

Graphics memory requirement goes from `(size of stage) * (number of total blends)` to just `(size of stage) * 1` for most cases.

Imagine a hypothetical draw list:
DrawRect, DrawCircle, BlendTrivial(DrawTriangle), BlendComplex(DrawStar), DrawSmilyFace

Before it would do this:
- DrawTriangle into a temp buffer A
- DrawStar into a temp buffer B
- DrawRect, DrawCircle, DrawTempBufferA all as one render pass
- DrawTempBufferB (as one render pass)
- DrawSmilyFace as one render pass

This meant for every (not nested) blend, we needed that many temp textures.

With this change, we instead do this:
- DrawRect, DrawCircle as one render pass
- DrawTriangle to TempBuffer as one render pass
- DrawTempBuffer as one render pass
- DrawStar to TempBuffer as one render pass
- DrawTempBuffer as one render pass
- DrawSmilyFace as one render pass


I'm not super happy with the code but I don't have better ideas for organization right now :(