### PR TITLE
core: Reimplement `Debug` for some structs

### DIFF
--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -1,4 +1,5 @@
 use gc_arena::Collect;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use swf::{CharacterId, Fixed8, HeaderExt, Rectangle, TagCode, Twips};
 use thiserror::Error;
@@ -44,7 +45,7 @@ pub type SwfStream<'a> = swf::read::Reader<'a>;
 
 /// An open, fully parsed SWF movie ready to play back, either in a Player or a
 /// MovieClip.
-#[derive(Debug, Clone, Collect)]
+#[derive(Clone, Collect)]
 #[collect(require_static)]
 pub struct SwfMovie {
     /// The SWF header parsed from the data stream.
@@ -325,6 +326,22 @@ impl SwfMovie {
 
     pub fn sandbox_type(&self) -> SandboxType {
         self.sandbox_type
+    }
+}
+
+impl Debug for SwfMovie {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SwfMovie")
+            .field("header", &self.header)
+            .field("data", &self.data.len())
+            .field("url", &self.url)
+            .field("loader_url", &self.loader_url)
+            .field("parameters", &self.parameters)
+            .field("encoding", &self.encoding)
+            .field("compressed_len", &self.compressed_len)
+            .field("is_movie", &self.is_movie)
+            .field("sandbox_type", &self.sandbox_type)
+            .finish()
     }
 }
 

--- a/swf/src/types/color.rs
+++ b/swf/src/types/color.rs
@@ -1,7 +1,9 @@
+use std::fmt::{Debug, Formatter};
+
 /// An RGBA (red, green, blue, alpha) color.
 ///
 /// All components are stored as [`u8`] and have a color range of 0-255.
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Hash)]
 pub struct Color {
     /// The red component value.
     pub r: u8,
@@ -14,6 +16,16 @@ pub struct Color {
 
     /// The alpha component value.
     pub a: u8,
+}
+
+impl Debug for Color {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Color(0x{:02x}{:02x}{:02x}{:02x})",
+            self.r, self.g, self.b, self.a,
+        )
+    }
 }
 
 impl Color {

--- a/swf/src/types/rectangle.rs
+++ b/swf/src/types/rectangle.rs
@@ -1,5 +1,5 @@
 use crate::{types::point::Coordinate as PointCoordinate, Point, Twips};
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
 pub trait Coordinate: PointCoordinate + Ord {
     const INVALID: Self;
@@ -10,7 +10,7 @@ impl Coordinate for Twips {
 }
 
 /// A rectangular region defined by minimum and maximum x- and y-coordinate positions.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Rectangle<T> {
     /// The minimum x-position of the rectangle.
     pub x_min: T,
@@ -23,6 +23,16 @@ pub struct Rectangle<T> {
 
     /// The maximum y-position of the rectangle.
     pub y_max: T,
+}
+
+impl<T: Debug> Debug for Rectangle<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Rectangle(x={:?}..{:?}, y={:?}..{:?})",
+            self.x_min, self.x_max, self.y_min, self.y_max
+        )
+    }
 }
 
 impl<T: PointCoordinate + Ord> Rectangle<T> {


### PR DESCRIPTION
The default `Debug` was producing too much output for those classes to make debugging them feasible.