### PR TITLE
avm2: Refactor TObject call and construct

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -572,8 +572,8 @@ impl<'gc> Avm2<'gc> {
         context: &mut UpdateContext<'gc>,
     ) -> Result<(), String> {
         let mut evt_activation = Activation::from_domain(context, domain);
-        callable
-            .call(receiver, args, &mut evt_activation)
+        Value::from(callable)
+            .call(&mut evt_activation, receiver, args)
             .map_err(|e| format!("{e:?}"))?;
 
         Ok(())

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1120,10 +1120,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     fn op_call(&mut self, arg_count: u32) -> Result<FrameControl<'gc>, Error<'gc>> {
         let args = self.pop_stack_args(arg_count);
         let receiver = self.pop_stack();
-        let function = self
-            .pop_stack()
-            .as_callable(self, None, Some(receiver), false)?;
-        let value = function.call(receiver, &args, self)?;
+        let function = self.pop_stack();
+
+        let value = function.call(self, receiver, &args)?;
 
         self.push_stack(value);
 
@@ -1183,13 +1182,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let receiver = self
             .pop_stack()
             .coerce_to_object_or_typeerror(self, Some(&multiname))?;
-        let function = receiver.get_property(&multiname, self)?.as_callable(
-            self,
-            Some(&multiname),
-            Some(receiver.into()),
-            false,
-        )?;
-        let value = function.call(Value::Null, &args, self)?;
+        let function = receiver.get_property(&multiname, self)?;
+        let value = function.call(self, Value::Null, &args)?;
 
         self.push_stack(value);
 
@@ -1224,7 +1218,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // TODO: What scope should the function be executed with?
         let scope = self.create_scopechain();
         let function = FunctionObject::from_method(self, method, scope, None, None, None);
-        let value = function.call(receiver, &args, self)?;
+        let value = function.call(self, receiver, &args)?;
 
         self.push_stack(value);
 
@@ -1775,7 +1769,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn op_construct(&mut self, arg_count: u32) -> Result<FrameControl<'gc>, Error<'gc>> {
         let args = self.pop_stack_args(arg_count);
-        let ctor = self.pop_stack().as_callable(self, None, None, true)?;
+        let ctor = self.pop_stack();
 
         let object = ctor.construct(self, &args)?;
 

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1452,15 +1452,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
             let name_value = self.context.avm2.peek(0);
             let object = self.context.avm2.peek(1);
-            if !name_value.is_primitive() {
+            if let Some(name_object) = name_value.as_object() {
                 let object = object.coerce_to_object_or_typeerror(self, None)?;
                 if let Some(dictionary) = object.as_dictionary_object() {
                     let _ = self.pop_stack();
                     let _ = self.pop_stack();
-                    dictionary.delete_property_by_object(
-                        name_value.as_object().unwrap(),
-                        self.context.gc_context,
-                    );
+                    dictionary.delete_property_by_object(name_object, self.context.gc_context);
 
                     self.push_raw(true);
                     return Ok(FrameControl::Continue);
@@ -1531,9 +1528,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let name_value = self.pop_stack();
 
         if let Some(dictionary) = obj.as_dictionary_object() {
-            if !name_value.is_primitive() {
-                let obj_key = name_value.as_object().unwrap();
-                self.push_raw(dictionary.has_property_by_object(obj_key));
+            if let Some(name_object) = name_value.as_object() {
+                self.push_raw(dictionary.has_property_by_object(name_object));
 
                 return Ok(FrameControl::Continue);
             }

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -401,7 +401,7 @@ fn dispatch_event_to_target<'gc>(
 
     let handlers: Vec<Object<'gc>> = dispatch_list
         .as_dispatch_mut(activation.context.gc_context)
-        .ok_or_else(|| Error::from("Internal dispatch list is missing during dispatch!"))?
+        .expect("Internal dispatch list is missing during dispatch!")
         .iter_event_handlers(name, use_capture)
         .collect();
 
@@ -428,7 +428,7 @@ fn dispatch_event_to_target<'gc>(
 
         let global = activation.context.avm2.toplevel_global_object().unwrap();
 
-        if let Err(err) = handler.call(global.into(), &[event.into()], activation) {
+        if let Err(err) = Value::from(*handler).call(activation, global.into(), &[event.into()]) {
             tracing::error!(
                 "Error dispatching event {:?} to handler {:?} : {:?}",
                 event,

--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -23,7 +23,7 @@ pub fn add_frame_script<'gc>(
     {
         for (frame_id, callable) in args.chunks_exact(2).map(|s| (s[0], s[1])) {
             let frame_id = frame_id.coerce_to_u32(activation)? as u16 + 1;
-            let callable = callable.as_callable(activation, None, None, false).ok();
+            let callable = callable.as_object();
 
             mc.register_frame_script(frame_id, callable, activation.context);
         }

--- a/core/src/avm2/globals/flash/events/EventDispatcher.as
+++ b/core/src/avm2/globals/flash/events/EventDispatcher.as
@@ -1,21 +1,21 @@
 // This is a stub - the actual class is defined in `eventdispatcher.rs`
 package flash.events {
-	public class EventDispatcher implements IEventDispatcher {
-		internal var _target:IEventDispatcher;
-		internal var _dispatchList:Object;
+    public class EventDispatcher implements IEventDispatcher {
+        internal var _target:IEventDispatcher;
+        internal var _dispatchList:Object;
 
-		public function EventDispatcher(target:IEventDispatcher = null) {
-			this._target = target;
-		}
+        public function EventDispatcher(target:IEventDispatcher = null) {
+            this._target = target;
+        }
 
-		public native function addEventListener(type:String, listener:Function, useCapture:Boolean = false, priority:int = 0, useWeakReference:Boolean = false):void;
-		public native function removeEventListener(type:String, listener:Function, useCapture:Boolean = false):void;
-		public native function dispatchEvent(event:Event):Boolean;
-		public native function hasEventListener(type:String):Boolean;
-		public native function willTrigger(type:String):Boolean;
+        public native function addEventListener(type:String, listener:Function, useCapture:Boolean = false, priority:int = 0, useWeakReference:Boolean = false):void;
+        public native function removeEventListener(type:String, listener:Function, useCapture:Boolean = false):void;
+        public native function dispatchEvent(event:Event):Boolean;
+        public native function hasEventListener(type:String):Boolean;
+        public native function willTrigger(type:String):Boolean;
 
-		public function toString():String {
+        public function toString():String {
             return Object.prototype.toString.call(this);
         }
-	}
+    }
 }

--- a/core/src/avm2/globals/flash/events/EventDispatcher.as
+++ b/core/src/avm2/globals/flash/events/EventDispatcher.as
@@ -14,6 +14,8 @@ package flash.events {
 		public native function hasEventListener(type:String):Boolean;
 		public native function willTrigger(type:String):Boolean;
 
-		public native function toString():String;
+		public function toString():String {
+            return Object.prototype.toString.call(this);
+        }
 	}
 }

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -137,9 +137,9 @@ fn call<'gc>(
     let this = args.get(0).copied().unwrap_or(Value::Null);
 
     if args.len() > 1 {
-        Ok(func.call(this, &args[1..], activation)?)
+        Ok(Value::from(func).call(activation, this, &args[1..])?)
     } else {
-        Ok(func.call(this, &[], activation)?)
+        Ok(Value::from(func).call(activation, this, &[])?)
     }
 }
 
@@ -170,7 +170,7 @@ fn apply<'gc>(
         Vec::new()
     };
 
-    func.call(this, &resolved_args, activation)
+    Value::from(func).call(activation, this, &resolved_args)
 }
 
 /// Implements `Function.prototype.toString` and `Function.prototype.toLocaleString`

--- a/core/src/avm2/globals/json.rs
+++ b/core/src/avm2/globals/json.rs
@@ -118,10 +118,7 @@ impl<'gc> AvmSerializer<'gc> {
         key: impl Fn() -> AvmString<'gc>,
         value: Value<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        let (eval_key, value) = if value.is_primitive() {
-            (None, value)
-        } else {
-            let obj = value.as_object().unwrap();
+        let (eval_key, value) = if let Some(obj) = value.as_object() {
             if obj.has_public_property("toJSON", activation) {
                 let key = key();
                 (
@@ -131,7 +128,10 @@ impl<'gc> AvmSerializer<'gc> {
             } else {
                 (None, value)
             }
+        } else {
+            (None, value)
         };
+
         if let Some(Replacer::Function(replacer)) = self.replacer {
             replacer.call(
                 activation,

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -372,7 +372,7 @@ fn replace<'gc>(
         // Replacement is either a function or treatable as string.
         if let Some(f) = replacement.as_object().and_then(|o| o.as_function_object()) {
             let args = [pattern.into(), position.into(), this.into()];
-            let v = f.call(Value::Null, &args, activation)?;
+            let v = f.call(activation, Value::Null, &args)?;
             ret.push_str(v.coerce_to_string(activation)?.as_wstr());
         } else {
             let replacement = replacement.coerce_to_string(activation)?;

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -4,9 +4,6 @@ use crate::avm2::activation::Activation;
 use crate::avm2::events::DispatchList;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
-use crate::avm2::value::Value;
-use crate::avm2::Error;
-use crate::string::StringContext;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
@@ -95,18 +92,6 @@ impl<'gc> TObject<'gc> for DispatchObject<'gc> {
 
     fn as_ptr(&self) -> *const ObjectPtr {
         Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn construct(
-        self,
-        _activation: &mut Activation<'_, 'gc>,
-        _args: &[Value<'gc>],
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Err("Cannot construct internal event dispatcher structures.".into())
-    }
-
-    fn value_of(&self, _context: &mut StringContext<'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Err("Cannot subclass internal event dispatcher structures.".into())
     }
 
     /// Unwrap this object as a list of event handlers.

--- a/core/src/avm2/object/responder_object.rs
+++ b/core/src/avm2/object/responder_object.rs
@@ -86,7 +86,7 @@ impl<'gc> ResponderObject<'gc> {
         if let Some(function) = function {
             let mut activation = Activation::from_nothing(context);
             let value = crate::avm2::amf::deserialize_value(&mut activation, message)?;
-            function.call((*self).into(), &[value], &mut activation)?;
+            function.call(&mut activation, (*self).into(), &[value])?;
         }
 
         Ok(())

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -613,9 +613,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
             }
         }
 
-        return method
-            .as_callable(activation, Some(multiname), Some(self.into()), false)?
-            .call(self.into(), arguments, activation);
+        method.call(activation, self.into(), arguments)
     }
 
     fn has_own_property(self, name: &Multiname<'gc>) -> bool {

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -383,9 +383,7 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
             }
         }
 
-        return method
-            .as_callable(activation, Some(multiname), Some(self.into()), false)?
-            .call(self.into(), arguments, activation);
+        method.call(activation, self.into(), arguments)
     }
 
     fn has_own_property(self, name: &Multiname<'gc>) -> bool {

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -245,7 +245,7 @@ impl<'gc> RegExp<'gc> {
                 .chain(std::iter::once(m.range.start.into()))
                 .chain(std::iter::once((*txt).into()))
                 .collect::<Vec<_>>();
-            let r = f.call(Value::Null, &args, activation)?;
+            let r = f.call(activation, Value::Null, &args)?;
             return Ok(Cow::Owned(WString::from(
                 r.coerce_to_string(activation)?.as_wstr(),
             )));

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -320,6 +320,8 @@ impl<'gc> Callback<'gc> {
                 Value::Null
             }
             Callback::Avm2 { method } => {
+                let method = Avm2Value::from(*method);
+
                 let domain = context
                     .library
                     .library_for_movie(context.swf.clone())
@@ -331,7 +333,7 @@ impl<'gc> Callback<'gc> {
                     .map(|v| v.into_avm2(&mut activation))
                     .collect();
                 match method
-                    .call(Avm2Value::Null, &args, &mut activation)
+                    .call(&mut activation, Avm2Value::Null, &args)
                     .and_then(|value| Value::from_avm2(&mut activation, value))
                 {
                     Ok(result) => result,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -5,9 +5,7 @@ use crate::avm1::SystemProperties;
 use crate::avm1::VariableDumper;
 use crate::avm1::{Activation, ActivationIdentifier};
 use crate::avm1::{TObject, Value};
-use crate::avm2::{
-    object::TObject as _, Activation as Avm2Activation, Avm2, CallStack, Object as Avm2Object,
-};
+use crate::avm2::{Activation as Avm2Activation, Avm2, CallStack, Object as Avm2Object};
 use crate::backend::ui::FontDefinition;
 use crate::backend::{
     audio::{AudioBackend, AudioManager},

--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -3,10 +3,7 @@ use crate::{
         globals::xml_socket::XmlSocket, Activation as Avm1Activation, ActivationIdentifier,
         ExecutionReason, Object as Avm1Object, TObject as Avm1TObject,
     },
-    avm2::{
-        object::SocketObject, Activation as Avm2Activation, Avm2, EventObject,
-        TObject as Avm2TObject,
-    },
+    avm2::{object::SocketObject, Activation as Avm2Activation, Avm2, EventObject},
     backend::navigator::NavigatorBackend,
     context::UpdateContext,
     string::AvmString,

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -8,7 +8,6 @@ use crate::avm1::ExecutionReason;
 use crate::avm1::{
     Activation, ActivationIdentifier, Object as Avm1Object, TObject as _, Value as Avm1Value,
 };
-use crate::avm2::object::TObject;
 use crate::avm2::{Activation as Avm2Activation, Object as Avm2Object, Value as Avm2Value};
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, TDisplayObject};
@@ -142,7 +141,11 @@ impl<'gc> Timers<'gc> {
                 TimerCallback::Avm2Callback { closure, params } => {
                     let domain = context.avm2.stage_domain();
                     let mut avm2_activation = Avm2Activation::from_domain(context, domain);
-                    match closure.call(Avm2Value::Null, &params, &mut avm2_activation) {
+                    match Avm2Value::from(closure).call(
+                        &mut avm2_activation,
+                        Avm2Value::Null,
+                        &params,
+                    ) {
                         Ok(v) => v.coerce_to_boolean(),
                         Err(e) => {
                             tracing::error!("Unhandled AVM2 error in timer callback: {e:?}",);


### PR DESCRIPTION
Specifically, we can now directly call and construct `Value`s, as a step toward removing PrimitiveObject.

A microbenchmark shows no significant perf impact.