### PR TITLE
web: On browsers which support it, specify the type of audio Ruffle uses

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -1628,6 +1628,7 @@ export class InnerPlayer {
         }
 
         // TODO: Use `navigator.userAgentData` to detect the platform when support improves?
+        // Edit (danielhjacobs): Probably not an option since it's only available in secure contexts
         if (navigator.maxTouchPoints < 1) {
             isAudioContextUnmuted = true;
             return;

--- a/web/packages/core/src/plugin-polyfill.ts
+++ b/web/packages/core/src/plugin-polyfill.ts
@@ -231,9 +231,6 @@ declare global {
     interface MimeTypeArray {
         install?: (mimeType: MimeType) => void;
     }
-    interface AudioSession {
-        type?: string;
-    }
 }
 
 /**
@@ -247,11 +244,6 @@ declare global {
  * @param plugin The plugin to install
  */
 export function installPlugin(plugin: RufflePlugin): void {
-    // This code is not polyfill related, but while messing with the navigator API,
-    // we can specify https://www.w3.org/TR/audio-session/#audio-session-types
-    if ("audioSession" in navigator) {
-        (navigator.audioSession as AudioSession).type = "playback";
-    }
     if (navigator.plugins.namedItem("Shockwave Flash")) {
         return;
     }

--- a/web/packages/core/src/plugin-polyfill.ts
+++ b/web/packages/core/src/plugin-polyfill.ts
@@ -231,6 +231,9 @@ declare global {
     interface MimeTypeArray {
         install?: (mimeType: MimeType) => void;
     }
+    interface AudioSession {
+        type?: string;
+    }
 }
 
 /**
@@ -244,6 +247,11 @@ declare global {
  * @param plugin The plugin to install
  */
 export function installPlugin(plugin: RufflePlugin): void {
+    // This code is not polyfill related, but while messing with the navigator API,
+    // we can specify https://www.w3.org/TR/audio-session/#audio-session-types
+    if ("audioSession" in navigator) {
+        (navigator.audioSession as AudioSession).type = "playback";
+    }
     if (navigator.plugins.namedItem("Shockwave Flash")) {
         return;
     }


### PR DESCRIPTION
I've not tested this, but it may fix https://github.com/ruffle-rs/ruffle-rs.github.io/issues/177.