### PR TITLE
avm2: Group generated AS3 field slot constants by package

### DIFF
--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::error::make_error_2007;
-use crate::avm2::globals::slots::*;
+use crate::avm2::globals::slots::flash_events_event_dispatcher as slots;
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
@@ -383,9 +383,7 @@ fn dispatch_event_to_target<'gc>(
         event.as_event().unwrap().event_type(),
     );
 
-    let dispatch_list = dispatcher
-        .get_slot(FLASH_EVENTS_EVENT_DISPATCHER__DISPATCH_LIST_SLOT)
-        .as_object();
+    let dispatch_list = dispatcher.get_slot(slots::DISPATCH_LIST).as_object();
 
     if dispatch_list.is_none() {
         // Objects with no dispatch list act as if they had an empty one
@@ -446,10 +444,7 @@ pub fn dispatch_event<'gc>(
     event: Object<'gc>,
     simulate_dispatch: bool,
 ) -> Result<bool, Error<'gc>> {
-    let target = this
-        .get_slot(FLASH_EVENTS_EVENT_DISPATCHER__TARGET_SLOT)
-        .as_object()
-        .unwrap_or(this);
+    let target = this.get_slot(slots::TARGET).as_object().unwrap_or(this);
 
     let mut ancestor_list = Vec::new();
     // Edge case - during button construction, we fire bubbling events for objects

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use crate::avm2::activation::Activation;
 use crate::avm2::error::make_error_2007;
 use crate::avm2::globals::flash::display::display_object::initialize_for_allocator;
-use crate::avm2::globals::slots::*;
+use crate::avm2::globals::slots::flash_display_loader as slots;
 use crate::avm2::object::LoaderInfoObject;
 use crate::avm2::object::LoaderStream;
 use crate::avm2::object::TObject;
@@ -45,11 +45,7 @@ pub fn loader_allocator<'gc>(
         None,
         false,
     )?;
-    loader.set_slot(
-        FLASH_DISPLAY_LOADER__CONTENT_LOADER_INFO_SLOT,
-        loader_info.into(),
-        activation,
-    )?;
+    loader.set_slot(slots::_CONTENT_LOADER_INFO, loader_info.into(), activation)?;
     Ok(loader)
 }
 
@@ -62,7 +58,7 @@ pub fn load<'gc>(
     let context = args.try_get_object(activation, 1);
 
     let loader_info = this
-        .get_slot(FLASH_DISPLAY_LOADER__CONTENT_LOADER_INFO_SLOT)
+        .get_slot(slots::_CONTENT_LOADER_INFO)
         .as_object()
         .unwrap();
 
@@ -222,7 +218,7 @@ pub fn load_bytes<'gc>(
     let context = args.try_get_object(activation, 1);
 
     let loader_info = this
-        .get_slot(FLASH_DISPLAY_LOADER__CONTENT_LOADER_INFO_SLOT)
+        .get_slot(slots::_CONTENT_LOADER_INFO)
         .as_object()
         .unwrap();
 
@@ -279,7 +275,7 @@ pub fn unload<'gc>(
     avm2_stub_method!(activation, "flash.display.Loader", "unload");
 
     let loader_info = this
-        .get_slot(FLASH_DISPLAY_LOADER__CONTENT_LOADER_INFO_SLOT)
+        .get_slot(slots::_CONTENT_LOADER_INFO)
         .as_object()
         .unwrap();
 

--- a/core/src/avm2/globals/flash/display/shader_parameter.rs
+++ b/core/src/avm2/globals/flash/display/shader_parameter.rs
@@ -1,4 +1,5 @@
-use crate::avm2::globals::slots::*;
+use crate::avm2::globals::slots::flash_display_shader_input as input_slots;
+use crate::avm2::globals::slots::flash_display_shader_parameter as parameter_slots;
 use ruffle_render::pixel_bender::PixelBenderParam;
 
 use crate::{
@@ -26,16 +27,8 @@ pub fn make_shader_parameter<'gc>(
             let type_name =
                 AvmString::new_utf8(activation.context.gc_context, param_type.to_string());
 
-            obj.set_slot(
-                FLASH_DISPLAY_SHADER_PARAMETER__INDEX_SLOT,
-                index.into(),
-                activation,
-            )?;
-            obj.set_slot(
-                FLASH_DISPLAY_SHADER_PARAMETER__TYPE_SLOT,
-                type_name.into(),
-                activation,
-            )?;
+            obj.set_slot(parameter_slots::_INDEX, index.into(), activation)?;
+            obj.set_slot(parameter_slots::_TYPE, type_name.into(), activation)?;
             for meta in metadata {
                 let name = AvmString::new_utf8(activation.context.gc_context, &meta.key);
                 let value = meta.value.clone().as_avm2_value(activation, false)?;
@@ -58,16 +51,8 @@ pub fn make_shader_parameter<'gc>(
                 .classes()
                 .shaderinput
                 .construct(activation, &[])?;
-            obj.set_slot(
-                FLASH_DISPLAY_SHADER_INPUT__CHANNELS_SLOT,
-                (*channels).into(),
-                activation,
-            )?;
-            obj.set_slot(
-                FLASH_DISPLAY_SHADER_INPUT__INDEX_SLOT,
-                index.into(),
-                activation,
-            )?;
+            obj.set_slot(input_slots::_CHANNELS, (*channels).into(), activation)?;
+            obj.set_slot(input_slots::_INDEX, index.into(), activation)?;
             obj.set_public_property(
                 "name",
                 AvmString::new_utf8(activation.context.gc_context, name).into(),

--- a/core/src/avm2/globals/flash/display/shape.rs
+++ b/core/src/avm2/globals/flash/display/shape.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::globals::flash::display::display_object::initialize_for_allocator;
-use crate::avm2::globals::slots::*;
+use crate::avm2::globals::slots::flash_display_shape as slots;
 use crate::avm2::object::{ClassObject, Object, StageObject, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
@@ -25,10 +25,10 @@ pub fn get_graphics<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this.as_display_object() {
         // Lazily initialize the `Graphics` object in a hidden property.
-        let graphics = match this.get_slot(FLASH_DISPLAY_SHAPE__GRAPHICS_SLOT) {
+        let graphics = match this.get_slot(slots::_GRAPHICS) {
             Value::Undefined | Value::Null => {
                 let graphics = Value::from(StageObject::graphics(activation, dobj)?);
-                this.set_slot(FLASH_DISPLAY_SHAPE__GRAPHICS_SLOT, graphics, activation)?;
+                this.set_slot(slots::_GRAPHICS, graphics, activation)?;
                 graphics
             }
             graphics => graphics,

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::globals::flash::display::display_object::initialize_for_allocator;
-use crate::avm2::globals::slots::*;
+use crate::avm2::globals::slots::flash_display_sprite as slots;
 use crate::avm2::object::{Object, StageObject, TObject};
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
@@ -69,10 +69,10 @@ pub fn get_graphics<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this.as_display_object() {
         // Lazily initialize the `Graphics` object in a hidden property.
-        let graphics = match this.get_slot(FLASH_DISPLAY_SPRITE__GRAPHICS_SLOT) {
+        let graphics = match this.get_slot(slots::_GRAPHICS) {
             Value::Undefined | Value::Null => {
                 let graphics = Value::from(StageObject::graphics(activation, dobj)?);
-                this.set_slot(FLASH_DISPLAY_SPRITE__GRAPHICS_SLOT, graphics, activation)?;
+                this.set_slot(slots::_GRAPHICS, graphics, activation)?;
                 graphics
             }
             graphics => graphics,

--- a/core/src/avm2/globals/flash/events/event_dispatcher.rs
+++ b/core/src/avm2/globals/flash/events/event_dispatcher.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::events::{dispatch_event as dispatch_event_internal, parent_of};
-use crate::avm2::globals::slots::*;
+use crate::avm2::globals::slots::flash_events_event_dispatcher as slots;
 use crate::avm2::object::{DispatchObject, Object, TObject};
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
@@ -13,15 +13,11 @@ fn dispatch_list<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    match this.get_slot(FLASH_EVENTS_EVENT_DISPATCHER__DISPATCH_LIST_SLOT) {
+    match this.get_slot(slots::DISPATCH_LIST) {
         Value::Object(o) => Ok(o),
         _ => {
             let dispatch_list = DispatchObject::empty_list(activation);
-            this.set_slot(
-                FLASH_EVENTS_EVENT_DISPATCHER__DISPATCH_LIST_SLOT,
-                dispatch_list.into(),
-                activation,
-            )?;
+            this.set_slot(slots::DISPATCH_LIST, dispatch_list.into(), activation)?;
 
             Ok(dispatch_list)
         }
@@ -105,10 +101,7 @@ pub fn will_trigger<'gc>(
         return Ok(true.into());
     }
 
-    let target = this
-        .get_slot(FLASH_EVENTS_EVENT_DISPATCHER__TARGET_SLOT)
-        .as_object()
-        .unwrap_or(this);
+    let target = this.get_slot(slots::TARGET).as_object().unwrap_or(this);
 
     if let Some(parent) = parent_of(target) {
         return will_trigger(activation, parent, args);

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -1,4 +1,4 @@
-use crate::avm2::globals::slots::*;
+use crate::avm2::globals::slots::flash_geom_transform as slots;
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::{Activation, Error, Object, TObject, Value};
 use crate::display_object::TDisplayObject;
@@ -11,7 +11,7 @@ fn get_display_object<'gc>(
     _activation: &mut Activation<'_, 'gc>,
 ) -> Result<DisplayObject<'gc>, Error<'gc>> {
     Ok(this
-        .get_slot(FLASH_GEOM_TRANSFORM__DISPLAY_OBJECT_SLOT)
+        .get_slot(slots::DISPLAY_OBJECT)
         .as_object()
         .unwrap()
         .as_display_object()

--- a/core/src/avm2/globals/flash/utils/timer.rs
+++ b/core/src/avm2/globals/flash/utils/timer.rs
@@ -1,7 +1,7 @@
 //! `flash.utils.Timer` native methods
 
 use crate::avm2::activation::Activation;
-use crate::avm2::globals::slots::*;
+use crate::avm2::globals::slots::flash_utils_timer as slots;
 use crate::avm2::object::TObject;
 use crate::avm2::value::Value;
 use crate::avm2::Multiname;
@@ -14,13 +14,11 @@ pub fn stop<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let id = this
-        .get_slot(FLASH_UTILS_TIMER__TIMER_ID_SLOT)
-        .coerce_to_i32(activation)?;
+    let id = this.get_slot(slots::_TIMER_ID).coerce_to_i32(activation)?;
 
     if id != -1 {
         activation.context.timers.remove(id);
-        this.set_slot(FLASH_UTILS_TIMER__TIMER_ID_SLOT, (-1).into(), activation)?;
+        this.set_slot(slots::_TIMER_ID, (-1).into(), activation)?;
     }
 
     Ok(Value::Undefined)
@@ -34,13 +32,9 @@ pub fn start<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let namespaces = activation.avm2().namespaces;
 
-    let id = this
-        .get_slot(FLASH_UTILS_TIMER__TIMER_ID_SLOT)
-        .coerce_to_i32(activation)?;
+    let id = this.get_slot(slots::_TIMER_ID).coerce_to_i32(activation)?;
 
-    let delay = this
-        .get_slot(FLASH_UTILS_TIMER__DELAY_SLOT)
-        .coerce_to_number(activation)?;
+    let delay = this.get_slot(slots::_DELAY).coerce_to_number(activation)?;
 
     if id == -1 {
         let on_update = this
@@ -62,7 +56,7 @@ pub fn start<'gc>(
             delay as _,
             false,
         );
-        this.set_slot(FLASH_UTILS_TIMER__TIMER_ID_SLOT, id.into(), activation)?;
+        this.set_slot(slots::_TIMER_ID, id.into(), activation)?;
     }
     Ok(Value::Undefined)
 }
@@ -73,13 +67,9 @@ pub fn update_delay<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let id = this
-        .get_slot(FLASH_UTILS_TIMER__TIMER_ID_SLOT)
-        .coerce_to_i32(activation)?;
+    let id = this.get_slot(slots::_TIMER_ID).coerce_to_i32(activation)?;
 
-    let delay = this
-        .get_slot(FLASH_UTILS_TIMER__DELAY_SLOT)
-        .coerce_to_i32(activation)?;
+    let delay = this.get_slot(slots::_DELAY).coerce_to_i32(activation)?;
 
     if id != -1 {
         activation.context.timers.set_delay(id, delay);


### PR DESCRIPTION
A follow-up to #18747, as proposed on Discord.

The generated code now looks like this:

```rs
mod slots {
  mod flash_utils_timer {
    pub const _timerId: u32 = ...;
    pub const _delay: u32 = ...;
  }
  // ...
 }
```

This makes usage terser, as most files only need access to the slots of a single AS3 class, which can then be imported as `use avm2::globals::slots::the_class as slots`.