### PR TITLE
chore: Clean up a TODO about silencing a beta clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,6 @@ rfd = "0.15.0"
 # Don't warn about these new lints on stable.
 renamed_and_removed_lints = "allow"
 unknown_lints = "allow"
-# TODO: Remove when https://github.com/rustwasm/wasm-bindgen/issues/4283 is resolved.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
 
 [workspace.lints.clippy]
 # LONG-TERM: These lints are unhelpful.


### PR DESCRIPTION
Reverts b136254c21a4d080e4c602e5421721d7598cdd50 (part of #18781).

Ideally this should have been part of https://github.com/ruffle-rs/ruffle/pull/18809.

And this is what I confused with that "will make one commit unnecessary in another PR" part of its description.