### PR TITLE
chore: Update tracy and allow bots to update it from hereon

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,10 +48,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      - dependency-name: "tracing-tracy"
-      - dependency-name: "tracy-client"
-      - dependency-name: "profiling"
     labels:
       - "T-chore"
       - "A-deps"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5569,9 +5569,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.17.1"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63de1e1d4115534008d8fd5788b39324d6f58fc707849090533828619351d855"
+checksum = "746b078c6a09ebfd5594609049e07116735c304671eaab06ce749854d23435bc"
 dependencies = [
  "loom",
  "once_cell",
@@ -5581,11 +5581,12 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.23.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b98232a2447ce0a58f9a0bfb5f5e39647b5c597c994b63945fcccd1306fafb"
+checksum = "3637e734239e12ab152cd269302500bd063f37624ee210cd04b4936ed671f3b1"
 dependencies = [
  "cc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,9 +5547,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-tracy"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be7f8874d6438e4263f9874c84eded5095bda795d9c7da6ea0192e1750d3ffe"
+checksum = "dc775fdaf33c3dfd19dc354729e65e87914bc67dcdc390ca1210807b8bee5902"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",

--- a/deny.toml
+++ b/deny.toml
@@ -57,8 +57,7 @@ license-files = [
 multiple-versions = "warn"
 
 deny = [
-    # We are manually pinning `tracing-tracy` to match the version used by
-    # `profiling`, but this can get stale easily.
+    # Multiple version of this will conflict
     { name = "tracy-client", deny-multiple-versions = true },
     # Having multiple versions of this can silently cause images (such as
     # the logo in the about dialog) in egui to not appear.

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -46,8 +46,7 @@ toml_edit = { version = "0.22.22", features = ["parse"] }
 gilrs = "0.11"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
 
-# Deliberately held back to match tracy client used by profiling crate
-tracing-tracy = { version = "=0.11.1", optional = true, features = ["demangle"] }
+tracing-tracy = { version = "0.11.3", optional = true, features = ["demangle"] }
 rand = "0.8.5"
 thiserror.workspace = true
 


### PR DESCRIPTION
It was pinned before because conflicts would sometimes introduce multiple tracy clients, but we have cargo-deny for that now...