### PR TITLE
avm2: Improve some stubs, add API versioning

### DIFF
--- a/core/src/avm2/globals/flash/display/DisplayObject.as
+++ b/core/src/avm2/globals/flash/display/DisplayObject.as
@@ -146,6 +146,7 @@ package flash.display {
 
         public native function getRect(targetCoordinateSpace:DisplayObject):Rectangle;
 
+        [API("662")]
         public native function set blendShader(value:Shader):void;
     }
 

--- a/core/src/avm2/globals/flash/display/InteractiveObject.as
+++ b/core/src/avm2/globals/flash/display/InteractiveObject.as
@@ -10,7 +10,7 @@ package flash.display {
     public class InteractiveObject extends DisplayObject {
         private var _accessibilityImpl:AccessibilityImplementation = null;
         private var _needsSoftKeyboard:Boolean = false;
-        private var _softKeyboardInputAreaOfInterest:Rectangle = new Rectangle();
+        private var _softKeyboardInputAreaOfInterest:Rectangle = null;
 
         public function get accessibilityImplementation():AccessibilityImplementation {
             return this._accessibilityImpl;

--- a/core/src/avm2/globals/flash/geom/Transform.as
+++ b/core/src/avm2/globals/flash/geom/Transform.as
@@ -9,6 +9,8 @@ package flash.geom {
 	public class Transform {
 		internal var _displayObject:DisplayObject;
 
+		private var _matrix3D:Matrix3D = null;
+
 		function Transform(object:DisplayObject) {
 			this.init(object);
 		}
@@ -25,11 +27,12 @@ package flash.geom {
 
 		public function get matrix3D():Matrix3D {
 			stub_getter("flash.geom.Transform", "matrix3D");
-			return new Matrix3D();
+			return this._matrix3D;
 		}
 
 		public function set matrix3D(m:Matrix3D):void {
 			stub_setter("flash.geom.Transform", "matrix3D");
+			this._matrix3D = m;
 		}
 
 		public function get perspectiveProjection():PerspectiveProjection {

--- a/core/src/avm2/globals/flash/geom/Transform.as
+++ b/core/src/avm2/globals/flash/geom/Transform.as
@@ -22,7 +22,11 @@ package flash.geom {
 		public native function get matrix():Matrix;
 		public native function set matrix(value:Matrix):void;
 
-		public native function get concatenatedColorTransform():ColorTransform;
+		public function get concatenatedColorTransform():ColorTransform {
+			stub_getter("flash.geom.Transform", "concatenatedColorTransform");
+			return new ColorTransform();
+		}
+
 		public native function get concatenatedMatrix():Matrix;
 		public native function get pixelBounds():Rectangle;
 

--- a/core/src/avm2/globals/flash/geom/Transform.as
+++ b/core/src/avm2/globals/flash/geom/Transform.as
@@ -10,6 +10,7 @@ package flash.geom {
 		internal var _displayObject:DisplayObject;
 
 		private var _matrix3D:Matrix3D = null;
+		private var _perspectiveProjection:PerspectiveProjection = null;
 
 		function Transform(object:DisplayObject) {
 			this.init(object);
@@ -37,11 +38,12 @@ package flash.geom {
 
 		public function get perspectiveProjection():PerspectiveProjection {
 			stub_getter("flash.geom.Transform", "perspectiveProjection");
-			return new PerspectiveProjection();
+			return this._perspectiveProjection;
 		}
 
 		public function set perspectiveProjection(val: PerspectiveProjection):void {
 			stub_setter("flash.geom.Transform", "perspectiveProjection");
+			this._perspectiveProjection = val;
 		}
 
 		public function getRelativeMatrix3D(relativeTo:DisplayObject):Matrix3D {

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -1,7 +1,6 @@
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::Multiname;
 use crate::avm2::{Activation, Error, Object, TObject, Value};
-use crate::avm2_stub_getter;
 use crate::display_object::TDisplayObject;
 use crate::prelude::{DisplayObject, Matrix, Twips};
 use ruffle_render::quality::StageQuality;
@@ -131,19 +130,6 @@ pub fn get_concatenated_matrix<'gc>(
 
         matrix_to_object(mat, activation)
     }
-}
-
-pub fn get_concatenated_color_transform<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _this: Object<'gc>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    avm2_stub_getter!(
-        activation,
-        "flash.geom.Transform",
-        "concatenatedColorTransform"
-    );
-    Ok(Value::Undefined)
 }
 
 // FIXME - handle clamping. We're throwing away precision here in converting to an integer:


### PR DESCRIPTION
Improved stubs:

* `InteractiveObject.softKeyboardInputAreaOfInterest`
* `Transform.matrix3D`
* `Transform.perspectiveProjection`
* `Transform.concatenatedColorTransform`

Updated API versioning:

* `DisplayObject.blendShader`