### PR TITLE
chore: Bump naga to 23.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "23.0.0"
+version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5941e45a15b53aad4375eedf02033adb7a28931eedc31117faffa52e6a857e"
+checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
 dependencies = [
  "arrayvec",
  "bit-set",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ version = "0.1.0"
 [workspace.dependencies]
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-naga = { version = "23.0.0", features = ["wgsl-out"] }
+naga = { version = "23.1.0", features = ["wgsl-out"] }
 wgpu = "23.0.1"
 egui = { git = "https://github.com/emilk/egui.git", branch = "master" }
 clap = { version = "4.5.23", features = ["derive"] }


### PR DESCRIPTION
Doing it manually because Dependabot fricked it up in https://github.com/ruffle-rs/ruffle/pull/18993 by changing some windowsy crate versions, causing type mismatches.

See: https://github.com/gfx-rs/wgpu/releases/tag/v23.1.0