### PR TITLE
desktop: Switch to the egui 0.30.0 release from git master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,8 +1289,9 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "ecolor"
-version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?branch=master#9aae14cdf4e50907805303c60cc96b6b2fff788e"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d72e9c39f6e11a2e922d04a34ec5e7ef522ea3f5a1acfca7a19d16ad5fe50f5"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1298,20 +1299,23 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?branch=master#9aae14cdf4e50907805303c60cc96b6b2fff788e"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252d52224d35be1535d7fd1d6139ce071fb42c9097773e79f7665604f5596b5e"
 dependencies = [
  "ahash",
  "emath",
  "epaint",
  "log",
  "nohash-hasher",
+ "profiling",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?branch=master#9aae14cdf4e50907805303c60cc96b6b2fff788e"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c1e821d2d8921ef6ce98b258c7e24d9d6aab2ca1f9cdf374eca997e7f67f59"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1319,6 +1323,7 @@ dependencies = [
  "egui",
  "epaint",
  "log",
+ "profiling",
  "thiserror 1.0.69",
  "type-map",
  "web-time",
@@ -1328,13 +1333,15 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?branch=master#9aae14cdf4e50907805303c60cc96b6b2fff788e"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e84c2919cd9f3a38a91e8f84ac6a245c19251fd95226ed9fae61d5ea564fce3"
 dependencies = [
  "ahash",
  "arboard",
  "egui",
  "log",
+ "profiling",
  "raw-window-handle",
  "smithay-clipboard",
  "web-time",
@@ -1344,14 +1351,16 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?branch=master#9aae14cdf4e50907805303c60cc96b6b2fff788e"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7a8198c088b1007108cb2d403bc99a5e370999b200db4f14559610d7330126"
 dependencies = [
  "ahash",
  "egui",
  "enum-map",
  "image",
  "log",
+ "profiling",
 ]
 
 [[package]]
@@ -1362,8 +1371,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "emath"
-version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?branch=master#9aae14cdf4e50907805303c60cc96b6b2fff788e"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4fe73c1207b864ee40aa0b0c038d6092af1030744678c60188a05c28553515d"
 dependencies = [
  "bytemuck",
 ]
@@ -1491,8 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?branch=master#9aae14cdf4e50907805303c60cc96b6b2fff788e"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5666f8d25236293c966fbb3635eac18b04ad1914e3bab55bc7d44b9980cafcac"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1503,12 +1514,14 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
+ "profiling",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?branch=master#9aae14cdf4e50907805303c60cc96b6b2fff788e"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f6ddac3e6ac6fd4c3d48bb8b1943472f8da0f43a4303bcd8a18aa594401c80"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 naga = { version = "23.1.0", features = ["wgsl-out"] }
 wgpu = "23.0.1"
-egui = { git = "https://github.com/emilk/egui.git", branch = "master" }
+egui = "0.30.0"
 clap = { version = "4.5.23", features = ["derive"] }
 cpal = "0.15.3"
 anyhow = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.11.0"
 egui = { workspace = true, optional = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", branch = "master", default-features = false, optional = true }
+egui_extras = { version = "0.30.0", default-features = false, optional = true }
 png = { version = "0.17.15", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -84,9 +84,6 @@ unknown-git = "deny"
 # github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
-    # TODO: Remove once a release with https://github.com/emilk/egui/pull/5330
-    # (the wgpu bump to 23.0.0) in it is out.
-    "emilk",
 ]
 
 [advisories]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 clap = { workspace = true }
 cpal = { workspace = true }
 egui = { workspace = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", branch = "master", default-features = false, features = ["image"] }
-egui-wgpu = { git = "https://github.com/emilk/egui.git", branch = "master", features = ["winit"] }
+egui_extras = { version = "0.30.0", default-features = false, features = ["image"] }
+egui-wgpu = { version = "0.30.0", features = ["winit"] }
 image = { workspace = true, features = ["png"] }
-egui-winit =  { git = "https://github.com/emilk/egui.git", branch = "master" }
+egui-winit = "0.30.0"
 fontdb = "0.23"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "aac", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }


### PR DESCRIPTION
It just got released today, with the PR in it that we need (https://github.com/emilk/egui/pull/5330).

See: https://github.com/emilk/egui/releases/tag/0.30.0