### PR TITLE
refactor: Use constants from `Twips` where appropriate

### DIFF
--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -146,10 +146,10 @@ fn method<'gc>(
             // If the bounds are invalid, the pixelBounds rectangle consists only of zeroes.
             let bounds = if world_bounds == Rectangle::default() {
                 Rectangle {
-                    x_min: Twips::new(0),
-                    x_max: Twips::new(0),
-                    y_min: Twips::new(0),
-                    y_max: Twips::new(0),
+                    x_min: Twips::ZERO,
+                    x_max: Twips::ZERO,
+                    y_min: Twips::ZERO,
+                    y_max: Twips::ZERO,
                 }
             } else {
                 world_bounds

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2572,12 +2572,12 @@ impl<'gc> EditText<'gc> {
             // Top
             context.commands.draw_line(
                 border_color,
-                Matrix::create_box(width, 1.0, bounds.x_min - Twips::HALF, bounds.y_min),
+                Matrix::create_box(width, 1.0, bounds.x_min - Twips::HALF_PX, bounds.y_min),
             );
             // Bottom
             context.commands.draw_line(
                 border_color,
-                Matrix::create_box(width, 1.0, bounds.x_min - Twips::HALF, bounds.y_max),
+                Matrix::create_box(width, 1.0, bounds.x_min - Twips::HALF_PX, bounds.y_max),
             );
             // Left
             context.commands.draw_line(
@@ -2587,7 +2587,7 @@ impl<'gc> EditText<'gc> {
                     height,
                     std::f32::consts::FRAC_PI_2,
                     bounds.x_min,
-                    bounds.y_min - Twips::HALF,
+                    bounds.y_min - Twips::HALF_PX,
                 ),
             );
             // Right
@@ -2598,7 +2598,7 @@ impl<'gc> EditText<'gc> {
                     height,
                     std::f32::consts::FRAC_PI_2,
                     bounds.x_max,
-                    bounds.y_min - Twips::HALF,
+                    bounds.y_min - Twips::HALF_PX,
                 ),
             );
         }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -964,22 +964,22 @@ impl<'gc> EditText<'gc> {
         if flags.contains(LayoutDebugBoxesFlag::CHAR) {
             for i in 0..self.text().len() {
                 if let Some(bounds) = layout.char_bounds(i) {
-                    context.draw_rect_outline(Color::MAGENTA, bounds, Twips::ONE);
+                    context.draw_rect_outline(Color::MAGENTA, bounds, Twips::ONE_PX);
                 }
             }
         }
         if flags.contains(LayoutDebugBoxesFlag::BOX) {
             for lbox in layout.boxes_iter() {
-                context.draw_rect_outline(Color::RED, lbox.bounds().into(), Twips::ONE);
+                context.draw_rect_outline(Color::RED, lbox.bounds().into(), Twips::ONE_PX);
             }
         }
         if flags.contains(LayoutDebugBoxesFlag::LINE) {
             for line in layout.lines() {
-                context.draw_rect_outline(Color::BLUE, line.bounds().into(), Twips::ONE);
+                context.draw_rect_outline(Color::BLUE, line.bounds().into(), Twips::ONE_PX);
             }
         }
         if flags.contains(LayoutDebugBoxesFlag::TEXT) {
-            context.draw_rect_outline(Color::GREEN, layout.bounds().into(), Twips::ONE);
+            context.draw_rect_outline(Color::GREEN, layout.bounds().into(), Twips::ONE_PX);
         }
     }
 

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -682,7 +682,7 @@ impl<'gc> Font<'gc> {
         mut is_start_of_line: bool,
     ) -> Option<usize> {
         let mut remaining_width = width - offset;
-        if remaining_width < Twips::from_pixels(0.0) {
+        if remaining_width < Twips::ZERO {
             return Some(0);
         }
 
@@ -733,7 +733,7 @@ impl<'gc> Font<'gc> {
                 //If the additional space were to cause an overflow, then
                 //return now.
                 remaining_width -= measure;
-                if remaining_width < Twips::from_pixels(0.0) {
+                if remaining_width < Twips::ZERO {
                     return Some(word_end);
                 }
             }
@@ -1137,16 +1137,10 @@ mod tests {
     #[test]
     fn wrap_line_no_breakpoint() {
         with_device_font(|_mc, df| {
-            let params =
-                EvalParameters::from_parts(Twips::from_pixels(12.0), Twips::from_pixels(0.0), true);
+            let params = EvalParameters::from_parts(Twips::from_pixels(12.0), Twips::ZERO, true);
             let string = WStr::from_units(b"abcdefghijklmnopqrstuv");
-            let breakpoint = df.wrap_line(
-                string,
-                params,
-                Twips::from_pixels(200.0),
-                Twips::from_pixels(0.0),
-                true,
-            );
+            let breakpoint =
+                df.wrap_line(string, params, Twips::from_pixels(200.0), Twips::ZERO, true);
 
             assert_eq!(None, breakpoint);
         });
@@ -1155,17 +1149,11 @@ mod tests {
     #[test]
     fn wrap_line_breakpoint_every_word() {
         with_device_font(|_mc, df| {
-            let params =
-                EvalParameters::from_parts(Twips::from_pixels(12.0), Twips::from_pixels(0.0), true);
+            let params = EvalParameters::from_parts(Twips::from_pixels(12.0), Twips::ZERO, true);
             let string = WStr::from_units(b"abcd efgh ijkl mnop");
             let mut last_bp = 0;
-            let breakpoint = df.wrap_line(
-                string,
-                params,
-                Twips::from_pixels(35.0),
-                Twips::from_pixels(0.0),
-                true,
-            );
+            let breakpoint =
+                df.wrap_line(string, params, Twips::from_pixels(35.0), Twips::ZERO, true);
 
             assert_eq!(Some(4), breakpoint);
 
@@ -1175,7 +1163,7 @@ mod tests {
                 &string[last_bp..],
                 params,
                 Twips::from_pixels(35.0),
-                Twips::from_pixels(0.0),
+                Twips::ZERO,
                 true,
             );
 
@@ -1187,7 +1175,7 @@ mod tests {
                 &string[last_bp..],
                 params,
                 Twips::from_pixels(35.0),
-                Twips::from_pixels(0.0),
+                Twips::ZERO,
                 true,
             );
 
@@ -1199,7 +1187,7 @@ mod tests {
                 &string[last_bp..],
                 params,
                 Twips::from_pixels(35.0),
-                Twips::from_pixels(0.0),
+                Twips::ZERO,
                 true,
             );
 
@@ -1210,8 +1198,7 @@ mod tests {
     #[test]
     fn wrap_line_breakpoint_no_room() {
         with_device_font(|_mc, df| {
-            let params =
-                EvalParameters::from_parts(Twips::from_pixels(12.0), Twips::from_pixels(0.0), true);
+            let params = EvalParameters::from_parts(Twips::from_pixels(12.0), Twips::ZERO, true);
             let string = WStr::from_units(b"abcd efgh ijkl mnop");
             let breakpoint = df.wrap_line(
                 string,
@@ -1228,17 +1215,11 @@ mod tests {
     #[test]
     fn wrap_line_breakpoint_irregular_sized_words() {
         with_device_font(|_mc, df| {
-            let params =
-                EvalParameters::from_parts(Twips::from_pixels(12.0), Twips::from_pixels(0.0), true);
+            let params = EvalParameters::from_parts(Twips::from_pixels(12.0), Twips::ZERO, true);
             let string = WStr::from_units(b"abcdi j kl mnop q rstuv");
             let mut last_bp = 0;
-            let breakpoint = df.wrap_line(
-                string,
-                params,
-                Twips::from_pixels(37.0),
-                Twips::from_pixels(0.0),
-                true,
-            );
+            let breakpoint =
+                df.wrap_line(string, params, Twips::from_pixels(37.0), Twips::ZERO, true);
 
             assert_eq!(Some(5), breakpoint);
 
@@ -1248,7 +1229,7 @@ mod tests {
                 &string[last_bp..],
                 params,
                 Twips::from_pixels(37.0),
-                Twips::from_pixels(0.0),
+                Twips::ZERO,
                 true,
             );
 
@@ -1260,7 +1241,7 @@ mod tests {
                 &string[last_bp..],
                 params,
                 Twips::from_pixels(37.0),
-                Twips::from_pixels(0.0),
+                Twips::ZERO,
                 true,
             );
 
@@ -1272,7 +1253,7 @@ mod tests {
                 &string[last_bp..],
                 params,
                 Twips::from_pixels(37.0),
-                Twips::from_pixels(0.0),
+                Twips::ZERO,
                 true,
             );
 
@@ -1284,7 +1265,7 @@ mod tests {
                 &string[last_bp..],
                 params,
                 Twips::from_pixels(37.0),
-                Twips::from_pixels(0.0),
+                Twips::ZERO,
                 true,
             );
 

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -27,7 +27,7 @@ fn draw_underline(
     width: Twips,
     color: swf::Color,
 ) {
-    if width < Twips::ONE {
+    if width < Twips::ONE_PX {
         return;
     }
 

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -459,8 +459,8 @@ impl WebCanvasRenderBackend {
     }
 
     fn draw_lines(&mut self, color: Color, mut matrix: Matrix, rect: bool) {
-        matrix.tx += Twips::HALF;
-        matrix.ty += Twips::HALF;
+        matrix.tx += Twips::HALF_PX;
+        matrix.ty += Twips::HALF_PX;
         let dom_matrix = matrix.to_dom_matrix();
         let stroke = if rect { &self.line_rect } else { &self.line };
         match &self.mask_state {

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -355,10 +355,7 @@ impl PixelRegion {
         let (min, max) = ((a.0.min(b.0), a.1.min(b.1)), (a.0.max(b.0), a.1.max(b.1)));
 
         // Increase max by one pixel as we've calculated the *encompassed* max
-        let max = (
-            max.0 + Twips::from_pixels_i32(1),
-            max.1 + Twips::from_pixels_i32(1),
-        );
+        let max = (max.0 + Twips::ONE_PX, max.1 + Twips::ONE_PX);
 
         // Make sure we're never going below 0
         Self {

--- a/render/src/lines.rs
+++ b/render/src/lines.rs
@@ -41,10 +41,10 @@ fn emulate_line_as_rect(
     let angle = dy.atan2(dx) as f32;
 
     let rotation = Matrix::rotate(angle);
-    let translation = Matrix::translate(a.x + Twips::HALF, a.y + Twips::HALF);
+    let translation = Matrix::translate(a.x + Twips::HALF_PX, a.y + Twips::HALF_PX);
 
     // Step 1: Create a 1px thick line with the proper length.
-    let line = Matrix::create_box(len, 1.0, Twips::ZERO, -Twips::HALF);
+    let line = Matrix::create_box(len, 1.0, Twips::ZERO, -Twips::HALF_PX);
     // Step 2: Rotate it, so it still starts at `(0,0)` but points to `b-a`.
     let line = rotation * line;
     // Step 3: Translate it to `a`, so that it points to `b`.

--- a/render/src/lines.rs
+++ b/render/src/lines.rs
@@ -8,16 +8,16 @@ use swf::{Color, Point, PointDelta, Twips};
 /// the rendering backend's implementation and rasterization rules.
 pub fn emulate_line(handler: &mut impl CommandHandler, color: Color, matrix: Matrix) {
     let a = matrix * Point::new(Twips::ZERO, Twips::ZERO);
-    let b = matrix * Point::new(Twips::ONE, Twips::ZERO);
+    let b = matrix * Point::new(Twips::ONE_PX, Twips::ZERO);
     emulate_line_as_rect(handler, color, a, b);
 }
 
 /// Similar to [`emulate_line`], but emulates drawing a rectangle with lines as its sides.
 pub fn emulate_line_rect(handler: &mut impl CommandHandler, color: Color, matrix: Matrix) {
     let a = matrix * Point::new(Twips::ZERO, Twips::ZERO);
-    let b = matrix * Point::new(Twips::ONE, Twips::ZERO);
-    let c = matrix * Point::new(Twips::ONE, Twips::ONE);
-    let d = matrix * Point::new(Twips::ZERO, Twips::ONE);
+    let b = matrix * Point::new(Twips::ONE_PX, Twips::ZERO);
+    let c = matrix * Point::new(Twips::ONE_PX, Twips::ONE_PX);
+    let d = matrix * Point::new(Twips::ZERO, Twips::ONE_PX);
     emulate_line_as_rect(handler, color, a, b);
     emulate_line_as_rect(handler, color, b, c);
     emulate_line_as_rect(handler, color, c, d);

--- a/render/src/matrix.rs
+++ b/render/src/matrix.rs
@@ -437,7 +437,7 @@ mod tests {
             Matrix {
                 a: 1.5,
                 c: 1.2,
-                tx: Twips::from_pixels(1.0),
+                tx: Twips::ONE_PX,
                 b: -2.7,
                 d: 3.4,
                 ty: Twips::from_pixels(-2.4),

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1505,14 +1505,14 @@ impl CommandHandler for WebGlRenderBackend {
     }
 
     fn draw_line(&mut self, color: Color, mut matrix: Matrix) {
-        matrix.tx += Twips::HALF;
-        matrix.ty += Twips::HALF;
+        matrix.tx += Twips::HALF_PX;
+        matrix.ty += Twips::HALF_PX;
         self.draw_quad::<{ Gl::LINE_STRIP }, 2>(color, matrix)
     }
 
     fn draw_line_rect(&mut self, color: Color, mut matrix: Matrix) {
-        matrix.tx += Twips::HALF;
-        matrix.ty += Twips::HALF;
+        matrix.tx += Twips::HALF_PX;
+        matrix.ty += Twips::HALF_PX;
         self.draw_quad::<{ Gl::LINE_LOOP }, -1>(color, matrix)
     }
 

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -781,8 +781,8 @@ impl CommandHandler for WgpuCommandHandler<'_> {
             emulate_line(&mut cl, color, matrix);
             cl.execute(self);
         } else {
-            matrix.tx += Twips::HALF;
-            matrix.ty += Twips::HALF;
+            matrix.tx += Twips::HALF_PX;
+            matrix.ty += Twips::HALF_PX;
             self.add_to_current(
                 matrix,
                 ColorTransform::multiply_from(color),
@@ -797,8 +797,8 @@ impl CommandHandler for WgpuCommandHandler<'_> {
             emulate_line_rect(&mut cl, color, matrix);
             cl.execute(self);
         } else {
-            matrix.tx += Twips::HALF;
-            matrix.ty += Twips::HALF;
+            matrix.tx += Twips::HALF_PX;
+            matrix.ty += Twips::HALF_PX;
             self.add_to_current(
                 matrix,
                 ColorTransform::multiply_from(color),

--- a/swf/README.md
+++ b/swf/README.md
@@ -34,8 +34,8 @@ let header = Header {
     compression: Compression::Zlib,
     version: 6,
     stage_size: Rectangle {
-        x_min: Twips::from_pixels(0.0), x_max: Twips::from_pixels(400.0),
-        y_min: Twips::from_pixels(0.0), y_max: Twips::from_pixels(400.0)
+        x_min: Twips::ZERO, x_max: Twips::from_pixels(400.0),
+        y_min: Twips::ZERO, y_max: Twips::from_pixels(400.0)
     },
     frame_rate: Fixed8::from_f32(60.0),
     num_frames: 1,

--- a/swf/examples/writing.rs
+++ b/swf/examples/writing.rs
@@ -5,9 +5,9 @@ fn main() {
         compression: Compression::Zlib,
         version: 6,
         stage_size: Rectangle {
-            x_min: Twips::from_pixels(0.0),
+            x_min: Twips::ZERO,
             x_max: Twips::from_pixels(400.0),
-            y_min: Twips::from_pixels(0.0),
+            y_min: Twips::ZERO,
             y_max: Twips::from_pixels(400.0),
         },
         frame_rate: Fixed8::from_f32(60.0),

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -2816,10 +2816,10 @@ pub mod tests {
         assert_eq!(
             rectangle,
             Rectangle {
-                x_min: Twips::from_pixels(-1.0),
-                y_min: Twips::from_pixels(-1.0),
-                x_max: Twips::from_pixels(1.0),
-                y_max: Twips::from_pixels(1.0),
+                x_min: -Twips::ONE_PX,
+                y_min: -Twips::ONE_PX,
+                x_max: Twips::ONE_PX,
+                y_max: Twips::ONE_PX,
             }
         );
     }
@@ -2936,7 +2936,7 @@ pub mod tests {
         );
 
         let mut matrix = Matrix::IDENTITY;
-        matrix.tx = Twips::from_pixels(1.0);
+        matrix.tx = Twips::ONE_PX;
         let fill_style = FillStyle::Bitmap {
             id: 33,
             matrix,

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -2833,8 +2833,8 @@ pub mod tests {
             assert_eq!(
                 matrix,
                 Matrix {
-                    tx: Twips::from_pixels(0.0),
-                    ty: Twips::from_pixels(0.0),
+                    tx: Twips::ZERO,
+                    ty: Twips::ZERO,
                     a: Fixed16::ONE,
                     b: Fixed16::ZERO,
                     c: Fixed16::ZERO,
@@ -2953,7 +2953,7 @@ pub mod tests {
     fn read_line_style() {
         // DefineShape1 and 2 read RGB colors.
         let line_style = LineStyle::new()
-            .with_width(Twips::from_pixels(0.0))
+            .with_width(Twips::ZERO)
             .with_color(Color::from_rgba(0xffff0000));
         assert_eq!(
             reader(&[0, 0, 255, 0, 0]).read_line_style(2).unwrap(),
@@ -3064,8 +3064,8 @@ pub mod tests {
                 b: Fixed16::ZERO,
                 c: Fixed16::ZERO,
                 d: Fixed16::ONE,
-                tx: Twips::from_pixels(0.0),
-                ty: Twips::from_pixels(0.0),
+                tx: Twips::ZERO,
+                ty: Twips::ZERO,
             }),
             color_transform: None,
             ratio: None,

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -376,7 +376,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                         align: TextAlign::Justify,
                         left_margin: Twips::from_pixels(3.0),
                         right_margin: Twips::from_pixels(4.0),
-                        indent: Twips::from_pixels(1.0),
+                        indent: Twips::ONE_PX,
                         leading: Twips::from_pixels(2.0),
                     }))
                     .with_variable_name(

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -1076,15 +1076,15 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 flags: DefineMorphShapeFlag::HAS_SCALING_STROKES,
                 start: MorphShape {
                     shape_bounds: Rectangle {
-                        x_min: Twips::from_pixels(0.0),
+                        x_min: Twips::ZERO,
                         x_max: Twips::from_pixels(200.0),
-                        y_min: Twips::from_pixels(0.0),
+                        y_min: Twips::ZERO,
                         y_max: Twips::from_pixels(200.0),
                     },
                     edge_bounds: Rectangle {
-                        x_min: Twips::from_pixels(0.0),
+                        x_min: Twips::ZERO,
                         x_max: Twips::from_pixels(200.0),
-                        y_min: Twips::from_pixels(0.0),
+                        y_min: Twips::ZERO,
                         y_max: Twips::from_pixels(200.0),
                     },
                     fill_styles: vec![FillStyle::RadialGradient(Gradient {
@@ -1146,15 +1146,15 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 },
                 end: MorphShape {
                     shape_bounds: Rectangle {
-                        x_min: Twips::from_pixels(0.0),
+                        x_min: Twips::ZERO,
                         x_max: Twips::from_pixels(200.0),
-                        y_min: Twips::from_pixels(0.0),
+                        y_min: Twips::ZERO,
                         y_max: Twips::from_pixels(200.0),
                     },
                     edge_bounds: Rectangle {
-                        x_min: Twips::from_pixels(0.0),
+                        x_min: Twips::ZERO,
                         x_max: Twips::from_pixels(200.0),
-                        y_min: Twips::from_pixels(0.0),
+                        y_min: Twips::ZERO,
                         y_max: Twips::from_pixels(200.0),
                     },
                     fill_styles: vec![FillStyle::RadialGradient(Gradient {
@@ -1276,15 +1276,15 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 version: 1,
                 id: 1,
                 shape_bounds: Rectangle {
-                    x_min: Twips::from_pixels(0.0),
+                    x_min: Twips::ZERO,
                     x_max: Twips::from_pixels(20.0),
-                    y_min: Twips::from_pixels(0.0),
+                    y_min: Twips::ZERO,
                     y_max: Twips::from_pixels(20.0),
                 },
                 edge_bounds: Rectangle {
-                    x_min: Twips::from_pixels(0.0),
+                    x_min: Twips::ZERO,
                     x_max: Twips::from_pixels(20.0),
-                    y_min: Twips::from_pixels(0.0),
+                    y_min: Twips::ZERO,
                     y_max: Twips::from_pixels(20.0),
                 },
                 flags: ShapeFlag::HAS_NON_SCALING_STROKES,
@@ -1327,15 +1327,15 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 version: 3,
                 id: 1,
                 shape_bounds: Rectangle {
-                    x_min: Twips::from_pixels(0.0),
+                    x_min: Twips::ZERO,
                     x_max: Twips::from_pixels(50.0),
-                    y_min: Twips::from_pixels(0.0),
+                    y_min: Twips::ZERO,
                     y_max: Twips::from_pixels(50.0),
                 },
                 edge_bounds: Rectangle {
-                    x_min: Twips::from_pixels(0.0),
+                    x_min: Twips::ZERO,
                     x_max: Twips::from_pixels(50.0),
-                    y_min: Twips::from_pixels(0.0),
+                    y_min: Twips::ZERO,
                     y_max: Twips::from_pixels(50.0),
                 },
                 flags: ShapeFlag::HAS_NON_SCALING_STROKES,
@@ -1430,9 +1430,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                     y_max: Twips::from_pixels(110.0),
                 },
                 edge_bounds: Rectangle {
-                    x_min: Twips::from_pixels(0.0),
+                    x_min: Twips::ZERO,
                     x_max: Twips::from_pixels(250.0),
-                    y_min: Twips::from_pixels(0.0),
+                    y_min: Twips::ZERO,
                     y_max: Twips::from_pixels(100.0),
                 },
                 flags: ShapeFlag::HAS_NON_SCALING_STROKES,
@@ -1947,8 +1947,8 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 action: PlaceObjectAction::Place(1),
                 depth: 1,
                 matrix: Some(Matrix {
-                    tx: Twips::from_pixels(0.0),
-                    ty: Twips::from_pixels(0.0),
+                    tx: Twips::ZERO,
+                    ty: Twips::ZERO,
                     a: Fixed16::ONE,
                     b: Fixed16::ZERO,
                     c: Fixed16::ZERO,
@@ -2360,10 +2360,10 @@ pub fn tag_tests() -> Vec<TagTestData> {
                     y_max: Twips::from_pixels(20.0),
                 },
                 edge_bounds: Rectangle {
-                    x_min: Twips::from_pixels(0.0),
+                    x_min: Twips::ZERO,
                     x_max: Twips::from_pixels(200.0),
-                    y_min: Twips::from_pixels(0.0),
-                    y_max: Twips::from_pixels(0.0),
+                    y_min: Twips::ZERO,
+                    y_max: Twips::ZERO,
                 },
                 flags: ShapeFlag::HAS_SCALING_STROKES,
                 styles: ShapeStyles {

--- a/swf/src/types/twips.rs
+++ b/swf/src/types/twips.rs
@@ -45,9 +45,9 @@ impl Twips {
     /// # Examples
     ///
     /// ```rust
-    /// assert_eq!(swf::Twips::HALF.to_pixels(), 0.5);
+    /// assert_eq!(swf::Twips::HALF_PX.to_pixels(), 0.5);
     /// ```
-    pub const HALF: Self = Self(Self::TWIPS_PER_PIXEL / 2);
+    pub const HALF_PX: Self = Self(Self::TWIPS_PER_PIXEL / 2);
 
     /// Creates a new `Twips` object. Note that the `twips` value is in twips,
     /// not pixels. Use the [`from_pixels`] method to convert from pixel units.

--- a/swf/src/types/twips.rs
+++ b/swf/src/types/twips.rs
@@ -36,9 +36,9 @@ impl Twips {
     /// # Examples
     ///
     /// ```rust
-    /// assert_eq!(swf::Twips::ONE.to_pixels(), 1.0);
+    /// assert_eq!(swf::Twips::ONE_PX.to_pixels(), 1.0);
     /// ```
-    pub const ONE: Self = Self(Self::TWIPS_PER_PIXEL);
+    pub const ONE_PX: Self = Self(Self::TWIPS_PER_PIXEL);
 
     /// The `Twips` object with a value of `0.5` pixels.
     ///

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -2650,10 +2650,10 @@ mod tests {
     #[test]
     fn write_rectangle_signed() {
         let rectangle = Rectangle {
-            x_min: Twips::from_pixels(-1.0),
-            x_max: Twips::from_pixels(1.0),
-            y_min: Twips::from_pixels(-1.0),
-            y_max: Twips::from_pixels(1.0),
+            x_min: -Twips::ONE_PX,
+            x_max: Twips::ONE_PX,
+            y_min: -Twips::ONE_PX,
+            y_max: Twips::ONE_PX,
         };
         let mut buf = Vec::new();
         {

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -17,7 +17,12 @@ use std::io::{self, Write};
 /// let header = Header {
 ///     compression: Compression::Zlib,
 ///     version: 6,
-///     stage_size: Rectangle { x_min: Twips::from_pixels(0.0), x_max: Twips::from_pixels(400.0), y_min: Twips::from_pixels(0.0), y_max: Twips::from_pixels(400.0) },
+///     stage_size: Rectangle {
+///         x_min: Twips::ZERO,
+///         x_max: Twips::from_pixels(400.0),
+///         y_min: Twips::ZERO,
+///         y_max: Twips::from_pixels(400.0),
+///     },
 ///     frame_rate: Fixed8::from_f32(60.0),
 ///     num_frames: 1,
 /// };
@@ -2436,9 +2441,9 @@ mod tests {
                 compression,
                 version: 13,
                 stage_size: Rectangle {
-                    x_min: Twips::from_pixels(0.0),
+                    x_min: Twips::ZERO,
                     x_max: Twips::from_pixels(640.0),
-                    y_min: Twips::from_pixels(0.0),
+                    y_min: Twips::ZERO,
                     y_max: Twips::from_pixels(480.0),
                 },
                 frame_rate: Fixed8::from_f32(60.0),

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -2776,11 +2776,11 @@ mod tests {
             glyphs: vec![Glyph {
                 shape_records: vec![
                     ShapeRecord::StraightEdge {
-                        delta: PointDelta::new(Twips::ONE, -Twips::ONE),
+                        delta: PointDelta::new(Twips::ONE_PX, -Twips::ONE_PX),
                     },
                     ShapeRecord::CurvedEdge {
-                        control_delta: PointDelta::new(Twips::ONE, Twips::ONE),
-                        anchor_delta: PointDelta::new(Twips::ONE, -Twips::ONE),
+                        control_delta: PointDelta::new(Twips::ONE_PX, Twips::ONE_PX),
+                        anchor_delta: PointDelta::new(Twips::ONE_PX, -Twips::ONE_PX),
                     },
                     ShapeRecord::StraightEdge {
                         delta: PointDelta::new(Twips::ZERO, Twips::ZERO),


### PR DESCRIPTION
It's a refactor that replaces `Twips` instantiations with respective constants. Some instantiations in tests (by `Twips::new`) were left intact as they seem to focus on the pure numerical value instead of semantically the number of twips.