### PR TITLE
avm2: Use slot access in filter code

### DIFF
--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -3,6 +3,7 @@ use crate::avm2::globals::flash::display::shader_job::get_shader_args;
 use crate::avm2::globals::slots::flash_filters_bevel_filter as bevel_filter_slots;
 use crate::avm2::globals::slots::flash_filters_blur_filter as blur_filter_slots;
 use crate::avm2::globals::slots::flash_filters_color_matrix_filter as color_matrix_filter_slots;
+use crate::avm2::globals::slots::flash_filters_convolution_filter as convolution_filter_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
 use crate::avm2::{Activation, Error, Value};
@@ -361,7 +362,7 @@ fn avm2_to_convolution_filter<'gc>(
 ) -> Result<Filter, Error<'gc>> {
     let mut matrix = vec![];
     if let Some(matrix_object) = object
-        .get_public_property("matrix", activation)?
+        .get_slot(convolution_filter_slots::MATRIX)
         .as_object()
     {
         if let Some(array) = matrix_object.as_array_storage() {
@@ -375,28 +376,28 @@ fn avm2_to_convolution_filter<'gc>(
         }
     }
     let alpha = object
-        .get_public_property("alpha", activation)?
+        .get_slot(convolution_filter_slots::ALPHA)
         .coerce_to_number(activation)?;
     let bias = object
-        .get_public_property("bias", activation)?
+        .get_slot(convolution_filter_slots::BIAS)
         .coerce_to_number(activation)?;
     let clamp = object
-        .get_public_property("clamp", activation)?
+        .get_slot(convolution_filter_slots::CLAMP)
         .coerce_to_boolean();
     let color = object
-        .get_public_property("color", activation)?
+        .get_slot(convolution_filter_slots::COLOR)
         .coerce_to_u32(activation)?;
     let divisor = object
-        .get_public_property("divisor", activation)?
+        .get_slot(convolution_filter_slots::DIVISOR)
         .coerce_to_number(activation)?;
     let matrix_x = object
-        .get_public_property("matrixX", activation)?
+        .get_slot(convolution_filter_slots::MATRIX_X)
         .coerce_to_u32(activation)?;
     let matrix_y = object
-        .get_public_property("matrixY", activation)?
+        .get_slot(convolution_filter_slots::MATRIX_Y)
         .coerce_to_u32(activation)?;
     let preserve_alpha = object
-        .get_public_property("preserveAlpha", activation)?
+        .get_slot(convolution_filter_slots::PRESERVE_ALPHA)
         .coerce_to_boolean();
     let mut flags = ConvolutionFilterFlags::empty();
     flags.set(ConvolutionFilterFlags::CLAMP, clamp);

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -7,6 +7,8 @@ use crate::avm2::globals::slots::flash_filters_convolution_filter as convolution
 use crate::avm2::globals::slots::flash_filters_displacement_map_filter as displacement_map_filter_slots;
 use crate::avm2::globals::slots::flash_filters_drop_shadow_filter as drop_shadow_filter_slots;
 use crate::avm2::globals::slots::flash_filters_glow_filter as glow_filter_slots;
+use crate::avm2::globals::slots::flash_filters_gradient_bevel_filter as gradient_bevel_filter_slots;
+use crate::avm2::globals::slots::flash_filters_gradient_glow_filter as gradient_glow_filter_slots;
 use crate::avm2::globals::slots::flash_filters_shader_filter as shader_filter_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
@@ -697,29 +699,45 @@ fn avm2_to_gradient_filter<'gc>(
     activation: &mut Activation<'_, 'gc>,
     object: Object<'gc>,
 ) -> Result<GradientFilter, Error<'gc>> {
+    #[allow(clippy::assertions_on_constants)]
+    {
+        assert!(gradient_bevel_filter_slots::ANGLE == gradient_glow_filter_slots::ANGLE);
+        assert!(gradient_bevel_filter_slots::BLUR_X == gradient_glow_filter_slots::BLUR_X);
+        assert!(gradient_bevel_filter_slots::BLUR_Y == gradient_glow_filter_slots::BLUR_Y);
+        assert!(gradient_bevel_filter_slots::DISTANCE == gradient_glow_filter_slots::DISTANCE);
+        assert!(gradient_bevel_filter_slots::KNOCKOUT == gradient_glow_filter_slots::KNOCKOUT);
+        assert!(gradient_bevel_filter_slots::QUALITY == gradient_glow_filter_slots::QUALITY);
+        assert!(gradient_bevel_filter_slots::STRENGTH == gradient_glow_filter_slots::STRENGTH);
+        assert!(gradient_bevel_filter_slots::TYPE == gradient_glow_filter_slots::TYPE);
+
+        assert!(gradient_bevel_filter_slots::COLORS == gradient_glow_filter_slots::COLORS);
+        assert!(gradient_bevel_filter_slots::ALPHAS == gradient_glow_filter_slots::ALPHAS);
+        assert!(gradient_bevel_filter_slots::RATIOS == gradient_glow_filter_slots::RATIOS);
+    }
+
     let angle = object
-        .get_public_property("angle", activation)?
+        .get_slot(gradient_bevel_filter_slots::ANGLE)
         .coerce_to_number(activation)?;
     let blur_x = object
-        .get_public_property("blurX", activation)?
+        .get_slot(gradient_bevel_filter_slots::BLUR_X)
         .coerce_to_number(activation)?;
     let blur_y = object
-        .get_public_property("blurY", activation)?
+        .get_slot(gradient_bevel_filter_slots::BLUR_Y)
         .coerce_to_number(activation)?;
     let distance = object
-        .get_public_property("distance", activation)?
+        .get_slot(gradient_bevel_filter_slots::DISTANCE)
         .coerce_to_number(activation)?;
     let knockout = object
-        .get_public_property("knockout", activation)?
+        .get_slot(gradient_bevel_filter_slots::KNOCKOUT)
         .coerce_to_boolean();
     let quality = object
-        .get_public_property("quality", activation)?
+        .get_slot(gradient_bevel_filter_slots::QUALITY)
         .coerce_to_u32(activation)?;
     let strength = object
-        .get_public_property("strength", activation)?
+        .get_slot(gradient_bevel_filter_slots::STRENGTH)
         .coerce_to_number(activation)?;
     let bevel_type = object
-        .get_public_property("type", activation)?
+        .get_slot(gradient_bevel_filter_slots::TYPE)
         .coerce_to_string(activation)?;
     let colors = get_gradient_colors(activation, object)?;
     let mut flags = GradientFilterFlags::COMPOSITE_SOURCE;
@@ -857,17 +875,17 @@ fn get_gradient_colors<'gc>(
 ) -> Result<Vec<GradientRecord>, Error<'gc>> {
     let mut colors = vec![];
     if let Some(colors_object) = object
-        .get_public_property("colors", activation)?
+        .get_slot(gradient_bevel_filter_slots::COLORS)
         .as_object()
     {
         if let Some(colors_array) = colors_object.as_array_storage() {
             if let Some(alphas_object) = object
-                .get_public_property("alphas", activation)?
+                .get_slot(gradient_bevel_filter_slots::ALPHAS)
                 .as_object()
             {
                 if let Some(alphas_array) = alphas_object.as_array_storage() {
                     if let Some(ratios_object) = object
-                        .get_public_property("ratios", activation)?
+                        .get_slot(gradient_bevel_filter_slots::RATIOS)
                         .as_object()
                     {
                         if let Some(ratios_array) = ratios_object.as_array_storage() {

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -5,6 +5,7 @@ use crate::avm2::globals::slots::flash_filters_blur_filter as blur_filter_slots;
 use crate::avm2::globals::slots::flash_filters_color_matrix_filter as color_matrix_filter_slots;
 use crate::avm2::globals::slots::flash_filters_convolution_filter as convolution_filter_slots;
 use crate::avm2::globals::slots::flash_filters_displacement_map_filter as displacement_map_filter_slots;
+use crate::avm2::globals::slots::flash_filters_drop_shadow_filter as drop_shadow_filter_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
 use crate::avm2::{Activation, Error, Value};
@@ -558,37 +559,37 @@ fn avm2_to_drop_shadow_filter<'gc>(
     object: Object<'gc>,
 ) -> Result<Filter, Error<'gc>> {
     let alpha = object
-        .get_public_property("alpha", activation)?
+        .get_slot(drop_shadow_filter_slots::ALPHA)
         .coerce_to_number(activation)?;
     let angle = object
-        .get_public_property("angle", activation)?
+        .get_slot(drop_shadow_filter_slots::ANGLE)
         .coerce_to_number(activation)?;
     let blur_x = object
-        .get_public_property("blurX", activation)?
+        .get_slot(drop_shadow_filter_slots::BLUR_X)
         .coerce_to_number(activation)?;
     let blur_y = object
-        .get_public_property("blurY", activation)?
+        .get_slot(drop_shadow_filter_slots::BLUR_Y)
         .coerce_to_number(activation)?;
     let color = object
-        .get_public_property("color", activation)?
+        .get_slot(drop_shadow_filter_slots::COLOR)
         .coerce_to_u32(activation)?;
     let distance = object
-        .get_public_property("distance", activation)?
+        .get_slot(drop_shadow_filter_slots::DISTANCE)
         .coerce_to_number(activation)?;
     let hide_object = object
-        .get_public_property("hideObject", activation)?
+        .get_slot(drop_shadow_filter_slots::HIDE_OBJECT)
         .coerce_to_boolean();
     let inner = object
-        .get_public_property("inner", activation)?
+        .get_slot(drop_shadow_filter_slots::INNER)
         .coerce_to_boolean();
     let knockout = object
-        .get_public_property("knockout", activation)?
+        .get_slot(drop_shadow_filter_slots::KNOCKOUT)
         .coerce_to_boolean();
     let quality = object
-        .get_public_property("quality", activation)?
+        .get_slot(drop_shadow_filter_slots::QUALITY)
         .coerce_to_u32(activation)?;
     let strength = object
-        .get_public_property("strength", activation)?
+        .get_slot(drop_shadow_filter_slots::STRENGTH)
         .coerce_to_number(activation)?;
     let mut flags = DropShadowFilterFlags::empty();
     if !hide_object {

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -7,6 +7,7 @@ use crate::avm2::globals::slots::flash_filters_convolution_filter as convolution
 use crate::avm2::globals::slots::flash_filters_displacement_map_filter as displacement_map_filter_slots;
 use crate::avm2::globals::slots::flash_filters_drop_shadow_filter as drop_shadow_filter_slots;
 use crate::avm2::globals::slots::flash_filters_glow_filter as glow_filter_slots;
+use crate::avm2::globals::slots::flash_filters_shader_filter as shader_filter_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
 use crate::avm2::{Activation, Error, Value};
@@ -795,23 +796,23 @@ fn avm2_to_shader_filter<'gc>(
     object: Object<'gc>,
 ) -> Result<ShaderFilter<'static>, Error<'gc>> {
     let bottom_extension = object
-        .get_public_property("bottomExtension", activation)?
+        .get_slot(shader_filter_slots::_BOTTOM_EXTENSION)
         .coerce_to_i32(activation)?;
 
     let left_extension = object
-        .get_public_property("leftExtension", activation)?
+        .get_slot(shader_filter_slots::_LEFT_EXTENSION)
         .coerce_to_i32(activation)?;
 
     let right_extension = object
-        .get_public_property("rightExtension", activation)?
+        .get_slot(shader_filter_slots::_RIGHT_EXTENSION)
         .coerce_to_i32(activation)?;
 
     let top_extension = object
-        .get_public_property("topExtension", activation)?
+        .get_slot(shader_filter_slots::_TOP_EXTENSION)
         .coerce_to_i32(activation)?;
 
     let shader_obj = object
-        .get_public_property("shader", activation)?
+        .get_slot(shader_filter_slots::_SHADER)
         .as_object()
         .unwrap();
 

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -1,6 +1,7 @@
 use crate::avm2::error::{make_error_2008, type_error};
 use crate::avm2::globals::flash::display::shader_job::get_shader_args;
 use crate::avm2::globals::slots::flash_filters_bevel_filter as bevel_filter_slots;
+use crate::avm2::globals::slots::flash_filters_blur_filter as blur_filter_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
 use crate::avm2::{Activation, Error, Value};
@@ -288,13 +289,13 @@ fn avm2_to_blur_filter<'gc>(
     object: Object<'gc>,
 ) -> Result<Filter, Error<'gc>> {
     let blur_x = object
-        .get_public_property("blurX", activation)?
+        .get_slot(blur_filter_slots::BLUR_X)
         .coerce_to_number(activation)?;
     let blur_y = object
-        .get_public_property("blurY", activation)?
+        .get_slot(blur_filter_slots::BLUR_Y)
         .coerce_to_number(activation)?;
     let quality = object
-        .get_public_property("quality", activation)?
+        .get_slot(blur_filter_slots::QUALITY)
         .coerce_to_u32(activation)?;
     Ok(Filter::BlurFilter(BlurFilter {
         blur_x: Fixed16::from_f64(blur_x.max(0.0)),

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -2,6 +2,7 @@ use crate::avm2::error::{make_error_2008, type_error};
 use crate::avm2::globals::flash::display::shader_job::get_shader_args;
 use crate::avm2::globals::slots::flash_filters_bevel_filter as bevel_filter_slots;
 use crate::avm2::globals::slots::flash_filters_blur_filter as blur_filter_slots;
+use crate::avm2::globals::slots::flash_filters_color_matrix_filter as color_matrix_filter_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
 use crate::avm2::{Activation, Error, Value};
@@ -324,7 +325,7 @@ fn avm2_to_color_matrix_filter<'gc>(
 ) -> Result<Filter, Error<'gc>> {
     let mut matrix = [0.0; 20];
     if let Some(matrix_object) = object
-        .get_public_property("matrix", activation)?
+        .get_slot(color_matrix_filter_slots::_MATRIX)
         .as_object()
     {
         if let Some(array) = matrix_object.as_array_storage() {

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -6,6 +6,7 @@ use crate::avm2::globals::slots::flash_filters_color_matrix_filter as color_matr
 use crate::avm2::globals::slots::flash_filters_convolution_filter as convolution_filter_slots;
 use crate::avm2::globals::slots::flash_filters_displacement_map_filter as displacement_map_filter_slots;
 use crate::avm2::globals::slots::flash_filters_drop_shadow_filter as drop_shadow_filter_slots;
+use crate::avm2::globals::slots::flash_filters_glow_filter as glow_filter_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
 use crate::avm2::{Activation, Error, Value};
@@ -636,28 +637,28 @@ fn avm2_to_glow_filter<'gc>(
     object: Object<'gc>,
 ) -> Result<Filter, Error<'gc>> {
     let alpha = object
-        .get_public_property("alpha", activation)?
+        .get_slot(glow_filter_slots::ALPHA)
         .coerce_to_number(activation)?;
     let blur_x = object
-        .get_public_property("blurX", activation)?
+        .get_slot(glow_filter_slots::BLUR_X)
         .coerce_to_number(activation)?;
     let blur_y = object
-        .get_public_property("blurY", activation)?
+        .get_slot(glow_filter_slots::BLUR_Y)
         .coerce_to_number(activation)?;
     let color = object
-        .get_public_property("color", activation)?
+        .get_slot(glow_filter_slots::COLOR)
         .coerce_to_u32(activation)?;
     let inner = object
-        .get_public_property("inner", activation)?
+        .get_slot(glow_filter_slots::INNER)
         .coerce_to_boolean();
     let knockout = object
-        .get_public_property("knockout", activation)?
+        .get_slot(glow_filter_slots::KNOCKOUT)
         .coerce_to_boolean();
     let quality = object
-        .get_public_property("quality", activation)?
+        .get_slot(glow_filter_slots::QUALITY)
         .coerce_to_u32(activation)?;
     let strength = object
-        .get_public_property("strength", activation)?
+        .get_slot(glow_filter_slots::STRENGTH)
         .coerce_to_number(activation)?;
     let mut flags = GlowFilterFlags::COMPOSITE_SOURCE;
     flags.set(GlowFilterFlags::INNER_GLOW, inner);

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -1,3 +1,10 @@
+use crate::avm2::error::{make_error_2008, type_error};
+use crate::avm2::globals::flash::display::shader_job::get_shader_args;
+use crate::avm2::globals::slots::flash_filters_bevel_filter as bevel_filter_slots;
+use crate::avm2::globals::slots::flash_geom_point as point_slots;
+use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
+use crate::avm2::{Activation, Error, Value};
+
 use gc_arena::{Collect, DynamicRoot, Rootable};
 use ruffle_render::filters::{
     DisplacementMapFilter, DisplacementMapFilterMode, Filter, ShaderFilter, ShaderObject,
@@ -8,12 +15,6 @@ use swf::{
     ConvolutionFilter, ConvolutionFilterFlags, DropShadowFilter, DropShadowFilterFlags, Fixed16,
     Fixed8, GlowFilter, GlowFilterFlags, GradientFilter, GradientFilterFlags, GradientRecord,
 };
-
-use crate::avm2::error::{make_error_2008, type_error};
-use crate::avm2::globals::slots::flash_geom_point as point_slots;
-use crate::avm2::{Activation, ArrayObject, ClassObject, Error, Object, TObject, Value};
-
-use super::globals::flash::display::shader_job::get_shader_args;
 
 pub trait FilterAvm2Ext {
     fn from_avm2_object<'gc>(
@@ -197,40 +198,40 @@ fn avm2_to_bevel_filter<'gc>(
     object: Object<'gc>,
 ) -> Result<Filter, Error<'gc>> {
     let angle = object
-        .get_public_property("angle", activation)?
+        .get_slot(bevel_filter_slots::ANGLE)
         .coerce_to_number(activation)?;
     let blur_x = object
-        .get_public_property("blurX", activation)?
+        .get_slot(bevel_filter_slots::BLUR_X)
         .coerce_to_number(activation)?;
     let blur_y = object
-        .get_public_property("blurY", activation)?
+        .get_slot(bevel_filter_slots::BLUR_Y)
         .coerce_to_number(activation)?;
     let distance = object
-        .get_public_property("distance", activation)?
+        .get_slot(bevel_filter_slots::DISTANCE)
         .coerce_to_number(activation)?;
     let highlight_alpha = object
-        .get_public_property("highlightAlpha", activation)?
+        .get_slot(bevel_filter_slots::HIGHLIGHT_ALPHA)
         .coerce_to_number(activation)?;
     let highlight_color = object
-        .get_public_property("highlightColor", activation)?
+        .get_slot(bevel_filter_slots::HIGHLIGHT_COLOR)
         .coerce_to_u32(activation)?;
     let knockout = object
-        .get_public_property("knockout", activation)?
+        .get_slot(bevel_filter_slots::KNOCKOUT)
         .coerce_to_boolean();
     let quality = object
-        .get_public_property("quality", activation)?
+        .get_slot(bevel_filter_slots::QUALITY)
         .coerce_to_u32(activation)?;
     let shadow_alpha = object
-        .get_public_property("shadowAlpha", activation)?
+        .get_slot(bevel_filter_slots::SHADOW_ALPHA)
         .coerce_to_number(activation)?;
     let shadow_color = object
-        .get_public_property("shadowColor", activation)?
+        .get_slot(bevel_filter_slots::SHADOW_COLOR)
         .coerce_to_u32(activation)?;
     let strength = object
-        .get_public_property("strength", activation)?
+        .get_slot(bevel_filter_slots::STRENGTH)
         .coerce_to_number(activation)?;
     let bevel_type = object
-        .get_public_property("type", activation)?
+        .get_slot(bevel_filter_slots::TYPE)
         .coerce_to_string(activation)?;
     let mut flags = BevelFilterFlags::COMPOSITE_SOURCE;
     if &bevel_type == b"inner" {

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -4,6 +4,7 @@ use crate::avm2::globals::slots::flash_filters_bevel_filter as bevel_filter_slot
 use crate::avm2::globals::slots::flash_filters_blur_filter as blur_filter_slots;
 use crate::avm2::globals::slots::flash_filters_color_matrix_filter as color_matrix_filter_slots;
 use crate::avm2::globals::slots::flash_filters_convolution_filter as convolution_filter_slots;
+use crate::avm2::globals::slots::flash_filters_displacement_map_filter as displacement_map_filter_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
 use crate::avm2::{Activation, Error, Value};
@@ -449,19 +450,19 @@ fn avm2_to_displacement_map_filter<'gc>(
     object: Object<'gc>,
 ) -> Result<Filter, Error<'gc>> {
     let alpha = object
-        .get_public_property("alpha", activation)?
+        .get_slot(displacement_map_filter_slots::ALPHA)
         .coerce_to_number(activation)?;
     let color = object
-        .get_public_property("color", activation)?
+        .get_slot(displacement_map_filter_slots::COLOR)
         .coerce_to_u32(activation)?;
     let component_x = object
-        .get_public_property("componentX", activation)?
+        .get_slot(displacement_map_filter_slots::COMPONENT_X)
         .coerce_to_u32(activation)?;
     let component_y = object
-        .get_public_property("componentY", activation)?
+        .get_slot(displacement_map_filter_slots::COMPONENT_Y)
         .coerce_to_u32(activation)?;
     let map_point =
-        if let Value::Object(point) = object.get_public_property("mapPoint", activation)? {
+        if let Value::Object(point) = object.get_slot(displacement_map_filter_slots::MAP_POINT) {
             (
                 point.get_slot(point_slots::X).coerce_to_i32(activation)?,
                 point.get_slot(point_slots::Y).coerce_to_i32(activation)?,
@@ -469,7 +470,7 @@ fn avm2_to_displacement_map_filter<'gc>(
         } else {
             (0, 0)
         };
-    let mode = if let Value::String(mode) = object.get_public_property("mode", activation)? {
+    let mode = if let Value::String(mode) = object.get_slot(displacement_map_filter_slots::MODE) {
         if &mode == b"clamp" {
             DisplacementMapFilterMode::Clamp
         } else if &mode == b"ignore" {
@@ -485,16 +486,16 @@ fn avm2_to_displacement_map_filter<'gc>(
         DisplacementMapFilterMode::Wrap
     };
     let scale_x = object
-        .get_public_property("scaleX", activation)?
+        .get_slot(displacement_map_filter_slots::SCALE_X)
         .coerce_to_number(activation)?;
     let scale_y = object
-        .get_public_property("scaleY", activation)?
+        .get_slot(displacement_map_filter_slots::SCALE_Y)
         .coerce_to_number(activation)?;
     let map_bitmap = if let Value::Object(bitmap) =
-        object.get_public_property("mapBitmap", activation)?
+        object.get_slot(displacement_map_filter_slots::MAP_BITMAP)
     {
         if let Some(bitmap) = bitmap.as_bitmap_data() {
-            Some(bitmap.bitmap_handle(activation.context.gc_context, activation.context.renderer))
+            Some(bitmap.bitmap_handle(activation.gc(), activation.context.renderer))
         } else {
             return Err(Error::AvmError(type_error(
                 activation,

--- a/core/src/avm2/globals/flash/filters/BevelFilter.as
+++ b/core/src/avm2/globals/flash/filters/BevelFilter.as
@@ -1,86 +1,86 @@
 ﻿package flash.filters {
-	public final class BevelFilter extends BitmapFilter {
-	    // FIXME these should all be getters/setters to match Flash
+    public final class BevelFilter extends BitmapFilter {
+        // FIXME these should all be getters/setters to match Flash
 
-	    [Ruffle(InternalSlot)]
-		public var angle : Number;
+        [Ruffle(InternalSlot)]
+        public var angle : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var blurX : Number;
+        [Ruffle(InternalSlot)]
+        public var blurX : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var blurY : Number;
+        [Ruffle(InternalSlot)]
+        public var blurY : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var distance : Number;
+        [Ruffle(InternalSlot)]
+        public var distance : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var highlightAlpha : Number;
+        [Ruffle(InternalSlot)]
+        public var highlightAlpha : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var highlightColor : uint;
+        [Ruffle(InternalSlot)]
+        public var highlightColor : uint;
 
-	    [Ruffle(InternalSlot)]
-		public var knockout : Boolean;
+        [Ruffle(InternalSlot)]
+        public var knockout : Boolean;
 
-	    [Ruffle(InternalSlot)]
-		public var quality : int;
+        [Ruffle(InternalSlot)]
+        public var quality : int;
 
-	    [Ruffle(InternalSlot)]
-		public var shadowAlpha : Number;
+        [Ruffle(InternalSlot)]
+        public var shadowAlpha : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var shadowColor : uint;
+        [Ruffle(InternalSlot)]
+        public var shadowColor : uint;
 
-	    [Ruffle(InternalSlot)]
-		public var strength : Number;
+        [Ruffle(InternalSlot)]
+        public var strength : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var type : String;
+        [Ruffle(InternalSlot)]
+        public var type : String;
 
-		public function BevelFilter(
-			distance:Number = 4.0,
-			angle:Number = 45,
-			highlightColor:uint = 0xFFFFFF,
-			highlightAlpha:Number = 1.0,
-			shadowColor:uint = 0x000000,
-			shadowAlpha:Number = 1.0,
-			blurX:Number = 4.0,
-			blurY:Number = 4.0,
-			strength:Number = 1,
-			quality:int = 1,
-			type:String = "inner",
-			knockout:Boolean = false
-		) {
-			this.angle = angle;
-			this.blurX = blurX;
-			this.blurY = blurY;
-			this.distance = distance;
-			this.highlightAlpha = highlightAlpha;
-			this.highlightColor = highlightColor;
-			this.knockout = knockout;
-			this.quality = quality;
-			this.shadowAlpha = shadowAlpha;
-			this.shadowColor = shadowColor;
-			this.strength = strength;
-			this.type = type;
-		}
+        public function BevelFilter(
+            distance:Number = 4.0,
+            angle:Number = 45,
+            highlightColor:uint = 0xFFFFFF,
+            highlightAlpha:Number = 1.0,
+            shadowColor:uint = 0x000000,
+            shadowAlpha:Number = 1.0,
+            blurX:Number = 4.0,
+            blurY:Number = 4.0,
+            strength:Number = 1,
+            quality:int = 1,
+            type:String = "inner",
+            knockout:Boolean = false
+        ) {
+            this.angle = angle;
+            this.blurX = blurX;
+            this.blurY = blurY;
+            this.distance = distance;
+            this.highlightAlpha = highlightAlpha;
+            this.highlightColor = highlightColor;
+            this.knockout = knockout;
+            this.quality = quality;
+            this.shadowAlpha = shadowAlpha;
+            this.shadowColor = shadowColor;
+            this.strength = strength;
+            this.type = type;
+        }
 
-		override public function clone(): BitmapFilter {
-			return new BevelFilter(
-				this.distance,
-				this.angle,
-				this.highlightColor,
-				this.highlightAlpha,
-				this.shadowColor,
-				this.shadowAlpha,
-				this.blurX,
-				this.blurY,
-				this.strength,
-				this.quality,
-				this.type,
-				this.knockout
-			);
-		}
-	}
+        override public function clone(): BitmapFilter {
+            return new BevelFilter(
+                this.distance,
+                this.angle,
+                this.highlightColor,
+                this.highlightAlpha,
+                this.shadowColor,
+                this.shadowAlpha,
+                this.blurX,
+                this.blurY,
+                this.strength,
+                this.quality,
+                this.type,
+                this.knockout
+            );
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/BevelFilter.as
+++ b/core/src/avm2/globals/flash/filters/BevelFilter.as
@@ -1,16 +1,41 @@
 ﻿package flash.filters {
 	public final class BevelFilter extends BitmapFilter {
+	    // FIXME these should all be getters/setters to match Flash
+
+	    [Ruffle(InternalSlot)]
 		public var angle : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var blurX : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var blurY : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var distance : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var highlightAlpha : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var highlightColor : uint;
+
+	    [Ruffle(InternalSlot)]
 		public var knockout : Boolean;
+
+	    [Ruffle(InternalSlot)]
 		public var quality : int;
+
+	    [Ruffle(InternalSlot)]
 		public var shadowAlpha : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var shadowColor : uint;
+
+	    [Ruffle(InternalSlot)]
 		public var strength : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var type : String;
 
 		public function BevelFilter(

--- a/core/src/avm2/globals/flash/filters/BitmapFilter.as
+++ b/core/src/avm2/globals/flash/filters/BitmapFilter.as
@@ -1,7 +1,7 @@
 ﻿package flash.filters {
-	public class BitmapFilter {
-		public function clone(): BitmapFilter {
-			return null;
-		}
-	}
+    public class BitmapFilter {
+        public function clone(): BitmapFilter {
+            return null;
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/BlurFilter.as
+++ b/core/src/avm2/globals/flash/filters/BlurFilter.as
@@ -1,22 +1,22 @@
 ﻿package flash.filters {
-	public final class BlurFilter extends BitmapFilter {
-	    [Ruffle(InternalSlot)]
-		public var blurX: Number;
+    public final class BlurFilter extends BitmapFilter {
+        [Ruffle(InternalSlot)]
+        public var blurX: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var blurY: Number;
+        [Ruffle(InternalSlot)]
+        public var blurY: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var quality: int;
+        [Ruffle(InternalSlot)]
+        public var quality: int;
 
-		public function BlurFilter(blurX: Number = 4.0, blurY: Number = 4.0, quality: int = 1) {
-			this.blurX = blurX;
-			this.blurY = blurY;
-			this.quality = quality;
-		}
+        public function BlurFilter(blurX: Number = 4.0, blurY: Number = 4.0, quality: int = 1) {
+            this.blurX = blurX;
+            this.blurY = blurY;
+            this.quality = quality;
+        }
 
-		override public function clone(): BitmapFilter {
-			return new BlurFilter(this.blurX, this.blurY, this.quality);
-		}
-	}
+        override public function clone(): BitmapFilter {
+            return new BlurFilter(this.blurX, this.blurY, this.quality);
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/BlurFilter.as
+++ b/core/src/avm2/globals/flash/filters/BlurFilter.as
@@ -1,7 +1,12 @@
 ﻿package flash.filters {
 	public final class BlurFilter extends BitmapFilter {
+	    [Ruffle(InternalSlot)]
 		public var blurX: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var blurY: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var quality: int;
 
 		public function BlurFilter(blurX: Number = 4.0, blurY: Number = 4.0, quality: int = 1) {

--- a/core/src/avm2/globals/flash/filters/ColorMatrixFilter.as
+++ b/core/src/avm2/globals/flash/filters/ColorMatrixFilter.as
@@ -1,36 +1,36 @@
 ﻿package flash.filters {
-	public final class ColorMatrixFilter extends BitmapFilter {
-	    [Ruffle(InternalSlot)]
-		private var _matrix: Array;
+    public final class ColorMatrixFilter extends BitmapFilter {
+        [Ruffle(InternalSlot)]
+        private var _matrix: Array;
 
-		public function ColorMatrixFilter(matrix: Array = null) {
-			if (matrix == null) {
-				matrix = [
-					1, 0, 0, 0, 0,
-					0, 1, 0, 0, 0,
-					0, 0, 1, 0, 0,
-					0, 0, 0, 1, 0
-				];
-			}
-			this.matrix = matrix;
-		}
+        public function ColorMatrixFilter(matrix: Array = null) {
+            if (matrix == null) {
+                matrix = [
+                    1, 0, 0, 0, 0,
+                    0, 1, 0, 0, 0,
+                    0, 0, 1, 0, 0,
+                    0, 0, 0, 1, 0
+                ];
+            }
+            this.matrix = matrix;
+        }
 
-		// From the Flash docs, we need to make a copy of the `Array`,
-		// as modifying the `filter.matrix` directly should have no effect.
-		// We call the method in the AS3 namespace, as some SWFS define a
-		// extend `Array` and declare a *public* 'concat' method with a
-		// different signature.
+        // From the Flash docs, we need to make a copy of the `Array`,
+        // as modifying the `filter.matrix` directly should have no effect.
+        // We call the method in the AS3 namespace, as some SWFS define a
+        // extend `Array` and declare a *public* 'concat' method with a
+        // different signature.
 
-		public function get matrix(): Array {
-			return this._matrix.AS3::concat();
-		}
+        public function get matrix(): Array {
+            return this._matrix.AS3::concat();
+        }
 
-		public function set matrix(matrix:Array):void {
-			this._matrix = matrix.AS3::concat();
-		}
+        public function set matrix(matrix:Array):void {
+            this._matrix = matrix.AS3::concat();
+        }
 
-		override public function clone(): BitmapFilter {
-			return new ColorMatrixFilter(this.matrix.AS3::concat());
-		}
-	}
+        override public function clone(): BitmapFilter {
+            return new ColorMatrixFilter(this.matrix.AS3::concat());
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/ColorMatrixFilter.as
+++ b/core/src/avm2/globals/flash/filters/ColorMatrixFilter.as
@@ -1,5 +1,6 @@
 ﻿package flash.filters {
 	public final class ColorMatrixFilter extends BitmapFilter {
+	    [Ruffle(InternalSlot)]
 		private var _matrix: Array;
 
 		public function ColorMatrixFilter(matrix: Array = null) {

--- a/core/src/avm2/globals/flash/filters/ConvolutionFilter.as
+++ b/core/src/avm2/globals/flash/filters/ConvolutionFilter.as
@@ -1,56 +1,56 @@
 ﻿package flash.filters {
-	public final class ConvolutionFilter extends BitmapFilter {
-	    [Ruffle(InternalSlot)]
-		public var alpha : Number;
+    public final class ConvolutionFilter extends BitmapFilter {
+        [Ruffle(InternalSlot)]
+        public var alpha : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var bias : Number;
+        [Ruffle(InternalSlot)]
+        public var bias : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var clamp : Boolean;
+        [Ruffle(InternalSlot)]
+        public var clamp : Boolean;
 
-	    [Ruffle(InternalSlot)]
-		public var color : uint;
+        [Ruffle(InternalSlot)]
+        public var color : uint;
 
-	    [Ruffle(InternalSlot)]
-		public var divisor : Number;
+        [Ruffle(InternalSlot)]
+        public var divisor : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var matrix : Array;
+        [Ruffle(InternalSlot)]
+        public var matrix : Array;
 
-	    [Ruffle(InternalSlot)]
-		public var matrixX : Number;
+        [Ruffle(InternalSlot)]
+        public var matrixX : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var matrixY : Number;
+        [Ruffle(InternalSlot)]
+        public var matrixY : Number;
 
-	    [Ruffle(InternalSlot)]
-		public var preserveAlpha : Boolean;
+        [Ruffle(InternalSlot)]
+        public var preserveAlpha : Boolean;
 
-		public function ConvolutionFilter(
-			matrixX:Number = 0,
-			matrixY:Number = 0,
-			matrix:Array = null,
-			divisor:Number = 1.0,
-			bias:Number = 0.0,
-			preserveAlpha:Boolean = true,
-			clamp:Boolean = true,
-			color:uint = 0,
-			alpha:Number = 0.0
-		) {
-			this.alpha = alpha;
-			this.bias = bias;
-			this.clamp = clamp;
-			this.color = color;
-			this.divisor = divisor;
-			this.matrix = matrix;
-			this.matrixX = matrixX;
-			this.matrixY = matrixY;
-			this.preserveAlpha = preserveAlpha;
-		}
+        public function ConvolutionFilter(
+            matrixX:Number = 0,
+            matrixY:Number = 0,
+            matrix:Array = null,
+            divisor:Number = 1.0,
+            bias:Number = 0.0,
+            preserveAlpha:Boolean = true,
+            clamp:Boolean = true,
+            color:uint = 0,
+            alpha:Number = 0.0
+        ) {
+            this.alpha = alpha;
+            this.bias = bias;
+            this.clamp = clamp;
+            this.color = color;
+            this.divisor = divisor;
+            this.matrix = matrix;
+            this.matrixX = matrixX;
+            this.matrixY = matrixY;
+            this.preserveAlpha = preserveAlpha;
+        }
 
-		override public function clone(): BitmapFilter {
-			return new ConvolutionFilter(this.matrixX, this.matrixY, this.matrixull, this.divisor, this.bias, this.preserveAlpharue, this.clamprue, this.color, this.alpha);
-		}
-	}
+        override public function clone(): BitmapFilter {
+            return new ConvolutionFilter(this.matrixX, this.matrixY, this.matrixull, this.divisor, this.bias, this.preserveAlpharue, this.clamprue, this.color, this.alpha);
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/ConvolutionFilter.as
+++ b/core/src/avm2/globals/flash/filters/ConvolutionFilter.as
@@ -1,13 +1,30 @@
 ﻿package flash.filters {
 	public final class ConvolutionFilter extends BitmapFilter {
+	    [Ruffle(InternalSlot)]
 		public var alpha : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var bias : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var clamp : Boolean;
+
+	    [Ruffle(InternalSlot)]
 		public var color : uint;
+
+	    [Ruffle(InternalSlot)]
 		public var divisor : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var matrix : Array;
+
+	    [Ruffle(InternalSlot)]
 		public var matrixX : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var matrixY : Number;
+
+	    [Ruffle(InternalSlot)]
 		public var preserveAlpha : Boolean;
 
 		public function ConvolutionFilter(

--- a/core/src/avm2/globals/flash/filters/DisplacementMapFilter.as
+++ b/core/src/avm2/globals/flash/filters/DisplacementMapFilter.as
@@ -3,14 +3,33 @@
 	import flash.geom.Point;
 
 	public final class DisplacementMapFilter extends BitmapFilter {
+	    // FIXME these should all be getters/setters to match Flash
+
+	    [Ruffle(InternalSlot)]
 		public var alpha: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var color: uint;
+
+	    [Ruffle(InternalSlot)]
 		public var componentX: uint;
+
+	    [Ruffle(InternalSlot)]
 		public var componentY: uint;
+
+	    [Ruffle(InternalSlot)]
 		public var mapBitmap: BitmapData;
+
+	    [Ruffle(InternalSlot)]
 		public var mapPoint: Point;
+
+	    [Ruffle(InternalSlot)]
 		public var mode: String;
+
+	    [Ruffle(InternalSlot)]
 		public var scaleX: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var scaleY: Number;
 
 		public function DisplacementMapFilter(mapBitmap:BitmapData = null,

--- a/core/src/avm2/globals/flash/filters/DisplacementMapFilter.as
+++ b/core/src/avm2/globals/flash/filters/DisplacementMapFilter.as
@@ -1,59 +1,59 @@
 ﻿package flash.filters {
-	import flash.display.BitmapData;
-	import flash.geom.Point;
+    import flash.display.BitmapData;
+    import flash.geom.Point;
 
-	public final class DisplacementMapFilter extends BitmapFilter {
-	    // FIXME these should all be getters/setters to match Flash
+    public final class DisplacementMapFilter extends BitmapFilter {
+        // FIXME these should all be getters/setters to match Flash
 
-	    [Ruffle(InternalSlot)]
-		public var alpha: Number;
+        [Ruffle(InternalSlot)]
+        public var alpha: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var color: uint;
+        [Ruffle(InternalSlot)]
+        public var color: uint;
 
-	    [Ruffle(InternalSlot)]
-		public var componentX: uint;
+        [Ruffle(InternalSlot)]
+        public var componentX: uint;
 
-	    [Ruffle(InternalSlot)]
-		public var componentY: uint;
+        [Ruffle(InternalSlot)]
+        public var componentY: uint;
 
-	    [Ruffle(InternalSlot)]
-		public var mapBitmap: BitmapData;
+        [Ruffle(InternalSlot)]
+        public var mapBitmap: BitmapData;
 
-	    [Ruffle(InternalSlot)]
-		public var mapPoint: Point;
+        [Ruffle(InternalSlot)]
+        public var mapPoint: Point;
 
-	    [Ruffle(InternalSlot)]
-		public var mode: String;
+        [Ruffle(InternalSlot)]
+        public var mode: String;
 
-	    [Ruffle(InternalSlot)]
-		public var scaleX: Number;
+        [Ruffle(InternalSlot)]
+        public var scaleX: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var scaleY: Number;
+        [Ruffle(InternalSlot)]
+        public var scaleY: Number;
 
-		public function DisplacementMapFilter(mapBitmap:BitmapData = null,
-											  mapPoint:Point = null,
-											  componentX:uint = 0,
-											  componentY:uint = 0,
-											  scaleX:Number = 0.0,
-											  scaleY:Number = 0.0,
-											  mode:String = "wrap",
-											  color:uint = 0,
-											  alpha:Number = 0.0) {
-			this.mapBitmap = mapBitmap;
-			this.mapPoint = mapPoint;
-			this.componentX = componentX;
-			this.componentY = componentY;
-			this.scaleX = scaleX;
-			this.scaleY = scaleY;
-			this.mode = mode;
-			this.color = color;
-			this.alpha = alpha;
-		}
+        public function DisplacementMapFilter(mapBitmap:BitmapData = null,
+                                              mapPoint:Point = null,
+                                              componentX:uint = 0,
+                                              componentY:uint = 0,
+                                              scaleX:Number = 0.0,
+                                              scaleY:Number = 0.0,
+                                              mode:String = "wrap",
+                                              color:uint = 0,
+                                              alpha:Number = 0.0) {
+            this.mapBitmap = mapBitmap;
+            this.mapPoint = mapPoint;
+            this.componentX = componentX;
+            this.componentY = componentY;
+            this.scaleX = scaleX;
+            this.scaleY = scaleY;
+            this.mode = mode;
+            this.color = color;
+            this.alpha = alpha;
+        }
 
-		override public function clone(): BitmapFilter {
-			return new DisplacementMapFilter(this.mapBitmap.clone(), this.mapPoint.clone(), this.componentX, this.componentY, this.scaleX, this.scaleY, this.mode, this.color, this.alpha);
-		}
-	}
+        override public function clone(): BitmapFilter {
+            return new DisplacementMapFilter(this.mapBitmap.clone(), this.mapPoint.clone(), this.componentX, this.componentY, this.scaleX, this.scaleY, this.mode, this.color, this.alpha);
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/DropShadowFilter.as
+++ b/core/src/avm2/globals/flash/filters/DropShadowFilter.as
@@ -1,75 +1,75 @@
 package flash.filters {
-	public final class DropShadowFilter extends BitmapFilter {
-	    [Ruffle(InternalSlot)]
-		public var alpha: Number;
+    public final class DropShadowFilter extends BitmapFilter {
+        [Ruffle(InternalSlot)]
+        public var alpha: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var angle: Number;
+        [Ruffle(InternalSlot)]
+        public var angle: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var blurX: Number;
+        [Ruffle(InternalSlot)]
+        public var blurX: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var blurY: Number;
+        [Ruffle(InternalSlot)]
+        public var blurY: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var color: uint;
+        [Ruffle(InternalSlot)]
+        public var color: uint;
 
-	    [Ruffle(InternalSlot)]
-		public var distance: Number;
+        [Ruffle(InternalSlot)]
+        public var distance: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var hideObject: Boolean;
+        [Ruffle(InternalSlot)]
+        public var hideObject: Boolean;
 
-	    [Ruffle(InternalSlot)]
-		public var inner: Boolean;
+        [Ruffle(InternalSlot)]
+        public var inner: Boolean;
 
-	    [Ruffle(InternalSlot)]
-		public var knockout: Boolean;
+        [Ruffle(InternalSlot)]
+        public var knockout: Boolean;
 
-	    [Ruffle(InternalSlot)]
-		public var quality: int;
+        [Ruffle(InternalSlot)]
+        public var quality: int;
 
-	    [Ruffle(InternalSlot)]
-		public var strength: Number;
+        [Ruffle(InternalSlot)]
+        public var strength: Number;
 
-		public function DropShadowFilter(distance:Number = 4.0,
-										angle:Number = 45,
-										color:uint = 0,
-										alpha:Number = 1.0,
-										blurX:Number = 4.0,
-										blurY:Number = 4.0,
-										strength:Number = 1.0,
-										quality:int = 1,
-										inner:Boolean = false,
-										knockout:Boolean = false,
-										hideObject:Boolean = false)
-		{
-			this.alpha = alpha;
-			this.angle = angle;
-			this.blurX = blurX;
-			this.blurY = blurY;
-			this.color = color;
-			this.distance = distance;
-			this.hideObject = hideObject;
-			this.inner = inner;
-			this.knockout = knockout;
-			this.quality = quality;
-			this.strength = strength;
-		}
+        public function DropShadowFilter(distance:Number = 4.0,
+                                        angle:Number = 45,
+                                        color:uint = 0,
+                                        alpha:Number = 1.0,
+                                        blurX:Number = 4.0,
+                                        blurY:Number = 4.0,
+                                        strength:Number = 1.0,
+                                        quality:int = 1,
+                                        inner:Boolean = false,
+                                        knockout:Boolean = false,
+                                        hideObject:Boolean = false)
+        {
+            this.alpha = alpha;
+            this.angle = angle;
+            this.blurX = blurX;
+            this.blurY = blurY;
+            this.color = color;
+            this.distance = distance;
+            this.hideObject = hideObject;
+            this.inner = inner;
+            this.knockout = knockout;
+            this.quality = quality;
+            this.strength = strength;
+        }
 
-		override public function clone(): BitmapFilter {
-			return new DropShadowFilter(this.distance,
-										this.angle,
-										this.color,
-										this.alpha,
-										this.blurX, 
-										this.blurY,
-										this.strength,
-										this.quality,
-										this.inner,
-										this.knockout,
-										this.hideObject);
-		}
-	}
+        override public function clone(): BitmapFilter {
+            return new DropShadowFilter(this.distance,
+                                        this.angle,
+                                        this.color,
+                                        this.alpha,
+                                        this.blurX, 
+                                        this.blurY,
+                                        this.strength,
+                                        this.quality,
+                                        this.inner,
+                                        this.knockout,
+                                        this.hideObject);
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/DropShadowFilter.as
+++ b/core/src/avm2/globals/flash/filters/DropShadowFilter.as
@@ -1,15 +1,36 @@
 package flash.filters {
 	public final class DropShadowFilter extends BitmapFilter {
+	    [Ruffle(InternalSlot)]
 		public var alpha: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var angle: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var blurX: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var blurY: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var color: uint;
+
+	    [Ruffle(InternalSlot)]
 		public var distance: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var hideObject: Boolean;
+
+	    [Ruffle(InternalSlot)]
 		public var inner: Boolean;
+
+	    [Ruffle(InternalSlot)]
 		public var knockout: Boolean;
+
+	    [Ruffle(InternalSlot)]
 		public var quality: int;
+
+	    [Ruffle(InternalSlot)]
 		public var strength: Number;
 
 		public function DropShadowFilter(distance:Number = 4.0,

--- a/core/src/avm2/globals/flash/filters/GlowFilter.as
+++ b/core/src/avm2/globals/flash/filters/GlowFilter.as
@@ -1,12 +1,27 @@
 ﻿package flash.filters {
 	public final class GlowFilter extends BitmapFilter {
+	    [Ruffle(InternalSlot)]
 		public var alpha: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var blurX: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var blurY: Number;
+
+	    [Ruffle(InternalSlot)]
 		public var color: uint;
+
+	    [Ruffle(InternalSlot)]
 		public var inner: Boolean;
+
+	    [Ruffle(InternalSlot)]
 		public var knockout: Boolean;
+
+	    [Ruffle(InternalSlot)]
 		public var quality: int;
+
+	    [Ruffle(InternalSlot)]
 		public var strength: Number;
 
 		public function GlowFilter(color: uint = 0xFF0000, 

--- a/core/src/avm2/globals/flash/filters/GlowFilter.as
+++ b/core/src/avm2/globals/flash/filters/GlowFilter.as
@@ -1,30 +1,30 @@
 ﻿package flash.filters {
-	public final class GlowFilter extends BitmapFilter {
-	    [Ruffle(InternalSlot)]
-		public var alpha: Number;
+    public final class GlowFilter extends BitmapFilter {
+        [Ruffle(InternalSlot)]
+        public var alpha: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var blurX: Number;
+        [Ruffle(InternalSlot)]
+        public var blurX: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var blurY: Number;
+        [Ruffle(InternalSlot)]
+        public var blurY: Number;
 
-	    [Ruffle(InternalSlot)]
-		public var color: uint;
+        [Ruffle(InternalSlot)]
+        public var color: uint;
 
-	    [Ruffle(InternalSlot)]
-		public var inner: Boolean;
+        [Ruffle(InternalSlot)]
+        public var inner: Boolean;
 
-	    [Ruffle(InternalSlot)]
-		public var knockout: Boolean;
+        [Ruffle(InternalSlot)]
+        public var knockout: Boolean;
 
-	    [Ruffle(InternalSlot)]
-		public var quality: int;
+        [Ruffle(InternalSlot)]
+        public var quality: int;
 
-	    [Ruffle(InternalSlot)]
-		public var strength: Number;
+        [Ruffle(InternalSlot)]
+        public var strength: Number;
 
-		public function GlowFilter(color: uint = 0xFF0000, 
+        public function GlowFilter(color: uint = 0xFF0000, 
                                    alpha: Number = 1.0, 
                                    blurX: Number = 6.0, 
                                    blurY: Number = 6.0, 
@@ -32,19 +32,19 @@
                                    quality: int = 1, 
                                    inner: Boolean = false, 
                                    knockout: Boolean = false) 
-		{
-			this.alpha = alpha;
-			this.blurX = blurX;
-			this.blurY = blurY;
-			this.color = color;
-			this.inner = inner;
-			this.knockout = knockout;
-			this.quality = quality;
-			this.strength = strength;
-		}
+        {
+            this.alpha = alpha;
+            this.blurX = blurX;
+            this.blurY = blurY;
+            this.color = color;
+            this.inner = inner;
+            this.knockout = knockout;
+            this.quality = quality;
+            this.strength = strength;
+        }
 
-		override public function clone(): BitmapFilter {
-			return new GlowFilter(this.color, this.alpha, this.blurX, this.blurY, this.strength, this.quality, this.inner, this.knockout);
-		}
-	}
+        override public function clone(): BitmapFilter {
+            return new GlowFilter(this.color, this.alpha, this.blurX, this.blurY, this.strength, this.quality, this.inner, this.knockout);
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/GradientBevelFilter.as
+++ b/core/src/avm2/globals/flash/filters/GradientBevelFilter.as
@@ -1,82 +1,82 @@
 ﻿package flash.filters {
-	public final class GradientBevelFilter extends BitmapFilter {
-	    // NOTE if reordering these fields, make sure to use the same order in
-	    // GradientGlowFilter; filter code assumes the slot layouts are identical
+    public final class GradientBevelFilter extends BitmapFilter {
+        // NOTE if reordering these fields, make sure to use the same order in
+        // GradientGlowFilter; filter code assumes the slot layouts are identical
 
-	    // FIXME these should all be getters/setters to match Flash
+        // FIXME these should all be getters/setters to match Flash
         [Ruffle(InternalSlot)]
-		public var alphas : Array;
-
-        [Ruffle(InternalSlot)]
-		public var angle : Number;
+        public var alphas : Array;
 
         [Ruffle(InternalSlot)]
-		public var blurX : Number;
+        public var angle : Number;
 
         [Ruffle(InternalSlot)]
-		public var blurY : Number;
+        public var blurX : Number;
 
         [Ruffle(InternalSlot)]
-		public var colors : Array;
+        public var blurY : Number;
 
         [Ruffle(InternalSlot)]
-		public var distance : Number;
+        public var colors : Array;
 
         [Ruffle(InternalSlot)]
-		public var knockout : Boolean;
+        public var distance : Number;
 
         [Ruffle(InternalSlot)]
-		public var quality : int;
+        public var knockout : Boolean;
 
         [Ruffle(InternalSlot)]
-		public var ratios : Array;
+        public var quality : int;
 
         [Ruffle(InternalSlot)]
-		public var strength : Number;
+        public var ratios : Array;
 
         [Ruffle(InternalSlot)]
-		public var type : String;
+        public var strength : Number;
 
-		public function GradientBevelFilter(
-			distance:Number = 4.0,
-			angle:Number = 45,
-			colors:Array = null,
-			alphas:Array = null,
-			ratios:Array = null,
-			blurX:Number = 4.0,
-			blurY:Number = 4.0,
-			strength:Number = 1,
-			quality:int = 1,
-			type:String = "inner",
-			knockout:Boolean = false
-		) {
-			this.distance = distance;
-			this.angle = angle;
-			this.colors = colors;
-			this.alphas = alphas;
-			this.ratios = ratios;
-			this.blurX = blurX;
-			this.blurY = blurY;
-			this.strength = strength;
-			this.quality = quality;
-			this.type = type;
-			this.knockout = knockout;
-		}
+        [Ruffle(InternalSlot)]
+        public var type : String;
 
-		override public function clone(): BitmapFilter {
-			return new GradientBevelFilter(
-				this.distance,
-				this.angle,
-				this.colors,
-				this.alphas,
-				this.ratios,
-				this.blurX,
-				this.blurY,
-				this.strength,
-				this.quality,
-				this.type,
-				this.knockout
-			);
-		}
-	}
+        public function GradientBevelFilter(
+            distance:Number = 4.0,
+            angle:Number = 45,
+            colors:Array = null,
+            alphas:Array = null,
+            ratios:Array = null,
+            blurX:Number = 4.0,
+            blurY:Number = 4.0,
+            strength:Number = 1,
+            quality:int = 1,
+            type:String = "inner",
+            knockout:Boolean = false
+        ) {
+            this.distance = distance;
+            this.angle = angle;
+            this.colors = colors;
+            this.alphas = alphas;
+            this.ratios = ratios;
+            this.blurX = blurX;
+            this.blurY = blurY;
+            this.strength = strength;
+            this.quality = quality;
+            this.type = type;
+            this.knockout = knockout;
+        }
+
+        override public function clone(): BitmapFilter {
+            return new GradientBevelFilter(
+                this.distance,
+                this.angle,
+                this.colors,
+                this.alphas,
+                this.ratios,
+                this.blurX,
+                this.blurY,
+                this.strength,
+                this.quality,
+                this.type,
+                this.knockout
+            );
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/GradientBevelFilter.as
+++ b/core/src/avm2/globals/flash/filters/GradientBevelFilter.as
@@ -1,15 +1,40 @@
 ﻿package flash.filters {
 	public final class GradientBevelFilter extends BitmapFilter {
+	    // NOTE if reordering these fields, make sure to use the same order in
+	    // GradientGlowFilter; filter code assumes the slot layouts are identical
+
+	    // FIXME these should all be getters/setters to match Flash
+        [Ruffle(InternalSlot)]
 		public var alphas : Array;
+
+        [Ruffle(InternalSlot)]
 		public var angle : Number;
+
+        [Ruffle(InternalSlot)]
 		public var blurX : Number;
+
+        [Ruffle(InternalSlot)]
 		public var blurY : Number;
+
+        [Ruffle(InternalSlot)]
 		public var colors : Array;
+
+        [Ruffle(InternalSlot)]
 		public var distance : Number;
+
+        [Ruffle(InternalSlot)]
 		public var knockout : Boolean;
+
+        [Ruffle(InternalSlot)]
 		public var quality : int;
+
+        [Ruffle(InternalSlot)]
 		public var ratios : Array;
+
+        [Ruffle(InternalSlot)]
 		public var strength : Number;
+
+        [Ruffle(InternalSlot)]
 		public var type : String;
 
 		public function GradientBevelFilter(

--- a/core/src/avm2/globals/flash/filters/GradientGlowFilter.as
+++ b/core/src/avm2/globals/flash/filters/GradientGlowFilter.as
@@ -1,11 +1,12 @@
 ﻿package flash.filters {
-	public final class GradientGlowFilter extends BitmapFilter {
-	    // NOTE if reordering these fields, make sure to use the same order in
-	    // GradientBevelFilter; filter code assumes the slot layouts are identical
-	    // (these aren't annotated with [Ruffle(InternalSlot)] because we use the
-	    // slots from GradientBevelFilter to access them)
+    public final class GradientGlowFilter extends BitmapFilter {
+        // NOTE if reordering these fields, make sure to use the same order in
+        // GradientBevelFilter; filter code assumes the slot layouts are identical
+        // (these aren't annotated with [Ruffle(InternalSlot)] because we use the
+        // slots from GradientBevelFilter to access them)
 
         // FIXME these should all be getters/setters to match Flash
+
         [Ruffle(InternalSlot)]
         public var alphas : Array;
 
@@ -39,35 +40,35 @@
         [Ruffle(InternalSlot)]
         public var type : String;
 
-		public function GradientGlowFilter(
-			distance:Number = 4.0,
-			angle:Number = 45,
-			colors:Array = null,
-			alphas:Array = null,
-			ratios:Array = null,
-			blurX:Number = 4.0,
-			blurY:Number = 4.0,
-			strength:Number = 1,
-			quality:int = 1,
-			type:String = "inner",
-			knockout:Boolean = false
-		)
-		{
-			this.distance = distance;
-			this.angle = angle;
-			this.colors = colors;
-			this.alphas = alphas;
-			this.ratios = ratios;
-			this.blurX = blurX;
-			this.blurY = blurY;
-			this.strength = strength;
-			this.quality = quality;
-			this.type = type;
-			this.knockout = knockout;
-		}
+        public function GradientGlowFilter(
+            distance:Number = 4.0,
+            angle:Number = 45,
+            colors:Array = null,
+            alphas:Array = null,
+            ratios:Array = null,
+            blurX:Number = 4.0,
+            blurY:Number = 4.0,
+            strength:Number = 1,
+            quality:int = 1,
+            type:String = "inner",
+            knockout:Boolean = false
+        )
+        {
+            this.distance = distance;
+            this.angle = angle;
+            this.colors = colors;
+            this.alphas = alphas;
+            this.ratios = ratios;
+            this.blurX = blurX;
+            this.blurY = blurY;
+            this.strength = strength;
+            this.quality = quality;
+            this.type = type;
+            this.knockout = knockout;
+        }
 
-		override public function clone(): BitmapFilter {
-			return new GradientGlowFilter(this.distance, this.angle, this.colors, this.alphas, this.ratios, this.blurX, this.blurY, this.strength, this.quality, this.type, this.knockout);
-		}
-	}
+        override public function clone(): BitmapFilter {
+            return new GradientGlowFilter(this.distance, this.angle, this.colors, this.alphas, this.ratios, this.blurX, this.blurY, this.strength, this.quality, this.type, this.knockout);
+        }
+    }
 }

--- a/core/src/avm2/globals/flash/filters/GradientGlowFilter.as
+++ b/core/src/avm2/globals/flash/filters/GradientGlowFilter.as
@@ -1,16 +1,43 @@
 ﻿package flash.filters {
 	public final class GradientGlowFilter extends BitmapFilter {
-		public var alphas : Array;
-		public var angle : Number;
-		public var blurX : Number;
-		public var blurY : Number;
-		public var colors : Array;
-		public var distance : Number;
-		public var knockout : Boolean;
-		public var quality : int;
-		public var ratios : Array;
-		public var strength : Number;
-		public var type : String;
+	    // NOTE if reordering these fields, make sure to use the same order in
+	    // GradientBevelFilter; filter code assumes the slot layouts are identical
+	    // (these aren't annotated with [Ruffle(InternalSlot)] because we use the
+	    // slots from GradientBevelFilter to access them)
+
+        // FIXME these should all be getters/setters to match Flash
+        [Ruffle(InternalSlot)]
+        public var alphas : Array;
+
+        [Ruffle(InternalSlot)]
+        public var angle : Number;
+
+        [Ruffle(InternalSlot)]
+        public var blurX : Number;
+
+        [Ruffle(InternalSlot)]
+        public var blurY : Number;
+
+        [Ruffle(InternalSlot)]
+        public var colors : Array;
+
+        [Ruffle(InternalSlot)]
+        public var distance : Number;
+
+        [Ruffle(InternalSlot)]
+        public var knockout : Boolean;
+
+        [Ruffle(InternalSlot)]
+        public var quality : int;
+
+        [Ruffle(InternalSlot)]
+        public var ratios : Array;
+
+        [Ruffle(InternalSlot)]
+        public var strength : Number;
+
+        [Ruffle(InternalSlot)]
+        public var type : String;
 
 		public function GradientGlowFilter(
 			distance:Number = 4.0,

--- a/core/src/avm2/globals/flash/filters/ShaderFilter.as
+++ b/core/src/avm2/globals/flash/filters/ShaderFilter.as
@@ -1,25 +1,25 @@
 package flash.filters {
     import flash.display.Shader;
-    
+
     public class ShaderFilter extends BitmapFilter {
+        [Ruffle(InternalSlot)]
+        private var _bottomExtension:int = 0;
+
+        [Ruffle(InternalSlot)]
+        private var _leftExtension:int = 0;
+
+        [Ruffle(InternalSlot)]
+        private var _rightExtension:int = 0;
+
+        [Ruffle(InternalSlot)]
+        private var _topExtension:int = 0;
+
+        [Ruffle(InternalSlot)]
         private var _shader;
-        
+
         public function ShaderFilter(shader:Shader = null) {
             this._shader = shader;
         }
-        
-        public function get shader():Shader {
-            return this._shader;
-        }
-        
-        public function set shader(value:Shader):void {
-            this._shader = value;
-        }
-
-        private var _bottomExtension:int = 0;
-        private var _leftExtension:int = 0;
-        private var _rightExtension:int = 0;
-        private var _topExtension:int = 0;
 
         public function get bottomExtension():int {
             return this._bottomExtension;
@@ -52,7 +52,15 @@ package flash.filters {
         public function set topExtension(value:int):void {
             this._topExtension = value;
         }
-        
+
+        public function get shader():Shader {
+            return this._shader;
+        }
+
+        public function set shader(value:Shader):void {
+            this._shader = value;
+        }
+
         // ShaderFilter is the only filter class that doesn't override clone
     }
 }


### PR DESCRIPTION
This removes the last few easy-to-replace uses of `get_public_property`