### PR TITLE
chore: Fix building the web docs ...

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14162,9 +14162,9 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.0.tgz",
-            "integrity": "sha512-7AkTJhFdhsihthaBFHNpj5iFdLyR7FpQqXM+IABJmE1/qTjWypirCLrheToUP3fjpWHN1Drn3K7PWH1t37KvNQ==",
+            "version": "0.27.1",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.1.tgz",
+            "integrity": "sha512-cbFtNFpkCtHAHRvMnCDdtM2+xhO2uiJAcw4ooLmVMuaY9yLJswKvi6wOwPZgTnKKnm/HKpO/Ub6DVk4KRf/vRg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -14185,9 +14185,9 @@
             }
         },
         "node_modules/typedoc-plugin-mdn-links": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/typedoc-plugin-mdn-links/-/typedoc-plugin-mdn-links-4.0.1.tgz",
-            "integrity": "sha512-vt0+5VHvAhdZ02OvfD3O7NySoU+cDEUc5XjApBN4dxCR7CcLk2FqgzKHlDiJjzcsFkLZRvc4Znj2sV8m9AuDsg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-mdn-links/-/typedoc-plugin-mdn-links-4.0.2.tgz",
+            "integrity": "sha512-AsfhvYIYsTVfIXr5ZMTjYw0LlCIPiSLglnd2Q09DVthZBa1qfYDGZgnwOekTrF8q0RSDWTCY/ZM6LERRScoA9w==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {

--- a/web/packages/core/src/public/setup/index.ts
+++ b/web/packages/core/src/public/setup/index.ts
@@ -1,6 +1,6 @@
 /**
  * The Setup module contains the interfaces and methods needed to install Ruffle onto a page,
- * and create a {@link PlayerElement} with the latest version of Ruffle available.
+ * and create a {@link Player.PlayerElement} with the latest version of Ruffle available.
  *
  * This is primarily relevant to users of `ruffle-core` as a npm module, as the "selfhosted" version of Ruffle preinstalls itself,
  * and without type checking the interfaces here are of limited use.
@@ -10,7 +10,7 @@
  *
  * Multiple sources of Ruffle may exist - for example, the Ruffle browser extension also installs itself on page load.
  * For this reason, you are required to call `window.RufflePlayer.newest()` (for example) to grab the latest {@link SourceAPI},
- * from which you can create a {@link PlayerElement} via {@link SourceAPI.createPlayer}.
+ * from which you can create a {@link Player.PlayerElement} via {@link SourceAPI.createPlayer}.
  *
  * @module
  */


### PR DESCRIPTION
... by bumping typedoc versions in package-lock.json

This caused the latest nightly release GHA workflow to fail before the macOS and web packages could be built:
https://github.com/ruffle-rs/ruffle/actions/runs/12076786137/job/33678672883

See also the second commit message.