### PR TITLE
core: Rename BitmapData->BitmapRawData, wrap it in new BitmapData

### DIFF
--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -5,7 +5,7 @@ use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, Value};
-use crate::bitmap::bitmap_data::BitmapDataWrapper;
+use crate::bitmap::bitmap_data::BitmapData;
 use crate::context::UpdateContext;
 use crate::string::StringContext;
 use gc_arena::barrier::unlock;
@@ -20,7 +20,7 @@ use swf::{Color, Point};
 #[derive(Clone, Collect, Debug, Default)]
 #[collect(no_drop)]
 struct DisplacementMapFilterData<'gc> {
-    map_bitmap: Lock<Option<BitmapDataWrapper<'gc>>>,
+    map_bitmap: Lock<Option<BitmapData<'gc>>>,
     map_point: Cell<Point<i32>>,
     component_x: Cell<i32>,
     component_y: Cell<i32>,

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -23,7 +23,7 @@ use crate::avm1::globals::xml_socket::XmlSocket;
 use crate::avm1::object::super_object::SuperObject;
 use crate::avm1::xml::XmlNode;
 use crate::avm1::{Activation, Error, Value};
-use crate::bitmap::bitmap_data::BitmapDataWrapper;
+use crate::bitmap::bitmap_data::BitmapData;
 use crate::display_object::{
     Avm1Button, DisplayObject, EditText, MovieClip, TDisplayObject as _, Video,
 };
@@ -85,7 +85,7 @@ pub enum NativeObject<'gc> {
     Transform(TransformObject<'gc>),
     TextFormat(Gc<'gc, RefCell<TextFormat>>),
     NetStream(NetStream<'gc>),
-    BitmapData(BitmapDataWrapper<'gc>),
+    BitmapData(BitmapData<'gc>),
     Xml(Xml<'gc>),
     XmlNode(XmlNode<'gc>),
     SharedObject(Gc<'gc, RefCell<SharedObject>>),

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -11,7 +11,7 @@ use ruffle_render::bitmap::PixelSnapping;
 
 use crate::avm2::error::make_error_2008;
 use crate::avm2::parameters::ParametersExt;
-use crate::bitmap::bitmap_data::BitmapDataWrapper;
+use crate::bitmap::bitmap_data::BitmapData;
 use crate::character::Character;
 use crate::display_object::{Bitmap, TDisplayObject};
 
@@ -26,7 +26,7 @@ pub fn bitmap_allocator<'gc>(
     let orig_class = class;
     while let Some(class) = class_def {
         if class == bitmap_cls {
-            let bitmap_data = BitmapDataWrapper::dummy(activation.gc());
+            let bitmap_data = BitmapData::dummy(activation.gc());
             let display_object = Bitmap::new_with_bitmap_data(
                 activation.gc(),
                 0,
@@ -53,7 +53,7 @@ pub fn bitmap_allocator<'gc>(
                 let new_bitmap_data = fill_bitmap_data_from_symbol(activation, bitmap.compressed());
                 let bitmap_data_obj = BitmapDataObject::from_bitmap_data_internal(
                     activation,
-                    BitmapDataWrapper::dummy(activation.gc()),
+                    BitmapData::dummy(activation.gc()),
                     bitmapdata_cls,
                 )?;
                 bitmap_data_obj.init_bitmap_data(activation.gc(), new_bitmap_data);
@@ -121,7 +121,7 @@ pub fn get_bitmap_data<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
-        let mut value = bitmap.bitmap_data_wrapper().object2();
+        let mut value = bitmap.bitmap_data().object2();
 
         // AS3 expects an unset BitmapData to be null, not 'undefined'
         if matches!(value, Value::Undefined) {
@@ -148,7 +148,7 @@ pub fn set_bitmap_data<'gc>(
             bitmap_data.as_bitmap_data().expect("Must be a BitmapData")
         } else {
             // Passing null results in a dummy BitmapData being set.
-            BitmapDataWrapper::dummy(activation.gc())
+            BitmapData::dummy(activation.gc())
         };
 
         bitmap.set_bitmap_data(activation.context, bitmap_data);

--- a/core/src/avm2/globals/flash/display3D/textures/texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/texture.rs
@@ -1,5 +1,3 @@
-use gc_arena::GcCell;
-
 use ruffle_render::backend::Context3DTextureFormat;
 
 use super::atf_jpegxr::do_compressed_upload;
@@ -10,7 +8,6 @@ use crate::avm2::Value;
 use crate::avm2::{Error, Object};
 use crate::avm2_stub_method;
 use crate::bitmap::bitmap_data::BitmapData;
-use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::bitmap::bitmap_data::Color;
 
 pub fn do_copy<'gc>(
@@ -31,7 +28,7 @@ pub fn do_copy<'gc>(
         return Ok(());
     }
 
-    // FIXME - see if we can avoid this intermediate BitmapDataWrapper, and copy
+    // FIXME - see if we can avoid this intermediate BitmapData, and copy
     // directly from a buffer to the target GPU texture
     let bitmap_data = match texture.original_format() {
         Context3DTextureFormat::Bgra => {
@@ -50,8 +47,7 @@ pub fn do_copy<'gc>(
                 })
                 .collect();
 
-            let bitmap_data = BitmapData::new_with_pixels(width, height, true, colors);
-            BitmapDataWrapper::new(GcCell::new(activation.gc(), bitmap_data))
+            BitmapData::new_with_pixels(activation.context.gc_context, width, height, true, colors)
         }
         _ => {
             tracing::warn!(

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -15,7 +15,7 @@ use crate::avm2::vtable::VTable;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
-use crate::bitmap::bitmap_data::BitmapDataWrapper;
+use crate::bitmap::bitmap_data::BitmapData;
 use crate::display_object::DisplayObject;
 use crate::html::TextFormat;
 use crate::streams::NetStream;
@@ -870,7 +870,7 @@ impl<'gc> Object<'gc> {
     }
 
     /// Unwrap this object as a bitmap data.
-    pub fn as_bitmap_data(&self) -> Option<BitmapDataWrapper<'gc>> {
+    pub fn as_bitmap_data(&self) -> Option<BitmapData<'gc>> {
         self.as_bitmap_data_object().map(|o| o.get_bitmap_data())
     }
 

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -6,7 +6,7 @@ use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2_stub_method;
-use crate::bitmap::bitmap_data::BitmapData;
+use crate::bitmap::bitmap_data::BitmapRawData;
 use crate::context::RenderContext;
 use crate::utils::HasPrefixField;
 use gc_arena::{Collect, Gc, GcCell, GcWeak};
@@ -345,7 +345,7 @@ impl<'gc> Context3DObject<'gc> {
     }
     pub(crate) fn copy_bitmapdata_to_texture(
         &self,
-        source: GcCell<'gc, BitmapData<'gc>>,
+        source: GcCell<'gc, BitmapRawData<'gc>>,
         dest: Rc<dyn Texture>,
         layer: u32,
     ) {

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -730,7 +730,8 @@ impl DisplayObjectWindow {
         Grid::new(ui.id().with("bitmap"))
             .num_columns(2)
             .show(ui, |ui| {
-                let bitmap_data = object.bitmap_data(context.renderer);
+                let bitmap_data = object.bitmap_data();
+                let bitmap_data = bitmap_data.sync(context.renderer);
                 let bitmap_data = bitmap_data.read();
 
                 ui.label("Width");
@@ -775,7 +776,8 @@ impl DisplayObjectWindow {
         CollapsingHeader::new("Preview")
             .id_salt(ui.id().with("bitmap-preview"))
             .show(ui, |ui| {
-                let bitmap_data = object.bitmap_data(context.renderer);
+                let bitmap_data = object.bitmap_data();
+                let bitmap_data = bitmap_data.sync(context.renderer);
                 let bitmap_data = bitmap_data.read();
 
                 if bitmap_data.width() == 0 || bitmap_data.height() == 0 {

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -17,8 +17,8 @@ use crate::avm2::{
 use crate::avm2_stub_method_context;
 use crate::backend::navigator::{ErrorResponse, OwnedFuture, Request, SuccessResponse};
 use crate::backend::ui::DialogResultFuture;
+use crate::bitmap::bitmap_data::BitmapData;
 use crate::bitmap::bitmap_data::Color;
-use crate::bitmap::bitmap_data::{BitmapData, BitmapDataWrapper};
 use crate::context::{ActionQueue, ActionType, UpdateContext};
 use crate::display_object::{
     DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer, TInteractiveObject,
@@ -34,7 +34,7 @@ use crate::vminterface::Instantiator;
 use chardetng::EncodingDetector;
 use encoding_rs::{UTF_8, WINDOWS_1252};
 use gc_arena::collect::Trace;
-use gc_arena::{Collect, GcCell};
+use gc_arena::Collect;
 use indexmap::IndexMap;
 use ruffle_macros::istr;
 use ruffle_render::utils::{determine_jpeg_tag_format, JpegTagFormat};
@@ -2186,18 +2186,17 @@ impl<'gc> Loader<'gc> {
                 let bitmap = ruffle_render::utils::decode_define_bits_jpeg(data, None)?;
 
                 let transparency = true;
-                let bitmap_data = BitmapData::new_with_pixels(
+                let bitmapdata = BitmapData::new_with_pixels(
+                    activation.context.gc_context,
                     bitmap.width(),
                     bitmap.height(),
                     transparency,
                     bitmap.as_colors().map(Color::from).collect(),
                 );
-                let bitmapdata_wrapper =
-                    BitmapDataWrapper::new(GcCell::new(activation.gc(), bitmap_data));
                 let bitmapdata_class = activation.context.avm2.classes().bitmapdata;
                 let bitmapdata_avm2 = BitmapDataObject::from_bitmap_data_internal(
                     &mut activation,
-                    bitmapdata_wrapper,
+                    bitmapdata,
                     bitmapdata_class,
                 )
                 .unwrap();


### PR DESCRIPTION
This does make `bitmap_data.rs` uglier (it now has three copies of `fn height()` and similar methods), but on the other hand:

- The new names are clearer
- Most two-phase construction and `GcCell` handling are abstracted away:

```rs
// before
let bitmap_data = BitmapData::new_with_pixels(...);
let bitmapdata_wrapper = BitmapDataWrapper::new(GcCell::new(mc, bitmap_data));
let bitmapdata_avm2 = BitmapDataObject::from_bitmap_data_internal(..., bitmapdata_wrapper);
// after
let bitmapdata = BitmapData::new_with_pixels(mc, ...);
let bitmapdata_avm2 = BitmapDataObject::from_bitmap_data_internal(..., bitmapdata);
```

- It's a nice middle step towards future BitmapData refactors (including possibly data sharing), possibly without having to touch all these places again.