### PR TITLE
web: Improve error when WASM extensions are unsupported but only the module which uses them is available

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -26,7 +26,6 @@ import { showPanicScreen } from "../ui/panic";
 import { createRuffleBuilder } from "../../load-ruffle";
 import { lookupElement } from "../register-element";
 import { configureBuilder } from "../builder";
-import { referenceTypes } from "wasm-feature-detect";
 
 const DIMENSION_REGEX = /^\s*(\d+(\.\d+)?(%)?)/;
 
@@ -854,16 +853,6 @@ export class InnerPlayer {
             ) {
                 this.container.style.backgroundColor =
                     this.loadedConfig.backgroundColor;
-            }
-
-            // We may theoretically need to check everything listed on https://github.com/rust-lang/rust/blob/master/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md#enabled-webassembly-features
-            // but this is the only extension I know completely breaks our WASM module if unsupported
-            const necessaryExtensionsSupported: boolean = await referenceTypes();
-            if (!necessaryExtensionsSupported) {
-                const baseError = new Error("Necessary WebAssembly extensions unsupported");
-                const loadError = new LoadRuffleWasmError(baseError);
-                this.panic(loadError);
-                return;
             }
 
             await this.ensureFreshInstance();

--- a/web/packages/core/src/internal/ui/panic.tsx
+++ b/web/packages/core/src/internal/ui/panic.tsx
@@ -246,6 +246,19 @@ function createPanicError(error: Error | null): {
             };
         }
 
+        if (error.cause.name === "CompileError" && message.includes("bad type")) {
+            // Self hosted: User has a browser without support for necessary WebAssembly extensions
+            return {
+                body: textAsParagraphs("error-wasm-unsupported-browser"),
+                actions: [
+                    CommonActions.openWiki(
+                        "#web",
+                    ),
+                    CommonActions.ShowDetails,
+                ],
+            };
+        }
+
         if (error.cause.name === "CompileError") {
             // Self hosted: Cannot load `.wasm` file - incorrect configuration or missing files
             return {
@@ -302,19 +315,6 @@ function createPanicError(error: Error | null): {
                     CommonActions.openWiki(
                         "Frequently-Asked-Questions-For-Users#edge-webassembly-error",
                         text("more-info"),
-                    ),
-                    CommonActions.ShowDetails,
-                ],
-            };
-        }
-
-        if (message === "necessary webassembly extensions unsupported") {
-            // Self hosted: User has a browser without support for necessary WebAssembly extensions
-            return {
-                body: textAsParagraphs("error-wasm-unsupported-browser"),
-                actions: [
-                    CommonActions.openWiki(
-                        "#web",
                     ),
                     CommonActions.ShowDetails,
                 ],

--- a/web/packages/core/src/internal/ui/panic.tsx
+++ b/web/packages/core/src/internal/ui/panic.tsx
@@ -308,6 +308,19 @@ function createPanicError(error: Error | null): {
             };
         }
 
+        if (message === "necessary webassembly extensions unsupported") {
+            // Self hosted: User has a browser without support for necessary WebAssembly extensions
+            return {
+                body: textAsParagraphs("error-wasm-unsupported-browser"),
+                actions: [
+                    CommonActions.openWiki(
+                        "#web",
+                    ),
+                    CommonActions.ShowDetails,
+                ],
+            };
+        }
+
         // Self hosted: Cannot load `.wasm` file - file not found
         return {
             body: textAsParagraphs("error-wasm-not-found"),

--- a/web/packages/core/texts/en-US/messages.ftl
+++ b/web/packages/core/texts/en-US/messages.ftl
@@ -68,6 +68,10 @@ error-wasm-disabled-on-edge =
     To fix this, try opening your browser's settings, clicking "Privacy, search, and services", scrolling down, and turning off "Enhance your security on the web".
     This will allow your browser to load the required ".wasm" files.
     If the issue persists, you might have to use a different browser.
+error-wasm-unsupported-browser =
+    The browser you are using does not support the WebAssembly extensions Ruffle requires to run.
+    Please switch to a supported browser.
+    You can find a list of supported browsers on the Wiki.
 error-javascript-conflict =
     Ruffle has encountered a major issue whilst trying to initialize.
     It seems like this page uses JavaScript code that conflicts with Ruffle.


### PR DESCRIPTION
~~This is somewhat the antithesis of https://github.com/ruffle-rs/ruffle/pull/18528. That PR keeps Ruffle running on browsers without reference types support.~~ This shows a better error on browsers without reference-types support when only the with-extensions WASM module is available for use.

~~Merging https://github.com/ruffle-rs/ruffle/pull/18399 will break Ruffle on Safari versions below 15 and Pale Moon. We can keep Ruffle working on those browsers, or we can officially designate them to be unsupported.~~