### PR TITLE
core: Set BitmapData as synced after texture creation

### DIFF
--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -626,6 +626,8 @@ impl<'gc> BitmapData<'gc> {
             let bitmap_handle = renderer.register_bitmap(bitmap);
             if let Err(e) = &bitmap_handle {
                 tracing::warn!("Failed to register raw bitmap for BitmapData: {:?}", e);
+            } else {
+                self.dirty_state = DirtyState::Clean;
             }
             self.bitmap_handle = bitmap_handle.ok();
         }


### PR DESCRIPTION
This prevents a a scenario where when a cpu-dirty texture is uploaded for the first time, we accidentally upload it twice.
This is nontrivial work, but I don't think this'll save any major real-world fps (I imagine the upload itself is faster than us sending the call with data to wgpu) or memory.

In a firefox profile of a microbenchmark it _did_ spend ~20% of time in `pixels_rgba()` of the 2nd upload, but for some reason with the PR, the total jank barely decreased; probably because the profile didn't account for gpu time itself.