### PR TITLE
core: Use `gc()` instead of `gc_context` where possible

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -370,7 +370,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .object()
             .coerce_to_object(&mut parent_activation);
         let child_scope = Gc::new(
-            parent_activation.context.gc(),
+            parent_activation.gc(),
             Scope::new(
                 parent_activation.scope(),
                 scope::ScopeClass::Target,
@@ -408,7 +408,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             _ => panic!("No script object for display object"),
         };
         let child_scope = Gc::new(
-            self.context.gc(),
+            self.gc(),
             Scope::new(
                 self.context.avm1.global_scope(),
                 scope::ScopeClass::Target,
@@ -605,14 +605,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let b = self.context.avm1.pop().to_primitive(self)?;
 
         let result: Value<'_> = match (a, b) {
-            (Value::String(a), Value::String(b)) => {
-                AvmString::concat(self.context.gc(), b, a).into()
-            }
+            (Value::String(a), Value::String(b)) => AvmString::concat(self.gc(), b, a).into(),
             (Value::String(a), b) => {
-                AvmString::concat(self.context.gc(), b.coerce_to_string(self)?, a).into()
+                AvmString::concat(self.gc(), b.coerce_to_string(self)?, a).into()
             }
             (a, Value::String(b)) => {
-                AvmString::concat(self.context.gc(), b, a.coerce_to_string(self)?).into()
+                AvmString::concat(self.gc(), b, a.coerce_to_string(self)?).into()
             }
             _ => (b.coerce_to_f64(self)? + a.coerce_to_f64(self)?).into(),
         };
@@ -642,7 +640,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         };
         self.context
             .avm1
-            .push(AvmString::new(self.context.gc(), result).into());
+            .push(AvmString::new(self.gc(), result).into());
         Ok(FrameControl::Continue)
     }
 
@@ -877,7 +875,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         self.context
             .avm1
-            .set_constant_pool(Gc::new(self.context.gc(), constants));
+            .set_constant_pool(Gc::new(self.gc(), constants));
         self.set_constant_pool(self.context.avm1.constant_pool());
 
         Ok(FrameControl::Continue)
@@ -899,7 +897,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let func_data = parent_data.to_unbounded_subslice(action.actions);
         let constant_pool = self.constant_pool();
         let func = Avm1Function::from_swf_function(
-            self.context.gc(),
+            self.gc(),
             swf_version,
             func_data,
             action,
@@ -908,14 +906,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             self.base_clip(),
         );
         let name = func.name();
-        let prototype = ScriptObject::new(
-            self.context.gc(),
-            Some(self.context.avm1.prototypes().object),
-        )
-        .into();
+        let prototype =
+            ScriptObject::new(self.gc(), Some(self.context.avm1.prototypes().object)).into();
         let func_obj = FunctionObject::function(
-            self.context.gc(),
-            Gc::new(self.context.gc(), func),
+            self.gc(),
+            Gc::new(self.gc(), func),
             self.context.avm1.prototypes().function,
             prototype,
         );
@@ -1103,14 +1098,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let sub_prototype = super_prototype.create_bare_object(self, super_prototype)?;
 
         sub_prototype.define_value(
-            self.context.gc(),
+            self.gc(),
             "constructor",
             superclass.into(),
             Attribute::DONT_ENUM,
         );
 
         sub_prototype.define_value(
-            self.context.gc(),
+            self.gc(),
             "__constructor__",
             superclass.into(),
             Attribute::DONT_ENUM,
@@ -1472,7 +1467,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             Value::Undefined
         } else {
             ArrayObject::new(
-                self.context.gc(),
+                self.gc(),
                 self.context.avm1.prototypes().array,
                 (0..num_elements as i32).map(|_| self.context.avm1.pop()),
             )
@@ -1489,10 +1484,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             // InitArray pops no args and pushes undefined if num_props is out of range.
             Value::Undefined
         } else {
-            let object = ScriptObject::new(
-                self.context.gc(),
-                Some(self.context.avm1.prototypes().object),
-            );
+            let object = ScriptObject::new(self.gc(), Some(self.context.avm1.prototypes().object));
             for _ in 0..num_props as usize {
                 let value = self.context.avm1.pop();
                 let name_val = self.context.avm1.pop();
@@ -1529,7 +1521,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
 
         let prototype = constructor.get("prototype", self)?.coerce_to_object(self);
-        prototype.set_interfaces(self.context.gc(), interfaces);
+        prototype.set_interfaces(self.gc(), interfaces);
 
         Ok(FrameControl::Continue)
     }
@@ -1606,7 +1598,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         };
         self.context
             .avm1
-            .push(AvmString::new_utf8(self.context.gc(), result).into());
+            .push(AvmString::new_utf8(self.gc(), result).into());
         Ok(FrameControl::Continue)
     }
 
@@ -1650,7 +1642,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let result = &s[start.min(end)..end];
         self.context
             .avm1
-            .push(AvmString::new(self.context.gc(), result).into());
+            .push(AvmString::new(self.gc(), result).into());
         Ok(FrameControl::Continue)
     }
 
@@ -1823,9 +1815,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 SwfValue::Int(v) => v.into(),
                 SwfValue::Float(v) => v.into(),
                 SwfValue::Double(v) => v.into(),
-                SwfValue::Str(v) => {
-                    AvmString::new(self.context.gc(), v.decode(self.encoding())).into()
-                }
+                SwfValue::Str(v) => AvmString::new(self.gc(), v.decode(self.encoding())).into(),
                 SwfValue::Register(v) => self.current_register(v),
                 SwfValue::ConstantPool(i) => {
                     if let Some(value) = self.constant_pool().get(i as usize) {
@@ -2020,11 +2010,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .object()
             .coerce_to_object(self);
 
-        self.set_scope(Scope::new_target_scope(
-            self.scope(),
-            clip_obj,
-            self.context.gc(),
-        ));
+        self.set_scope(Scope::new_target_scope(self.scope(), clip_obj, self.gc()));
         Ok(FrameControl::Continue)
     }
 
@@ -2101,7 +2087,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // TODO(Herschel): Result with non-string operands?
         let a = self.context.avm1.pop().coerce_to_string(self)?;
         let b = self.context.avm1.pop().coerce_to_string(self)?;
-        let s = AvmString::concat(self.context.gc(), b, a);
+        let s = AvmString::concat(self.gc(), b, a);
         self.context.avm1.push(s.into());
         Ok(FrameControl::Continue)
     }
@@ -2135,7 +2121,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let result = &s[start.min(end)..end];
         self.context
             .avm1
-            .push(AvmString::new(self.context.gc(), result).into());
+            .push(AvmString::new(self.gc(), result).into());
         Ok(FrameControl::Continue)
     }
 
@@ -2180,7 +2166,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let param = self.context.avm1.pop().coerce_to_object(self);
         let result = if let Some(display_object) = param.as_display_object() {
             let path = display_object.path();
-            AvmString::new(self.context.gc(), path).into()
+            AvmString::new(self.gc(), path).into()
         } else {
             Value::Undefined
         };
@@ -2214,7 +2200,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.context.stage.set_quality(self.context, new_quality);
         self.context
             .stage
-            .set_use_bitmap_downsampling(self.context.gc(), use_bitmap_downsamping);
+            .set_use_bitmap_downsampling(self.gc(), use_bitmap_downsamping);
         Ok(FrameControl::Continue)
     }
 
@@ -2276,10 +2262,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
                 match catch_vars {
                     CatchVar::Var(name) => {
-                        let name = AvmString::new(
-                            activation.context.gc(),
-                            name.decode(activation.encoding()),
-                        );
+                        let name =
+                            AvmString::new(activation.gc(), name.decode(activation.encoding()));
                         activation.set_variable(name, value.to_owned())?
                     }
                     CatchVar::Register(id) => {
@@ -2399,10 +2383,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             value => {
                 // Note that primitives get boxed at this point.
                 let object = value.coerce_to_object(self);
-                let with_scope = Gc::new(
-                    self.context.gc(),
-                    Scope::new_with_scope(self.scope(), object),
-                );
+                let with_scope = Gc::new(self.gc(), Scope::new_with_scope(self.scope(), object));
                 let mut new_activation = self.with_new_scope("[With]", with_scope);
                 if let ReturnType::Explicit(value) = new_activation.run_actions(code)? {
                     Ok(FrameControl::Return(ReturnType::Explicit(value)))
@@ -2676,7 +2657,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                             child.object()
                         }
                     } else {
-                        let name = AvmString::new(self.context.gc(), name);
+                        let name = AvmString::new(self.gc(), name);
                         if path_has_slash {
                             object.get(name, self).unwrap()
                         } else {
@@ -2791,7 +2772,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                     true,
                     path_has_slash,
                 )? {
-                    let var_name = AvmString::new(self.context.gc(), var_name);
+                    let var_name = AvmString::new(self.gc(), var_name);
                     if object.has_property(self, var_name) {
                         return Ok(CallableValue::Callable(object, object.get(var_name, self)?));
                     }
@@ -2877,7 +2858,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 if let Some(object) =
                     self.resolve_target_path(avm1_root, *scope.locals(), path, true, true)?
                 {
-                    let var_name = AvmString::new(self.context.gc(), var_name);
+                    let var_name = AvmString::new(self.gc(), var_name);
                     object.set(var_name, value, self)?;
                     return Ok(());
                 }
@@ -2904,9 +2885,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             level
         } else {
             let level: DisplayObject<'_> =
-                MovieClip::new(self.base_clip().movie(), self.context.gc()).into();
+                MovieClip::new(self.base_clip().movie(), self.gc()).into();
 
-            level.set_depth(self.context.gc(), level_id);
+            level.set_depth(self.gc(), level_id);
             level.set_default_root_name(self.context);
             self.get_root_parent_container()
                 .and_then(|c| c.replace_at_depth(self.context, level, level_id));
@@ -2989,7 +2970,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     pub fn set_scope_to_display_object(&mut self, object: DisplayObject<'gc>) {
         self.scope = Gc::new(
-            self.context.gc(),
+            self.gc(),
             Scope::new(
                 self.scope,
                 ScopeClass::Target,
@@ -3059,8 +3040,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     /// This inserts a value as a stored property on the local scope. If the property already
     /// exists, it will be forcefully overwritten. Used internally to initialize objects.
     pub fn force_define_local(&mut self, name: AvmString<'gc>, value: Value<'gc>) {
-        self.scope
-            .force_define_local(name, value, self.context.gc())
+        self.scope.force_define_local(name, value, self.gc())
     }
 
     /// Returns value of `this` as a reference.
@@ -3165,11 +3145,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let clip_obj = self.target_clip_or_root().object().coerce_to_object(self);
 
-        self.set_scope(Scope::new_target_scope(
-            self.scope(),
-            clip_obj,
-            self.context.gc(),
-        ));
+        self.set_scope(Scope::new_target_scope(self.scope(), clip_obj, self.gc()));
         Ok(FrameControl::Continue)
     }
 }

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -240,7 +240,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     /// `self.context.gc_context` can be sometimes necessary to satisfy the borrow checker.
     #[inline(always)]
     pub fn gc(&self) -> &'gc Mutation<'gc> {
-        self.context.gc_context
+        self.context.gc()
     }
 
     #[inline(always)]
@@ -370,7 +370,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .object()
             .coerce_to_object(&mut parent_activation);
         let child_scope = Gc::new(
-            parent_activation.context.gc_context,
+            parent_activation.context.gc(),
             Scope::new(
                 parent_activation.scope(),
                 scope::ScopeClass::Target,
@@ -408,7 +408,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             _ => panic!("No script object for display object"),
         };
         let child_scope = Gc::new(
-            self.context.gc_context,
+            self.context.gc(),
             Scope::new(
                 self.context.avm1.global_scope(),
                 scope::ScopeClass::Target,
@@ -606,13 +606,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let result: Value<'_> = match (a, b) {
             (Value::String(a), Value::String(b)) => {
-                AvmString::concat(self.context.gc_context, b, a).into()
+                AvmString::concat(self.context.gc(), b, a).into()
             }
             (Value::String(a), b) => {
-                AvmString::concat(self.context.gc_context, b.coerce_to_string(self)?, a).into()
+                AvmString::concat(self.context.gc(), b.coerce_to_string(self)?, a).into()
             }
             (a, Value::String(b)) => {
-                AvmString::concat(self.context.gc_context, b, a.coerce_to_string(self)?).into()
+                AvmString::concat(self.context.gc(), b, a.coerce_to_string(self)?).into()
             }
             _ => (b.coerce_to_f64(self)? + a.coerce_to_f64(self)?).into(),
         };
@@ -642,7 +642,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         };
         self.context
             .avm1
-            .push(AvmString::new(self.context.gc_context, result).into());
+            .push(AvmString::new(self.context.gc(), result).into());
         Ok(FrameControl::Continue)
     }
 
@@ -877,7 +877,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         self.context
             .avm1
-            .set_constant_pool(Gc::new(self.context.gc_context, constants));
+            .set_constant_pool(Gc::new(self.context.gc(), constants));
         self.set_constant_pool(self.context.avm1.constant_pool());
 
         Ok(FrameControl::Continue)
@@ -899,7 +899,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let func_data = parent_data.to_unbounded_subslice(action.actions);
         let constant_pool = self.constant_pool();
         let func = Avm1Function::from_swf_function(
-            self.context.gc_context,
+            self.context.gc(),
             swf_version,
             func_data,
             action,
@@ -909,13 +909,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         );
         let name = func.name();
         let prototype = ScriptObject::new(
-            self.context.gc_context,
+            self.context.gc(),
             Some(self.context.avm1.prototypes().object),
         )
         .into();
         let func_obj = FunctionObject::function(
-            self.context.gc_context,
-            Gc::new(self.context.gc_context, func),
+            self.context.gc(),
+            Gc::new(self.context.gc(), func),
             self.context.avm1.prototypes().function,
             prototype,
         );
@@ -1103,14 +1103,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let sub_prototype = super_prototype.create_bare_object(self, super_prototype)?;
 
         sub_prototype.define_value(
-            self.context.gc_context,
+            self.context.gc(),
             "constructor",
             superclass.into(),
             Attribute::DONT_ENUM,
         );
 
         sub_prototype.define_value(
-            self.context.gc_context,
+            self.context.gc(),
             "__constructor__",
             superclass.into(),
             Attribute::DONT_ENUM,
@@ -1472,7 +1472,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             Value::Undefined
         } else {
             ArrayObject::new(
-                self.context.gc_context,
+                self.context.gc(),
                 self.context.avm1.prototypes().array,
                 (0..num_elements as i32).map(|_| self.context.avm1.pop()),
             )
@@ -1490,7 +1490,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             Value::Undefined
         } else {
             let object = ScriptObject::new(
-                self.context.gc_context,
+                self.context.gc(),
                 Some(self.context.avm1.prototypes().object),
             );
             for _ in 0..num_props as usize {
@@ -1529,7 +1529,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
 
         let prototype = constructor.get("prototype", self)?.coerce_to_object(self);
-        prototype.set_interfaces(self.context.gc_context, interfaces);
+        prototype.set_interfaces(self.context.gc(), interfaces);
 
         Ok(FrameControl::Continue)
     }
@@ -1606,7 +1606,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         };
         self.context
             .avm1
-            .push(AvmString::new_utf8(self.context.gc_context, result).into());
+            .push(AvmString::new_utf8(self.context.gc(), result).into());
         Ok(FrameControl::Continue)
     }
 
@@ -1650,7 +1650,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let result = &s[start.min(end)..end];
         self.context
             .avm1
-            .push(AvmString::new(self.context.gc_context, result).into());
+            .push(AvmString::new(self.context.gc(), result).into());
         Ok(FrameControl::Continue)
     }
 
@@ -1824,7 +1824,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 SwfValue::Float(v) => v.into(),
                 SwfValue::Double(v) => v.into(),
                 SwfValue::Str(v) => {
-                    AvmString::new(self.context.gc_context, v.decode(self.encoding())).into()
+                    AvmString::new(self.context.gc(), v.decode(self.encoding())).into()
                 }
                 SwfValue::Register(v) => self.current_register(v),
                 SwfValue::ConstantPool(i) => {
@@ -2023,7 +2023,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.set_scope(Scope::new_target_scope(
             self.scope(),
             clip_obj,
-            self.context.gc_context,
+            self.context.gc(),
         ));
         Ok(FrameControl::Continue)
     }
@@ -2101,7 +2101,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // TODO(Herschel): Result with non-string operands?
         let a = self.context.avm1.pop().coerce_to_string(self)?;
         let b = self.context.avm1.pop().coerce_to_string(self)?;
-        let s = AvmString::concat(self.context.gc_context, b, a);
+        let s = AvmString::concat(self.context.gc(), b, a);
         self.context.avm1.push(s.into());
         Ok(FrameControl::Continue)
     }
@@ -2135,7 +2135,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let result = &s[start.min(end)..end];
         self.context
             .avm1
-            .push(AvmString::new(self.context.gc_context, result).into());
+            .push(AvmString::new(self.context.gc(), result).into());
         Ok(FrameControl::Continue)
     }
 
@@ -2180,7 +2180,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let param = self.context.avm1.pop().coerce_to_object(self);
         let result = if let Some(display_object) = param.as_display_object() {
             let path = display_object.path();
-            AvmString::new(self.context.gc_context, path).into()
+            AvmString::new(self.context.gc(), path).into()
         } else {
             Value::Undefined
         };
@@ -2214,7 +2214,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.context.stage.set_quality(self.context, new_quality);
         self.context
             .stage
-            .set_use_bitmap_downsampling(self.context.gc_context, use_bitmap_downsamping);
+            .set_use_bitmap_downsampling(self.context.gc(), use_bitmap_downsamping);
         Ok(FrameControl::Continue)
     }
 
@@ -2277,7 +2277,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 match catch_vars {
                     CatchVar::Var(name) => {
                         let name = AvmString::new(
-                            activation.context.gc_context,
+                            activation.context.gc(),
                             name.decode(activation.encoding()),
                         );
                         activation.set_variable(name, value.to_owned())?
@@ -2400,7 +2400,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 // Note that primitives get boxed at this point.
                 let object = value.coerce_to_object(self);
                 let with_scope = Gc::new(
-                    self.context.gc_context,
+                    self.context.gc(),
                     Scope::new_with_scope(self.scope(), object),
                 );
                 let mut new_activation = self.with_new_scope("[With]", with_scope);
@@ -2676,7 +2676,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                             child.object()
                         }
                     } else {
-                        let name = AvmString::new(self.context.gc_context, name);
+                        let name = AvmString::new(self.context.gc(), name);
                         if path_has_slash {
                             object.get(name, self).unwrap()
                         } else {
@@ -2791,7 +2791,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                     true,
                     path_has_slash,
                 )? {
-                    let var_name = AvmString::new(self.context.gc_context, var_name);
+                    let var_name = AvmString::new(self.context.gc(), var_name);
                     if object.has_property(self, var_name) {
                         return Ok(CallableValue::Callable(object, object.get(var_name, self)?));
                     }
@@ -2877,7 +2877,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 if let Some(object) =
                     self.resolve_target_path(avm1_root, *scope.locals(), path, true, true)?
                 {
-                    let var_name = AvmString::new(self.context.gc_context, var_name);
+                    let var_name = AvmString::new(self.context.gc(), var_name);
                     object.set(var_name, value, self)?;
                     return Ok(());
                 }
@@ -2904,9 +2904,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             level
         } else {
             let level: DisplayObject<'_> =
-                MovieClip::new(self.base_clip().movie(), self.context.gc_context).into();
+                MovieClip::new(self.base_clip().movie(), self.context.gc()).into();
 
-            level.set_depth(self.context.gc_context, level_id);
+            level.set_depth(self.context.gc(), level_id);
             level.set_default_root_name(self.context);
             self.get_root_parent_container()
                 .and_then(|c| c.replace_at_depth(self.context, level, level_id));
@@ -2989,7 +2989,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     pub fn set_scope_to_display_object(&mut self, object: DisplayObject<'gc>) {
         self.scope = Gc::new(
-            self.context.gc_context,
+            self.context.gc(),
             Scope::new(
                 self.scope,
                 ScopeClass::Target,
@@ -3060,7 +3060,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     /// exists, it will be forcefully overwritten. Used internally to initialize objects.
     pub fn force_define_local(&mut self, name: AvmString<'gc>, value: Value<'gc>) {
         self.scope
-            .force_define_local(name, value, self.context.gc_context)
+            .force_define_local(name, value, self.context.gc())
     }
 
     /// Returns value of `this` as a reference.
@@ -3094,7 +3094,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     /// Set a local register.
     pub fn set_local_register(&mut self, id: u8, value: Value<'gc>) {
         if let Some(ref mut local_registers) = self.local_registers {
-            if let Some(r) = local_registers.write(self.context.gc_context).get_mut(id) {
+            if let Some(r) = local_registers.write(self.context.gc()).get_mut(id) {
                 *r = value;
             }
         }
@@ -3168,7 +3168,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.set_scope(Scope::new_target_scope(
             self.scope(),
             clip_obj,
-            self.context.gc_context,
+            self.context.gc(),
         ));
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm1/debug.rs
+++ b/core/src/avm1/debug.rs
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn dump_empty_object() {
         with_avm(19, |activation, _root| -> Result<(), Error> {
-            let object = ScriptObject::new(activation.context.gc_context, None);
+            let object = ScriptObject::new(activation.context.gc(), None);
             assert_eq!(
                 VariableDumper::dump(&object.into(), " ", activation),
                 "[object #0] {}"
@@ -274,8 +274,8 @@ mod tests {
     #[test]
     fn dump_object() {
         with_avm(19, |activation, _root| -> Result<(), Error> {
-            let object = ScriptObject::new(activation.context.gc_context, None);
-            let child = ScriptObject::new(activation.context.gc_context, None);
+            let object = ScriptObject::new(activation.context.gc(), None);
+            let child = ScriptObject::new(activation.context.gc(), None);
             object.set("self", object.into(), activation)?;
             object.set("test", "value".into(), activation)?;
             object.set("child", child.into(), activation)?;
@@ -292,8 +292,8 @@ mod tests {
     #[test]
     fn dump_variables() {
         with_avm(19, |activation, _root| -> Result<(), Error> {
-            let object = ScriptObject::new(activation.context.gc_context, None);
-            let child = ScriptObject::new(activation.context.gc_context, None);
+            let object = ScriptObject::new(activation.context.gc(), None);
+            let child = ScriptObject::new(activation.context.gc(), None);
             object.set("self", object.into(), activation)?;
             object.set("test", "value".into(), activation)?;
             object.set("child", child.into(), activation)?;

--- a/core/src/avm1/debug.rs
+++ b/core/src/avm1/debug.rs
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn dump_empty_object() {
         with_avm(19, |activation, _root| -> Result<(), Error> {
-            let object = ScriptObject::new(activation.context.gc(), None);
+            let object = ScriptObject::new(activation.gc(), None);
             assert_eq!(
                 VariableDumper::dump(&object.into(), " ", activation),
                 "[object #0] {}"
@@ -274,8 +274,8 @@ mod tests {
     #[test]
     fn dump_object() {
         with_avm(19, |activation, _root| -> Result<(), Error> {
-            let object = ScriptObject::new(activation.context.gc(), None);
-            let child = ScriptObject::new(activation.context.gc(), None);
+            let object = ScriptObject::new(activation.gc(), None);
+            let child = ScriptObject::new(activation.gc(), None);
             object.set("self", object.into(), activation)?;
             object.set("test", "value".into(), activation)?;
             object.set("child", child.into(), activation)?;
@@ -292,8 +292,8 @@ mod tests {
     #[test]
     fn dump_variables() {
         with_avm(19, |activation, _root| -> Result<(), Error> {
-            let object = ScriptObject::new(activation.context.gc(), None);
-            let child = ScriptObject::new(activation.context.gc(), None);
+            let object = ScriptObject::new(activation.gc(), None);
+            let child = ScriptObject::new(activation.gc(), None);
             object.set("self", object.into(), activation)?;
             object.set("test", "value".into(), activation)?;
             object.set("child", child.into(), activation)?;

--- a/core/src/avm1/flv.rs
+++ b/core/src/avm1/flv.rs
@@ -7,14 +7,14 @@ fn avm1_object_from_flv_variables<'gc>(
     variables: Vec<FlvVariable>,
 ) -> Avm1Value<'gc> {
     let object_proto = activation.context.avm1.prototypes().object;
-    let info_object = ScriptObject::new(activation.context.gc_context, Some(object_proto));
+    let info_object = ScriptObject::new(activation.context.gc(), Some(object_proto));
 
     for value in variables {
         let property_name = value.name;
 
         info_object
             .set(
-                AvmString::new_utf8_bytes(activation.context.gc_context, property_name),
+                AvmString::new_utf8_bytes(activation.context.gc(), property_name),
                 value.data.to_avm1_value(activation),
                 activation,
             )
@@ -40,7 +40,7 @@ fn avm1_array_from_flv_values<'gc>(
     values: Vec<FlvValue>,
 ) -> Avm1Value<'gc> {
     ArrayObject::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.avm1.prototypes().array,
         values.iter().map(|v| v.clone().to_avm1_value(activation)),
     )
@@ -59,7 +59,7 @@ impl<'gc> FlvValueAvm1Ext<'gc> for FlvValue<'_> {
             }
             FlvValue::StrictArray(values) => avm1_array_from_flv_values(activation, values),
             FlvValue::String(string_data) | FlvValue::LongString(string_data) => {
-                AvmString::new_utf8_bytes(activation.context.gc_context, string_data).into()
+                AvmString::new_utf8_bytes(activation.context.gc(), string_data).into()
             }
             FlvValue::Date {
                 unix_time,

--- a/core/src/avm1/flv.rs
+++ b/core/src/avm1/flv.rs
@@ -7,14 +7,14 @@ fn avm1_object_from_flv_variables<'gc>(
     variables: Vec<FlvVariable>,
 ) -> Avm1Value<'gc> {
     let object_proto = activation.context.avm1.prototypes().object;
-    let info_object = ScriptObject::new(activation.context.gc(), Some(object_proto));
+    let info_object = ScriptObject::new(activation.gc(), Some(object_proto));
 
     for value in variables {
         let property_name = value.name;
 
         info_object
             .set(
-                AvmString::new_utf8_bytes(activation.context.gc(), property_name),
+                AvmString::new_utf8_bytes(activation.gc(), property_name),
                 value.data.to_avm1_value(activation),
                 activation,
             )
@@ -40,7 +40,7 @@ fn avm1_array_from_flv_values<'gc>(
     values: Vec<FlvValue>,
 ) -> Avm1Value<'gc> {
     ArrayObject::new(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.avm1.prototypes().array,
         values.iter().map(|v| v.clone().to_avm1_value(activation)),
     )
@@ -59,7 +59,7 @@ impl<'gc> FlvValueAvm1Ext<'gc> for FlvValue<'_> {
             }
             FlvValue::StrictArray(values) => avm1_array_from_flv_values(activation, values),
             FlvValue::String(string_data) | FlvValue::LongString(string_data) => {
-                AvmString::new_utf8_bytes(activation.context.gc(), string_data).into()
+                AvmString::new_utf8_bytes(activation.gc(), string_data).into()
             }
             FlvValue::Date {
                 unix_time,

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -187,20 +187,20 @@ impl<'gc> Avm1Function<'gc> {
         }
 
         let arguments = ArrayObject::new(
-            frame.context.gc(),
+            frame.gc(),
             frame.context.avm1.prototypes().array,
             args.iter().cloned(),
         );
 
         arguments.define_value(
-            frame.context.gc(),
+            frame.gc(),
             "callee",
             frame.callee.unwrap().into(),
             Attribute::DONT_ENUM,
         );
 
         arguments.define_value(
-            frame.context.gc(),
+            frame.gc(),
             "caller",
             caller.map(Value::from).unwrap_or(Value::Null),
             Attribute::DONT_ENUM,
@@ -382,7 +382,7 @@ impl<'gc> Executable<'gc> {
             };
             // TODO: It would be nice to avoid these extra Scope allocs.
             let scope = Gc::new(
-                activation.context.gc(),
+                activation.gc(),
                 Scope::new(
                     activation.context.avm1.global_scope(),
                     super::scope::ScopeClass::Target,
@@ -393,8 +393,8 @@ impl<'gc> Executable<'gc> {
         };
 
         let child_scope = Gc::new(
-            activation.context.gc(),
-            Scope::new_local_scope(parent_scope, activation.context.gc()),
+            activation.gc(),
+            Scope::new_local_scope(parent_scope, activation.gc()),
         );
 
         // The caller is the previous callee.
@@ -427,7 +427,7 @@ impl<'gc> Executable<'gc> {
             Some(callee),
         );
 
-        frame.allocate_local_registers(af.register_count(), frame.context.gc());
+        frame.allocate_local_registers(af.register_count(), frame.gc());
 
         let mut preload_r = 1;
         af.load_this(&mut frame, this, &mut preload_r);
@@ -605,14 +605,14 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         args: &[Value<'gc>],
     ) -> Result<(), Error<'gc>> {
         this.define_value(
-            activation.context.gc(),
+            activation.gc(),
             "__constructor__",
             (*self).into(),
             Attribute::DONT_ENUM,
         );
         if activation.swf_version() < 7 {
             this.define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "constructor",
                 (*self).into(),
                 Attribute::DONT_ENUM,
@@ -654,14 +654,14 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         let this = prototype.create_bare_object(activation, prototype)?;
 
         this.define_value(
-            activation.context.gc(),
+            activation.gc(),
             "__constructor__",
             (*self).into(),
             Attribute::DONT_ENUM,
         );
         if activation.swf_version() < 7 {
             this.define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "constructor",
                 (*self).into(),
                 Attribute::DONT_ENUM,
@@ -703,9 +703,9 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         prototype: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(FunctionObject(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             FunctionObjectData {
-                base: ScriptObject::new(activation.context.gc(), Some(prototype)),
+                base: ScriptObject::new(activation.gc(), Some(prototype)),
                 function: None,
                 constructor: None,
             },

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -187,20 +187,20 @@ impl<'gc> Avm1Function<'gc> {
         }
 
         let arguments = ArrayObject::new(
-            frame.context.gc_context,
+            frame.context.gc(),
             frame.context.avm1.prototypes().array,
             args.iter().cloned(),
         );
 
         arguments.define_value(
-            frame.context.gc_context,
+            frame.context.gc(),
             "callee",
             frame.callee.unwrap().into(),
             Attribute::DONT_ENUM,
         );
 
         arguments.define_value(
-            frame.context.gc_context,
+            frame.context.gc(),
             "caller",
             caller.map(Value::from).unwrap_or(Value::Null),
             Attribute::DONT_ENUM,
@@ -382,7 +382,7 @@ impl<'gc> Executable<'gc> {
             };
             // TODO: It would be nice to avoid these extra Scope allocs.
             let scope = Gc::new(
-                activation.context.gc_context,
+                activation.context.gc(),
                 Scope::new(
                     activation.context.avm1.global_scope(),
                     super::scope::ScopeClass::Target,
@@ -393,8 +393,8 @@ impl<'gc> Executable<'gc> {
         };
 
         let child_scope = Gc::new(
-            activation.context.gc_context,
-            Scope::new_local_scope(parent_scope, activation.context.gc_context),
+            activation.context.gc(),
+            Scope::new_local_scope(parent_scope, activation.context.gc()),
         );
 
         // The caller is the previous callee.
@@ -427,7 +427,7 @@ impl<'gc> Executable<'gc> {
             Some(callee),
         );
 
-        frame.allocate_local_registers(af.register_count(), frame.context.gc_context);
+        frame.allocate_local_registers(af.register_count(), frame.context.gc());
 
         let mut preload_r = 1;
         af.load_this(&mut frame, this, &mut preload_r);
@@ -605,14 +605,14 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         args: &[Value<'gc>],
     ) -> Result<(), Error<'gc>> {
         this.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "__constructor__",
             (*self).into(),
             Attribute::DONT_ENUM,
         );
         if activation.swf_version() < 7 {
             this.define_value(
-                activation.context.gc_context,
+                activation.context.gc(),
                 "constructor",
                 (*self).into(),
                 Attribute::DONT_ENUM,
@@ -654,14 +654,14 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         let this = prototype.create_bare_object(activation, prototype)?;
 
         this.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "__constructor__",
             (*self).into(),
             Attribute::DONT_ENUM,
         );
         if activation.swf_version() < 7 {
             this.define_value(
-                activation.context.gc_context,
+                activation.context.gc(),
                 "constructor",
                 (*self).into(),
                 Attribute::DONT_ENUM,
@@ -703,9 +703,9 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         prototype: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(FunctionObject(GcCell::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             FunctionObjectData {
-                base: ScriptObject::new(activation.context.gc_context, Some(prototype)),
+                base: ScriptObject::new(activation.context.gc(), Some(prototype)),
                 function: None,
                 constructor: None,
             },

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -404,7 +404,7 @@ pub fn escape<'gc>(
             }
         };
     }
-    Ok(AvmString::new(activation.context.gc(), WString::from_buf(buffer)).into())
+    Ok(AvmString::new(activation.gc(), WString::from_buf(buffer)).into())
 }
 
 pub fn unescape<'gc>(
@@ -458,7 +458,7 @@ pub fn unescape<'gc>(
             }
         }
     }
-    Ok(AvmString::new_utf8(activation.context.gc(), String::from_utf8_lossy(&out_bytes)).into())
+    Ok(AvmString::new_utf8(activation.gc(), String::from_utf8_lossy(&out_bytes)).into())
 }
 
 /// This structure represents all system builtins that are used regardless of

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -404,7 +404,7 @@ pub fn escape<'gc>(
             }
         };
     }
-    Ok(AvmString::new(activation.context.gc_context, WString::from_buf(buffer)).into())
+    Ok(AvmString::new(activation.context.gc(), WString::from_buf(buffer)).into())
 }
 
 pub fn unescape<'gc>(
@@ -458,11 +458,7 @@ pub fn unescape<'gc>(
             }
         }
     }
-    Ok(AvmString::new_utf8(
-        activation.context.gc_context,
-        String::from_utf8_lossy(&out_bytes),
-    )
-    .into())
+    Ok(AvmString::new_utf8(activation.context.gc(), String::from_utf8_lossy(&out_bytes)).into())
 }
 
 /// This structure represents all system builtins that are used regardless of
@@ -523,7 +519,7 @@ pub fn create_globals<'gc>(
     Object<'gc>,
     as_broadcaster::BroadcasterFunctions<'gc>,
 ) {
-    let gc_context = context.gc_context;
+    let gc_context = context.gc();
 
     let object_proto = ScriptObject::new(gc_context, None).into();
     let function_proto = function::create_proto(context, object_proto);
@@ -854,7 +850,7 @@ pub fn create_globals<'gc>(
         Attribute::empty(),
     );
 
-    let bitmap_data_proto = ScriptObject::new(context.gc_context, Some(object_proto));
+    let bitmap_data_proto = ScriptObject::new(context.gc(), Some(object_proto));
     let bitmap_data = bitmap_data::create_constructor(context, bitmap_data_proto, function_proto);
 
     display.define_value(

--- a/core/src/avm1/globals/accessibility.rs
+++ b/core/src/avm1/globals/accessibility.rs
@@ -45,7 +45,7 @@ pub fn create_accessibility_object<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let accessibility = ScriptObject::new(context.gc_context, Some(proto));
+    let accessibility = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(OBJECT_DECLS, context, accessibility, fn_proto);
     accessibility.into()
 }

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -93,7 +93,7 @@ pub fn constructor<'gc>(
         Ok(array.into())
     } else {
         Ok(ArrayObject::new(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.avm1.prototypes().array,
             args.iter().cloned(),
         )
@@ -267,7 +267,7 @@ pub fn join<'gc>(
         .collect::<Result<Vec<_>, _>>()?;
 
     let joined = crate::string::join(&parts, &separator);
-    Ok(AvmString::new(activation.context.gc(), joined).into())
+    Ok(AvmString::new(activation.gc(), joined).into())
 }
 
 /// Handles an index parameter that may be positive (starting from beginning) or negaitve (starting from end).
@@ -302,7 +302,7 @@ pub fn slice<'gc>(
     };
 
     Ok(ArrayObject::new(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.avm1.prototypes().array,
         (start..end).map(|i| this.get_element(activation, i)),
     )
@@ -367,7 +367,7 @@ pub fn splice<'gc>(
     this.set_length(activation, length - delete_count + items.len() as i32)?;
 
     Ok(ArrayObject::new(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.avm1.prototypes().array,
         result_elements,
     )
@@ -402,7 +402,7 @@ pub fn concat<'gc>(
         }
     }
     Ok(ArrayObject::new(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.avm1.prototypes().array,
         elements,
     )
@@ -647,7 +647,7 @@ fn sort_internal<'gc>(
         // Array.RETURNINDEXEDARRAY returns an array containing the sorted indices, and does not modify
         // the original array.
         Ok(ArrayObject::new(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.avm1.prototypes().array,
             elements.into_iter().map(|(index, _)| index.into()),
         )

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -66,7 +66,7 @@ pub fn create_array_object<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let array = FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         Executable::Native(constructor),
         fn_proto,
@@ -93,7 +93,7 @@ pub fn constructor<'gc>(
         Ok(array.into())
     } else {
         Ok(ArrayObject::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.avm1.prototypes().array,
             args.iter().cloned(),
         )
@@ -267,7 +267,7 @@ pub fn join<'gc>(
         .collect::<Result<Vec<_>, _>>()?;
 
     let joined = crate::string::join(&parts, &separator);
-    Ok(AvmString::new(activation.context.gc_context, joined).into())
+    Ok(AvmString::new(activation.context.gc(), joined).into())
 }
 
 /// Handles an index parameter that may be positive (starting from beginning) or negaitve (starting from end).
@@ -302,7 +302,7 @@ pub fn slice<'gc>(
     };
 
     Ok(ArrayObject::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.avm1.prototypes().array,
         (start..end).map(|i| this.get_element(activation, i)),
     )
@@ -367,7 +367,7 @@ pub fn splice<'gc>(
     this.set_length(activation, length - delete_count + items.len() as i32)?;
 
     Ok(ArrayObject::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.avm1.prototypes().array,
         result_elements,
     )
@@ -402,7 +402,7 @@ pub fn concat<'gc>(
         }
     }
     Ok(ArrayObject::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.avm1.prototypes().array,
         elements,
     )
@@ -647,7 +647,7 @@ fn sort_internal<'gc>(
         // Array.RETURNINDEXEDARRAY returns an array containing the sorted indices, and does not modify
         // the original array.
         Ok(ArrayObject::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.avm1.prototypes().array,
             elements.into_iter().map(|(index, _)| index.into()),
         )
@@ -737,7 +737,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let array = ArrayObject::empty_with_proto(context.gc_context, proto);
+    let array = ArrayObject::empty_with_proto(context.gc(), proto);
     let object = array.raw_script_object();
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -22,7 +22,7 @@ pub fn create<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> (BroadcasterFunctions<'gc>, Object<'gc>) {
-    let gc_context = context.gc_context;
+    let gc_context = context.gc();
     let as_broadcaster_proto = ScriptObject::new(gc_context, Some(proto));
     let as_broadcaster = FunctionObject::constructor(
         gc_context,
@@ -187,7 +187,7 @@ fn initialize<'gc>(
     if let Some(val) = args.get(0) {
         let broadcaster = val.coerce_to_object(activation);
         initialize_internal(
-            activation.context.gc_context,
+            activation.context.gc(),
             broadcaster,
             activation.context.avm1.broadcaster_functions(),
             activation.context.avm1.prototypes().array,

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -187,7 +187,7 @@ fn initialize<'gc>(
     if let Some(val) = args.get(0) {
         let broadcaster = val.coerce_to_object(activation);
         initialize_internal(
-            activation.context.gc(),
+            activation.gc(),
             broadcaster,
             activation.context.avm1.broadcaster_functions(),
             activation.context.avm1.prototypes().array,

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -169,10 +169,7 @@ pub struct BevelFilter<'gc>(GcCell<'gc, BevelFilterData>);
 
 impl<'gc> BevelFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let bevel_filter = Self(GcCell::new(
-            activation.context.gc_context,
-            Default::default(),
-        ));
+        let bevel_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
         bevel_filter.set_distance(activation, args.get(0))?;
         bevel_filter.set_angle(activation, args.get(1))?;
         bevel_filter.set_highlight_color(activation, args.get(2))?;
@@ -207,7 +204,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let distance = value.coerce_to_f64(activation)?;
-            self.0.write(activation.context.gc_context).distance = distance;
+            self.0.write(activation.context.gc()).distance = distance;
         }
         Ok(())
     }
@@ -223,7 +220,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let angle = (value.coerce_to_f64(activation)? % 360.0).to_radians();
-            self.0.write(activation.context.gc_context).angle = angle;
+            self.0.write(activation.context.gc()).angle = angle;
         }
         Ok(())
     }
@@ -239,7 +236,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc_context);
+            let mut write = self.0.write(activation.context.gc());
             write.highlight = Color::from_rgb(value, write.highlight.a);
         }
         Ok(())
@@ -256,7 +253,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.0.write(activation.context.gc_context).highlight.a = alpha;
+            self.0.write(activation.context.gc()).highlight.a = alpha;
         }
         Ok(())
     }
@@ -272,7 +269,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc_context);
+            let mut write = self.0.write(activation.context.gc());
             write.shadow = Color::from_rgb(value, write.shadow.a);
         }
         Ok(())
@@ -289,7 +286,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.0.write(activation.context.gc_context).shadow.a = alpha;
+            self.0.write(activation.context.gc()).shadow.a = alpha;
         }
         Ok(())
     }
@@ -305,7 +302,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.context.gc_context).quality = quality;
+            self.0.write(activation.context.gc()).quality = quality;
         }
         Ok(())
     }
@@ -321,7 +318,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             self.0
-                .write(activation.context.gc_context)
+                .write(activation.context.gc())
                 .set_strength(value.coerce_to_f64(activation)?);
         }
         Ok(())
@@ -338,7 +335,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc_context).knockout = knockout;
+            self.0.write(activation.context.gc()).knockout = knockout;
         }
         Ok(())
     }
@@ -354,7 +351,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc_context).blur_x = blur_x;
+            self.0.write(activation.context.gc()).blur_x = blur_x;
         }
         Ok(())
     }
@@ -370,7 +367,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc_context).blur_y = blur_y;
+            self.0.write(activation.context.gc()).blur_y = blur_y;
         }
         Ok(())
     }
@@ -386,7 +383,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let type_ = value.coerce_to_string(activation)?.as_wstr().into();
-            self.0.write(activation.context.gc_context).type_ = type_;
+            self.0.write(activation.context.gc()).type_ = type_;
         }
         Ok(())
     }
@@ -452,7 +449,7 @@ fn method<'gc>(
     if index == CONSTRUCTOR {
         let bevel_filter = BevelFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc_context,
+            activation.context.gc(),
             NativeObject::BevelFilter(bevel_filter),
         );
         return Ok(this.into());
@@ -536,7 +533,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let bevel_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let bevel_filter_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, bevel_filter_proto, fn_proto);
     bevel_filter_proto.into()
 }
@@ -547,7 +544,7 @@ pub fn create_constructor<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(bevel_filter_method!(0)),
         constructor_to_fn!(bevel_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -169,7 +169,7 @@ pub struct BevelFilter<'gc>(GcCell<'gc, BevelFilterData>);
 
 impl<'gc> BevelFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let bevel_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
+        let bevel_filter = Self(GcCell::new(activation.gc(), Default::default()));
         bevel_filter.set_distance(activation, args.get(0))?;
         bevel_filter.set_angle(activation, args.get(1))?;
         bevel_filter.set_highlight_color(activation, args.get(2))?;
@@ -204,7 +204,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let distance = value.coerce_to_f64(activation)?;
-            self.0.write(activation.context.gc()).distance = distance;
+            self.0.write(activation.gc()).distance = distance;
         }
         Ok(())
     }
@@ -220,7 +220,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let angle = (value.coerce_to_f64(activation)? % 360.0).to_radians();
-            self.0.write(activation.context.gc()).angle = angle;
+            self.0.write(activation.gc()).angle = angle;
         }
         Ok(())
     }
@@ -236,7 +236,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc());
+            let mut write = self.0.write(activation.gc());
             write.highlight = Color::from_rgb(value, write.highlight.a);
         }
         Ok(())
@@ -253,7 +253,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.0.write(activation.context.gc()).highlight.a = alpha;
+            self.0.write(activation.gc()).highlight.a = alpha;
         }
         Ok(())
     }
@@ -269,7 +269,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc());
+            let mut write = self.0.write(activation.gc());
             write.shadow = Color::from_rgb(value, write.shadow.a);
         }
         Ok(())
@@ -286,7 +286,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.0.write(activation.context.gc()).shadow.a = alpha;
+            self.0.write(activation.gc()).shadow.a = alpha;
         }
         Ok(())
     }
@@ -302,7 +302,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.context.gc()).quality = quality;
+            self.0.write(activation.gc()).quality = quality;
         }
         Ok(())
     }
@@ -318,7 +318,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             self.0
-                .write(activation.context.gc())
+                .write(activation.gc())
                 .set_strength(value.coerce_to_f64(activation)?);
         }
         Ok(())
@@ -335,7 +335,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc()).knockout = knockout;
+            self.0.write(activation.gc()).knockout = knockout;
         }
         Ok(())
     }
@@ -351,7 +351,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_x = blur_x;
+            self.0.write(activation.gc()).blur_x = blur_x;
         }
         Ok(())
     }
@@ -367,7 +367,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_y = blur_y;
+            self.0.write(activation.gc()).blur_y = blur_y;
         }
         Ok(())
     }
@@ -383,7 +383,7 @@ impl<'gc> BevelFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let type_ = value.coerce_to_string(activation)?.as_wstr().into();
-            self.0.write(activation.context.gc()).type_ = type_;
+            self.0.write(activation.gc()).type_ = type_;
         }
         Ok(())
     }
@@ -448,10 +448,7 @@ fn method<'gc>(
 
     if index == CONSTRUCTOR {
         let bevel_filter = BevelFilter::new(activation, args)?;
-        this.set_native(
-            activation.context.gc(),
-            NativeObject::BevelFilter(bevel_filter),
-        );
+        this.set_native(activation.gc(), NativeObject::BevelFilter(bevel_filter));
         return Ok(this.into());
     }
 

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -105,9 +105,9 @@ fn constructor<'gc>(
 
     let bitmap_data = BitmapData::new(width, height, transparency, fill_color);
     this.set_native(
-        activation.context.gc(),
+        activation.gc(),
         NativeObject::BitmapData(BitmapDataWrapper::new(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             bitmap_data,
         ))),
     );
@@ -237,7 +237,7 @@ fn set_pixel<'gc>(
                 let color = color_val.coerce_to_u32(activation)?;
 
                 operations::set_pixel(
-                    activation.context.gc(),
+                    activation.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x,
@@ -268,7 +268,7 @@ fn set_pixel32<'gc>(
                 let color = color_val.coerce_to_u32(activation)?;
 
                 operations::set_pixel32(
-                    activation.context.gc(),
+                    activation.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x,
@@ -335,7 +335,7 @@ fn copy_channel<'gc>(
                     .coerce_to_i32(activation)?;
 
                 operations::copy_channel(
-                    activation.context.gc(),
+                    activation.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     (min_x, min_y),
@@ -378,7 +378,7 @@ fn fill_rect<'gc>(
                     .coerce_to_i32(activation)?;
 
                 operations::fill_rect(
-                    activation.context.gc(),
+                    activation.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x,
@@ -403,7 +403,7 @@ fn clone<'gc>(
     if let NativeObject::BitmapData(bitmap_data) = this.native() {
         if !bitmap_data.disposed() {
             return Ok(new_bitmap_data(
-                activation.context.gc(),
+                activation.gc(),
                 this.get_local_stored("__proto__", activation, false),
                 bitmap_data.clone_data(activation.context.renderer),
             )
@@ -421,7 +421,7 @@ fn dispose<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::BitmapData(bitmap_data) = this.native() {
         if !bitmap_data.disposed() {
-            bitmap_data.dispose(activation.context.gc());
+            bitmap_data.dispose(activation.gc());
             return Ok(Value::Undefined);
         }
     }
@@ -444,7 +444,7 @@ fn flood_fill<'gc>(
                 let color = color_val.coerce_to_u32(activation)?;
 
                 operations::flood_fill(
-                    activation.context.gc(),
+                    activation.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x,
@@ -487,7 +487,7 @@ fn noise<'gc>(
             if let Some(random_seed_val) = args.get(0) {
                 let random_seed = random_seed_val.coerce_to_i32(activation)?;
                 operations::noise(
-                    activation.context.gc(),
+                    activation.gc(),
                     bitmap_data,
                     random_seed,
                     low,
@@ -705,7 +705,7 @@ fn color_transform<'gc>(
                 };
 
                 operations::color_transform(
-                    activation.context.gc(),
+                    activation.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x_min,
@@ -815,7 +815,7 @@ fn perlin_noise<'gc>(
             let octave_offsets = octave_offsets?;
 
             operations::perlin_noise(
-                activation.context.gc(),
+                activation.gc(),
                 bitmap_data,
                 (base_x, base_y),
                 num_octaves,
@@ -1121,7 +1121,7 @@ fn merge<'gc>(
             if let NativeObject::BitmapData(src_bitmap) = source_bitmap.native() {
                 if !src_bitmap.disposed() {
                     operations::merge(
-                        activation.context.gc(),
+                        activation.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap,
@@ -1201,7 +1201,7 @@ fn palette_map<'gc>(
             if let NativeObject::BitmapData(src_bitmap) = source_bitmap.native() {
                 if !src_bitmap.disposed() {
                     operations::palette_map(
-                        activation.context.gc(),
+                        activation.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap,
@@ -1279,7 +1279,7 @@ fn pixel_dissolve<'gc>(
                     };
 
                     return Ok(operations::pixel_dissolve(
-                        activation.context.gc(),
+                        activation.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap_data,
@@ -1315,7 +1315,7 @@ fn scroll<'gc>(
                 .coerce_to_i32(activation)?;
 
             operations::scroll(
-                activation.context.gc(),
+                activation.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 x,
@@ -1397,7 +1397,7 @@ fn threshold<'gc>(
             if let NativeObject::BitmapData(src_bitmap) = source_bitmap.native() {
                 if !src_bitmap.disposed() {
                     let modified_count = operations::threshold(
-                        activation.context.gc(),
+                        activation.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap,
@@ -1469,7 +1469,7 @@ fn compare<'gc>(
         other_bitmap_data,
     ) {
         Some(bitmap_data) => Ok(new_bitmap_data(
-            activation.context.gc(),
+            activation.gc(),
             this.get_local_stored("__proto__", activation, false),
             bitmap_data,
         )
@@ -1514,7 +1514,7 @@ fn load_bitmap<'gc>(
             .collect(),
     );
     Ok(new_bitmap_data(
-        activation.context.gc(),
+        activation.gc(),
         this.get_local_stored("prototype", activation, false),
         bitmap_data,
     )

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -105,9 +105,9 @@ fn constructor<'gc>(
 
     let bitmap_data = BitmapData::new(width, height, transparency, fill_color);
     this.set_native(
-        activation.context.gc_context,
+        activation.context.gc(),
         NativeObject::BitmapData(BitmapDataWrapper::new(GcCell::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             bitmap_data,
         ))),
     );
@@ -237,7 +237,7 @@ fn set_pixel<'gc>(
                 let color = color_val.coerce_to_u32(activation)?;
 
                 operations::set_pixel(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x,
@@ -268,7 +268,7 @@ fn set_pixel32<'gc>(
                 let color = color_val.coerce_to_u32(activation)?;
 
                 operations::set_pixel32(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x,
@@ -335,7 +335,7 @@ fn copy_channel<'gc>(
                     .coerce_to_i32(activation)?;
 
                 operations::copy_channel(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     (min_x, min_y),
@@ -378,7 +378,7 @@ fn fill_rect<'gc>(
                     .coerce_to_i32(activation)?;
 
                 operations::fill_rect(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x,
@@ -403,7 +403,7 @@ fn clone<'gc>(
     if let NativeObject::BitmapData(bitmap_data) = this.native() {
         if !bitmap_data.disposed() {
             return Ok(new_bitmap_data(
-                activation.context.gc_context,
+                activation.context.gc(),
                 this.get_local_stored("__proto__", activation, false),
                 bitmap_data.clone_data(activation.context.renderer),
             )
@@ -421,7 +421,7 @@ fn dispose<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::BitmapData(bitmap_data) = this.native() {
         if !bitmap_data.disposed() {
-            bitmap_data.dispose(activation.context.gc_context);
+            bitmap_data.dispose(activation.context.gc());
             return Ok(Value::Undefined);
         }
     }
@@ -444,7 +444,7 @@ fn flood_fill<'gc>(
                 let color = color_val.coerce_to_u32(activation)?;
 
                 operations::flood_fill(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x,
@@ -487,7 +487,7 @@ fn noise<'gc>(
             if let Some(random_seed_val) = args.get(0) {
                 let random_seed = random_seed_val.coerce_to_i32(activation)?;
                 operations::noise(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     bitmap_data,
                     random_seed,
                     low,
@@ -705,7 +705,7 @@ fn color_transform<'gc>(
                 };
 
                 operations::color_transform(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     x_min,
@@ -815,7 +815,7 @@ fn perlin_noise<'gc>(
             let octave_offsets = octave_offsets?;
 
             operations::perlin_noise(
-                activation.context.gc_context,
+                activation.context.gc(),
                 bitmap_data,
                 (base_x, base_y),
                 num_octaves,
@@ -1121,7 +1121,7 @@ fn merge<'gc>(
             if let NativeObject::BitmapData(src_bitmap) = source_bitmap.native() {
                 if !src_bitmap.disposed() {
                     operations::merge(
-                        activation.context.gc_context,
+                        activation.context.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap,
@@ -1201,7 +1201,7 @@ fn palette_map<'gc>(
             if let NativeObject::BitmapData(src_bitmap) = source_bitmap.native() {
                 if !src_bitmap.disposed() {
                     operations::palette_map(
-                        activation.context.gc_context,
+                        activation.context.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap,
@@ -1279,7 +1279,7 @@ fn pixel_dissolve<'gc>(
                     };
 
                     return Ok(operations::pixel_dissolve(
-                        activation.context.gc_context,
+                        activation.context.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap_data,
@@ -1315,7 +1315,7 @@ fn scroll<'gc>(
                 .coerce_to_i32(activation)?;
 
             operations::scroll(
-                activation.context.gc_context,
+                activation.context.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 x,
@@ -1397,7 +1397,7 @@ fn threshold<'gc>(
             if let NativeObject::BitmapData(src_bitmap) = source_bitmap.native() {
                 if !src_bitmap.disposed() {
                     let modified_count = operations::threshold(
-                        activation.context.gc_context,
+                        activation.context.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap,
@@ -1469,7 +1469,7 @@ fn compare<'gc>(
         other_bitmap_data,
     ) {
         Some(bitmap_data) => Ok(new_bitmap_data(
-            activation.context.gc_context,
+            activation.context.gc(),
             this.get_local_stored("__proto__", activation, false),
             bitmap_data,
         )
@@ -1514,7 +1514,7 @@ fn load_bitmap<'gc>(
             .collect(),
     );
     Ok(new_bitmap_data(
-        activation.context.gc_context,
+        activation.context.gc(),
         this.get_local_stored("prototype", activation, false),
         bitmap_data,
     )
@@ -1529,7 +1529,7 @@ pub fn create_constructor<'gc>(
     define_properties_on(PROTO_DECLS, context, proto, fn_proto);
 
     let bitmap_data_constructor = FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -36,36 +36,32 @@ pub fn clone<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let native = match this.native() {
         NativeObject::BlurFilter(blur_filter) => {
-            NativeObject::BlurFilter(blur_filter.duplicate(activation.context.gc()))
+            NativeObject::BlurFilter(blur_filter.duplicate(activation.gc()))
         }
         NativeObject::BevelFilter(bevel_filter) => {
-            NativeObject::BevelFilter(bevel_filter.duplicate(activation.context.gc()))
+            NativeObject::BevelFilter(bevel_filter.duplicate(activation.gc()))
         }
         NativeObject::GlowFilter(glow_filter) => {
-            NativeObject::GlowFilter(glow_filter.duplicate(activation.context.gc()))
+            NativeObject::GlowFilter(glow_filter.duplicate(activation.gc()))
         }
         NativeObject::DropShadowFilter(drop_shadow_filter) => {
-            NativeObject::DropShadowFilter(drop_shadow_filter.duplicate(activation.context.gc()))
+            NativeObject::DropShadowFilter(drop_shadow_filter.duplicate(activation.gc()))
         }
         NativeObject::ColorMatrixFilter(color_matrix_filter) => {
-            NativeObject::ColorMatrixFilter(color_matrix_filter.duplicate(activation.context.gc()))
+            NativeObject::ColorMatrixFilter(color_matrix_filter.duplicate(activation.gc()))
         }
         NativeObject::DisplacementMapFilter(displacement_map_filter) => {
-            NativeObject::DisplacementMapFilter(
-                displacement_map_filter.duplicate(activation.context.gc()),
-            )
+            NativeObject::DisplacementMapFilter(displacement_map_filter.duplicate(activation.gc()))
         }
         NativeObject::ConvolutionFilter(convolution_filter) => {
-            NativeObject::ConvolutionFilter(convolution_filter.duplicate(activation.context.gc()))
+            NativeObject::ConvolutionFilter(convolution_filter.duplicate(activation.gc()))
         }
         NativeObject::GradientBevelFilter(gradient_bevel_filter) => {
-            NativeObject::GradientBevelFilter(
-                gradient_bevel_filter.duplicate(activation.context.gc()),
-            )
+            NativeObject::GradientBevelFilter(gradient_bevel_filter.duplicate(activation.gc()))
         }
-        NativeObject::GradientGlowFilter(gradient_glow_filter) => NativeObject::GradientGlowFilter(
-            gradient_glow_filter.duplicate(activation.context.gc()),
-        ),
+        NativeObject::GradientGlowFilter(gradient_glow_filter) => {
+            NativeObject::GradientGlowFilter(gradient_glow_filter.duplicate(activation.gc()))
+        }
         _ => return Ok(Value::Undefined),
     };
     let proto = this.get_local_stored("__proto__", activation, false);
@@ -102,57 +98,48 @@ pub fn avm1_to_filter<'gc>(
 pub fn filter_to_avm1<'gc>(activation: &mut Activation<'_, 'gc>, filter: Filter) -> Value<'gc> {
     let (native, proto) = match filter {
         Filter::BevelFilter(filter) => (
-            NativeObject::BevelFilter(BevelFilter::from_filter(activation.context.gc(), filter)),
+            NativeObject::BevelFilter(BevelFilter::from_filter(activation.gc(), filter)),
             activation.context.avm1.prototypes().bevel_filter,
         ),
         Filter::BlurFilter(filter) => (
-            NativeObject::BlurFilter(BlurFilter::from_filter(activation.context.gc(), filter)),
+            NativeObject::BlurFilter(BlurFilter::from_filter(activation.gc(), filter)),
             activation.context.avm1.prototypes().blur_filter,
         ),
         Filter::ColorMatrixFilter(filter) => (
             NativeObject::ColorMatrixFilter(ColorMatrixFilter::from_filter(
-                activation.context.gc(),
+                activation.gc(),
                 filter,
             )),
             activation.context.avm1.prototypes().color_matrix_filter,
         ),
         Filter::ConvolutionFilter(filter) => (
             NativeObject::ConvolutionFilter(ConvolutionFilter::from_filter(
-                activation.context.gc(),
+                activation.gc(),
                 filter,
             )),
             activation.context.avm1.prototypes().convolution_filter,
         ),
         Filter::GlowFilter(filter) => (
-            NativeObject::GlowFilter(GlowFilter::from_filter(activation.context.gc(), filter)),
+            NativeObject::GlowFilter(GlowFilter::from_filter(activation.gc(), filter)),
             activation.context.avm1.prototypes().glow_filter,
         ),
         Filter::DropShadowFilter(filter) => (
-            NativeObject::DropShadowFilter(DropShadowFilter::from_filter(
-                activation.context.gc(),
-                filter,
-            )),
+            NativeObject::DropShadowFilter(DropShadowFilter::from_filter(activation.gc(), filter)),
             activation.context.avm1.prototypes().drop_shadow_filter,
         ),
         Filter::DisplacementMapFilter(filter) => (
             NativeObject::DisplacementMapFilter(DisplacementMapFilter::from_filter(
-                activation.context.gc(),
+                activation.gc(),
                 filter,
             )),
             activation.context.avm1.prototypes().displacement_map_filter,
         ),
         Filter::GradientBevelFilter(filter) => (
-            NativeObject::GradientBevelFilter(GradientFilter::from_filter(
-                activation.context.gc(),
-                filter,
-            )),
+            NativeObject::GradientBevelFilter(GradientFilter::from_filter(activation.gc(), filter)),
             activation.context.avm1.prototypes().gradient_bevel_filter,
         ),
         Filter::GradientGlowFilter(filter) => (
-            NativeObject::GradientGlowFilter(GradientFilter::from_filter(
-                activation.context.gc(),
-                filter,
-            )),
+            NativeObject::GradientGlowFilter(GradientFilter::from_filter(activation.gc(), filter)),
             activation.context.avm1.prototypes().gradient_glow_filter,
         ),
         Filter::ShaderFilter(_) => {
@@ -170,18 +157,18 @@ pub fn create_instance<'gc>(
     native: NativeObject<'gc>,
     proto: Option<Value<'gc>>,
 ) -> ScriptObject<'gc> {
-    let result = ScriptObject::new(activation.context.gc(), None);
+    let result = ScriptObject::new(activation.gc(), None);
     // Set `__proto__` manually since `ScriptObject::new()` doesn't support primitive prototypes.
     // TODO: Pass `proto` to `ScriptObject::new()` once possible.
     if let Some(proto) = proto {
         result.define_value(
-            activation.context.gc(),
+            activation.gc(),
             "__proto__",
             proto,
             Attribute::DONT_ENUM | Attribute::DONT_DELETE,
         );
     }
-    result.set_native(activation.context.gc(), native);
+    result.set_native(activation.gc(), native);
     result
 }
 

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -36,35 +36,35 @@ pub fn clone<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let native = match this.native() {
         NativeObject::BlurFilter(blur_filter) => {
-            NativeObject::BlurFilter(blur_filter.duplicate(activation.context.gc_context))
+            NativeObject::BlurFilter(blur_filter.duplicate(activation.context.gc()))
         }
         NativeObject::BevelFilter(bevel_filter) => {
-            NativeObject::BevelFilter(bevel_filter.duplicate(activation.context.gc_context))
+            NativeObject::BevelFilter(bevel_filter.duplicate(activation.context.gc()))
         }
         NativeObject::GlowFilter(glow_filter) => {
-            NativeObject::GlowFilter(glow_filter.duplicate(activation.context.gc_context))
+            NativeObject::GlowFilter(glow_filter.duplicate(activation.context.gc()))
         }
-        NativeObject::DropShadowFilter(drop_shadow_filter) => NativeObject::DropShadowFilter(
-            drop_shadow_filter.duplicate(activation.context.gc_context),
-        ),
-        NativeObject::ColorMatrixFilter(color_matrix_filter) => NativeObject::ColorMatrixFilter(
-            color_matrix_filter.duplicate(activation.context.gc_context),
-        ),
+        NativeObject::DropShadowFilter(drop_shadow_filter) => {
+            NativeObject::DropShadowFilter(drop_shadow_filter.duplicate(activation.context.gc()))
+        }
+        NativeObject::ColorMatrixFilter(color_matrix_filter) => {
+            NativeObject::ColorMatrixFilter(color_matrix_filter.duplicate(activation.context.gc()))
+        }
         NativeObject::DisplacementMapFilter(displacement_map_filter) => {
             NativeObject::DisplacementMapFilter(
-                displacement_map_filter.duplicate(activation.context.gc_context),
+                displacement_map_filter.duplicate(activation.context.gc()),
             )
         }
-        NativeObject::ConvolutionFilter(convolution_filter) => NativeObject::ConvolutionFilter(
-            convolution_filter.duplicate(activation.context.gc_context),
-        ),
+        NativeObject::ConvolutionFilter(convolution_filter) => {
+            NativeObject::ConvolutionFilter(convolution_filter.duplicate(activation.context.gc()))
+        }
         NativeObject::GradientBevelFilter(gradient_bevel_filter) => {
             NativeObject::GradientBevelFilter(
-                gradient_bevel_filter.duplicate(activation.context.gc_context),
+                gradient_bevel_filter.duplicate(activation.context.gc()),
             )
         }
         NativeObject::GradientGlowFilter(gradient_glow_filter) => NativeObject::GradientGlowFilter(
-            gradient_glow_filter.duplicate(activation.context.gc_context),
+            gradient_glow_filter.duplicate(activation.context.gc()),
         ),
         _ => return Ok(Value::Undefined),
     };
@@ -102,64 +102,55 @@ pub fn avm1_to_filter<'gc>(
 pub fn filter_to_avm1<'gc>(activation: &mut Activation<'_, 'gc>, filter: Filter) -> Value<'gc> {
     let (native, proto) = match filter {
         Filter::BevelFilter(filter) => (
-            NativeObject::BevelFilter(BevelFilter::from_filter(
-                activation.context.gc_context,
-                filter,
-            )),
+            NativeObject::BevelFilter(BevelFilter::from_filter(activation.context.gc(), filter)),
             activation.context.avm1.prototypes().bevel_filter,
         ),
         Filter::BlurFilter(filter) => (
-            NativeObject::BlurFilter(BlurFilter::from_filter(
-                activation.context.gc_context,
-                filter,
-            )),
+            NativeObject::BlurFilter(BlurFilter::from_filter(activation.context.gc(), filter)),
             activation.context.avm1.prototypes().blur_filter,
         ),
         Filter::ColorMatrixFilter(filter) => (
             NativeObject::ColorMatrixFilter(ColorMatrixFilter::from_filter(
-                activation.context.gc_context,
+                activation.context.gc(),
                 filter,
             )),
             activation.context.avm1.prototypes().color_matrix_filter,
         ),
         Filter::ConvolutionFilter(filter) => (
             NativeObject::ConvolutionFilter(ConvolutionFilter::from_filter(
-                activation.context.gc_context,
+                activation.context.gc(),
                 filter,
             )),
             activation.context.avm1.prototypes().convolution_filter,
         ),
         Filter::GlowFilter(filter) => (
-            NativeObject::GlowFilter(GlowFilter::from_filter(
-                activation.context.gc_context,
-                filter,
-            )),
+            NativeObject::GlowFilter(GlowFilter::from_filter(activation.context.gc(), filter)),
             activation.context.avm1.prototypes().glow_filter,
         ),
         Filter::DropShadowFilter(filter) => (
             NativeObject::DropShadowFilter(DropShadowFilter::from_filter(
-                activation.context.gc_context,
+                activation.context.gc(),
                 filter,
             )),
             activation.context.avm1.prototypes().drop_shadow_filter,
         ),
         Filter::DisplacementMapFilter(filter) => (
             NativeObject::DisplacementMapFilter(DisplacementMapFilter::from_filter(
-                activation.context.gc_context,
+                activation.context.gc(),
                 filter,
             )),
             activation.context.avm1.prototypes().displacement_map_filter,
         ),
         Filter::GradientBevelFilter(filter) => (
             NativeObject::GradientBevelFilter(GradientFilter::from_filter(
-                activation.context.gc_context,
+                activation.context.gc(),
                 filter,
             )),
             activation.context.avm1.prototypes().gradient_bevel_filter,
         ),
         Filter::GradientGlowFilter(filter) => (
             NativeObject::GradientGlowFilter(GradientFilter::from_filter(
-                activation.context.gc_context,
+                activation.context.gc(),
                 filter,
             )),
             activation.context.avm1.prototypes().gradient_glow_filter,
@@ -179,18 +170,18 @@ pub fn create_instance<'gc>(
     native: NativeObject<'gc>,
     proto: Option<Value<'gc>>,
 ) -> ScriptObject<'gc> {
-    let result = ScriptObject::new(activation.context.gc_context, None);
+    let result = ScriptObject::new(activation.context.gc(), None);
     // Set `__proto__` manually since `ScriptObject::new()` doesn't support primitive prototypes.
     // TODO: Pass `proto` to `ScriptObject::new()` once possible.
     if let Some(proto) = proto {
         result.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "__proto__",
             proto,
             Attribute::DONT_ENUM | Attribute::DONT_DELETE,
         );
     }
-    result.set_native(activation.context.gc_context, native);
+    result.set_native(activation.context.gc(), native);
     result
 }
 
@@ -199,7 +190,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -54,10 +54,7 @@ pub struct BlurFilter<'gc>(GcCell<'gc, BlurFilterData>);
 
 impl<'gc> BlurFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let blur_filter = Self(GcCell::new(
-            activation.context.gc_context,
-            Default::default(),
-        ));
+        let blur_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
         blur_filter.set_blur_x(activation, args.get(0))?;
         blur_filter.set_blur_y(activation, args.get(1))?;
         blur_filter.set_quality(activation, args.get(2))?;
@@ -83,7 +80,7 @@ impl<'gc> BlurFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc_context).blur_x = blur_x;
+            self.0.write(activation.context.gc()).blur_x = blur_x;
         }
         Ok(())
     }
@@ -99,7 +96,7 @@ impl<'gc> BlurFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc_context).blur_y = blur_y;
+            self.0.write(activation.context.gc()).blur_y = blur_y;
         }
         Ok(())
     }
@@ -115,7 +112,7 @@ impl<'gc> BlurFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.context.gc_context).quality = quality;
+            self.0.write(activation.context.gc()).quality = quality;
         }
         Ok(())
     }
@@ -154,7 +151,7 @@ fn method<'gc>(
     if index == CONSTRUCTOR {
         let blur_filter = BlurFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc_context,
+            activation.context.gc(),
             NativeObject::BlurFilter(blur_filter),
         );
         return Ok(this.into());
@@ -190,7 +187,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let blur_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let blur_filter_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, blur_filter_proto, fn_proto);
     blur_filter_proto.into()
 }
@@ -201,7 +198,7 @@ pub fn create_constructor<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(blur_filter_method!(0)),
         constructor_to_fn!(blur_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -54,7 +54,7 @@ pub struct BlurFilter<'gc>(GcCell<'gc, BlurFilterData>);
 
 impl<'gc> BlurFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let blur_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
+        let blur_filter = Self(GcCell::new(activation.gc(), Default::default()));
         blur_filter.set_blur_x(activation, args.get(0))?;
         blur_filter.set_blur_y(activation, args.get(1))?;
         blur_filter.set_quality(activation, args.get(2))?;
@@ -80,7 +80,7 @@ impl<'gc> BlurFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_x = blur_x;
+            self.0.write(activation.gc()).blur_x = blur_x;
         }
         Ok(())
     }
@@ -96,7 +96,7 @@ impl<'gc> BlurFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_y = blur_y;
+            self.0.write(activation.gc()).blur_y = blur_y;
         }
         Ok(())
     }
@@ -112,7 +112,7 @@ impl<'gc> BlurFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.context.gc()).quality = quality;
+            self.0.write(activation.gc()).quality = quality;
         }
         Ok(())
     }
@@ -150,10 +150,7 @@ fn method<'gc>(
 
     if index == CONSTRUCTOR {
         let blur_filter = BlurFilter::new(activation, args)?;
-        this.set_native(
-            activation.context.gc(),
-            NativeObject::BlurFilter(blur_filter),
-        );
+        this.set_native(activation.gc(), NativeObject::BlurFilter(blur_filter));
         return Ok(this.into());
     }
 

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -50,7 +50,7 @@ pub fn create_boolean_object<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         Executable::Native(boolean_function),
         fn_proto,
@@ -78,7 +78,7 @@ pub fn to_string<'gc>(
         // Must be a bool.
         // Boolean.prototype.toString.call(x) returns undefined for non-bools.
         if let Value::Bool(b) = *vbox {
-            return Ok(AvmString::new_utf8(activation.context.gc_context, b.to_string()).into());
+            return Ok(AvmString::new_utf8(activation.context.gc(), b.to_string()).into());
         }
     }
 

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -78,7 +78,7 @@ pub fn to_string<'gc>(
         // Must be a bool.
         // Boolean.prototype.toString.call(x) returns undefined for non-bools.
         if let Value::Bool(b) = *vbox {
-            return Ok(AvmString::new_utf8(activation.context.gc(), b.to_string()).into());
+            return Ok(AvmString::new_utf8(activation.gc(), b.to_string()).into());
         }
     }
 

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -55,7 +55,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
@@ -73,7 +73,7 @@ fn blend_mode<'gc>(
     this: Avm1Button<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mode = AvmString::new_utf8(activation.context.gc_context, this.blend_mode().to_string());
+    let mode = AvmString::new_utf8(activation.context.gc(), this.blend_mode().to_string());
     Ok(mode.into())
 }
 
@@ -84,7 +84,7 @@ fn set_blend_mode<'gc>(
 ) -> Result<(), Error<'gc>> {
     // No-op if value is not a valid blend mode.
     if let Some(mode) = value.as_blend_mode() {
-        this.set_blend_mode(activation.context.gc_context, mode.into());
+        this.set_blend_mode(activation.context.gc(), mode.into());
     } else {
         tracing::error!("Unknown blend mode {value:?}");
     }
@@ -96,7 +96,7 @@ fn filters<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(ArrayObject::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.avm1.prototypes().array,
         this.filters()
             .into_iter()
@@ -119,7 +119,7 @@ fn set_filters<'gc>(
             }
         }
     }
-    this.set_filters(activation.context.gc_context, filters);
+    this.set_filters(activation.context.gc(), filters);
     Ok(())
 }
 
@@ -138,7 +138,7 @@ fn set_cache_as_bitmap<'gc>(
 ) -> Result<(), Error<'gc>> {
     // Note that the *getter* returns actual, and *setter* is preference
     this.set_bitmap_cached_preference(
-        activation.context.gc_context,
+        activation.context.gc(),
         value.as_bool(activation.swf_version()),
     );
     Ok(())
@@ -165,10 +165,10 @@ fn set_scale_9_grid<'gc>(
     avm1_stub!(activation, "Button", "scale9Grid");
     if let Value::Object(object) = value {
         if let Some(rectangle) = object_to_rectangle(activation, object)? {
-            this.set_scaling_grid(activation.context.gc_context, rectangle);
+            this.set_scaling_grid(activation.context.gc(), rectangle);
         }
     } else {
-        this.set_scaling_grid(activation.context.gc_context, Default::default());
+        this.set_scaling_grid(activation.context.gc(), Default::default());
     };
     Ok(())
 }

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -73,7 +73,7 @@ fn blend_mode<'gc>(
     this: Avm1Button<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mode = AvmString::new_utf8(activation.context.gc(), this.blend_mode().to_string());
+    let mode = AvmString::new_utf8(activation.gc(), this.blend_mode().to_string());
     Ok(mode.into())
 }
 
@@ -84,7 +84,7 @@ fn set_blend_mode<'gc>(
 ) -> Result<(), Error<'gc>> {
     // No-op if value is not a valid blend mode.
     if let Some(mode) = value.as_blend_mode() {
-        this.set_blend_mode(activation.context.gc(), mode.into());
+        this.set_blend_mode(activation.gc(), mode.into());
     } else {
         tracing::error!("Unknown blend mode {value:?}");
     }
@@ -96,7 +96,7 @@ fn filters<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(ArrayObject::new(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.avm1.prototypes().array,
         this.filters()
             .into_iter()
@@ -119,7 +119,7 @@ fn set_filters<'gc>(
             }
         }
     }
-    this.set_filters(activation.context.gc(), filters);
+    this.set_filters(activation.gc(), filters);
     Ok(())
 }
 
@@ -137,10 +137,7 @@ fn set_cache_as_bitmap<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     // Note that the *getter* returns actual, and *setter* is preference
-    this.set_bitmap_cached_preference(
-        activation.context.gc(),
-        value.as_bool(activation.swf_version()),
-    );
+    this.set_bitmap_cached_preference(activation.gc(), value.as_bool(activation.swf_version()));
     Ok(())
 }
 
@@ -165,10 +162,10 @@ fn set_scale_9_grid<'gc>(
     avm1_stub!(activation, "Button", "scale9Grid");
     if let Value::Object(object) = value {
         if let Some(rectangle) = object_to_rectangle(activation, object)? {
-            this.set_scaling_grid(activation.context.gc(), rectangle);
+            this.set_scaling_grid(activation.gc(), rectangle);
         }
     } else {
-        this.set_scaling_grid(activation.context.gc(), Default::default());
+        this.set_scaling_grid(activation.gc(), Default::default());
     };
     Ok(())
 }

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -29,7 +29,7 @@ pub fn constructor<'gc>(
     let target = args.get(0).cloned().unwrap_or(Value::Undefined);
     // Set undocumented `target` property
     this.define_value(
-        activation.context.gc_context,
+        activation.context.gc(),
         "target",
         target,
         Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
@@ -42,7 +42,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
@@ -91,7 +91,7 @@ fn get_transform<'gc>(
         let base = target.base();
         let color_transform = base.color_transform();
         let out = ScriptObject::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             Some(activation.context.avm1.prototypes().object),
         );
         out.set(
@@ -130,9 +130,9 @@ fn set_rgb<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(target) = target(activation, this)? {
-        target.set_transformed_by_script(activation.context.gc_context, true);
+        target.set_transformed_by_script(activation.context.gc(), true);
         if let Some(parent) = target.parent() {
-            parent.invalidate_cached_bitmap(activation.context.gc_context);
+            parent.invalidate_cached_bitmap(activation.context.gc());
         }
 
         let rgb = args
@@ -141,7 +141,7 @@ fn set_rgb<'gc>(
             .coerce_to_i32(activation)?;
         let [b, g, r, _] = rgb.to_le_bytes();
 
-        let mut base = target.base_mut(activation.context.gc_context);
+        let mut base = target.base_mut(activation.context.gc());
         let color_transform = base.color_transform_mut();
         color_transform.r_multiply = Fixed8::ZERO;
         color_transform.g_multiply = Fixed8::ZERO;
@@ -192,12 +192,12 @@ fn set_transform<'gc>(
     }
 
     if let Some(target) = target(activation, this)? {
-        target.set_transformed_by_script(activation.context.gc_context, true);
+        target.set_transformed_by_script(activation.context.gc(), true);
         if let Some(parent) = target.parent() {
-            parent.invalidate_cached_bitmap(activation.context.gc_context);
+            parent.invalidate_cached_bitmap(activation.context.gc());
         }
 
-        let mut base = target.base_mut(activation.context.gc_context);
+        let mut base = target.base_mut(activation.context.gc());
         let color_transform = base.color_transform_mut();
         let transform = args
             .get(0)

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -29,7 +29,7 @@ pub fn constructor<'gc>(
     let target = args.get(0).cloned().unwrap_or(Value::Undefined);
     // Set undocumented `target` property
     this.define_value(
-        activation.context.gc(),
+        activation.gc(),
         "target",
         target,
         Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
@@ -91,7 +91,7 @@ fn get_transform<'gc>(
         let base = target.base();
         let color_transform = base.color_transform();
         let out = ScriptObject::new(
-            activation.context.gc(),
+            activation.gc(),
             Some(activation.context.avm1.prototypes().object),
         );
         out.set(
@@ -130,9 +130,9 @@ fn set_rgb<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(target) = target(activation, this)? {
-        target.set_transformed_by_script(activation.context.gc(), true);
+        target.set_transformed_by_script(activation.gc(), true);
         if let Some(parent) = target.parent() {
-            parent.invalidate_cached_bitmap(activation.context.gc());
+            parent.invalidate_cached_bitmap(activation.gc());
         }
 
         let rgb = args
@@ -141,7 +141,7 @@ fn set_rgb<'gc>(
             .coerce_to_i32(activation)?;
         let [b, g, r, _] = rgb.to_le_bytes();
 
-        let mut base = target.base_mut(activation.context.gc());
+        let mut base = target.base_mut(activation.gc());
         let color_transform = base.color_transform_mut();
         color_transform.r_multiply = Fixed8::ZERO;
         color_transform.g_multiply = Fixed8::ZERO;
@@ -192,12 +192,12 @@ fn set_transform<'gc>(
     }
 
     if let Some(target) = target(activation, this)? {
-        target.set_transformed_by_script(activation.context.gc(), true);
+        target.set_transformed_by_script(activation.gc(), true);
         if let Some(parent) = target.parent() {
-            parent.invalidate_cached_bitmap(activation.context.gc());
+            parent.invalidate_cached_bitmap(activation.gc());
         }
 
-        let mut base = target.base_mut(activation.context.gc());
+        let mut base = target.base_mut(activation.gc());
         let color_transform = base.color_transform_mut();
         let transform = args
             .get(0)

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -51,10 +51,7 @@ pub struct ColorMatrixFilter<'gc>(GcCell<'gc, ColorMatrixFilterData>);
 
 impl<'gc> ColorMatrixFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let color_matrix_filter = Self(GcCell::new(
-            activation.context.gc_context,
-            Default::default(),
-        ));
+        let color_matrix_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
         color_matrix_filter.set_matrix(activation, args.get(0))?;
         Ok(color_matrix_filter)
     }
@@ -69,7 +66,7 @@ impl<'gc> ColorMatrixFilter<'gc> {
 
     fn matrix(&self, activation: &mut Activation<'_, 'gc>) -> Value<'gc> {
         ArrayObject::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.avm1.prototypes().array,
             self.0.read().matrix.iter().map(|&v| v.into()),
         )
@@ -104,7 +101,7 @@ impl<'gc> ColorMatrixFilter<'gc> {
             _ => (),
         }
 
-        self.0.write(activation.context.gc_context).matrix = matrix;
+        self.0.write(activation.context.gc()).matrix = matrix;
         Ok(())
     }
 
@@ -136,7 +133,7 @@ fn method<'gc>(
     if index == CONSTRUCTOR {
         let color_matrix_filter = ColorMatrixFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc_context,
+            activation.context.gc(),
             NativeObject::ColorMatrixFilter(color_matrix_filter),
         );
         return Ok(this.into());
@@ -162,7 +159,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let color_matrix_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let color_matrix_filter_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, color_matrix_filter_proto, fn_proto);
     color_matrix_filter_proto.into()
 }
@@ -173,7 +170,7 @@ pub fn create_constructor<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(color_matrix_filter_method!(0)),
         constructor_to_fn!(color_matrix_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -51,7 +51,7 @@ pub struct ColorMatrixFilter<'gc>(GcCell<'gc, ColorMatrixFilterData>);
 
 impl<'gc> ColorMatrixFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let color_matrix_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
+        let color_matrix_filter = Self(GcCell::new(activation.gc(), Default::default()));
         color_matrix_filter.set_matrix(activation, args.get(0))?;
         Ok(color_matrix_filter)
     }
@@ -66,7 +66,7 @@ impl<'gc> ColorMatrixFilter<'gc> {
 
     fn matrix(&self, activation: &mut Activation<'_, 'gc>) -> Value<'gc> {
         ArrayObject::new(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.avm1.prototypes().array,
             self.0.read().matrix.iter().map(|&v| v.into()),
         )
@@ -101,7 +101,7 @@ impl<'gc> ColorMatrixFilter<'gc> {
             _ => (),
         }
 
-        self.0.write(activation.context.gc()).matrix = matrix;
+        self.0.write(activation.gc()).matrix = matrix;
         Ok(())
     }
 
@@ -133,7 +133,7 @@ fn method<'gc>(
     if index == CONSTRUCTOR {
         let color_matrix_filter = ColorMatrixFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc(),
+            activation.gc(),
             NativeObject::ColorMatrixFilter(color_matrix_filter),
         );
         return Ok(this.into());

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -127,8 +127,8 @@ pub fn constructor<'gc>(
         _ => ColorTransformObject::IDENTITY,
     };
     this.set_native(
-        activation.context.gc_context,
-        NativeObject::ColorTransform(GcCell::new(activation.context.gc_context, color_transform)),
+        activation.context.gc(),
+        NativeObject::ColorTransform(GcCell::new(activation.context.gc(), color_transform)),
     );
     Ok(this.into())
 }
@@ -158,7 +158,7 @@ fn set_rgb<'gc>(
         if let [rgb, ..] = args {
             let rgb = rgb.coerce_to_u32(activation)?;
             let [b, g, r, _] = rgb.to_le_bytes();
-            let mut color_transform = color_transform.write(activation.context.gc_context);
+            let mut color_transform = color_transform.write(activation.context.gc());
             color_transform.red_multiplier = 0.0;
             color_transform.green_multiplier = 0.0;
             color_transform.blue_multiplier = 0.0;
@@ -194,7 +194,7 @@ macro_rules! color_transform_value_accessor {
                 if let Some(color_transform) = ColorTransformObject::cast(this.into()) {
                     if let [value, ..] = args {
                         let value = value.coerce_to_f64(activation)?;
-                        color_transform.write(activation.context.gc_context).$field = value;
+                        color_transform.write(activation.context.gc()).$field = value;
                     }
                 }
                 Ok(Value::Undefined.into())
@@ -230,7 +230,7 @@ fn to_string<'gc>(
             this.get("alphaOffset", activation)?.coerce_to_string(activation)?
     );
 
-    Ok(AvmString::new_utf8(activation.context.gc_context, formatted).into())
+    Ok(AvmString::new_utf8(activation.context.gc(), formatted).into())
 }
 
 fn concat<'gc>(
@@ -247,7 +247,7 @@ fn concat<'gc>(
             _ => return Ok(Value::Undefined),
         };
 
-        let mut this = this.write(activation.context.gc_context);
+        let mut this = this.write(activation.context.gc());
         *this = ColorTransformObject {
             red_multiplier: other.red_multiplier * this.red_multiplier,
             green_multiplier: other.green_multiplier * this.green_multiplier,
@@ -268,7 +268,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -127,8 +127,8 @@ pub fn constructor<'gc>(
         _ => ColorTransformObject::IDENTITY,
     };
     this.set_native(
-        activation.context.gc(),
-        NativeObject::ColorTransform(GcCell::new(activation.context.gc(), color_transform)),
+        activation.gc(),
+        NativeObject::ColorTransform(GcCell::new(activation.gc(), color_transform)),
     );
     Ok(this.into())
 }
@@ -158,7 +158,7 @@ fn set_rgb<'gc>(
         if let [rgb, ..] = args {
             let rgb = rgb.coerce_to_u32(activation)?;
             let [b, g, r, _] = rgb.to_le_bytes();
-            let mut color_transform = color_transform.write(activation.context.gc());
+            let mut color_transform = color_transform.write(activation.gc());
             color_transform.red_multiplier = 0.0;
             color_transform.green_multiplier = 0.0;
             color_transform.blue_multiplier = 0.0;
@@ -194,7 +194,7 @@ macro_rules! color_transform_value_accessor {
                 if let Some(color_transform) = ColorTransformObject::cast(this.into()) {
                     if let [value, ..] = args {
                         let value = value.coerce_to_f64(activation)?;
-                        color_transform.write(activation.context.gc()).$field = value;
+                        color_transform.write(activation.gc()).$field = value;
                     }
                 }
                 Ok(Value::Undefined.into())
@@ -230,7 +230,7 @@ fn to_string<'gc>(
             this.get("alphaOffset", activation)?.coerce_to_string(activation)?
     );
 
-    Ok(AvmString::new_utf8(activation.context.gc(), formatted).into())
+    Ok(AvmString::new_utf8(activation.gc(), formatted).into())
 }
 
 fn concat<'gc>(
@@ -247,7 +247,7 @@ fn concat<'gc>(
             _ => return Ok(Value::Undefined),
         };
 
-        let mut this = this.write(activation.context.gc());
+        let mut this = this.write(activation.gc());
         *this = ColorTransformObject {
             red_multiplier: other.red_multiplier * this.red_multiplier,
             green_multiplier: other.green_multiplier * this.green_multiplier,

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -26,7 +26,7 @@ pub fn constructor<'gc>(
     this.set("onSelect", callback.into(), activation)?;
 
     let built_in_items = ScriptObject::new(
-        activation.context.gc(),
+        activation.gc(),
         Some(activation.context.avm1.prototypes().object),
     );
 

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -26,7 +26,7 @@ pub fn constructor<'gc>(
     this.set("onSelect", callback.into(), activation)?;
 
     let built_in_items = ScriptObject::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         Some(activation.context.avm1.prototypes().object),
     );
 
@@ -146,7 +146,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -77,7 +77,7 @@ pub fn copy<'gc>(
     let copy = constructor.construct(
         activation,
         &[
-            AvmString::new_utf8(activation.context.gc(), caption).into(),
+            AvmString::new_utf8(activation.gc(), caption).into(),
             callback.into(),
             separator_before.into(),
             enabled.into(),

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -77,7 +77,7 @@ pub fn copy<'gc>(
     let copy = constructor.construct(
         activation,
         &[
-            AvmString::new_utf8(activation.context.gc_context, caption).into(),
+            AvmString::new_utf8(activation.context.gc(), caption).into(),
             callback.into(),
             separator_before.into(),
             enabled.into(),
@@ -93,7 +93,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -102,7 +102,7 @@ pub struct ConvolutionFilter<'gc>(GcCell<'gc, ConvolutionFilterData>);
 
 impl<'gc> ConvolutionFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let convolution_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
+        let convolution_filter = Self(GcCell::new(activation.gc(), Default::default()));
         convolution_filter.set_matrix_x(activation, args.get(0))?;
         convolution_filter.set_matrix_y(activation, args.get(1))?;
         convolution_filter.set_matrix(activation, args.get(2))?;
@@ -110,7 +110,7 @@ impl<'gc> ConvolutionFilter<'gc> {
             convolution_filter.set_divisor(activation, Some(value))?;
         } else if !args.is_empty() {
             let divisor = convolution_filter.0.read().matrix.iter().sum();
-            convolution_filter.0.write(activation.context.gc()).divisor = divisor;
+            convolution_filter.0.write(activation.gc()).divisor = divisor;
         }
         convolution_filter.set_bias(activation, args.get(4))?;
         convolution_filter.set_preserve_alpha(activation, args.get(5))?;
@@ -121,7 +121,7 @@ impl<'gc> ConvolutionFilter<'gc> {
             // If a substitute color is specified in the constructor in AVM1,
             // the substitute alpha is set to 1, despite the documentation claiming otherwise.
             // This does not happen in AVM2.
-            convolution_filter.0.write(activation.context.gc()).color.a = 255;
+            convolution_filter.0.write(activation.gc()).color.a = 255;
         }
         convolution_filter.set_alpha(activation, args.get(8))?;
         Ok(convolution_filter)
@@ -146,7 +146,7 @@ impl<'gc> ConvolutionFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let matrix_x = value.coerce_to_i32(activation)?.clamp(0, 15) as u8;
-            self.0.write(activation.context.gc()).set_matrix_x(matrix_x);
+            self.0.write(activation.gc()).set_matrix_x(matrix_x);
         }
         Ok(())
     }
@@ -162,7 +162,7 @@ impl<'gc> ConvolutionFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let matrix_y = value.coerce_to_i32(activation)?.clamp(0, 15) as u8;
-            self.0.write(activation.context.gc()).set_matrix_y(matrix_y);
+            self.0.write(activation.gc()).set_matrix_y(matrix_y);
         }
         Ok(())
     }
@@ -210,7 +210,7 @@ impl<'gc> ConvolutionFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let divisor = value.coerce_to_f64(activation)? as f32;
-            self.0.write(activation.context.gc()).divisor = divisor;
+            self.0.write(activation.gc()).divisor = divisor;
         }
         Ok(())
     }
@@ -226,7 +226,7 @@ impl<'gc> ConvolutionFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let bias = value.coerce_to_f64(activation)? as f32;
-            self.0.write(activation.context.gc()).bias = bias;
+            self.0.write(activation.gc()).bias = bias;
         }
         Ok(())
     }
@@ -242,7 +242,7 @@ impl<'gc> ConvolutionFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let preserve_alpha = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc()).preserve_alpha = preserve_alpha;
+            self.0.write(activation.gc()).preserve_alpha = preserve_alpha;
         }
         Ok(())
     }
@@ -258,7 +258,7 @@ impl<'gc> ConvolutionFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let clamp = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc()).clamp = clamp;
+            self.0.write(activation.gc()).clamp = clamp;
         }
         Ok(())
     }
@@ -274,7 +274,7 @@ impl<'gc> ConvolutionFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc());
+            let mut write = self.0.write(activation.gc());
             write.color = Color::from_rgb(value, write.color.a);
         }
         Ok(())
@@ -287,7 +287,7 @@ impl<'gc> ConvolutionFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = value.coerce_to_f64(activation)?.clamp_also_nan(0.0, 1.0);
-            self.0.write(activation.context.gc()).color.a = (alpha * 255.0) as u8;
+            self.0.write(activation.gc()).color.a = (alpha * 255.0) as u8;
         }
         Ok(())
     }
@@ -344,7 +344,7 @@ fn method<'gc>(
     if index == CONSTRUCTOR {
         let convolution_filter = ConvolutionFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc(),
+            activation.gc(),
             NativeObject::ConvolutionFilter(convolution_filter),
         );
         return Ok(this.into());

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -113,8 +113,7 @@ pub struct DisplacementMapFilter<'gc>(GcCell<'gc, DisplacementMapFilterData<'gc>
 
 impl<'gc> DisplacementMapFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let displacement_map_filter =
-            Self(GcCell::new(activation.context.gc(), Default::default()));
+        let displacement_map_filter = Self(GcCell::new(activation.gc(), Default::default()));
         displacement_map_filter.set_map_bitmap(activation, args.get(0))?;
         displacement_map_filter.set_map_point(activation, args.get(1))?;
         displacement_map_filter.set_component_x(activation, args.get(2))?;
@@ -156,7 +155,7 @@ impl<'gc> DisplacementMapFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(Value::Object(object)) = value {
             if let NativeObject::BitmapData(bitmap_data) = object.native() {
-                self.0.write(activation.context.gc()).map_bitmap = Some(bitmap_data);
+                self.0.write(activation.gc()).map_bitmap = Some(bitmap_data);
             }
         }
         Ok(())
@@ -181,13 +180,13 @@ impl<'gc> DisplacementMapFilter<'gc> {
                 let x = x.coerce_to_f64(activation)?.clamp_to_i32();
                 if let Some(y) = object.get_local_stored("y", activation, false) {
                     let y = y.coerce_to_f64(activation)?.clamp_to_i32();
-                    self.0.write(activation.context.gc()).map_point = Point::new(x, y);
+                    self.0.write(activation.gc()).map_point = Point::new(x, y);
                     return Ok(());
                 }
             }
         }
 
-        self.0.write(activation.context.gc()).map_point = Point::default();
+        self.0.write(activation.gc()).map_point = Point::default();
         Ok(())
     }
 
@@ -202,7 +201,7 @@ impl<'gc> DisplacementMapFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let component_x = value.coerce_to_i32(activation)?;
-            self.0.write(activation.context.gc()).component_x = component_x;
+            self.0.write(activation.gc()).component_x = component_x;
         }
         Ok(())
     }
@@ -218,7 +217,7 @@ impl<'gc> DisplacementMapFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let component_y = value.coerce_to_i32(activation)?;
-            self.0.write(activation.context.gc()).component_y = component_y;
+            self.0.write(activation.gc()).component_y = component_y;
         }
         Ok(())
     }
@@ -236,7 +235,7 @@ impl<'gc> DisplacementMapFilter<'gc> {
             const MAX: f64 = u16::MAX as f64;
             const MIN: f64 = -MAX;
             let scale_x = value.coerce_to_f64(activation)?.clamp_also_nan(MIN, MAX);
-            self.0.write(activation.context.gc()).scale_x = scale_x as f32;
+            self.0.write(activation.gc()).scale_x = scale_x as f32;
         }
         Ok(())
     }
@@ -254,7 +253,7 @@ impl<'gc> DisplacementMapFilter<'gc> {
             const MAX: f64 = u16::MAX as f64;
             const MIN: f64 = -MAX;
             let scale_y = value.coerce_to_f64(activation)?.clamp_also_nan(MIN, MAX);
-            self.0.write(activation.context.gc()).scale_y = scale_y as f32;
+            self.0.write(activation.gc()).scale_y = scale_y as f32;
         }
         Ok(())
     }
@@ -270,7 +269,7 @@ impl<'gc> DisplacementMapFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let mode = value.coerce_to_string(activation)?.parse().unwrap();
-            self.0.write(activation.context.gc()).mode = mode;
+            self.0.write(activation.gc()).mode = mode;
         }
         Ok(())
     }
@@ -286,7 +285,7 @@ impl<'gc> DisplacementMapFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc());
+            let mut write = self.0.write(activation.gc());
             write.color = Color::from_rgb(value, write.color.a);
         }
         Ok(())
@@ -299,7 +298,7 @@ impl<'gc> DisplacementMapFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = value.coerce_to_f64(activation)?.clamp_also_nan(0.0, 1.0);
-            self.0.write(activation.context.gc()).color.a = (alpha * 255.0) as u8;
+            self.0.write(activation.gc()).color.a = (alpha * 255.0) as u8;
         }
         Ok(())
     }
@@ -373,7 +372,7 @@ fn method<'gc>(
     if index == CONSTRUCTOR {
         let displacement_map_filter = DisplacementMapFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc(),
+            activation.gc(),
             NativeObject::DisplacementMapFilter(displacement_map_filter),
         );
         return Ok(this.into());

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -97,10 +97,7 @@ pub struct DropShadowFilter<'gc>(GcCell<'gc, DropShadowFilterData>);
 
 impl<'gc> DropShadowFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let drop_shadow_filter = Self(GcCell::new(
-            activation.context.gc_context,
-            Default::default(),
-        ));
+        let drop_shadow_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
         drop_shadow_filter.set_distance(activation, args.get(0))?;
         drop_shadow_filter.set_angle(activation, args.get(1))?;
         drop_shadow_filter.set_color(activation, args.get(2))?;
@@ -134,7 +131,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let distance = value.coerce_to_f64(activation)?;
-            self.0.write(activation.context.gc_context).distance = distance;
+            self.0.write(activation.context.gc()).distance = distance;
         }
         Ok(())
     }
@@ -150,7 +147,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let angle = (value.coerce_to_f64(activation)? % 360.0).to_radians();
-            self.0.write(activation.context.gc_context).angle = angle;
+            self.0.write(activation.context.gc()).angle = angle;
         }
         Ok(())
     }
@@ -166,7 +163,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc_context);
+            let mut write = self.0.write(activation.context.gc());
             write.color = Color::from_rgb(value, write.color.a);
         }
         Ok(())
@@ -183,7 +180,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.0.write(activation.context.gc_context).color.a = alpha;
+            self.0.write(activation.context.gc()).color.a = alpha;
         }
         Ok(())
     }
@@ -199,7 +196,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.context.gc_context).quality = quality;
+            self.0.write(activation.context.gc()).quality = quality;
         }
         Ok(())
     }
@@ -215,7 +212,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let inner = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc_context).inner = inner;
+            self.0.write(activation.context.gc()).inner = inner;
         }
         Ok(())
     }
@@ -231,7 +228,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc_context).knockout = knockout;
+            self.0.write(activation.context.gc()).knockout = knockout;
         }
         Ok(())
     }
@@ -247,7 +244,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc_context).blur_x = blur_x;
+            self.0.write(activation.context.gc()).blur_x = blur_x;
         }
         Ok(())
     }
@@ -263,7 +260,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc_context).blur_y = blur_y;
+            self.0.write(activation.context.gc()).blur_y = blur_y;
         }
         Ok(())
     }
@@ -279,7 +276,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             self.0
-                .write(activation.context.gc_context)
+                .write(activation.context.gc())
                 .set_strength(value.coerce_to_f64(activation)?);
         }
         Ok(())
@@ -296,7 +293,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let hide_object = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc_context).hide_object = hide_object;
+            self.0.write(activation.context.gc()).hide_object = hide_object;
         }
         Ok(())
     }
@@ -359,7 +356,7 @@ fn method<'gc>(
     if index == CONSTRUCTOR {
         let drop_shadow_filter = DropShadowFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc_context,
+            activation.context.gc(),
             NativeObject::DropShadowFilter(drop_shadow_filter),
         );
         return Ok(this.into());
@@ -435,7 +432,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let drop_shadow_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let drop_shadow_filter_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, drop_shadow_filter_proto, fn_proto);
     drop_shadow_filter_proto.into()
 }
@@ -446,7 +443,7 @@ pub fn create_constructor<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(drop_shadow_filter_method!(0)),
         constructor_to_fn!(drop_shadow_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -97,7 +97,7 @@ pub struct DropShadowFilter<'gc>(GcCell<'gc, DropShadowFilterData>);
 
 impl<'gc> DropShadowFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let drop_shadow_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
+        let drop_shadow_filter = Self(GcCell::new(activation.gc(), Default::default()));
         drop_shadow_filter.set_distance(activation, args.get(0))?;
         drop_shadow_filter.set_angle(activation, args.get(1))?;
         drop_shadow_filter.set_color(activation, args.get(2))?;
@@ -131,7 +131,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let distance = value.coerce_to_f64(activation)?;
-            self.0.write(activation.context.gc()).distance = distance;
+            self.0.write(activation.gc()).distance = distance;
         }
         Ok(())
     }
@@ -147,7 +147,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let angle = (value.coerce_to_f64(activation)? % 360.0).to_radians();
-            self.0.write(activation.context.gc()).angle = angle;
+            self.0.write(activation.gc()).angle = angle;
         }
         Ok(())
     }
@@ -163,7 +163,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc());
+            let mut write = self.0.write(activation.gc());
             write.color = Color::from_rgb(value, write.color.a);
         }
         Ok(())
@@ -180,7 +180,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.0.write(activation.context.gc()).color.a = alpha;
+            self.0.write(activation.gc()).color.a = alpha;
         }
         Ok(())
     }
@@ -196,7 +196,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.context.gc()).quality = quality;
+            self.0.write(activation.gc()).quality = quality;
         }
         Ok(())
     }
@@ -212,7 +212,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let inner = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc()).inner = inner;
+            self.0.write(activation.gc()).inner = inner;
         }
         Ok(())
     }
@@ -228,7 +228,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc()).knockout = knockout;
+            self.0.write(activation.gc()).knockout = knockout;
         }
         Ok(())
     }
@@ -244,7 +244,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_x = blur_x;
+            self.0.write(activation.gc()).blur_x = blur_x;
         }
         Ok(())
     }
@@ -260,7 +260,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_y = blur_y;
+            self.0.write(activation.gc()).blur_y = blur_y;
         }
         Ok(())
     }
@@ -276,7 +276,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             self.0
-                .write(activation.context.gc())
+                .write(activation.gc())
                 .set_strength(value.coerce_to_f64(activation)?);
         }
         Ok(())
@@ -293,7 +293,7 @@ impl<'gc> DropShadowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let hide_object = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc()).hide_object = hide_object;
+            self.0.write(activation.gc()).hide_object = hide_object;
         }
         Ok(())
     }
@@ -356,7 +356,7 @@ fn method<'gc>(
     if index == CONSTRUCTOR {
         let drop_shadow_filter = DropShadowFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc(),
+            activation.gc(),
             NativeObject::DropShadowFilter(drop_shadow_filter),
         );
         return Ok(this.into());

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -31,7 +31,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -79,12 +79,12 @@ pub fn create_external_interface_object<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     object.into()
 }
 
 pub fn create_proto<'gc>(context: &mut StringContext<'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
-    ScriptObject::new(context.gc_context, Some(proto)).into()
+    ScriptObject::new(context.gc(), Some(proto)).into()
 }

--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -121,7 +121,7 @@ pub fn creator<'gc>(
             .creator
             .as_ref()
             .map_or(Value::Undefined, |x| {
-                AvmString::new_utf8(activation.context.gc(), x).into()
+                AvmString::new_utf8(activation.gc(), x).into()
             }));
     }
 
@@ -156,7 +156,7 @@ pub fn name<'gc>(
             .name
             .as_ref()
             .map_or(Value::Undefined, |x| {
-                AvmString::new_utf8(activation.context.gc(), x).into()
+                AvmString::new_utf8(activation.gc(), x).into()
             }));
     }
 
@@ -169,11 +169,9 @@ pub fn post_data<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::FileReference(file_ref) = this.native() {
-        return Ok(AvmString::new_utf8(
-            activation.context.gc(),
-            file_ref.0.read().post_data.clone(),
-        )
-        .into());
+        return Ok(
+            AvmString::new_utf8(activation.gc(), file_ref.0.read().post_data.clone()).into(),
+        );
     }
 
     Ok(Value::Undefined)
@@ -190,7 +188,7 @@ pub fn set_post_data<'gc>(
         .coerce_to_string(activation)?;
 
     if let NativeObject::FileReference(file_ref) = this.native() {
-        file_ref.0.write(activation.context.gc()).post_data = post_data.to_string();
+        file_ref.0.write(activation.gc()).post_data = post_data.to_string();
     }
 
     Ok(Value::Undefined)
@@ -224,7 +222,7 @@ pub fn file_type<'gc>(
             .file_type
             .as_ref()
             .map_or(Value::Undefined, |x| {
-                AvmString::new_utf8(activation.context.gc(), x).into()
+                AvmString::new_utf8(activation.gc(), x).into()
             }));
     }
 
@@ -426,9 +424,9 @@ fn constructor<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     this.set_native(
-        activation.context.gc(),
+        activation.gc(),
         NativeObject::FileReference(FileReferenceObject(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             Default::default(),
         ))),
     );

--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -121,7 +121,7 @@ pub fn creator<'gc>(
             .creator
             .as_ref()
             .map_or(Value::Undefined, |x| {
-                AvmString::new_utf8(activation.context.gc_context, x).into()
+                AvmString::new_utf8(activation.context.gc(), x).into()
             }));
     }
 
@@ -156,7 +156,7 @@ pub fn name<'gc>(
             .name
             .as_ref()
             .map_or(Value::Undefined, |x| {
-                AvmString::new_utf8(activation.context.gc_context, x).into()
+                AvmString::new_utf8(activation.context.gc(), x).into()
             }));
     }
 
@@ -170,7 +170,7 @@ pub fn post_data<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::FileReference(file_ref) = this.native() {
         return Ok(AvmString::new_utf8(
-            activation.context.gc_context,
+            activation.context.gc(),
             file_ref.0.read().post_data.clone(),
         )
         .into());
@@ -190,7 +190,7 @@ pub fn set_post_data<'gc>(
         .coerce_to_string(activation)?;
 
     if let NativeObject::FileReference(file_ref) = this.native() {
-        file_ref.0.write(activation.context.gc_context).post_data = post_data.to_string();
+        file_ref.0.write(activation.context.gc()).post_data = post_data.to_string();
     }
 
     Ok(Value::Undefined)
@@ -224,7 +224,7 @@ pub fn file_type<'gc>(
             .file_type
             .as_ref()
             .map_or(Value::Undefined, |x| {
-                AvmString::new_utf8(activation.context.gc_context, x).into()
+                AvmString::new_utf8(activation.context.gc(), x).into()
             }));
     }
 
@@ -426,9 +426,9 @@ fn constructor<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     this.set_native(
-        activation.context.gc_context,
+        activation.context.gc(),
         NativeObject::FileReference(FileReferenceObject(GcCell::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             Default::default(),
         ))),
     );
@@ -442,11 +442,11 @@ pub fn create_constructor<'gc>(
     array_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let file_reference_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let file_reference_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, file_reference_proto, fn_proto);
-    broadcaster_functions.initialize(context.gc_context, file_reference_proto.into(), array_proto);
+    broadcaster_functions.initialize(context.gc(), file_reference_proto.into(), array_proto);
     let constructor = FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -31,7 +31,7 @@ pub fn function<'gc>(
         Ok(arg.to_owned())
     } else {
         // Calling `Function()` seems to give a prototypeless bare object.
-        Ok(ScriptObject::new(activation.context.gc(), None).into())
+        Ok(ScriptObject::new(activation.gc(), None).into())
     }
 }
 
@@ -87,10 +87,7 @@ pub fn apply<'gc>(
         let args = args_object.coerce_to_object(activation);
         // TODO: why don't this use args_object.array_element?
         let next_arg = format!("{}", child_args.len());
-        let next_arg = args.get(
-            AvmString::new_utf8(activation.context.gc(), next_arg),
-            activation,
-        )?;
+        let next_arg = args.get(AvmString::new_utf8(activation.gc(), next_arg), activation)?;
 
         child_args.push(next_arg);
     }

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -31,7 +31,7 @@ pub fn function<'gc>(
         Ok(arg.to_owned())
     } else {
         // Calling `Function()` seems to give a prototypeless bare object.
-        Ok(ScriptObject::new(activation.context.gc_context, None).into())
+        Ok(ScriptObject::new(activation.context.gc(), None).into())
     }
 }
 
@@ -88,7 +88,7 @@ pub fn apply<'gc>(
         // TODO: why don't this use args_object.array_element?
         let next_arg = format!("{}", child_args.len());
         let next_arg = args.get(
-            AvmString::new_utf8(activation.context.gc_context, next_arg),
+            AvmString::new_utf8(activation.context.gc(), next_arg),
             activation,
         )?;
 
@@ -117,7 +117,7 @@ pub fn apply<'gc>(
 /// returned object is also a bare object, which will need to be linked into
 /// the prototype of `Object`.
 pub fn create_proto<'gc>(context: &mut StringContext<'gc>, proto: Object<'gc>) -> Object<'gc> {
-    let function_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let function_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, function_proto, function_proto.into());
     function_proto.into()
 }

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -85,10 +85,7 @@ pub struct GlowFilter<'gc>(GcCell<'gc, GlowFilterData>);
 
 impl<'gc> GlowFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let glow_filter = Self(GcCell::new(
-            activation.context.gc_context,
-            Default::default(),
-        ));
+        let glow_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
         glow_filter.set_color(activation, args.get(0))?;
         glow_filter.set_alpha(activation, args.get(1))?;
         glow_filter.set_blur_x(activation, args.get(2))?;
@@ -119,7 +116,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc_context);
+            let mut write = self.0.write(activation.context.gc());
             write.color = Color::from_rgb(value, write.color.a);
         }
         Ok(())
@@ -136,7 +133,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.0.write(activation.context.gc_context).color.a = alpha;
+            self.0.write(activation.context.gc()).color.a = alpha;
         }
         Ok(())
     }
@@ -152,7 +149,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.context.gc_context).quality = quality;
+            self.0.write(activation.context.gc()).quality = quality;
         }
         Ok(())
     }
@@ -168,7 +165,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let inner = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc_context).inner = inner;
+            self.0.write(activation.context.gc()).inner = inner;
         }
         Ok(())
     }
@@ -184,7 +181,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc_context).knockout = knockout;
+            self.0.write(activation.context.gc()).knockout = knockout;
         }
         Ok(())
     }
@@ -200,7 +197,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc_context).blur_x = blur_x;
+            self.0.write(activation.context.gc()).blur_x = blur_x;
         }
         Ok(())
     }
@@ -216,7 +213,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc_context).blur_y = blur_y;
+            self.0.write(activation.context.gc()).blur_y = blur_y;
         }
         Ok(())
     }
@@ -232,7 +229,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             self.0
-                .write(activation.context.gc_context)
+                .write(activation.context.gc())
                 .set_strength(value.coerce_to_f64(activation)?);
         }
         Ok(())
@@ -287,7 +284,7 @@ fn method<'gc>(
     if index == CONSTRUCTOR {
         let glow_filter = GlowFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc_context,
+            activation.context.gc(),
             NativeObject::GlowFilter(glow_filter),
         );
         return Ok(this.into());
@@ -348,7 +345,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let glow_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let glow_filter_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, glow_filter_proto, fn_proto);
     glow_filter_proto.into()
 }
@@ -359,7 +356,7 @@ pub fn create_constructor<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(glow_filter_method!(0)),
         constructor_to_fn!(glow_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -85,7 +85,7 @@ pub struct GlowFilter<'gc>(GcCell<'gc, GlowFilterData>);
 
 impl<'gc> GlowFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let glow_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
+        let glow_filter = Self(GcCell::new(activation.gc(), Default::default()));
         glow_filter.set_color(activation, args.get(0))?;
         glow_filter.set_alpha(activation, args.get(1))?;
         glow_filter.set_blur_x(activation, args.get(2))?;
@@ -116,7 +116,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.context.gc());
+            let mut write = self.0.write(activation.gc());
             write.color = Color::from_rgb(value, write.color.a);
         }
         Ok(())
@@ -133,7 +133,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.0.write(activation.context.gc()).color.a = alpha;
+            self.0.write(activation.gc()).color.a = alpha;
         }
         Ok(())
     }
@@ -149,7 +149,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.context.gc()).quality = quality;
+            self.0.write(activation.gc()).quality = quality;
         }
         Ok(())
     }
@@ -165,7 +165,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let inner = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc()).inner = inner;
+            self.0.write(activation.gc()).inner = inner;
         }
         Ok(())
     }
@@ -181,7 +181,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc()).knockout = knockout;
+            self.0.write(activation.gc()).knockout = knockout;
         }
         Ok(())
     }
@@ -197,7 +197,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_x = blur_x;
+            self.0.write(activation.gc()).blur_x = blur_x;
         }
         Ok(())
     }
@@ -213,7 +213,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_y = blur_y;
+            self.0.write(activation.gc()).blur_y = blur_y;
         }
         Ok(())
     }
@@ -229,7 +229,7 @@ impl<'gc> GlowFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             self.0
-                .write(activation.context.gc())
+                .write(activation.gc())
                 .set_strength(value.coerce_to_f64(activation)?);
         }
         Ok(())
@@ -283,10 +283,7 @@ fn method<'gc>(
 
     if index == CONSTRUCTOR {
         let glow_filter = GlowFilter::new(activation, args)?;
-        this.set_native(
-            activation.context.gc(),
-            NativeObject::GlowFilter(glow_filter),
-        );
+        this.set_native(activation.gc(), NativeObject::GlowFilter(glow_filter));
         return Ok(this.into());
     }
 

--- a/core/src/avm1/globals/gradient_filter.rs
+++ b/core/src/avm1/globals/gradient_filter.rs
@@ -109,7 +109,7 @@ pub struct GradientFilter<'gc>(GcCell<'gc, GradientFilterData>);
 
 impl<'gc> GradientFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let gradient_bevel_filter = Self(GcCell::new(activation.context.gc(), Default::default()));
+        let gradient_bevel_filter = Self(GcCell::new(activation.gc(), Default::default()));
         gradient_bevel_filter.set_distance(activation, args.get(0))?;
         gradient_bevel_filter.set_angle(activation, args.get(1))?;
         gradient_bevel_filter.set_colors(activation, args.get(2))?;
@@ -143,7 +143,7 @@ impl<'gc> GradientFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let distance = value.coerce_to_f64(activation)?;
-            self.0.write(activation.context.gc()).distance = distance;
+            self.0.write(activation.gc()).distance = distance;
         }
         Ok(())
     }
@@ -159,7 +159,7 @@ impl<'gc> GradientFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let angle = (value.coerce_to_f64(activation)? % 360.0).to_radians();
-            self.0.write(activation.context.gc()).angle = angle;
+            self.0.write(activation.gc()).angle = angle;
         }
         Ok(())
     }
@@ -260,7 +260,7 @@ impl<'gc> GradientFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(Value::Object(object)) = value {
             let num_colors = usize::try_from(object.length(activation)?).unwrap_or_default();
-            let mut write = self.0.write(activation.context.gc());
+            let mut write = self.0.write(activation.gc());
             // Modifying `ratios` can only reduce the number of colors, never increase it.
             let num_colors = num_colors.min(write.num_colors);
             write.num_colors = num_colors;
@@ -271,7 +271,7 @@ impl<'gc> GradientFilter<'gc> {
                     .get_element(activation, i as i32)
                     .coerce_to_i32(activation)?
                     .clamp(0, u8::MAX.into()) as u8;
-                self.0.write(activation.context.gc()).colors[i].ratio = ratio;
+                self.0.write(activation.gc()).colors[i].ratio = ratio;
             }
         }
         Ok(())
@@ -288,7 +288,7 @@ impl<'gc> GradientFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp_also_nan(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_x = blur_x;
+            self.0.write(activation.gc()).blur_x = blur_x;
         }
         Ok(())
     }
@@ -304,7 +304,7 @@ impl<'gc> GradientFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp_also_nan(0.0, 255.0);
-            self.0.write(activation.context.gc()).blur_y = blur_y;
+            self.0.write(activation.gc()).blur_y = blur_y;
         }
         Ok(())
     }
@@ -320,7 +320,7 @@ impl<'gc> GradientFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             self.0
-                .write(activation.context.gc())
+                .write(activation.gc())
                 .set_strength(value.coerce_to_f64(activation)?);
         }
         Ok(())
@@ -337,7 +337,7 @@ impl<'gc> GradientFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.context.gc()).quality = quality;
+            self.0.write(activation.gc()).quality = quality;
         }
         Ok(())
     }
@@ -353,7 +353,7 @@ impl<'gc> GradientFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let type_ = value.coerce_to_string(activation)?.as_wstr().into();
-            self.0.write(activation.context.gc()).type_ = type_;
+            self.0.write(activation.gc()).type_ = type_;
         }
         Ok(())
     }
@@ -369,7 +369,7 @@ impl<'gc> GradientFilter<'gc> {
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.0.write(activation.context.gc()).knockout = knockout;
+            self.0.write(activation.gc()).knockout = knockout;
         }
         Ok(())
     }
@@ -433,7 +433,7 @@ fn method<'gc>(
     if index == BEVEL_CONSTRUCTOR {
         let gradient_bevel_filter = GradientFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc(),
+            activation.gc(),
             NativeObject::GradientBevelFilter(gradient_bevel_filter),
         );
         return Ok(this.into());
@@ -441,7 +441,7 @@ fn method<'gc>(
     if index == GLOW_CONSTRUCTOR {
         let gradient_glow_filter = GradientFilter::new(activation, args)?;
         this.set_native(
-            activation.context.gc(),
+            activation.gc(),
             NativeObject::GradientGlowFilter(gradient_glow_filter),
         );
         return Ok(this.into());

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -88,8 +88,8 @@ pub fn create_key_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let key = ScriptObject::new(context.gc_context, Some(proto));
-    broadcaster_functions.initialize(context.gc_context, key.into(), array_proto);
+    let key = ScriptObject::new(context.gc(), Some(proto));
+    broadcaster_functions.initialize(context.gc(), key.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, key, fn_proto);
     key.into()
 }

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -40,7 +40,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
@@ -64,8 +64,8 @@ fn decode<'gc>(
     if let Some(data) = args.get(0) {
         let data = data.coerce_to_string(activation)?;
         for (k, v) in url::form_urlencoded::parse(data.to_utf8_lossy().as_bytes()) {
-            let k = AvmString::new_utf8(activation.context.gc_context, k);
-            let v = AvmString::new_utf8(activation.context.gc_context, v);
+            let k = AvmString::new_utf8(activation.context.gc(), k);
+            let v = AvmString::new_utf8(activation.context.gc(), v);
             this.set(k, v.into(), activation)?;
         }
     }
@@ -245,7 +245,7 @@ fn to_string<'gc>(
         .extend_pairs(form_values.iter())
         .finish();
 
-    Ok(AvmString::new_utf8(activation.context.gc_context, query_string).into())
+    Ok(AvmString::new_utf8(activation.context.gc(), query_string).into())
 }
 
 fn spawn_load_var_fetch<'gc>(
@@ -272,7 +272,7 @@ fn spawn_load_var_fetch<'gc>(
     // Create hidden properties on object.
     if !loader_object.has_property(activation, "_bytesLoaded".into()) {
         loader_object.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "_bytesLoaded",
             0.into(),
             Attribute::DONT_DELETE | Attribute::DONT_ENUM,
@@ -283,7 +283,7 @@ fn spawn_load_var_fetch<'gc>(
 
     if !loader_object.has_property(activation, "_bytesTotal".into()) {
         loader_object.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "_bytesTotal",
             Value::Undefined,
             Attribute::DONT_DELETE | Attribute::DONT_ENUM,
@@ -294,7 +294,7 @@ fn spawn_load_var_fetch<'gc>(
 
     if !loader_object.has_property(activation, "loaded".into()) {
         loader_object.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "loaded",
             false.into(),
             Attribute::DONT_DELETE | Attribute::DONT_ENUM,

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -64,8 +64,8 @@ fn decode<'gc>(
     if let Some(data) = args.get(0) {
         let data = data.coerce_to_string(activation)?;
         for (k, v) in url::form_urlencoded::parse(data.to_utf8_lossy().as_bytes()) {
-            let k = AvmString::new_utf8(activation.context.gc(), k);
-            let v = AvmString::new_utf8(activation.context.gc(), v);
+            let k = AvmString::new_utf8(activation.gc(), k);
+            let v = AvmString::new_utf8(activation.gc(), v);
             this.set(k, v.into(), activation)?;
         }
     }
@@ -245,7 +245,7 @@ fn to_string<'gc>(
         .extend_pairs(form_values.iter())
         .finish();
 
-    Ok(AvmString::new_utf8(activation.context.gc(), query_string).into())
+    Ok(AvmString::new_utf8(activation.gc(), query_string).into())
 }
 
 fn spawn_load_var_fetch<'gc>(
@@ -272,7 +272,7 @@ fn spawn_load_var_fetch<'gc>(
     // Create hidden properties on object.
     if !loader_object.has_property(activation, "_bytesLoaded".into()) {
         loader_object.define_value(
-            activation.context.gc(),
+            activation.gc(),
             "_bytesLoaded",
             0.into(),
             Attribute::DONT_DELETE | Attribute::DONT_ENUM,
@@ -283,7 +283,7 @@ fn spawn_load_var_fetch<'gc>(
 
     if !loader_object.has_property(activation, "_bytesTotal".into()) {
         loader_object.define_value(
-            activation.context.gc(),
+            activation.gc(),
             "_bytesTotal",
             Value::Undefined,
             Attribute::DONT_DELETE | Attribute::DONT_ENUM,
@@ -294,7 +294,7 @@ fn spawn_load_var_fetch<'gc>(
 
     if !loader_object.has_property(activation, "loaded".into()) {
         loader_object.define_value(
-            activation.context.gc(),
+            activation.gc(),
             "loaded",
             false.into(),
             Attribute::DONT_DELETE | Attribute::DONT_ENUM,

--- a/core/src/avm1/globals/local_connection.rs
+++ b/core/src/avm1/globals/local_connection.rs
@@ -145,10 +145,7 @@ pub fn domain<'gc>(
     let movie = activation.base_clip().movie();
     let domain = LocalConnections::get_domain(movie.url());
 
-    Ok(Value::String(AvmString::new_utf8(
-        activation.context.gc(),
-        domain,
-    )))
+    Ok(Value::String(AvmString::new_utf8(activation.gc(), domain)))
 }
 
 pub fn connect<'gc>(

--- a/core/src/avm1/globals/local_connection.rs
+++ b/core/src/avm1/globals/local_connection.rs
@@ -146,7 +146,7 @@ pub fn domain<'gc>(
     let domain = LocalConnections::get_domain(movie.url());
 
     Ok(Value::String(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         domain,
     )))
 }
@@ -249,7 +249,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -166,7 +166,7 @@ pub fn create<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let math = ScriptObject::new(context.gc_context, Some(proto));
+    let math = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(OBJECT_DECLS, context, math, fn_proto);
     math.into()
 }

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -439,7 +439,7 @@ fn to_string<'gc>(
     let ty = this.get("ty", activation)?;
 
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         format!(
             "(a={}, b={}, c={}, d={}, tx={}, ty={})",
             a.coerce_to_string(activation)?,

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -439,7 +439,7 @@ fn to_string<'gc>(
     let ty = this.get("ty", activation)?;
 
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         format!(
             "(a={}, b={}, c={}, d={}, tx={}, ty={})",
             a.coerce_to_string(activation)?,
@@ -459,7 +459,7 @@ pub fn create_matrix_object<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,
@@ -472,7 +472,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -37,8 +37,8 @@ pub fn create_mouse_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mouse = ScriptObject::new(context.gc_context, Some(proto));
-    broadcaster_functions.initialize(context.gc_context, mouse.into(), array_proto);
+    let mouse = ScriptObject::new(context.gc(), Some(proto));
+    broadcaster_functions.initialize(context.gc(), mouse.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, mouse, fn_proto);
     mouse.into()
 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -182,12 +182,12 @@ fn set_scroll_rect<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Value::Object(object) = value {
-        this.set_has_scroll_rect(activation.context.gc(), true);
+        this.set_has_scroll_rect(activation.gc(), true);
         if let Some(rectangle) = object_to_rectangle(activation, object)? {
-            this.set_next_scroll_rect(activation.context.gc(), rectangle);
+            this.set_next_scroll_rect(activation.gc(), rectangle);
         }
     } else {
-        this.set_has_scroll_rect(activation.context.gc(), false);
+        this.set_has_scroll_rect(activation.gc(), false);
     };
     Ok(())
 }
@@ -213,10 +213,10 @@ fn set_scale_9_grid<'gc>(
     avm1_stub!(activation, "MovieClip", "scale9Grid");
     if let Value::Object(object) = value {
         if let Some(rectangle) = object_to_rectangle(activation, object)? {
-            this.set_scaling_grid(activation.context.gc(), rectangle);
+            this.set_scaling_grid(activation.gc(), rectangle);
         }
     } else {
-        this.set_scaling_grid(activation.context.gc(), Rectangle::default());
+        this.set_scaling_grid(activation.gc(), Rectangle::default());
     };
     Ok(())
 }
@@ -295,7 +295,7 @@ fn attach_bitmap<'gc>(
 
                 //TODO: do attached BitmapDatas have character ids?
                 let display_object = Bitmap::new_with_bitmap_data(
-                    activation.context.gc(),
+                    activation.gc(),
                     0,
                     bitmap_data,
                     smoothing,
@@ -593,8 +593,7 @@ fn begin_bitmap_fill<'gc>(
     let fill_style = if let [Value::Object(bitmap_data), ..] = args {
         if let NativeObject::BitmapData(bitmap_data) = bitmap_data.native() {
             // Register the bitmap data with the drawing.
-            let handle =
-                bitmap_data.bitmap_handle(activation.context.gc(), activation.context.renderer);
+            let handle = bitmap_data.bitmap_handle(activation.gc(), activation.context.renderer);
             let bitmap = ruffle_render::bitmap::BitmapInfo {
                 handle,
                 width: bitmap_data.width() as u16,
@@ -815,10 +814,10 @@ fn attach_movie<'gc>(
         .library
         .library_for_movie(movie_clip.movie())
         .ok_or("Movie is missing!".into())
-        .and_then(|l| l.instantiate_by_export_name(export_name, activation.context.gc()))
+        .and_then(|l| l.instantiate_by_export_name(export_name, activation.gc()))
     {
         // Set name and attach to parent.
-        new_clip.set_name(activation.context.gc(), new_instance_name);
+        new_clip.set_name(activation.gc(), new_instance_name);
         movie_clip.replace_at_depth(activation.context, new_clip, depth);
         let init_object = if let Some(Value::Object(init_object)) = init_object {
             Some(init_object.to_owned())
@@ -857,10 +856,10 @@ fn create_empty_movie_clip<'gc>(
 
     // Create empty movie clip.
     let swf_movie = movie_clip.movie();
-    let new_clip = MovieClip::new(swf_movie, activation.context.gc());
+    let new_clip = MovieClip::new(swf_movie, activation.gc());
 
     // Set name and attach to parent.
-    new_clip.set_name(activation.context.gc(), new_instance_name);
+    new_clip.set_name(activation.gc(), new_instance_name);
     movie_clip.replace_at_depth(activation.context, new_clip.into(), depth);
     new_clip.post_instantiation(activation.context, None, Instantiator::Avm1, true);
 
@@ -904,10 +903,7 @@ fn create_text_field<'gc>(
 
     let text_field: DisplayObject<'gc> =
         EditText::new(activation.context, movie, x, y, width, height).into();
-    text_field.set_name(
-        activation.context.gc(),
-        instance_name.coerce_to_string(activation)?,
-    );
+    text_field.set_name(activation.gc(), instance_name.coerce_to_string(activation)?);
     movie_clip.replace_at_depth(
         activation.context,
         text_field,
@@ -1382,7 +1378,7 @@ fn swap_depths<'gc>(
 
         if depth != movie_clip.depth() {
             parent.swap_at_depth(activation.context, movie_clip.into(), depth);
-            movie_clip.set_transformed_by_script(activation.context.gc(), true);
+            movie_clip.set_transformed_by_script(activation.gc(), true);
         }
     }
 
@@ -1481,7 +1477,7 @@ fn get_bounds<'gc>(
         };
 
         let out = ScriptObject::new(
-            activation.context.gc(),
+            activation.gc(),
             Some(activation.context.avm1.prototypes().object),
         );
         out.set("xMin", out_bounds.x_min.to_pixels().into(), activation)?;
@@ -1663,18 +1659,18 @@ fn set_transform<'gc>(
         if let NativeObject::Transform(transform) = object.native() {
             if let Some(clip) = transform.clip(activation) {
                 let matrix = *clip.base().matrix();
-                this.set_matrix(activation.context.gc(), matrix);
+                this.set_matrix(activation.gc(), matrix);
 
                 let color_transform = *clip.base().color_transform();
-                this.set_color_transform(activation.context.gc(), color_transform);
+                this.set_color_transform(activation.gc(), color_transform);
 
                 if let Some(parent) = this.parent() {
                     // Self-transform changes are automatically handled,
                     // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
-                    parent.invalidate_cached_bitmap(activation.context.gc());
+                    parent.invalidate_cached_bitmap(activation.gc());
                 }
 
-                this.set_transformed_by_script(activation.context.gc(), true);
+                this.set_transformed_by_script(activation.gc(), true);
             }
         }
     }
@@ -1695,7 +1691,7 @@ fn set_lock_root<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let lock_root = value.as_bool(activation.swf_version());
-    this.set_lock_root(activation.context.gc(), lock_root);
+    this.set_lock_root(activation.gc(), lock_root);
     Ok(())
 }
 
@@ -1703,7 +1699,7 @@ fn blend_mode<'gc>(
     this: MovieClip<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mode = AvmString::new_utf8(activation.context.gc(), this.blend_mode().to_string());
+    let mode = AvmString::new_utf8(activation.gc(), this.blend_mode().to_string());
     Ok(mode.into())
 }
 
@@ -1714,7 +1710,7 @@ fn set_blend_mode<'gc>(
 ) -> Result<(), Error<'gc>> {
     // No-op if value is not a valid blend mode.
     if let Some(mode) = value.as_blend_mode() {
-        this.set_blend_mode(activation.context.gc(), mode.into());
+        this.set_blend_mode(activation.gc(), mode.into());
     } else {
         tracing::error!("Unknown blend mode {value:?}");
     }
@@ -1735,10 +1731,7 @@ fn set_cache_as_bitmap<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     // Note that the *getter* returns actual, and *setter* is preference
-    this.set_bitmap_cached_preference(
-        activation.context.gc(),
-        value.as_bool(activation.swf_version()),
-    );
+    this.set_bitmap_cached_preference(activation.gc(), value.as_bool(activation.swf_version()));
     Ok(())
 }
 
@@ -1759,10 +1752,10 @@ fn set_opaque_background<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if matches!(value, Value::Undefined | Value::Null) {
-        this.set_opaque_background(activation.context.gc(), None);
+        this.set_opaque_background(activation.gc(), None);
     } else {
         this.set_opaque_background(
-            activation.context.gc(),
+            activation.gc(),
             Some(Color::from_rgb(value.coerce_to_u32(activation)?, 255)),
         );
     }
@@ -1774,7 +1767,7 @@ fn filters<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(ArrayObject::new(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.avm1.prototypes().array,
         this.filters()
             .into_iter()
@@ -1797,7 +1790,7 @@ fn set_filters<'gc>(
             }
         }
     }
-    this.set_filters(activation.context.gc(), filters);
+    this.set_filters(activation.gc(), filters);
     Ok(())
 }
 

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -25,12 +25,12 @@ pub fn constructor<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let listeners = ArrayObject::new(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.avm1.prototypes().array,
         [this.into()],
     );
     this.define_value(
-        activation.context.gc(),
+        activation.gc(),
         "_listeners",
         Value::Object(listeners.into()),
         Attribute::DONT_ENUM,
@@ -141,16 +141,16 @@ fn get_progress<'gc>(
             Value::MovieClip(_) => target.coerce_to_object(activation).as_display_object(),
             _ => return Ok(Value::Undefined),
         };
-        let result = ScriptObject::new(activation.context.gc(), None);
+        let result = ScriptObject::new(activation.gc(), None);
         if let Some(target) = target {
             result.define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "bytesLoaded",
                 target.movie().compressed_len().into(),
                 Attribute::empty(),
             );
             result.define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "bytesTotal",
                 target.movie().compressed_len().into(),
                 Attribute::empty(),

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -25,12 +25,12 @@ pub fn constructor<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let listeners = ArrayObject::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.avm1.prototypes().array,
         [this.into()],
     );
     this.define_value(
-        activation.context.gc_context,
+        activation.context.gc(),
         "_listeners",
         Value::Object(listeners.into()),
         Attribute::DONT_ENUM,
@@ -141,16 +141,16 @@ fn get_progress<'gc>(
             Value::MovieClip(_) => target.coerce_to_object(activation).as_display_object(),
             _ => return Ok(Value::Undefined),
         };
-        let result = ScriptObject::new(activation.context.gc_context, None);
+        let result = ScriptObject::new(activation.context.gc(), None);
         if let Some(target) = target {
             result.define_value(
-                activation.context.gc_context,
+                activation.context.gc(),
                 "bytesLoaded",
                 target.movie().compressed_len().into(),
                 Attribute::empty(),
             );
             result.define_value(
-                activation.context.gc_context,
+                activation.context.gc(),
                 "bytesTotal",
                 target.movie().compressed_len().into(),
                 Attribute::empty(),
@@ -169,8 +169,8 @@ pub fn create_proto<'gc>(
     array_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let mcl_proto = ScriptObject::new(context.gc_context, Some(proto));
-    broadcaster_functions.initialize(context.gc_context, mcl_proto.into(), array_proto);
+    let mcl_proto = ScriptObject::new(context.gc(), Some(proto));
+    broadcaster_functions.initialize(context.gc(), mcl_proto.into(), array_proto);
     define_properties_on(PROTO_DECLS, context, mcl_proto, fn_proto);
     mcl_proto.into()
 }

--- a/core/src/avm1/globals/netconnection.rs
+++ b/core/src/avm1/globals/netconnection.rs
@@ -339,7 +339,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
@@ -350,7 +350,7 @@ pub fn create_class<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -11,8 +11,8 @@ pub fn constructor<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let netstream = NetStream::new(activation.context.gc(), Some(this.into()));
-    this.set_native(activation.context.gc(), NativeObject::NetStream(netstream));
+    let netstream = NetStream::new(activation.gc(), Some(this.into()));
+    this.set_native(activation.gc(), NativeObject::NetStream(netstream));
 
     Ok(this.into())
 }
@@ -150,7 +150,7 @@ fn set_buffer_time<'gc>(
             .unwrap_or(Value::Undefined)
             .coerce_to_f64(activation)?;
 
-        ns.set_buffer_time(activation.context.gc(), buffer_time);
+        ns.set_buffer_time(activation.gc(), buffer_time);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -11,11 +11,8 @@ pub fn constructor<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let netstream = NetStream::new(activation.context.gc_context, Some(this.into()));
-    this.set_native(
-        activation.context.gc_context,
-        NativeObject::NetStream(netstream),
-    );
+    let netstream = NetStream::new(activation.context.gc(), Some(this.into()));
+    this.set_native(activation.context.gc(), NativeObject::NetStream(netstream));
 
     Ok(this.into())
 }
@@ -153,7 +150,7 @@ fn set_buffer_time<'gc>(
             .unwrap_or(Value::Undefined)
             .coerce_to_f64(activation)?;
 
-        ns.set_buffer_time(activation.context.gc_context, buffer_time);
+        ns.set_buffer_time(activation.context.gc(), buffer_time);
     }
 
     Ok(Value::Undefined)
@@ -176,7 +173,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
@@ -187,7 +184,7 @@ pub fn create_class<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -156,7 +156,7 @@ fn to_string<'gc>(
             i -= 1;
             digits[i] = b'-';
         }
-        Ok(AvmString::new_utf8_bytes(activation.context.gc(), &digits[i..]).into())
+        Ok(AvmString::new_utf8_bytes(activation.gc(), &digits[i..]).into())
     }
 }
 

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -66,7 +66,7 @@ pub fn create_number_object<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let number = FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(number),
         Executable::Native(number_function),
         fn_proto,
@@ -156,7 +156,7 @@ fn to_string<'gc>(
             i -= 1;
             digits[i] = b'-';
         }
-        Ok(AvmString::new_utf8_bytes(activation.context.gc_context, &digits[i..]).into())
+        Ok(AvmString::new_utf8_bytes(activation.context.gc(), &digits[i..]).into())
     }
 }
 

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -45,9 +45,7 @@ pub fn object_function<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let obj = match args.get(0).unwrap_or(&Value::Undefined) {
-        Value::Undefined | Value::Null => {
-            Object::from(ScriptObject::new(activation.context.gc(), None))
-        }
+        Value::Undefined | Value::Null => Object::from(ScriptObject::new(activation.gc(), None)),
         val => val.coerce_to_object(activation),
     };
     Ok(obj.into())
@@ -281,26 +279,23 @@ pub fn as_set_prop_flags<'gc>(
     }
 
     match args.get(1) {
-        Some(&Value::Null) => object.set_attributes(
-            activation.context.gc(),
-            None,
-            set_attributes,
-            clear_attributes,
-        ),
+        Some(&Value::Null) => {
+            object.set_attributes(activation.gc(), None, set_attributes, clear_attributes)
+        }
         Some(v) => {
             let props = v.coerce_to_string(activation)?;
             if props.contains(b',') {
                 for prop_name in props.split(b',') {
                     object.set_attributes(
-                        activation.context.gc(),
-                        Some(AvmString::new(activation.context.gc(), prop_name)),
+                        activation.gc(),
+                        Some(AvmString::new(activation.gc(), prop_name)),
                         set_attributes,
                         clear_attributes,
                     )
                 }
             } else {
                 object.set_attributes(
-                    activation.context.gc(),
+                    activation.gc(),
                     Some(props),
                     set_attributes,
                     clear_attributes,

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -46,7 +46,7 @@ pub fn object_function<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let obj = match args.get(0).unwrap_or(&Value::Undefined) {
         Value::Undefined | Value::Null => {
-            Object::from(ScriptObject::new(activation.context.gc_context, None))
+            Object::from(ScriptObject::new(activation.context.gc(), None))
         }
         val => val.coerce_to_object(activation),
     };
@@ -282,7 +282,7 @@ pub fn as_set_prop_flags<'gc>(
 
     match args.get(1) {
         Some(&Value::Null) => object.set_attributes(
-            activation.context.gc_context,
+            activation.context.gc(),
             None,
             set_attributes,
             clear_attributes,
@@ -292,15 +292,15 @@ pub fn as_set_prop_flags<'gc>(
             if props.contains(b',') {
                 for prop_name in props.split(b',') {
                     object.set_attributes(
-                        activation.context.gc_context,
-                        Some(AvmString::new(activation.context.gc_context, prop_name)),
+                        activation.context.gc(),
+                        Some(AvmString::new(activation.context.gc(), prop_name)),
                         set_attributes,
                         clear_attributes,
                     )
                 }
             } else {
                 object.set_attributes(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     Some(props),
                     set_attributes,
                     clear_attributes,
@@ -321,7 +321,7 @@ pub fn create_object_object<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let object_function = FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         Executable::Native(object_function),
         fn_proto,

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -213,7 +213,7 @@ fn to_string<'gc>(
     let y = this.get("y", activation)?;
 
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         format!(
             "(x={}, y={})",
             x.coerce_to_string(activation)?,
@@ -288,7 +288,7 @@ pub fn create_point_object<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let point = FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,
@@ -304,7 +304,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -213,7 +213,7 @@ fn to_string<'gc>(
     let y = this.get("y", activation)?;
 
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         format!(
             "(x={}, y={})",
             x.coerce_to_string(activation)?,

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -80,7 +80,7 @@ fn to_string<'gc>(
     let height = this.get("height", activation)?;
 
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         format!(
             "(x={}, y={}, w={}, h={})",
             x.coerce_to_string(activation)?,

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -80,7 +80,7 @@ fn to_string<'gc>(
     let height = this.get("height", activation)?;
 
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         format!(
             "(x={}, y={}, w={}, h={})",
             x.coerce_to_string(activation)?,
@@ -98,7 +98,7 @@ pub fn create_rectangle_object<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,
@@ -707,7 +707,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -89,7 +89,7 @@ pub fn set_selection<'gc>(
             .unwrap_or(i32::MAX)
             .max(0);
         let selection = TextSelection::for_range(start as usize, end as usize);
-        edit_box.set_selection(Some(selection), activation.context.gc_context);
+        edit_box.set_selection(Some(selection), activation.context.gc());
     }
     Ok(Value::Undefined)
 }
@@ -144,13 +144,13 @@ pub fn create_selection_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
-    broadcaster_functions.initialize(context.gc_context, object.into(), array_proto);
+    let object = ScriptObject::new(context.gc(), Some(proto));
+    broadcaster_functions.initialize(context.gc(), object.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     object.into()
 }
 
 pub fn create_proto<'gc>(context: &mut StringContext<'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
-    ScriptObject::new(context.gc_context, Some(proto)).into()
+    ScriptObject::new(context.gc(), Some(proto)).into()
 }

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -89,7 +89,7 @@ pub fn set_selection<'gc>(
             .unwrap_or(i32::MAX)
             .max(0);
         let selection = TextSelection::for_range(start as usize, end as usize);
-        edit_box.set_selection(Some(selection), activation.context.gc());
+        edit_box.set_selection(Some(selection), activation.gc());
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -154,7 +154,7 @@ pub fn deserialize_value<'gc>(
         AmfValue::Null => Value::Null,
         AmfValue::Undefined => Value::Undefined,
         AmfValue::Number(f) => (*f).into(),
-        AmfValue::String(s) => Value::String(AvmString::new_utf8(activation.context.gc(), s)),
+        AmfValue::String(s) => Value::String(AvmString::new_utf8(activation.gc(), s)),
         AmfValue::Bool(b) => (*b).into(),
         AmfValue::ECMAArray(_, _, associative, len) => {
             let array_constructor = activation.context.avm1.prototypes().array_constructor;
@@ -175,8 +175,8 @@ pub fn deserialize_value<'gc>(
                         obj.set_element(activation, i, value).unwrap();
                     } else {
                         obj.define_value(
-                            activation.context.gc(),
-                            AvmString::new_utf8(activation.context.gc(), &entry.name),
+                            activation.gc(),
+                            AvmString::new_utf8(activation.gc(), &entry.name),
                             value,
                             Attribute::empty(),
                         );
@@ -191,7 +191,7 @@ pub fn deserialize_value<'gc>(
         AmfValue::Object(_, elements, _) => {
             // Deserialize Object
             let obj = ScriptObject::new(
-                activation.context.gc(),
+                activation.gc(),
                 Some(activation.context.avm1.prototypes().object),
             );
 
@@ -204,8 +204,8 @@ pub fn deserialize_value<'gc>(
 
             for entry in elements {
                 let value = deserialize_value(activation, entry.value(), lso, reference_cache);
-                let name = AvmString::new_utf8(activation.context.gc(), &entry.name);
-                obj.define_value(activation.context.gc(), name, value, Attribute::empty());
+                let name = AvmString::new_utf8(activation.gc(), &entry.name);
+                obj.define_value(activation.gc(), name, value, Attribute::empty());
             }
 
             v
@@ -224,10 +224,7 @@ pub fn deserialize_value<'gc>(
 
             if let Ok(Value::Object(obj)) = xml_proto.construct(
                 activation,
-                &[Value::String(AvmString::new_utf8(
-                    activation.context.gc(),
-                    content,
-                ))],
+                &[Value::String(AvmString::new_utf8(activation.gc(), content))],
             ) {
                 Value::Object(obj)
             } else {
@@ -251,7 +248,7 @@ fn deserialize_lso<'gc>(
     decoder: &AMF0Decoder,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let obj = ScriptObject::new(
-        activation.context.gc(),
+        activation.gc(),
         Some(activation.context.avm1.prototypes().object),
     );
 
@@ -259,8 +256,8 @@ fn deserialize_lso<'gc>(
 
     for child in &lso.body {
         obj.define_value(
-            activation.context.gc(),
-            AvmString::new_utf8(activation.context.gc(), &child.name),
+            activation.gc(),
+            AvmString::new_utf8(activation.gc(), &child.name),
             deserialize_value(activation, child.value(), decoder, &mut reference_cache),
             Attribute::empty(),
         );
@@ -413,7 +410,7 @@ fn get_local<'gc>(
     // Set the internal name
     if let NativeObject::SharedObject(shared_object) = this.native() {
         shared_object
-            .write(activation.context.gc())
+            .write(activation.gc())
             .set_name(full_name.clone());
     }
 
@@ -430,18 +427,13 @@ fn get_local<'gc>(
     if data == Value::Undefined {
         // No data; create a fresh data object.
         data = ScriptObject::new(
-            activation.context.gc(),
+            activation.gc(),
             Some(activation.context.avm1.prototypes().object),
         )
         .into();
     }
 
-    this.define_value(
-        activation.context.gc(),
-        "data",
-        data,
-        Attribute::DONT_DELETE,
-    );
+    this.define_value(activation.gc(), "data", data, Attribute::DONT_DELETE);
 
     activation
         .context
@@ -580,8 +572,8 @@ fn constructor<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     this.set_native(
-        activation.context.gc(),
-        NativeObject::SharedObject(GcCell::new(activation.context.gc(), Default::default())),
+        activation.gc(),
+        NativeObject::SharedObject(GcCell::new(activation.gc(), Default::default())),
     );
     Ok(this.into())
 }

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -283,7 +283,7 @@ fn get_transform<'gc>(
             .unwrap_or_else(|| activation.context.global_sound_transform().clone());
 
         let obj = ScriptObject::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             Some(activation.context.avm1.prototypes().object),
         );
         // Surprisingly `lr` means "right-to-left" and `rl` means "left-to-right".

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -283,7 +283,7 @@ fn get_transform<'gc>(
             .unwrap_or_else(|| activation.context.global_sound_transform().clone());
 
         let obj = ScriptObject::new(
-            activation.context.gc(),
+            activation.gc(),
             Some(activation.context.avm1.prototypes().object),
         );
         // Surprisingly `lr` means "right-to-left" and `rl` means "left-to-right".

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -26,8 +26,8 @@ pub fn create_stage_object<'gc>(
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let stage = ScriptObject::new(context.gc_context, Some(proto));
-    broadcaster_functions.initialize(context.gc_context, stage.into(), array_proto);
+    let stage = ScriptObject::new(context.gc(), Some(proto));
+    broadcaster_functions.initialize(context.gc(), stage.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, stage, fn_proto);
     stage.into()
 }
@@ -56,7 +56,7 @@ fn align<'gc>(
     if align.contains(StageAlign::BOTTOM) {
         s.push_byte(b'B');
     }
-    let align = AvmString::new(activation.context.gc_context, s);
+    let align = AvmString::new(activation.context.gc(), s);
     Ok(align.into())
 }
 
@@ -92,7 +92,7 @@ fn scale_mode<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let scale_mode = AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.stage.scale_mode().to_string(),
     );
     Ok(scale_mode.into())

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -56,7 +56,7 @@ fn align<'gc>(
     if align.contains(StageAlign::BOTTOM) {
         s.push_byte(b'B');
     }
-    let align = AvmString::new(activation.context.gc(), s);
+    let align = AvmString::new(activation.gc(), s);
     Ok(align.into())
 }
 
@@ -92,7 +92,7 @@ fn scale_mode<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let scale_mode = AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.stage.scale_mode().to_string(),
     );
     Ok(scale_mode.into())

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -77,7 +77,7 @@ pub fn create_string_object<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let string = FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(string),
         Executable::Native(string_function),
         fn_proto,
@@ -115,7 +115,7 @@ fn char_at<'gc>(
         .ok()
         .and_then(|i| string.get(i))
         .map(WString::from_unit)
-        .map(|ret| AvmString::new(activation.context.gc_context, ret))
+        .map(|ret| AvmString::new(activation.context.gc(), ret))
         .unwrap_or_else(|| activation.strings().empty());
 
     Ok(ret.into())
@@ -156,7 +156,7 @@ fn concat<'gc>(
         let s = arg.coerce_to_string(activation)?;
         ret.push_str(&s);
     }
-    Ok(AvmString::new(activation.context.gc_context, ret).into())
+    Ok(AvmString::new(activation.context.gc(), ret).into())
 }
 
 fn from_char_code<'gc>(
@@ -173,7 +173,7 @@ fn from_char_code<'gc>(
         }
         out.push(i);
     }
-    Ok(AvmString::new(activation.context.gc_context, out).into())
+    Ok(AvmString::new(activation.context.gc(), out).into())
 }
 
 fn index_of<'gc>(
@@ -248,7 +248,7 @@ fn slice<'gc>(
     };
     if start_index < end_index {
         let ret = WString::from(&this[start_index..end_index]);
-        Ok(AvmString::new(activation.context.gc_context, ret).into())
+        Ok(AvmString::new(activation.context.gc(), ret).into())
     } else {
         Ok(activation.strings().empty().into())
     }
@@ -277,26 +277,26 @@ fn split<'gc>(
             // e.g., split("foo", "") returns ["", "f", "o", "o", ""] in Rust but ["f, "o", "o"] in Flash.
             // Special case this to match Flash's behavior.
             Ok(ArrayObject::new(
-                activation.context.gc_context,
+                activation.context.gc(),
                 activation.context.avm1.prototypes().array,
-                this.iter().take(limit).map(|c| {
-                    AvmString::new(activation.context.gc_context, WString::from_unit(c)).into()
-                }),
+                this.iter()
+                    .take(limit)
+                    .map(|c| AvmString::new(activation.context.gc(), WString::from_unit(c)).into()),
             )
             .into())
         } else {
             Ok(ArrayObject::new(
-                activation.context.gc_context,
+                activation.context.gc(),
                 activation.context.avm1.prototypes().array,
                 this.split(&delimiter)
                     .take(limit)
-                    .map(|c| AvmString::new(activation.context.gc_context, c).into()),
+                    .map(|c| AvmString::new(activation.context.gc(), c).into()),
             )
             .into())
         }
     } else {
         Ok(ArrayObject::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.avm1.prototypes().array,
             [this.into()],
         )
@@ -330,7 +330,7 @@ fn substr<'gc>(
 
     if start_index < end_index {
         let ret = WString::from(&this[start_index..end_index]);
-        Ok(AvmString::new(activation.context.gc_context, ret).into())
+        Ok(AvmString::new(activation.context.gc(), ret).into())
     } else {
         Ok(activation.strings().empty().into())
     }
@@ -359,7 +359,7 @@ fn substring<'gc>(
         std::mem::swap(&mut end_index, &mut start_index);
     }
     let ret = WString::from(&this[start_index..end_index]);
-    Ok(AvmString::new(activation.context.gc_context, ret).into())
+    Ok(AvmString::new(activation.context.gc(), ret).into())
 }
 
 fn to_lower_case<'gc>(
@@ -370,7 +370,7 @@ fn to_lower_case<'gc>(
     let this_val = Value::from(this);
     let this = this_val.coerce_to_string(activation)?;
     Ok(AvmString::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         this.iter()
             .map(string_utils::swf_to_lowercase)
             .collect::<WString>(),
@@ -404,7 +404,7 @@ fn to_upper_case<'gc>(
     let this_val = Value::from(this);
     let this = this_val.coerce_to_string(activation)?;
     Ok(AvmString::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         this.iter()
             .map(string_utils::swf_to_uppercase)
             .collect::<WString>(),

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -115,7 +115,7 @@ fn char_at<'gc>(
         .ok()
         .and_then(|i| string.get(i))
         .map(WString::from_unit)
-        .map(|ret| AvmString::new(activation.context.gc(), ret))
+        .map(|ret| AvmString::new(activation.gc(), ret))
         .unwrap_or_else(|| activation.strings().empty());
 
     Ok(ret.into())
@@ -156,7 +156,7 @@ fn concat<'gc>(
         let s = arg.coerce_to_string(activation)?;
         ret.push_str(&s);
     }
-    Ok(AvmString::new(activation.context.gc(), ret).into())
+    Ok(AvmString::new(activation.gc(), ret).into())
 }
 
 fn from_char_code<'gc>(
@@ -173,7 +173,7 @@ fn from_char_code<'gc>(
         }
         out.push(i);
     }
-    Ok(AvmString::new(activation.context.gc(), out).into())
+    Ok(AvmString::new(activation.gc(), out).into())
 }
 
 fn index_of<'gc>(
@@ -248,7 +248,7 @@ fn slice<'gc>(
     };
     if start_index < end_index {
         let ret = WString::from(&this[start_index..end_index]);
-        Ok(AvmString::new(activation.context.gc(), ret).into())
+        Ok(AvmString::new(activation.gc(), ret).into())
     } else {
         Ok(activation.strings().empty().into())
     }
@@ -277,26 +277,26 @@ fn split<'gc>(
             // e.g., split("foo", "") returns ["", "f", "o", "o", ""] in Rust but ["f, "o", "o"] in Flash.
             // Special case this to match Flash's behavior.
             Ok(ArrayObject::new(
-                activation.context.gc(),
+                activation.gc(),
                 activation.context.avm1.prototypes().array,
                 this.iter()
                     .take(limit)
-                    .map(|c| AvmString::new(activation.context.gc(), WString::from_unit(c)).into()),
+                    .map(|c| AvmString::new(activation.gc(), WString::from_unit(c)).into()),
             )
             .into())
         } else {
             Ok(ArrayObject::new(
-                activation.context.gc(),
+                activation.gc(),
                 activation.context.avm1.prototypes().array,
                 this.split(&delimiter)
                     .take(limit)
-                    .map(|c| AvmString::new(activation.context.gc(), c).into()),
+                    .map(|c| AvmString::new(activation.gc(), c).into()),
             )
             .into())
         }
     } else {
         Ok(ArrayObject::new(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.avm1.prototypes().array,
             [this.into()],
         )
@@ -330,7 +330,7 @@ fn substr<'gc>(
 
     if start_index < end_index {
         let ret = WString::from(&this[start_index..end_index]);
-        Ok(AvmString::new(activation.context.gc(), ret).into())
+        Ok(AvmString::new(activation.gc(), ret).into())
     } else {
         Ok(activation.strings().empty().into())
     }
@@ -359,7 +359,7 @@ fn substring<'gc>(
         std::mem::swap(&mut end_index, &mut start_index);
     }
     let ret = WString::from(&this[start_index..end_index]);
-    Ok(AvmString::new(activation.context.gc(), ret).into())
+    Ok(AvmString::new(activation.gc(), ret).into())
 }
 
 fn to_lower_case<'gc>(
@@ -370,7 +370,7 @@ fn to_lower_case<'gc>(
     let this_val = Value::from(this);
     let this = this_val.coerce_to_string(activation)?;
     Ok(AvmString::new(
-        activation.context.gc(),
+        activation.gc(),
         this.iter()
             .map(string_utils::swf_to_lowercase)
             .collect::<WString>(),
@@ -404,7 +404,7 @@ fn to_upper_case<'gc>(
     let this_val = Value::from(this);
     let this = this_val.coerce_to_string(activation)?;
     Ok(AvmString::new(
-        activation.context.gc(),
+        activation.gc(),
         this.iter()
             .map(string_utils::swf_to_uppercase)
             .collect::<WString>(),

--- a/core/src/avm1/globals/style_sheet.rs
+++ b/core/src/avm1/globals/style_sheet.rs
@@ -27,7 +27,7 @@ fn shallow_copy<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Value::Object(object) = value {
         let object_proto = activation.context.avm1.prototypes().object;
-        let result = ScriptObject::new(activation.context.gc_context, Some(object_proto));
+        let result = ScriptObject::new(activation.context.gc(), Some(object_proto));
 
         for key in object.get_keys(activation, false) {
             result.set(key, object.get_stored(key, activation)?, activation)?;
@@ -102,7 +102,7 @@ fn get_style_names<'gc>(
         .get_stored("_css".into(), activation)?
         .coerce_to_object(activation);
     Ok(ArrayObject::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.avm1.prototypes().array,
         css.get_keys(activation, false)
             .into_iter()
@@ -143,10 +143,10 @@ fn transform<'gc>(
     let text_format = TextFormat::default();
 
     let proto = activation.context.avm1.prototypes().text_format;
-    let object = ScriptObject::new(activation.context.gc_context, Some(proto));
+    let object = ScriptObject::new(activation.context.gc(), Some(proto));
     object.set_native(
-        activation.context.gc_context,
-        NativeObject::TextFormat(Gc::new(activation.context.gc_context, text_format.into())),
+        activation.context.gc(),
+        NativeObject::TextFormat(Gc::new(activation.context.gc(), text_format.into())),
     );
     Ok(object.into())
 }
@@ -165,7 +165,7 @@ fn parse_css<'gc>(
         for (selector, properties) in css.into_iter() {
             if !selector.is_empty() {
                 let proto = activation.context.avm1.prototypes().object;
-                let object = ScriptObject::new(activation.context.gc_context, Some(proto));
+                let object = ScriptObject::new(activation.context.gc(), Some(proto));
 
                 for (key, value) in properties.into_iter() {
                     object.set(
@@ -214,7 +214,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let style_sheet_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let style_sheet_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, style_sheet_proto, fn_proto);
     style_sheet_proto.into()
 }

--- a/core/src/avm1/globals/style_sheet.rs
+++ b/core/src/avm1/globals/style_sheet.rs
@@ -27,7 +27,7 @@ fn shallow_copy<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Value::Object(object) = value {
         let object_proto = activation.context.avm1.prototypes().object;
-        let result = ScriptObject::new(activation.context.gc(), Some(object_proto));
+        let result = ScriptObject::new(activation.gc(), Some(object_proto));
 
         for key in object.get_keys(activation, false) {
             result.set(key, object.get_stored(key, activation)?, activation)?;
@@ -102,7 +102,7 @@ fn get_style_names<'gc>(
         .get_stored("_css".into(), activation)?
         .coerce_to_object(activation);
     Ok(ArrayObject::new(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.avm1.prototypes().array,
         css.get_keys(activation, false)
             .into_iter()
@@ -143,10 +143,10 @@ fn transform<'gc>(
     let text_format = TextFormat::default();
 
     let proto = activation.context.avm1.prototypes().text_format;
-    let object = ScriptObject::new(activation.context.gc(), Some(proto));
+    let object = ScriptObject::new(activation.gc(), Some(proto));
     object.set_native(
-        activation.context.gc(),
-        NativeObject::TextFormat(Gc::new(activation.context.gc(), text_format.into())),
+        activation.gc(),
+        NativeObject::TextFormat(Gc::new(activation.gc(), text_format.into())),
     );
     Ok(object.into())
 }
@@ -165,7 +165,7 @@ fn parse_css<'gc>(
         for (selector, properties) in css.into_iter() {
             if !selector.is_empty() {
                 let proto = activation.context.avm1.prototypes().object;
-                let object = ScriptObject::new(activation.context.gc(), Some(proto));
+                let object = ScriptObject::new(activation.gc(), Some(proto));
 
                 for (key, value) in properties.into_iter() {
                     object.set(

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -508,7 +508,7 @@ pub fn create<'gc>(
     capabilities: Object<'gc>,
     ime: Object<'gc>,
 ) -> Object<'gc> {
-    let gc_context = context.gc_context;
+    let gc_context = context.gc();
     let system = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(OBJECT_DECLS, context, system, fn_proto);
     system.define_value(gc_context, "IME", ime.into(), Attribute::empty());

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -103,7 +103,7 @@ pub fn get_player_type<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.system.player_type.to_string(),
     )
     .into())
@@ -115,7 +115,7 @@ pub fn get_screen_color<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.system.screen_color.to_string(),
     )
     .into())
@@ -127,7 +127,7 @@ pub fn get_language<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         activation
             .context
             .system
@@ -181,7 +181,7 @@ pub fn get_manufacturer<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         activation
             .context
             .system
@@ -196,11 +196,7 @@ pub fn get_os_name<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new_utf8(
-        activation.context.gc(),
-        activation.context.system.os.to_string(),
-    )
-    .into())
+    Ok(AvmString::new_utf8(activation.gc(), activation.context.system.os.to_string()).into())
 }
 
 pub fn get_version<'gc>(
@@ -209,7 +205,7 @@ pub fn get_version<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         activation
             .context
             .system
@@ -227,7 +223,7 @@ pub fn get_server_string<'gc>(
         .context
         .system
         .get_server_string(activation.context);
-    Ok(AvmString::new_utf8(activation.context.gc(), server_string).into())
+    Ok(AvmString::new_utf8(activation.gc(), server_string).into())
 }
 
 pub fn get_cpu_architecture<'gc>(
@@ -236,7 +232,7 @@ pub fn get_cpu_architecture<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.system.cpu_architecture.to_string(),
     )
     .into())
@@ -247,11 +243,7 @@ pub fn get_max_idc_level<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new_utf8(
-        activation.context.gc(),
-        &activation.context.system.idc_level,
-    )
-    .into())
+    Ok(AvmString::new_utf8(activation.gc(), &activation.context.system.idc_level).into())
 }
 
 pub fn create<'gc>(

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -103,7 +103,7 @@ pub fn get_player_type<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.system.player_type.to_string(),
     )
     .into())
@@ -115,7 +115,7 @@ pub fn get_screen_color<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.system.screen_color.to_string(),
     )
     .into())
@@ -127,7 +127,7 @@ pub fn get_language<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation
             .context
             .system
@@ -181,7 +181,7 @@ pub fn get_manufacturer<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation
             .context
             .system
@@ -197,7 +197,7 @@ pub fn get_os_name<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.system.os.to_string(),
     )
     .into())
@@ -209,7 +209,7 @@ pub fn get_version<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation
             .context
             .system
@@ -227,7 +227,7 @@ pub fn get_server_string<'gc>(
         .context
         .system
         .get_server_string(activation.context);
-    Ok(AvmString::new_utf8(activation.context.gc_context, server_string).into())
+    Ok(AvmString::new_utf8(activation.context.gc(), server_string).into())
 }
 
 pub fn get_cpu_architecture<'gc>(
@@ -236,7 +236,7 @@ pub fn get_cpu_architecture<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.system.cpu_architecture.to_string(),
     )
     .into())
@@ -248,7 +248,7 @@ pub fn get_max_idc_level<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         &activation.context.system.idc_level,
     )
     .into())
@@ -259,7 +259,7 @@ pub fn create<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let capabilities = ScriptObject::new(context.gc_context, Some(proto));
+    let capabilities = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(OBJECT_DECLS, context, capabilities, fn_proto);
     capabilities.into()
 }

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -86,8 +86,8 @@ pub fn create<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let ime = ScriptObject::new(context.gc_context, Some(proto));
-    broadcaster_functions.initialize(context.gc_context, ime.into(), array_proto);
+    let ime = ScriptObject::new(context.gc(), Some(proto));
+    broadcaster_functions.initialize(context.gc(), ime.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, ime, fn_proto);
     ime.into()
 }

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -61,7 +61,7 @@ fn get_sandbox_type<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let movie = activation.base_clip().movie();
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         match movie.sandbox_type() {
             SandboxType::Remote => "remote",
             SandboxType::LocalWithFile => "localWithFile",

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -61,7 +61,7 @@ fn get_sandbox_type<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let movie = activation.base_clip().movie();
     Ok(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         match movie.sandbox_type() {
             SandboxType::Remote => "remote",
             SandboxType::LocalWithFile => "localWithFile",
@@ -95,7 +95,7 @@ pub fn create<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let security = ScriptObject::new(context.gc_context, Some(proto));
+    let security = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(OBJECT_DECLS, context, security, fn_proto);
     security.into()
 }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -138,10 +138,10 @@ fn new_text_format<'gc>(
     text_format: TextFormat,
 ) -> ScriptObject<'gc> {
     let proto = activation.context.avm1.prototypes().text_format;
-    let object = ScriptObject::new(activation.context.gc(), Some(proto));
+    let object = ScriptObject::new(activation.gc(), Some(proto));
     object.set_native(
-        activation.context.gc(),
-        NativeObject::TextFormat(Gc::new(activation.context.gc(), text_format.into())),
+        activation.gc(),
+        NativeObject::TextFormat(Gc::new(activation.gc(), text_format.into())),
     );
     object
 }
@@ -258,7 +258,7 @@ fn replace_sel<'gc>(
     );
     text_field.set_selection(
         Some(TextSelection::for_position(selection.start() + text.len())),
-        activation.context.gc(),
+        activation.gc(),
     );
 
     text_field.propagate_text_binding(activation);
@@ -305,7 +305,7 @@ pub fn text<'gc>(
     this: EditText<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(activation.context.gc(), this.text()).into())
+    Ok(AvmString::new(activation.gc(), this.text()).into())
 }
 
 pub fn set_text<'gc>(
@@ -370,7 +370,7 @@ pub fn html_text<'gc>(
     this: EditText<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(activation.context.gc(), this.html_text()).into())
+    Ok(AvmString::new(activation.gc(), this.html_text()).into())
 }
 
 pub fn set_html_text<'gc>(
@@ -397,7 +397,7 @@ pub fn set_background<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let has_background = value.as_bool(activation.swf_version());
-    this.set_has_background(activation.context.gc(), has_background);
+    this.set_has_background(activation.gc(), has_background);
     Ok(())
 }
 
@@ -415,7 +415,7 @@ pub fn set_background_color<'gc>(
 ) -> Result<(), Error<'gc>> {
     let rgb = value.coerce_to_u32(activation)?;
     let color = Color::from_rgb(rgb, 255);
-    this.set_background_color(activation.context.gc(), color);
+    this.set_background_color(activation.gc(), color);
     Ok(())
 }
 
@@ -432,7 +432,7 @@ pub fn set_border<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let has_border = value.as_bool(activation.swf_version());
-    this.set_has_border(activation.context.gc(), has_border);
+    this.set_has_border(activation.gc(), has_border);
     Ok(())
 }
 
@@ -450,7 +450,7 @@ pub fn set_border_color<'gc>(
 ) -> Result<(), Error<'gc>> {
     let rgb = value.coerce_to_u32(activation)?;
     let color = Color::from_rgb(rgb, 255);
-    this.set_border_color(activation.context.gc(), color);
+    this.set_border_color(activation.gc(), color);
     Ok(())
 }
 
@@ -550,7 +550,7 @@ fn variable<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(variable) = this.variable() {
-        return Ok(AvmString::new_utf8(activation.context.gc(), &variable[..]).into());
+        return Ok(AvmString::new_utf8(activation.gc(), &variable[..]).into());
     }
 
     // Unset `variable` returns null, not undefined
@@ -744,15 +744,9 @@ pub fn set_anti_alias_type<'gc>(
     let new_type = value.coerce_to_string(activation)?;
 
     if &new_type == b"advanced" {
-        this.set_render_settings(
-            activation.context.gc(),
-            old_settings.with_advanced_rendering(),
-        );
+        this.set_render_settings(activation.gc(), old_settings.with_advanced_rendering());
     } else if &new_type == b"normal" {
-        this.set_render_settings(
-            activation.context.gc(),
-            old_settings.with_normal_rendering(),
-        );
+        this.set_render_settings(activation.gc(), old_settings.with_normal_rendering());
     }
 
     Ok(())
@@ -779,17 +773,17 @@ pub fn set_grid_fit_type<'gc>(
 
     if &new_type == b"pixel" {
         this.set_render_settings(
-            activation.context.gc(),
+            activation.gc(),
             old_settings.with_grid_fit(swf::TextGridFit::Pixel),
         );
     } else if &new_type == b"subpixel" {
         this.set_render_settings(
-            activation.context.gc(),
+            activation.gc(),
             old_settings.with_grid_fit(swf::TextGridFit::SubPixel),
         );
     } else if &new_type == b"none" {
         this.set_render_settings(
-            activation.context.gc(),
+            activation.gc(),
             old_settings.with_grid_fit(swf::TextGridFit::None),
         );
     } // NOTE: In AS2 invalid values do nothing.
@@ -813,7 +807,7 @@ pub fn set_thickness<'gc>(
     let new_thickness = value.coerce_to_f64(activation)?;
 
     this.set_render_settings(
-        activation.context.gc(),
+        activation.gc(),
         old_settings.with_thickness(new_thickness as f32),
     );
 
@@ -836,7 +830,7 @@ pub fn set_sharpness<'gc>(
     let new_sharpness = value.coerce_to_f64(activation)?;
 
     this.set_render_settings(
-        activation.context.gc(),
+        activation.gc(),
         old_settings.with_sharpness(new_sharpness as f32),
     );
 
@@ -848,7 +842,7 @@ fn filters<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(ArrayObject::new(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.avm1.prototypes().array,
         this.filters()
             .into_iter()
@@ -871,7 +865,7 @@ fn set_filters<'gc>(
             }
         }
     }
-    this.set_filters(activation.context.gc(), filters);
+    this.set_filters(activation.gc(), filters);
     Ok(())
 }
 
@@ -880,7 +874,7 @@ fn restrict<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     match this.restrict() {
-        Some(value) => Ok(AvmString::new(activation.context.gc(), value).into()),
+        Some(value) => Ok(AvmString::new(activation.gc(), value).into()),
         None => Ok(Value::Null),
     }
 }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -112,7 +112,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
@@ -138,10 +138,10 @@ fn new_text_format<'gc>(
     text_format: TextFormat,
 ) -> ScriptObject<'gc> {
     let proto = activation.context.avm1.prototypes().text_format;
-    let object = ScriptObject::new(activation.context.gc_context, Some(proto));
+    let object = ScriptObject::new(activation.context.gc(), Some(proto));
     object.set_native(
-        activation.context.gc_context,
-        NativeObject::TextFormat(Gc::new(activation.context.gc_context, text_format.into())),
+        activation.context.gc(),
+        NativeObject::TextFormat(Gc::new(activation.context.gc(), text_format.into())),
     );
     object
 }
@@ -258,7 +258,7 @@ fn replace_sel<'gc>(
     );
     text_field.set_selection(
         Some(TextSelection::for_position(selection.start() + text.len())),
-        activation.context.gc_context,
+        activation.context.gc(),
     );
 
     text_field.propagate_text_binding(activation);
@@ -305,7 +305,7 @@ pub fn text<'gc>(
     this: EditText<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(activation.context.gc_context, this.text()).into())
+    Ok(AvmString::new(activation.context.gc(), this.text()).into())
 }
 
 pub fn set_text<'gc>(
@@ -370,7 +370,7 @@ pub fn html_text<'gc>(
     this: EditText<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(activation.context.gc_context, this.html_text()).into())
+    Ok(AvmString::new(activation.context.gc(), this.html_text()).into())
 }
 
 pub fn set_html_text<'gc>(
@@ -397,7 +397,7 @@ pub fn set_background<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let has_background = value.as_bool(activation.swf_version());
-    this.set_has_background(activation.context.gc_context, has_background);
+    this.set_has_background(activation.context.gc(), has_background);
     Ok(())
 }
 
@@ -415,7 +415,7 @@ pub fn set_background_color<'gc>(
 ) -> Result<(), Error<'gc>> {
     let rgb = value.coerce_to_u32(activation)?;
     let color = Color::from_rgb(rgb, 255);
-    this.set_background_color(activation.context.gc_context, color);
+    this.set_background_color(activation.context.gc(), color);
     Ok(())
 }
 
@@ -432,7 +432,7 @@ pub fn set_border<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let has_border = value.as_bool(activation.swf_version());
-    this.set_has_border(activation.context.gc_context, has_border);
+    this.set_has_border(activation.context.gc(), has_border);
     Ok(())
 }
 
@@ -450,7 +450,7 @@ pub fn set_border_color<'gc>(
 ) -> Result<(), Error<'gc>> {
     let rgb = value.coerce_to_u32(activation)?;
     let color = Color::from_rgb(rgb, 255);
-    this.set_border_color(activation.context.gc_context, color);
+    this.set_border_color(activation.context.gc(), color);
     Ok(())
 }
 
@@ -550,7 +550,7 @@ fn variable<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(variable) = this.variable() {
-        return Ok(AvmString::new_utf8(activation.context.gc_context, &variable[..]).into());
+        return Ok(AvmString::new_utf8(activation.context.gc(), &variable[..]).into());
     }
 
     // Unset `variable` returns null, not undefined
@@ -745,12 +745,12 @@ pub fn set_anti_alias_type<'gc>(
 
     if &new_type == b"advanced" {
         this.set_render_settings(
-            activation.context.gc_context,
+            activation.context.gc(),
             old_settings.with_advanced_rendering(),
         );
     } else if &new_type == b"normal" {
         this.set_render_settings(
-            activation.context.gc_context,
+            activation.context.gc(),
             old_settings.with_normal_rendering(),
         );
     }
@@ -779,17 +779,17 @@ pub fn set_grid_fit_type<'gc>(
 
     if &new_type == b"pixel" {
         this.set_render_settings(
-            activation.context.gc_context,
+            activation.context.gc(),
             old_settings.with_grid_fit(swf::TextGridFit::Pixel),
         );
     } else if &new_type == b"subpixel" {
         this.set_render_settings(
-            activation.context.gc_context,
+            activation.context.gc(),
             old_settings.with_grid_fit(swf::TextGridFit::SubPixel),
         );
     } else if &new_type == b"none" {
         this.set_render_settings(
-            activation.context.gc_context,
+            activation.context.gc(),
             old_settings.with_grid_fit(swf::TextGridFit::None),
         );
     } // NOTE: In AS2 invalid values do nothing.
@@ -813,7 +813,7 @@ pub fn set_thickness<'gc>(
     let new_thickness = value.coerce_to_f64(activation)?;
 
     this.set_render_settings(
-        activation.context.gc_context,
+        activation.context.gc(),
         old_settings.with_thickness(new_thickness as f32),
     );
 
@@ -836,7 +836,7 @@ pub fn set_sharpness<'gc>(
     let new_sharpness = value.coerce_to_f64(activation)?;
 
     this.set_render_settings(
-        activation.context.gc_context,
+        activation.context.gc(),
         old_settings.with_sharpness(new_sharpness as f32),
     );
 
@@ -848,7 +848,7 @@ fn filters<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(ArrayObject::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.avm1.prototypes().array,
         this.filters()
             .into_iter()
@@ -871,7 +871,7 @@ fn set_filters<'gc>(
             }
         }
     }
-    this.set_filters(activation.context.gc_context, filters);
+    this.set_filters(activation.context.gc(), filters);
     Ok(())
 }
 
@@ -880,7 +880,7 @@ fn restrict<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     match this.restrict() {
-        Some(value) => Ok(AvmString::new(activation.context.gc_context, value).into()),
+        Some(value) => Ok(AvmString::new(activation.context.gc(), value).into()),
         None => Ok(Value::Null),
     }
 }

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -71,10 +71,7 @@ fn method<'gc>(
         let Some(transform) = TransformObject::new(activation, args) else {
             return Ok(Value::Undefined);
         };
-        this.set_native(
-            activation.context.gc_context,
-            NativeObject::Transform(transform),
-        );
+        this.set_native(activation.context.gc(), NativeObject::Transform(transform));
         return Ok(this.into());
     }
 
@@ -96,12 +93,12 @@ fn method<'gc>(
                     .all(|p| object.has_own_property(activation, (*p).into()));
                 if is_matrix {
                     let matrix = object_to_matrix(object, activation)?;
-                    clip.set_matrix(activation.context.gc_context, matrix);
-                    clip.set_transformed_by_script(activation.context.gc_context, true);
+                    clip.set_matrix(activation.context.gc(), matrix);
+                    clip.set_transformed_by_script(activation.context.gc(), true);
                     if let Some(parent) = clip.parent() {
                         // Self-transform changes are automatically handled,
                         // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
-                        parent.invalidate_cached_bitmap(activation.context.gc_context);
+                        parent.invalidate_cached_bitmap(activation.context.gc());
                     }
                 }
             }
@@ -123,11 +120,11 @@ fn method<'gc>(
                 // Set only occurs for an object with actual ColorTransform data.
                 if let Some(color_transform) = ColorTransformObject::cast(*value) {
                     clip.set_color_transform(
-                        activation.context.gc_context,
+                        activation.context.gc(),
                         color_transform.read().clone().into(),
                     );
-                    clip.invalidate_cached_bitmap(activation.context.gc_context);
-                    clip.set_transformed_by_script(activation.context.gc_context, true);
+                    clip.invalidate_cached_bitmap(activation.context.gc());
+                    clip.set_transformed_by_script(activation.context.gc(), true);
                 }
             }
             Value::Undefined
@@ -179,10 +176,10 @@ pub fn create_constructor<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let transform_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let transform_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, transform_proto, fn_proto);
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(transform_method!(0)),
         constructor_to_fn!(transform_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -71,7 +71,7 @@ fn method<'gc>(
         let Some(transform) = TransformObject::new(activation, args) else {
             return Ok(Value::Undefined);
         };
-        this.set_native(activation.context.gc(), NativeObject::Transform(transform));
+        this.set_native(activation.gc(), NativeObject::Transform(transform));
         return Ok(this.into());
     }
 
@@ -93,12 +93,12 @@ fn method<'gc>(
                     .all(|p| object.has_own_property(activation, (*p).into()));
                 if is_matrix {
                     let matrix = object_to_matrix(object, activation)?;
-                    clip.set_matrix(activation.context.gc(), matrix);
-                    clip.set_transformed_by_script(activation.context.gc(), true);
+                    clip.set_matrix(activation.gc(), matrix);
+                    clip.set_transformed_by_script(activation.gc(), true);
                     if let Some(parent) = clip.parent() {
                         // Self-transform changes are automatically handled,
                         // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
-                        parent.invalidate_cached_bitmap(activation.context.gc());
+                        parent.invalidate_cached_bitmap(activation.gc());
                     }
                 }
             }
@@ -120,11 +120,11 @@ fn method<'gc>(
                 // Set only occurs for an object with actual ColorTransform data.
                 if let Some(color_transform) = ColorTransformObject::cast(*value) {
                     clip.set_color_transform(
-                        activation.context.gc(),
+                        activation.gc(),
                         color_transform.read().clone().into(),
                     );
-                    clip.invalidate_cached_bitmap(activation.context.gc());
-                    clip.set_transformed_by_script(activation.context.gc(), true);
+                    clip.invalidate_cached_bitmap(activation.gc());
+                    clip.set_transformed_by_script(activation.gc(), true);
                 }
             }
             Value::Undefined

--- a/core/src/avm1/globals/video.rs
+++ b/core/src/avm1/globals/video.rs
@@ -60,7 +60,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context.gc_context, Some(proto));
+    let object = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -136,11 +136,11 @@ impl<'gc> Xml<'gc> {
         let mut parser = Reader::from_str(&data_utf8);
         let mut open_tags = vec![self.root()];
 
-        self.0.write(activation.context.gc_context).status = XmlStatus::NoError;
+        self.0.write(activation.context.gc()).status = XmlStatus::NoError;
 
         loop {
             let event = parser.read_event().map_err(|error| {
-                self.0.write(activation.context.gc_context).status = match error {
+                self.0.write(activation.context.gc()).status = match error {
                     quick_xml::Error::Syntax(_)
                     | quick_xml::Error::InvalidAttr(AttrError::ExpectedEq(_))
                     | quick_xml::Error::InvalidAttr(AttrError::Duplicated(_, _)) => {
@@ -173,7 +173,7 @@ impl<'gc> Xml<'gc> {
                     open_tags
                         .last_mut()
                         .unwrap()
-                        .append_child(activation.context.gc_context, child);
+                        .append_child(activation.context.gc(), child);
                     open_tags.push(child);
                 }
                 Event::Empty(bs) => {
@@ -182,7 +182,7 @@ impl<'gc> Xml<'gc> {
                     open_tags
                         .last_mut()
                         .unwrap()
-                        .append_child(activation.context.gc_context, child);
+                        .append_child(activation.context.gc(), child);
                 }
                 Event::End(_) => {
                     open_tags.pop();
@@ -208,8 +208,8 @@ impl<'gc> Xml<'gc> {
                     let mut xml_decl = WString::from_buf(b"<?".to_vec());
                     xml_decl.push_str(WStr::from_units(&*bd));
                     xml_decl.push_str(WStr::from_units(b"?>"));
-                    self.0.write(activation.context.gc_context).xml_decl =
-                        Some(AvmString::new(activation.context.gc_context, xml_decl));
+                    self.0.write(activation.context.gc()).xml_decl =
+                        Some(AvmString::new(activation.context.gc(), xml_decl));
                 }
                 Event::DocType(bt) => {
                     // TODO: `quick-xml` is case-insensitive for DOCTYPE declarations,
@@ -219,8 +219,8 @@ impl<'gc> Xml<'gc> {
                     let mut doctype = WString::from_buf(b"<!DOCTYPE ".to_vec());
                     doctype.push_str(WStr::from_units(&*bt.escape_ascii().collect::<Vec<_>>()));
                     doctype.push_byte(b'>');
-                    self.0.write(activation.context.gc_context).doctype =
-                        Some(AvmString::new(activation.context.gc_context, doctype));
+                    self.0.write(activation.context.gc()).doctype =
+                        Some(AvmString::new(activation.context.gc(), doctype));
                 }
                 Event::Eof => break,
                 _ => {}
@@ -241,12 +241,12 @@ impl<'gc> Xml<'gc> {
         let is_whitespace_char = |c: &u8| matches!(*c, b'\t' | b'\n' | b'\r' | b' ');
         let is_whitespace_text = text.iter().all(is_whitespace_char);
         if !(text.is_empty() || ignore_white && is_whitespace_text) {
-            let text = AvmString::new_utf8_bytes(activation.context.gc_context, text);
-            let child = XmlNode::new(activation.context.gc_context, TEXT_NODE, Some(text));
+            let text = AvmString::new_utf8_bytes(activation.context.gc(), text);
+            let child = XmlNode::new(activation.context.gc(), TEXT_NODE, Some(text));
             open_tags
                 .last_mut()
                 .unwrap()
-                .append_child(activation.context.gc_context, child);
+                .append_child(activation.context.gc(), child);
         }
     }
 }
@@ -274,7 +274,7 @@ fn constructor<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = Xml::empty(activation.context.gc_context, this);
+    let xml = Xml::empty(activation.context.gc(), this);
 
     if let [text, ..] = args {
         let text = text.coerce_to_string(activation)?;
@@ -298,7 +298,7 @@ fn create_element<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let (NativeObject::Xml(_), [name, ..]) = (this.native(), args) {
         let name = name.coerce_to_string(activation)?;
-        let mut node = XmlNode::new(activation.context.gc_context, ELEMENT_NODE, Some(name));
+        let mut node = XmlNode::new(activation.context.gc(), ELEMENT_NODE, Some(name));
         return Ok(node.script_object(activation).into());
     }
 
@@ -312,7 +312,7 @@ fn create_text_node<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let (NativeObject::Xml(_), [text, ..]) = (this.native(), args) {
         let text = text.coerce_to_string(activation)?;
-        let mut node = XmlNode::new(activation.context.gc_context, TEXT_NODE, Some(text));
+        let mut node = XmlNode::new(activation.context.gc(), TEXT_NODE, Some(text));
         return Ok(node.script_object(activation).into());
     }
 
@@ -344,7 +344,7 @@ fn parse_xml<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::Xml(xml) = this.native() {
         for mut child in xml.root().children().rev() {
-            child.remove_node(activation.context.gc_context);
+            child.remove_node(activation.context.gc());
         }
 
         if let [text, ..] = args {
@@ -523,7 +523,7 @@ fn spawn_xml_fetch<'gc>(
     // Create hidden properties on object.
     if !this.has_property(activation, "_bytesLoaded".into()) {
         this.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "_bytesLoaded",
             0.into(),
             Attribute::DONT_DELETE | Attribute::DONT_ENUM,
@@ -534,7 +534,7 @@ fn spawn_xml_fetch<'gc>(
 
     if !this.has_property(activation, "_bytesTotal".into()) {
         this.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "_bytesTotal",
             Value::Undefined,
             Attribute::DONT_DELETE | Attribute::DONT_ENUM,
@@ -545,7 +545,7 @@ fn spawn_xml_fetch<'gc>(
 
     if !this.has_property(activation, "loaded".into()) {
         this.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "loaded",
             false.into(),
             Attribute::DONT_DELETE | Attribute::DONT_ENUM,
@@ -569,10 +569,10 @@ pub fn create_constructor<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xml_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let xml_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, xml_proto, fn_proto);
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -63,7 +63,7 @@ fn append_child<'gc>(
     ) {
         if !xmlnode.has_child(child_xmlnode) {
             let position = xmlnode.children_len();
-            xmlnode.insert_child(activation.context.gc(), position, child_xmlnode);
+            xmlnode.insert_child(activation.gc(), position, child_xmlnode);
             xmlnode.refresh_cached_child_nodes(activation)?;
         }
     }
@@ -85,7 +85,7 @@ fn insert_before<'gc>(
     ) {
         if !xmlnode.has_child(child_xmlnode) {
             if let Some(position) = xmlnode.child_position(insertpoint_xmlnode) {
-                xmlnode.insert_child(activation.context.gc(), position, child_xmlnode);
+                xmlnode.insert_child(activation.gc(), position, child_xmlnode);
                 xmlnode.refresh_cached_child_nodes(activation)?;
             }
         }
@@ -105,7 +105,7 @@ fn clone_node<'gc>(
             .map(|v| v.as_bool(activation.swf_version()))
             .unwrap_or(false),
     ) {
-        let mut clone_node = xmlnode.duplicate(activation.context.gc(), deep);
+        let mut clone_node = xmlnode.duplicate(activation.gc(), deep);
         return Ok(clone_node.script_object(activation).into());
     }
 
@@ -144,7 +144,7 @@ fn get_prefix_for_namespace<'gc>(
                 if value == uri {
                     if let Some(prefix) = key.strip_prefix(WStr::from_units(b"xmlns")) {
                         if let Some(prefix) = prefix.strip_prefix(b':') {
-                            return Ok(AvmString::new(activation.context.gc(), prefix).into());
+                            return Ok(AvmString::new(activation.gc(), prefix).into());
                         } else {
                             return Ok(activation.strings().empty().into());
                         }
@@ -176,7 +176,7 @@ fn remove_node<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mut node) = this.as_xml_node() {
         let old_parent = node.parent();
-        node.remove_node(activation.context.gc());
+        node.remove_node(activation.gc());
         if let Some(old_parent) = old_parent {
             old_parent.refresh_cached_child_nodes(activation)?;
         }
@@ -192,7 +192,7 @@ fn to_string<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
         let string = node.into_string(activation)?;
-        return Ok(AvmString::new(activation.context.gc(), string).into());
+        return Ok(AvmString::new(activation.gc(), string).into());
     }
 
     Ok(activation.strings().empty().into())
@@ -205,7 +205,7 @@ fn local_name<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
         .as_xml_node()
-        .and_then(|n| n.local_name(activation.context.gc()))
+        .and_then(|n| n.local_name(activation.gc()))
         .map_or(Value::Null, Value::from))
 }
 
@@ -232,7 +232,7 @@ fn set_node_value<'gc>(
         }
 
         if let Some(node) = this.as_xml_node() {
-            node.set_node_value(activation.context.gc(), name.coerce_to_string(activation)?);
+            node.set_node_value(activation.gc(), name.coerce_to_string(activation)?);
         }
     }
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/xml_socket.rs
+++ b/core/src/avm1/globals/xml_socket.rs
@@ -125,7 +125,7 @@ pub fn connect<'gc>(
                     if url.scheme() == "file" {
                         "localhost".into()
                     } else if let Some(domain) = url.domain() {
-                        AvmString::new_utf8(activation.context.gc(), domain).into()
+                        AvmString::new_utf8(activation.gc(), domain).into()
                     } else {
                         // no domain?
                         "localhost".into()

--- a/core/src/avm1/globals/xml_socket.rs
+++ b/core/src/avm1/globals/xml_socket.rs
@@ -125,7 +125,7 @@ pub fn connect<'gc>(
                     if url.scheme() == "file" {
                         "localhost".into()
                     } else if let Some(domain) = url.domain() {
-                        AvmString::new_utf8(activation.context.gc_context, domain).into()
+                        AvmString::new_utf8(activation.context.gc(), domain).into()
                     } else {
                         // no domain?
                         "localhost".into()
@@ -251,7 +251,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xml_socket_proto = ScriptObject::new(context.gc_context, Some(proto));
+    let xml_socket_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, xml_socket_proto, fn_proto);
     xml_socket_proto.into()
 }
@@ -262,7 +262,7 @@ pub fn create_class<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        context.gc_context,
+        context.gc(),
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,

--- a/core/src/avm1/object/array_object.rs
+++ b/core/src/avm1/object/array_object.rs
@@ -20,7 +20,7 @@ impl fmt::Debug for ArrayObject<'_> {
 impl<'gc> ArrayObject<'gc> {
     pub fn empty(activation: &Activation<'_, 'gc>) -> Self {
         Self::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.avm1.prototypes().array,
             [],
         )
@@ -103,7 +103,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(Self::empty_with_proto(activation.context.gc_context, this).into())
+        Ok(Self::empty_with_proto(activation.context.gc(), this).into())
     }
 
     fn as_array_object(&self) -> Option<ArrayObject<'gc>> {

--- a/core/src/avm1/object/array_object.rs
+++ b/core/src/avm1/object/array_object.rs
@@ -20,7 +20,7 @@ impl fmt::Debug for ArrayObject<'_> {
 impl<'gc> ArrayObject<'gc> {
     pub fn empty(activation: &Activation<'_, 'gc>) -> Self {
         Self::new(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.avm1.prototypes().array,
             [],
         )
@@ -103,7 +103,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(Self::empty_with_proto(activation.context.gc(), this).into())
+        Ok(Self::empty_with_proto(activation.gc(), this).into())
     }
 
     fn as_array_object(&self) -> Option<ArrayObject<'gc>> {

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -118,7 +118,7 @@ impl<'gc> ScriptObject<'gc> {
         // TODO: Call watchers.
         match self
             .0
-            .write(activation.context.gc())
+            .write(activation.gc())
             .properties
             .entry(name, activation.is_case_sensitive())
         {
@@ -175,7 +175,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     ) -> Result<(), Error<'gc>> {
         let setter = match self
             .0
-            .write(activation.context.gc())
+            .write(activation.gc())
             .properties
             .entry(name, activation.is_case_sensitive())
         {
@@ -255,7 +255,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(ScriptObject::new(activation.context.gc(), Some(this)).into())
+        Ok(ScriptObject::new(activation.gc(), Some(this)).into())
     }
 
     /// Delete a named property from the object.
@@ -264,7 +264,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     fn delete(&self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) -> bool {
         if let Entry::Occupied(mut entry) = self
             .0
-            .write(activation.context.gc())
+            .write(activation.gc())
             .properties
             .entry(name, activation.is_case_sensitive())
         {
@@ -300,7 +300,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     ) {
         match self
             .0
-            .write(activation.context.gc())
+            .write(activation.gc())
             .properties
             .entry(name, activation.is_case_sensitive())
         {
@@ -345,7 +345,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         callback: Object<'gc>,
         user_data: Value<'gc>,
     ) {
-        self.0.write(activation.context.gc()).watchers.insert(
+        self.0.write(activation.gc()).watchers.insert(
             name,
             Watcher::new(callback, user_data),
             activation.is_case_sensitive(),
@@ -354,7 +354,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     fn unwatch(&self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) -> bool {
         self.0
-            .write(activation.context.gc())
+            .write(activation.gc())
             .watchers
             .remove(name, activation.is_case_sensitive())
             .is_some()
@@ -518,12 +518,12 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     }
 
     fn has_element(&self, activation: &mut Activation<'_, 'gc>, index: i32) -> bool {
-        let index_str = AvmString::new_utf8(activation.context.gc(), index.to_string());
+        let index_str = AvmString::new_utf8(activation.gc(), index.to_string());
         self.has_own_property(activation, index_str)
     }
 
     fn get_element(&self, activation: &mut Activation<'_, 'gc>, index: i32) -> Value<'gc> {
-        let index_str = AvmString::new_utf8(activation.context.gc(), index.to_string());
+        let index_str = AvmString::new_utf8(activation.gc(), index.to_string());
         self.get_data(index_str, activation)
     }
 
@@ -533,12 +533,12 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         index: i32,
         value: Value<'gc>,
     ) -> Result<(), Error<'gc>> {
-        let index_str = AvmString::new_utf8(activation.context.gc(), index.to_string());
+        let index_str = AvmString::new_utf8(activation.gc(), index.to_string());
         self.set_data(index_str, value, activation)
     }
 
     fn delete_element(&self, activation: &mut Activation<'_, 'gc>, index: i32) -> bool {
-        let index_str = AvmString::new_utf8(activation.context.gc(), index.to_string());
+        let index_str = AvmString::new_utf8(activation.gc(), index.to_string());
         self.delete(activation, index_str)
     }
 }
@@ -556,7 +556,7 @@ mod tests {
     {
         crate::avm1::test_utils::with_avm(swf_version, |activation, _root| {
             let object = ScriptObject::new(
-                activation.context.gc(),
+                activation.gc(),
                 Some(activation.context.avm1.prototypes().object),
             )
             .into();
@@ -579,7 +579,7 @@ mod tests {
     fn test_set_get() {
         with_object(0, |activation, object| {
             object.raw_script_object().define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "forced",
                 "forced".into(),
                 Attribute::empty(),
@@ -595,13 +595,13 @@ mod tests {
     fn test_set_readonly() {
         with_object(0, |activation, object| {
             object.raw_script_object().define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "normal",
                 "initial".into(),
                 Attribute::empty(),
             );
             object.raw_script_object().define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "readonly",
                 "initial".into(),
                 Attribute::READ_ONLY,
@@ -624,7 +624,7 @@ mod tests {
     fn test_deletable_not_readonly() {
         with_object(0, |activation, object| {
             object.raw_script_object().define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "test",
                 "initial".into(),
                 Attribute::DONT_DELETE,
@@ -647,14 +647,14 @@ mod tests {
     fn test_virtual_get() {
         with_object(0, |activation, object| {
             let getter = FunctionObject::function(
-                activation.context.gc(),
+                activation.gc(),
                 Executable::Native(|_avm, _this, _args| Ok("Virtual!".into())),
                 activation.context.avm1.prototypes().function,
                 activation.context.avm1.prototypes().function,
             );
 
             object.raw_script_object().add_property(
-                activation.context.gc(),
+                activation.gc(),
                 "test".into(),
                 getter,
                 None,
@@ -673,34 +673,34 @@ mod tests {
     fn test_delete() {
         with_object(0, |activation, object| {
             let getter = FunctionObject::function(
-                activation.context.gc(),
+                activation.gc(),
                 Executable::Native(|_avm, _this, _args| Ok("Virtual!".into())),
                 activation.context.avm1.prototypes().function,
                 activation.context.avm1.prototypes().function,
             );
 
             object.raw_script_object().add_property(
-                activation.context.gc(),
+                activation.gc(),
                 "virtual".into(),
                 getter,
                 None,
                 Attribute::empty(),
             );
             object.raw_script_object().add_property(
-                activation.context.gc(),
+                activation.gc(),
                 "virtual_un".into(),
                 getter,
                 None,
                 Attribute::DONT_DELETE,
             );
             object.raw_script_object().define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "stored",
                 "Stored!".into(),
                 Attribute::empty(),
             );
             object.raw_script_object().define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "stored_un",
                 "Stored!".into(),
                 Attribute::DONT_DELETE,
@@ -729,33 +729,33 @@ mod tests {
     fn test_get_keys() {
         with_object(0, |activation, object| {
             let getter = FunctionObject::function(
-                activation.context.gc(),
+                activation.gc(),
                 Executable::Native(|_avm, _this, _args| Ok(Value::Null)),
                 activation.context.avm1.prototypes().function,
                 activation.context.avm1.prototypes().function,
             );
 
             object.raw_script_object().define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "stored",
                 Value::Null,
                 Attribute::empty(),
             );
             object.raw_script_object().define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "stored_hidden",
                 Value::Null,
                 Attribute::DONT_ENUM,
             );
             object.raw_script_object().add_property(
-                activation.context.gc(),
+                activation.gc(),
                 "virtual".into(),
                 getter,
                 None,
                 Attribute::empty(),
             );
             object.raw_script_object().add_property(
-                activation.context.gc(),
+                activation.gc(),
                 "virtual_hidden".into(),
                 getter,
                 None,

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -491,7 +491,7 @@ fn set_x<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(x) = property_coerce_to_number(activation, val)? {
-        this.set_x(activation.context.gc(), Twips::from_pixels(x));
+        this.set_x(activation.gc(), Twips::from_pixels(x));
     }
     Ok(())
 }
@@ -506,13 +506,13 @@ fn set_y<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(y) = property_coerce_to_number(activation, val)? {
-        this.set_y(activation.context.gc(), Twips::from_pixels(y));
+        this.set_y(activation.gc(), Twips::from_pixels(y));
     }
     Ok(())
 }
 
 fn x_scale<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.scale_x(activation.context.gc()).percent().into()
+    this.scale_x(activation.gc()).percent().into()
 }
 
 fn set_x_scale<'gc>(
@@ -521,13 +521,13 @@ fn set_x_scale<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
-        this.set_scale_x(activation.context.gc(), Percent::from(val));
+        this.set_scale_x(activation.gc(), Percent::from(val));
     }
     Ok(())
 }
 
 fn y_scale<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.scale_y(activation.context.gc()).percent().into()
+    this.scale_y(activation.gc()).percent().into()
 }
 
 fn set_y_scale<'gc>(
@@ -536,7 +536,7 @@ fn set_y_scale<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
-        this.set_scale_y(activation.context.gc(), Percent::from(val));
+        this.set_scale_y(activation.gc(), Percent::from(val));
     }
     Ok(())
 }
@@ -569,7 +569,7 @@ fn set_alpha<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
-        this.set_alpha(activation.context.gc(), val / 100.0);
+        this.set_alpha(activation.gc(), val / 100.0);
     }
     Ok(())
 }
@@ -622,7 +622,7 @@ fn set_height<'gc>(
 }
 
 fn rotation<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    let degrees: f64 = this.rotation(activation.context.gc()).into();
+    let degrees: f64 = this.rotation(activation.gc()).into();
     degrees.into()
 }
 
@@ -639,13 +639,13 @@ fn set_rotation<'gc>(
         } else if degrees > 180.0 {
             degrees -= 360.0
         }
-        this.set_rotation(activation.context.gc(), degrees.into());
+        this.set_rotation(activation.gc(), degrees.into());
     }
     Ok(())
 }
 
 fn target<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    AvmString::new(activation.context.gc(), this.slash_path()).into()
+    AvmString::new(activation.gc(), this.slash_path()).into()
 }
 
 fn frames_loaded<'gc>(
@@ -667,7 +667,7 @@ fn set_name<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let name = val.coerce_to_string(activation)?;
-    this.set_name(activation.context.gc(), name);
+    this.set_name(activation.gc(), name);
     Ok(())
 }
 
@@ -765,13 +765,13 @@ fn set_focus_rect<'gc>(
         activation
             .context
             .stage
-            .set_stage_focus_rect(activation.context.gc(), val);
+            .set_stage_focus_rect(activation.gc(), val);
     } else if let Some(obj) = this.as_interactive() {
         let val = match val {
             Value::Undefined | Value::Null => None,
             _ => Some(val.as_bool(activation.swf_version())),
         };
-        obj.set_focus_rect(activation.context.gc(), val);
+        obj.set_focus_rect(activation.gc(), val);
     }
     Ok(())
 }

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -88,12 +88,7 @@ impl<'gc> StageObject<'gc> {
     /// Clears all text field bindings from this stage object, and places the textfields on the unbound list.
     /// This is called when the object is removed from the stage.
     pub fn unregister_text_field_bindings(self, context: &mut UpdateContext<'gc>) {
-        for binding in self
-            .0
-            .write(context.gc_context)
-            .text_field_bindings
-            .drain(..)
-        {
+        for binding in self.0.write(context.gc()).text_field_bindings.drain(..) {
             binding.text_field.clear_bound_stage_object(context);
             context.unbound_text_fields.push(binding.text_field);
         }
@@ -496,7 +491,7 @@ fn set_x<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(x) = property_coerce_to_number(activation, val)? {
-        this.set_x(activation.context.gc_context, Twips::from_pixels(x));
+        this.set_x(activation.context.gc(), Twips::from_pixels(x));
     }
     Ok(())
 }
@@ -511,13 +506,13 @@ fn set_y<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(y) = property_coerce_to_number(activation, val)? {
-        this.set_y(activation.context.gc_context, Twips::from_pixels(y));
+        this.set_y(activation.context.gc(), Twips::from_pixels(y));
     }
     Ok(())
 }
 
 fn x_scale<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.scale_x(activation.context.gc_context).percent().into()
+    this.scale_x(activation.context.gc()).percent().into()
 }
 
 fn set_x_scale<'gc>(
@@ -526,13 +521,13 @@ fn set_x_scale<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
-        this.set_scale_x(activation.context.gc_context, Percent::from(val));
+        this.set_scale_x(activation.context.gc(), Percent::from(val));
     }
     Ok(())
 }
 
 fn y_scale<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.scale_y(activation.context.gc_context).percent().into()
+    this.scale_y(activation.context.gc()).percent().into()
 }
 
 fn set_y_scale<'gc>(
@@ -541,7 +536,7 @@ fn set_y_scale<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
-        this.set_scale_y(activation.context.gc_context, Percent::from(val));
+        this.set_scale_y(activation.context.gc(), Percent::from(val));
     }
     Ok(())
 }
@@ -574,7 +569,7 @@ fn set_alpha<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
-        this.set_alpha(activation.context.gc_context, val / 100.0);
+        this.set_alpha(activation.context.gc(), val / 100.0);
     }
     Ok(())
 }
@@ -627,7 +622,7 @@ fn set_height<'gc>(
 }
 
 fn rotation<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    let degrees: f64 = this.rotation(activation.context.gc_context).into();
+    let degrees: f64 = this.rotation(activation.context.gc()).into();
     degrees.into()
 }
 
@@ -644,13 +639,13 @@ fn set_rotation<'gc>(
         } else if degrees > 180.0 {
             degrees -= 360.0
         }
-        this.set_rotation(activation.context.gc_context, degrees.into());
+        this.set_rotation(activation.context.gc(), degrees.into());
     }
     Ok(())
 }
 
 fn target<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    AvmString::new(activation.context.gc_context, this.slash_path()).into()
+    AvmString::new(activation.context.gc(), this.slash_path()).into()
 }
 
 fn frames_loaded<'gc>(
@@ -672,7 +667,7 @@ fn set_name<'gc>(
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let name = val.coerce_to_string(activation)?;
-    this.set_name(activation.context.gc_context, name);
+    this.set_name(activation.context.gc(), name);
     Ok(())
 }
 

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -43,7 +43,7 @@ impl<'gc> SuperObject<'gc> {
     /// Construct a `super` for an incoming stack frame.
     pub fn new(activation: &mut Activation<'_, 'gc>, this: Object<'gc>, depth: u8) -> Self {
         Self(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             SuperObjectData { this, depth },
         ))
     }

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -42,10 +42,7 @@ pub struct SuperObjectData<'gc> {
 impl<'gc> SuperObject<'gc> {
     /// Construct a `super` for an incoming stack frame.
     pub fn new(activation: &mut Activation<'_, 'gc>, this: Object<'gc>, depth: u8) -> Self {
-        Self(Gc::new(
-            activation.context.gc(),
-            SuperObjectData { this, depth },
-        ))
+        Self(Gc::new(activation.gc(), SuperObjectData { this, depth }))
     }
 
     pub fn this(&self) -> Object<'gc> {

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -67,7 +67,7 @@ impl Declaration {
         this: ScriptObject<'gc>,
         fn_proto: Object<'gc>,
     ) -> Value<'gc> {
-        let mc = context.gc_context;
+        let mc = context.gc();
 
         let mut intern_utf8 = |s: &'static str| -> AvmAtom<'gc> {
             match ruffle_wstr::from_utf8(s) {

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -91,7 +91,7 @@ pub struct Avm1<'gc> {
 
 impl<'gc> Avm1<'gc> {
     pub fn new(context: &mut StringContext<'gc>, player_version: u8) -> Self {
-        let gc_context = context.gc_context;
+        let gc_context = context.gc();
         let (prototypes, globals, broadcaster_functions) = create_globals(context);
 
         Self {
@@ -145,7 +145,7 @@ impl<'gc> Avm1<'gc> {
             .object()
             .coerce_to_object(&mut parent_activation);
         let child_scope = Gc::new(
-            parent_activation.context.gc_context,
+            parent_activation.context.gc(),
             Scope::new(
                 parent_activation.scope(),
                 scope::ScopeClass::Target,
@@ -185,7 +185,7 @@ impl<'gc> Avm1<'gc> {
             _ => panic!("No script object for display object"),
         };
         let child_scope = Gc::new(
-            action_context.gc_context,
+            action_context.gc(),
             Scope::new(
                 action_context.avm1.global_scope,
                 scope::ScopeClass::Target,
@@ -229,7 +229,7 @@ impl<'gc> Avm1<'gc> {
             .object()
             .coerce_to_object(&mut parent_activation);
         let child_scope = Gc::new(
-            parent_activation.context.gc_context,
+            parent_activation.context.gc(),
             Scope::new(
                 parent_activation.scope(),
                 scope::ScopeClass::Target,
@@ -454,7 +454,7 @@ impl<'gc> Avm1<'gc> {
 
             // Update pending removal state
             parent_container
-                .raw_container_mut(context.gc_context)
+                .raw_container_mut(context.gc())
                 .update_pending_removals();
         }
     }
@@ -478,11 +478,11 @@ impl<'gc> Avm1<'gc> {
             if clip.avm1_removed() {
                 // Clean up removed clips from this frame or a previous frame.
                 if let Some(prev) = prev {
-                    prev.set_next_avm1_clip(context.gc_context, next);
+                    prev.set_next_avm1_clip(context.gc(), next);
                 } else {
                     context.avm1.clip_exec_list = next;
                 }
-                clip.set_next_avm1_clip(context.gc_context, None);
+                clip.set_next_avm1_clip(context.gc(), None);
             } else {
                 clip.run_frame_avm1(context);
                 prev = Some(clip);

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -145,7 +145,7 @@ impl<'gc> Avm1<'gc> {
             .object()
             .coerce_to_object(&mut parent_activation);
         let child_scope = Gc::new(
-            parent_activation.context.gc(),
+            parent_activation.gc(),
             Scope::new(
                 parent_activation.scope(),
                 scope::ScopeClass::Target,
@@ -229,7 +229,7 @@ impl<'gc> Avm1<'gc> {
             .object()
             .coerce_to_object(&mut parent_activation);
         let child_scope = Gc::new(
-            parent_activation.context.gc(),
+            parent_activation.gc(),
             Scope::new(
                 parent_activation.scope(),
                 scope::ScopeClass::Target,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -418,7 +418,7 @@ impl<'gc> Value<'gc> {
                     .filter(|_| !matches!(object, Object::SuperObject(_)))
                 {
                     // StageObjects are special-cased to return their path.
-                    AvmString::new(activation.context.gc_context, object.path())
+                    AvmString::new(activation.context.gc(), object.path())
                 } else {
                     match object.call_method(
                         "toString".into(),
@@ -444,7 +444,7 @@ impl<'gc> Value<'gc> {
             Value::Bool(false) => "false".into(),
             Value::Number(v) => match f64_to_string(*v) {
                 Cow::Borrowed(s) => s.into(),
-                Cow::Owned(s) => AvmString::new_utf8(activation.context.gc_context, s),
+                Cow::Owned(s) => AvmString::new_utf8(activation.context.gc(), s),
             },
             Value::String(v) => v.to_owned(),
         })
@@ -951,15 +951,15 @@ mod test {
             }
 
             let valueof = FunctionObject::function(
-                activation.context.gc_context,
+                activation.context.gc(),
                 Executable::Native(value_of_impl),
                 protos.function,
                 protos.function,
             );
 
-            let o = ScriptObject::new(activation.context.gc_context, Some(protos.object));
+            let o = ScriptObject::new(activation.context.gc(), Some(protos.object));
             o.define_value(
-                activation.context.gc_context,
+                activation.context.gc(),
                 "valueOf",
                 valueof.into(),
                 Attribute::empty(),
@@ -988,7 +988,7 @@ mod test {
             assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
             assert!(n.coerce_to_f64(activation).unwrap().is_nan());
 
-            let o = ScriptObject::new(activation.context.gc_context, None);
+            let o = ScriptObject::new(activation.context.gc(), None);
 
             assert!(Value::from(o).coerce_to_f64(activation).unwrap().is_nan());
 
@@ -1010,7 +1010,7 @@ mod test {
             assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
             assert_eq!(n.coerce_to_f64(activation).unwrap(), 0.0);
 
-            let o = ScriptObject::new(activation.context.gc_context, None);
+            let o = ScriptObject::new(activation.context.gc(), None);
 
             assert_eq!(Value::from(o).coerce_to_f64(activation).unwrap(), 0.0);
 
@@ -1075,8 +1075,8 @@ mod test {
     #[test]
     fn abstract_lt_str() {
         with_avm(8, |activation, _this| -> Result<(), Error> {
-            let a = Value::String(AvmString::new_utf8(activation.context.gc_context, "a"));
-            let b = Value::String(AvmString::new_utf8(activation.context.gc_context, "b"));
+            let a = Value::String(AvmString::new_utf8(activation.context.gc(), "a"));
+            let b = Value::String(AvmString::new_utf8(activation.context.gc(), "b"));
 
             assert_eq!(a.abstract_lt(b, activation).unwrap(), Value::Bool(true));
 
@@ -1087,8 +1087,8 @@ mod test {
     #[test]
     fn abstract_gt_str() {
         with_avm(8, |activation, _this| -> Result<(), Error> {
-            let a = Value::String(AvmString::new_utf8(activation.context.gc_context, "a"));
-            let b = Value::String(AvmString::new_utf8(activation.context.gc_context, "b"));
+            let a = Value::String(AvmString::new_utf8(activation.context.gc(), "a"));
+            let b = Value::String(AvmString::new_utf8(activation.context.gc(), "b"));
 
             assert_eq!(b.abstract_lt(a, activation).unwrap(), Value::Bool(false));
 

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -418,7 +418,7 @@ impl<'gc> Value<'gc> {
                     .filter(|_| !matches!(object, Object::SuperObject(_)))
                 {
                     // StageObjects are special-cased to return their path.
-                    AvmString::new(activation.context.gc(), object.path())
+                    AvmString::new(activation.gc(), object.path())
                 } else {
                     match object.call_method(
                         "toString".into(),
@@ -444,7 +444,7 @@ impl<'gc> Value<'gc> {
             Value::Bool(false) => "false".into(),
             Value::Number(v) => match f64_to_string(*v) {
                 Cow::Borrowed(s) => s.into(),
-                Cow::Owned(s) => AvmString::new_utf8(activation.context.gc(), s),
+                Cow::Owned(s) => AvmString::new_utf8(activation.gc(), s),
             },
             Value::String(v) => v.to_owned(),
         })
@@ -951,15 +951,15 @@ mod test {
             }
 
             let valueof = FunctionObject::function(
-                activation.context.gc(),
+                activation.gc(),
                 Executable::Native(value_of_impl),
                 protos.function,
                 protos.function,
             );
 
-            let o = ScriptObject::new(activation.context.gc(), Some(protos.object));
+            let o = ScriptObject::new(activation.gc(), Some(protos.object));
             o.define_value(
-                activation.context.gc(),
+                activation.gc(),
                 "valueOf",
                 valueof.into(),
                 Attribute::empty(),
@@ -988,7 +988,7 @@ mod test {
             assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
             assert!(n.coerce_to_f64(activation).unwrap().is_nan());
 
-            let o = ScriptObject::new(activation.context.gc(), None);
+            let o = ScriptObject::new(activation.gc(), None);
 
             assert!(Value::from(o).coerce_to_f64(activation).unwrap().is_nan());
 
@@ -1010,7 +1010,7 @@ mod test {
             assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
             assert_eq!(n.coerce_to_f64(activation).unwrap(), 0.0);
 
-            let o = ScriptObject::new(activation.context.gc(), None);
+            let o = ScriptObject::new(activation.gc(), None);
 
             assert_eq!(Value::from(o).coerce_to_f64(activation).unwrap(), 0.0);
 
@@ -1075,8 +1075,8 @@ mod test {
     #[test]
     fn abstract_lt_str() {
         with_avm(8, |activation, _this| -> Result<(), Error> {
-            let a = Value::String(AvmString::new_utf8(activation.context.gc(), "a"));
-            let b = Value::String(AvmString::new_utf8(activation.context.gc(), "b"));
+            let a = Value::String(AvmString::new_utf8(activation.gc(), "a"));
+            let b = Value::String(AvmString::new_utf8(activation.gc(), "b"));
 
             assert_eq!(a.abstract_lt(b, activation).unwrap(), Value::Bool(true));
 
@@ -1087,8 +1087,8 @@ mod test {
     #[test]
     fn abstract_gt_str() {
         with_avm(8, |activation, _this| -> Result<(), Error> {
-            let a = Value::String(AvmString::new_utf8(activation.context.gc(), "a"));
-            let b = Value::String(AvmString::new_utf8(activation.context.gc(), "b"));
+            let a = Value::String(AvmString::new_utf8(activation.gc(), "a"));
+            let b = Value::String(AvmString::new_utf8(activation.gc(), "b"));
 
             assert_eq!(b.abstract_lt(a, activation).unwrap(), Value::Bool(false));
 

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -310,24 +310,24 @@ impl<'gc> Avm2<'gc> {
                 init_activation
                     .context
                     .avm2
-                    .push_global_init(init_activation.context.gc_context, script);
+                    .push_global_init(init_activation.context.gc(), script);
                 let r = (method.method)(&mut init_activation, Value::Object(scope), &[]);
                 init_activation
                     .context
                     .avm2
-                    .pop_call(init_activation.context.gc_context);
+                    .pop_call(init_activation.context.gc());
                 r?;
             }
             Method::Bytecode(method) => {
                 init_activation
                     .context
                     .avm2
-                    .push_global_init(init_activation.context.gc_context, script);
+                    .push_global_init(init_activation.context.gc(), script);
                 let r = init_activation.run_actions(method);
                 init_activation
                     .context
                     .avm2
-                    .pop_call(init_activation.context.gc_context);
+                    .pop_call(init_activation.context.gc());
                 r?;
             }
         };
@@ -367,7 +367,7 @@ impl<'gc> Avm2<'gc> {
         let orphan_objs: Rc<_> = context.avm2.orphan_objects.clone();
 
         for orphan in orphan_objs.iter() {
-            if let Some(dobj) = valid_orphan(*orphan, context.gc_context) {
+            if let Some(dobj) = valid_orphan(*orphan, context.gc()) {
                 f(dobj, context);
             }
         }
@@ -540,7 +540,7 @@ impl<'gc> Avm2<'gc> {
                 .get(i)
                 .copied();
 
-            if let Some(object) = object.and_then(|obj| obj.upgrade(context.gc_context)) {
+            if let Some(object) = object.and_then(|obj| obj.upgrade(context.gc())) {
                 let mut activation = Activation::from_nothing(context);
 
                 if object.is_of_type(on_type.inner_class_definition()) {

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -310,24 +310,18 @@ impl<'gc> Avm2<'gc> {
                 init_activation
                     .context
                     .avm2
-                    .push_global_init(init_activation.context.gc(), script);
+                    .push_global_init(init_activation.gc(), script);
                 let r = (method.method)(&mut init_activation, Value::Object(scope), &[]);
-                init_activation
-                    .context
-                    .avm2
-                    .pop_call(init_activation.context.gc());
+                init_activation.context.avm2.pop_call(init_activation.gc());
                 r?;
             }
             Method::Bytecode(method) => {
                 init_activation
                     .context
                     .avm2
-                    .push_global_init(init_activation.context.gc(), script);
+                    .push_global_init(init_activation.gc(), script);
                 let r = init_activation.run_actions(method);
-                init_activation
-                    .context
-                    .avm2
-                    .pop_call(init_activation.context.gc());
+                init_activation.context.avm2.pop_call(init_activation.gc());
                 r?;
             }
         };

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -409,7 +409,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         *local_registers.get_unchecked_mut(0) = this.into();
 
         let activation_class =
-            BytecodeMethod::get_or_init_activation_class(method, self.context.gc(), || {
+            BytecodeMethod::get_or_init_activation_class(method, self.gc(), || {
                 let translation_unit = method.translation_unit();
                 let abc_method = method.method();
                 let mut dummy_activation = Activation::from_domain(self.context, outer.domain());
@@ -495,11 +495,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 .contains(AbcMethodFlags::NEED_ARGUMENTS)
             {
                 args_object.set_string_property_local("callee", callee.into(), self)?;
-                args_object.set_local_property_is_enumerable(
-                    self.context.gc(),
-                    "callee".into(),
-                    false,
-                );
+                args_object.set_local_property_is_enumerable(self.gc(), "callee".into(), false);
             }
 
             *self
@@ -580,7 +576,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     /// Creates a new ScopeChain by chaining the current state of this
     /// activation's scope stack with the outer scope.
     pub fn create_scopechain(&self) -> ScopeChain<'gc> {
-        self.outer.chain(self.context.gc(), self.scope_frame())
+        self.outer.chain(self.gc(), self.scope_frame())
     }
 
     /// Returns the domain of the original AS3 caller. This will be `None`
@@ -688,7 +684,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.bound_superclass_object.unwrap_or_else(|| {
             panic!(
                 "Cannot call supermethod {} without a superclass",
-                name.to_qualified_name(self.context.gc()),
+                name.to_qualified_name(self.gc()),
             )
         })
     }
@@ -1376,7 +1372,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             if let Value::Object(object) = object_value {
                 match name_value {
                     Value::Integer(name_int) if name_int >= 0 => {
-                        if let Some(mut array) = object.as_array_storage_mut(self.context.gc()) {
+                        if let Some(mut array) = object.as_array_storage_mut(self.gc()) {
                             let _ = self.pop_stack();
                             let _ = self.pop_stack();
                             array.set(name_int as usize, value);
@@ -1388,11 +1384,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                         if let Some(dictionary) = object.as_dictionary_object() {
                             let _ = self.pop_stack();
                             let _ = self.pop_stack();
-                            dictionary.set_property_by_object(
-                                name_object,
-                                value,
-                                self.context.gc(),
-                            );
+                            dictionary.set_property_by_object(name_object, value, self.gc());
 
                             return Ok(FrameControl::Continue);
                         }
@@ -1454,7 +1446,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 if let Some(dictionary) = object.as_dictionary_object() {
                     let _ = self.pop_stack();
                     let _ = self.pop_stack();
-                    dictionary.delete_property_by_object(name_object, self.context.gc());
+                    dictionary.delete_property_by_object(name_object, self.gc());
 
                     self.push_raw(true);
                     return Ok(FrameControl::Continue);
@@ -1686,7 +1678,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             let class_name = object
                 .instance_class()
                 .name()
-                .to_qualified_name_err_message(self.context.gc());
+                .to_qualified_name_err_message(self.gc());
             return Err(Error::AvmError(type_error(
                 self,
                 &format!(
@@ -1734,7 +1726,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .as_object()
             .expect("Cannot set_slot on primitive");
 
-        object.set_slot_no_coerce(index, value, self.context.gc());
+        object.set_slot_no_coerce(index, value, self.gc());
 
         Ok(FrameControl::Continue)
     }
@@ -2016,12 +2008,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             (Value::Integer(n1), Value::Integer(n2)) => (n1 + n2).into(),
             (Value::Number(n1), Value::Number(n2)) => (n1 + n2).into(),
             (Value::String(s), value2) => Value::String(AvmString::concat(
-                self.context.gc(),
+                self.gc(),
                 s,
                 value2.coerce_to_string(self)?,
             )),
             (value1, Value::String(s)) => Value::String(AvmString::concat(
-                self.context.gc(),
+                self.gc(),
                 value1.coerce_to_string(self)?,
                 s,
             )),
@@ -2042,12 +2034,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
                 match (prim_value1, prim_value2) {
                     (Value::String(s), value2) => Value::String(AvmString::concat(
-                        self.context.gc(),
+                        self.gc(),
                         s,
                         value2.coerce_to_string(self)?,
                     )),
                     (value1, Value::String(s)) => Value::String(AvmString::concat(
-                        self.context.gc(),
+                        self.gc(),
                         value1.coerce_to_string(self)?,
                         s,
                     )),
@@ -2801,7 +2793,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         // Implementation of `EscapeAttributeValue` from ECMA-357(10.2.1.2)
         let r = escape_attribute_value(s);
-        self.push_raw(AvmString::new(self.context.gc(), r));
+        self.push_raw(AvmString::new(self.gc(), r));
 
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -511,7 +511,7 @@ impl<'gc> Class<'gc> {
                     vec![],
                     None,
                     true,
-                    activation.context.gc(),
+                    activation.gc(),
                 );
                 call_handler = Some(method);
             }
@@ -529,7 +529,7 @@ impl<'gc> Class<'gc> {
             .unwrap_or(Allocator(scriptobject_allocator));
 
         let i_class = Class(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             ClassData {
                 name,
                 param: None,
@@ -541,7 +541,7 @@ impl<'gc> Class<'gc> {
                 instance_allocator,
                 instance_init,
                 traits: Vec::new(),
-                vtable: VTable::empty(activation.context.gc()),
+                vtable: VTable::empty(activation.gc()),
                 call_handler,
                 custom_constructor: custom_constructor.map(CustomConstructor),
                 traits_loaded: false,
@@ -558,11 +558,11 @@ impl<'gc> Class<'gc> {
 
         let c_name = QName::new(
             name_namespace,
-            AvmString::new(activation.context.gc(), local_name_buf),
+            AvmString::new(activation.gc(), local_name_buf),
         );
 
         let c_class = Class(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             ClassData {
                 name: c_name,
                 param: None,
@@ -574,7 +574,7 @@ impl<'gc> Class<'gc> {
                 instance_allocator: Allocator(scriptobject_allocator),
                 instance_init: class_init,
                 traits: Vec::new(),
-                vtable: VTable::empty(activation.context.gc()),
+                vtable: VTable::empty(activation.gc()),
                 call_handler: None,
                 custom_constructor: None,
                 traits_loaded: false,
@@ -585,7 +585,7 @@ impl<'gc> Class<'gc> {
             },
         ));
 
-        i_class.set_c_class(activation.context.gc(), c_class);
+        i_class.set_c_class(activation.gc(), c_class);
 
         Ok(i_class)
     }
@@ -613,9 +613,9 @@ impl<'gc> Class<'gc> {
         let c_class = self
             .c_class()
             .expect("Just checked that this class was an i_class");
-        let mut c_class_write = c_class.0.write(activation.context.gc());
+        let mut c_class_write = c_class.0.write(activation.gc());
 
-        let mut i_class_write = self.0.write(activation.context.gc());
+        let mut i_class_write = self.0.write(activation.gc());
 
         i_class_write.traits_loaded = true;
         c_class_write.traits_loaded = true;
@@ -813,7 +813,7 @@ impl<'gc> Class<'gc> {
         let name = QName::new(activation.avm2().namespaces.public_all(), name);
 
         let i_class = Class(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             ClassData {
                 name,
                 param: None,
@@ -826,10 +826,10 @@ impl<'gc> Class<'gc> {
                 instance_init: Method::from_builtin(
                     |_, _, _| Ok(Value::Undefined),
                     "<Activation object constructor>",
-                    activation.context.gc(),
+                    activation.gc(),
                 ),
                 traits,
-                vtable: VTable::empty(activation.context.gc()),
+                vtable: VTable::empty(activation.gc()),
                 call_handler: None,
                 custom_constructor: None,
                 traits_loaded: true,
@@ -846,11 +846,11 @@ impl<'gc> Class<'gc> {
 
         let c_name = QName::new(
             name_namespace,
-            AvmString::new(activation.context.gc(), local_name_buf),
+            AvmString::new(activation.gc(), local_name_buf),
         );
 
         let c_class = Class(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             ClassData {
                 name: c_name,
                 param: None,
@@ -863,10 +863,10 @@ impl<'gc> Class<'gc> {
                 instance_init: Method::from_builtin(
                     |_, _, _| Ok(Value::Undefined),
                     "<Activation object class constructor>",
-                    activation.context.gc(),
+                    activation.gc(),
                 ),
                 traits: Vec::new(),
-                vtable: VTable::empty(activation.context.gc()),
+                vtable: VTable::empty(activation.gc()),
                 call_handler: None,
                 custom_constructor: None,
                 traits_loaded: true,
@@ -877,7 +877,7 @@ impl<'gc> Class<'gc> {
             },
         ));
 
-        i_class.set_c_class(activation.context.gc(), c_class);
+        i_class.set_c_class(activation.gc(), c_class);
 
         i_class.init_vtable(activation.context)?;
         c_class.init_vtable(activation.context)?;
@@ -994,7 +994,7 @@ impl<'gc> Class<'gc> {
         class_object: ClassObject<'gc>,
     ) {
         self.define_instance_trait(
-            activation.context.gc(),
+            activation.gc(),
             Trait::from_class(name, class_object.inner_class_definition()),
         );
     }
@@ -1063,7 +1063,7 @@ impl<'gc> Class<'gc> {
     ) {
         for &(name, value) in items {
             self.define_class_trait(
-                activation.context.gc(),
+                activation.gc(),
                 Trait::from_const(
                     QName::new(namespace, name),
                     Some(activation.avm2().multinames.int),
@@ -1175,7 +1175,7 @@ impl<'gc> Class<'gc> {
     ) {
         for &(name, value) in items {
             self.define_instance_trait(
-                activation.context.gc(),
+                activation.gc(),
                 Trait::from_const(
                     QName::new(namespace, name),
                     Some(activation.avm2().multinames.int),

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -118,7 +118,7 @@ impl<'gc> Domain<'gc> {
     /// fully allocated.
     pub fn movie_domain(activation: &mut Activation<'_, 'gc>, parent: Domain<'gc>) -> Domain<'gc> {
         let this = Self(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             DomainData {
                 defs: PropertyMap::new(),
                 classes: PropertyMap::new(),
@@ -133,7 +133,7 @@ impl<'gc> Domain<'gc> {
 
         parent
             .0
-            .write(activation.context.gc())
+            .write(activation.gc())
             .children
             .push(DomainWeak(GcCell::downgrade(this.0)));
 
@@ -286,7 +286,7 @@ impl<'gc> Domain<'gc> {
             let start = name.find(WStr::from_units(b".<")).unwrap();
 
             type_name = Some(AvmString::new(
-                activation.context.gc(),
+                activation.gc(),
                 &name[(start + 2)..(name.len() - 1)],
             ));
             name = "__AS3__.vec::Vector".into();
@@ -364,7 +364,7 @@ impl<'gc> Domain<'gc> {
         activation: &mut Activation<'_, 'gc>,
         domain_memory: Option<ByteArrayObject<'gc>>,
     ) -> Result<(), Error<'gc>> {
-        let mut write = self.0.write(activation.context.gc());
+        let mut write = self.0.write(activation.gc());
         let memory = if let Some(domain_memory) = domain_memory {
             if domain_memory.storage().len() < MIN_DOMAIN_MEMORY_LENGTH {
                 return Err(Error::AvmError(error(
@@ -401,7 +401,7 @@ impl<'gc> Domain<'gc> {
             .unwrap()
             .set_length(MIN_DOMAIN_MEMORY_LENGTH);
 
-        let mut write = self.0.write(activation.context.gc());
+        let mut write = self.0.write(activation.gc());
 
         assert!(
             write.domain_memory.is_none(),

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -118,7 +118,7 @@ impl<'gc> Domain<'gc> {
     /// fully allocated.
     pub fn movie_domain(activation: &mut Activation<'_, 'gc>, parent: Domain<'gc>) -> Domain<'gc> {
         let this = Self(GcCell::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             DomainData {
                 defs: PropertyMap::new(),
                 classes: PropertyMap::new(),
@@ -133,7 +133,7 @@ impl<'gc> Domain<'gc> {
 
         parent
             .0
-            .write(activation.context.gc_context)
+            .write(activation.context.gc())
             .children
             .push(DomainWeak(GcCell::downgrade(this.0)));
 
@@ -286,7 +286,7 @@ impl<'gc> Domain<'gc> {
             let start = name.find(WStr::from_units(b".<")).unwrap();
 
             type_name = Some(AvmString::new(
-                activation.context.gc_context,
+                activation.context.gc(),
                 &name[(start + 2)..(name.len() - 1)],
             ));
             name = "__AS3__.vec::Vector".into();
@@ -364,7 +364,7 @@ impl<'gc> Domain<'gc> {
         activation: &mut Activation<'_, 'gc>,
         domain_memory: Option<ByteArrayObject<'gc>>,
     ) -> Result<(), Error<'gc>> {
-        let mut write = self.0.write(activation.context.gc_context);
+        let mut write = self.0.write(activation.context.gc());
         let memory = if let Some(domain_memory) = domain_memory {
             if domain_memory.storage().len() < MIN_DOMAIN_MEMORY_LENGTH {
                 return Err(Error::AvmError(error(
@@ -401,7 +401,7 @@ impl<'gc> Domain<'gc> {
             .unwrap()
             .set_length(MIN_DOMAIN_MEMORY_LENGTH);
 
-        let mut write = self.0.write(activation.context.gc_context);
+        let mut write = self.0.write(activation.context.gc());
 
         assert!(
             write.domain_memory.is_none(),

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -780,7 +780,7 @@ impl<'gc> E4XNode<'gc> {
             activation: &mut Activation<'_, 'gc>,
         ) -> Result<(), Error<'gc>> {
             if let Some(current_tag) = open_tags.last_mut() {
-                current_tag.append_child(activation.context.gc(), node)?;
+                current_tag.append_child(activation.gc(), node)?;
             }
 
             if open_tags.is_empty() {
@@ -823,7 +823,7 @@ impl<'gc> E4XNode<'gc> {
             let is_whitespace_text = text.iter().all(is_whitespace_char);
             if !(is_text && ignore_white && is_whitespace_text) {
                 let text = AvmString::new_utf8_bytes(
-                    activation.context.gc(),
+                    activation.gc(),
                     if is_text && ignore_white {
                         trim_ascii(text)
                     } else {
@@ -831,7 +831,7 @@ impl<'gc> E4XNode<'gc> {
                     },
                 );
                 let node = E4XNode(GcCell::new(
-                    activation.context.gc(),
+                    activation.gc(),
                     E4XNodeData {
                         parent: None,
                         namespace: None,
@@ -884,7 +884,7 @@ impl<'gc> E4XNode<'gc> {
                         E4XNode::from_start_event(activation, &parser, bs, parser.decoder())?;
 
                     if let Some(current_tag) = open_tags.last_mut() {
-                        current_tag.append_child(activation.context.gc(), child)?;
+                        current_tag.append_child(activation.gc(), child)?;
                     }
                     open_tags.push(child);
                 }
@@ -929,9 +929,9 @@ impl<'gc> E4XNode<'gc> {
                     }
                     let text = custom_unescape(bt, parser.decoder())
                         .map_err(|e| make_xml_error(activation, e))?;
-                    let text = AvmString::new_utf8_bytes(activation.context.gc(), text.as_bytes());
+                    let text = AvmString::new_utf8_bytes(activation.gc(), text.as_bytes());
                     let node = E4XNode(GcCell::new(
-                        activation.context.gc(),
+                        activation.gc(),
                         E4XNodeData {
                             parent: None,
                             namespace: None,
@@ -951,20 +951,20 @@ impl<'gc> E4XNode<'gc> {
                         .map_err(|e| make_xml_error(activation, e))?;
                     let (name, value) = if let Some((name, value)) = text.split_once(' ') {
                         (
-                            AvmString::new_utf8_bytes(activation.context.gc(), name.as_bytes()),
+                            AvmString::new_utf8_bytes(activation.gc(), name.as_bytes()),
                             AvmString::new_utf8_bytes(
-                                activation.context.gc(),
+                                activation.gc(),
                                 value.trim_start().as_bytes(),
                             ),
                         )
                     } else {
                         (
-                            AvmString::new_utf8_bytes(activation.context.gc(), text.as_bytes()),
+                            AvmString::new_utf8_bytes(activation.gc(), text.as_bytes()),
                             AvmString::default(),
                         )
                     };
                     let node = E4XNode(GcCell::new(
-                        activation.context.gc(),
+                        activation.gc(),
                         E4XNodeData {
                             parent: None,
                             namespace: None,
@@ -1086,7 +1086,7 @@ impl<'gc> E4XNode<'gc> {
                 kind: E4XNodeKind::Attribute(value),
                 notification: None,
             };
-            let attribute = E4XNode(GcCell::new(activation.context.gc(), attribute_data));
+            let attribute = E4XNode(GcCell::new(activation.gc(), attribute_data));
             attribute_nodes.push(attribute);
         }
 
@@ -1122,12 +1122,12 @@ impl<'gc> E4XNode<'gc> {
             notification: None,
         };
 
-        let result = E4XNode(GcCell::new(activation.context.gc(), data));
+        let result = E4XNode(GcCell::new(activation.gc(), data));
 
-        let mut result_kind = result.kind_mut(activation.context.gc());
+        let mut result_kind = result.kind_mut(activation.gc());
         if let E4XNodeKind::Element { attributes, .. } = &mut *result_kind {
             for attribute in attributes {
-                attribute.set_parent(Some(result), activation.context.gc());
+                attribute.set_parent(Some(result), activation.gc());
             }
         }
 
@@ -1419,7 +1419,7 @@ pub fn simple_content_to_string<'gc>(
             continue;
         }
         let child_str = child.node().xml_to_string(activation);
-        out = AvmString::concat(activation.context.gc(), out, child_str);
+        out = AvmString::concat(activation.gc(), out, child_str);
     }
     out
 }
@@ -1678,7 +1678,7 @@ pub fn to_xml_string<'gc>(
     let mut buf = WString::new();
     let ancestor_namespaces = Vec::new();
     to_xml_string_inner(xml, &mut buf, &ancestor_namespaces, pretty);
-    AvmString::new(activation.context.gc(), buf)
+    AvmString::new(activation.gc(), buf)
 }
 
 // 10.6.1. ToXMLName Applied to the String Type
@@ -1691,7 +1691,7 @@ pub fn string_to_multiname<'gc>(
             return Multiname::any_attribute();
         }
 
-        let name = AvmString::new(activation.context.gc(), name);
+        let name = AvmString::new(activation.gc(), name);
         Multiname::attribute(activation.avm2().namespaces.public_all(), name)
     } else if &*name == b"*" {
         Multiname::any()

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -64,7 +64,7 @@ pub fn make_null_or_undefined_error<'gc>(
         if let Some(name) = name {
             msg.push_str(&format!(
                 " (accessing field: {})",
-                name.to_qualified_name(activation.context.gc_context)
+                name.to_qualified_name(activation.context.gc())
             ));
         }
         match error_constructor(activation, class, &msg, 1009) {
@@ -94,7 +94,7 @@ pub fn make_reference_error<'gc>(
     let qualified_name = multiname.as_uri(activation.strings());
     let class_name = object_class
         .name()
-        .to_qualified_name_err_message(activation.context.gc_context);
+        .to_qualified_name_err_message(activation.context.gc());
 
     let msg = match code {
         ReferenceErrorCode::AssignToMethod => format!(
@@ -183,7 +183,7 @@ pub fn make_error_1010<'gc>(
     if let Some(name) = name {
         msg.push_str(&format!(
             " (accessing field: {})",
-            name.to_qualified_name(activation.context.gc_context)
+            name.to_qualified_name(activation.context.gc())
         ));
     }
     let error = type_error(activation, &msg, 1010);
@@ -834,7 +834,7 @@ fn error_constructor<'gc>(
     message: &str,
     code: u32,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let message = AvmString::new_utf8(activation.context.gc_context, message);
+    let message = AvmString::new_utf8(activation.context.gc(), message);
     Ok(class
         .construct(activation, &[message.into(), code.into()])?
         .into())

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -64,7 +64,7 @@ pub fn make_null_or_undefined_error<'gc>(
         if let Some(name) = name {
             msg.push_str(&format!(
                 " (accessing field: {})",
-                name.to_qualified_name(activation.context.gc())
+                name.to_qualified_name(activation.gc())
             ));
         }
         match error_constructor(activation, class, &msg, 1009) {
@@ -94,7 +94,7 @@ pub fn make_reference_error<'gc>(
     let qualified_name = multiname.as_uri(activation.strings());
     let class_name = object_class
         .name()
-        .to_qualified_name_err_message(activation.context.gc());
+        .to_qualified_name_err_message(activation.gc());
 
     let msg = match code {
         ReferenceErrorCode::AssignToMethod => format!(
@@ -183,7 +183,7 @@ pub fn make_error_1010<'gc>(
     if let Some(name) = name {
         msg.push_str(&format!(
             " (accessing field: {})",
-            name.to_qualified_name(activation.context.gc())
+            name.to_qualified_name(activation.gc())
         ));
     }
     let error = type_error(activation, &msg, 1010);
@@ -834,7 +834,7 @@ fn error_constructor<'gc>(
     message: &str,
     code: u32,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let message = AvmString::new_utf8(activation.context.gc(), message);
+    let message = AvmString::new_utf8(activation.gc(), message);
     Ok(class
         .construct(activation, &[message.into(), code.into()])?
         .into())

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -392,12 +392,12 @@ fn dispatch_event_to_target<'gc>(
 
     let dispatch_list = dispatch_list.unwrap();
 
-    let mut evtmut = event.as_event_mut(activation.context.gc()).unwrap();
+    let mut evtmut = event.as_event_mut(activation.gc()).unwrap();
     let name = evtmut.event_type();
     let use_capture = evtmut.phase() == EventPhase::Capturing;
 
     let handlers: Vec<Object<'gc>> = dispatch_list
-        .as_dispatch_mut(activation.context.gc())
+        .as_dispatch_mut(activation.gc())
         .expect("Internal dispatch list is missing during dispatch!")
         .iter_event_handlers(name, use_capture)
         .collect();
@@ -470,7 +470,7 @@ pub fn dispatch_event<'gc>(
         event
     };
 
-    let mut evtmut = event.as_event_mut(activation.context.gc()).unwrap();
+    let mut evtmut = event.as_event_mut(activation.gc()).unwrap();
 
     evtmut.set_phase(EventPhase::Capturing);
     evtmut.set_target(target);
@@ -486,7 +486,7 @@ pub fn dispatch_event<'gc>(
     }
 
     event
-        .as_event_mut(activation.context.gc())
+        .as_event_mut(activation.gc())
         .unwrap()
         .set_phase(EventPhase::AtTarget);
 
@@ -495,7 +495,7 @@ pub fn dispatch_event<'gc>(
     }
 
     event
-        .as_event_mut(activation.context.gc())
+        .as_event_mut(activation.gc())
         .unwrap()
         .set_phase(EventPhase::Bubbling);
 

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -392,12 +392,12 @@ fn dispatch_event_to_target<'gc>(
 
     let dispatch_list = dispatch_list.unwrap();
 
-    let mut evtmut = event.as_event_mut(activation.context.gc_context).unwrap();
+    let mut evtmut = event.as_event_mut(activation.context.gc()).unwrap();
     let name = evtmut.event_type();
     let use_capture = evtmut.phase() == EventPhase::Capturing;
 
     let handlers: Vec<Object<'gc>> = dispatch_list
-        .as_dispatch_mut(activation.context.gc_context)
+        .as_dispatch_mut(activation.context.gc())
         .expect("Internal dispatch list is missing during dispatch!")
         .iter_event_handlers(name, use_capture)
         .collect();
@@ -470,7 +470,7 @@ pub fn dispatch_event<'gc>(
         event
     };
 
-    let mut evtmut = event.as_event_mut(activation.context.gc_context).unwrap();
+    let mut evtmut = event.as_event_mut(activation.context.gc()).unwrap();
 
     evtmut.set_phase(EventPhase::Capturing);
     evtmut.set_target(target);
@@ -486,7 +486,7 @@ pub fn dispatch_event<'gc>(
     }
 
     event
-        .as_event_mut(activation.context.gc_context)
+        .as_event_mut(activation.context.gc())
         .unwrap()
         .set_phase(EventPhase::AtTarget);
 
@@ -495,7 +495,7 @@ pub fn dispatch_event<'gc>(
     }
 
     event
-        .as_event_mut(activation.context.gc_context)
+        .as_event_mut(activation.context.gc())
         .unwrap()
         .set_phase(EventPhase::Bubbling);
 

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -837,7 +837,7 @@ fn avm2_to_shader_filter<'gc>(
     let dyn_root = activation
         .context
         .dynamic_root
-        .stash(activation.context.gc(), shader_obj);
+        .stash(activation.gc(), shader_obj);
 
     let (shader_handle, shader_args) = get_shader_args(shader_obj, activation)?;
 

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -837,7 +837,7 @@ fn avm2_to_shader_filter<'gc>(
     let dyn_root = activation
         .context
         .dynamic_root
-        .stash(activation.context.gc_context, shader_obj);
+        .stash(activation.context.gc(), shader_obj);
 
     let (shader_handle, shader_args) = get_shader_args(shader_obj, activation)?;
 

--- a/core/src/avm2/flv.rs
+++ b/core/src/avm2/flv.rs
@@ -17,7 +17,7 @@ fn avm2_object_from_flv_variables<'gc>(
 
         info_object
             .set_string_property_local(
-                AvmString::new_utf8_bytes(activation.context.gc_context, property_name),
+                AvmString::new_utf8_bytes(activation.context.gc(), property_name),
                 value.data.to_avm2_value(activation),
                 activation,
             )
@@ -65,7 +65,7 @@ impl<'gc> FlvValueAvm2Ext<'gc> for FlvValue<'_> {
             }
             FlvValue::StrictArray(values) => avm2_array_from_flv_values(activation, values),
             FlvValue::String(string_data) | FlvValue::LongString(string_data) => {
-                AvmString::new_utf8_bytes(activation.context.gc_context, string_data).into()
+                AvmString::new_utf8_bytes(activation.context.gc(), string_data).into()
             }
             FlvValue::Date {
                 unix_time,

--- a/core/src/avm2/flv.rs
+++ b/core/src/avm2/flv.rs
@@ -17,7 +17,7 @@ fn avm2_object_from_flv_variables<'gc>(
 
         info_object
             .set_string_property_local(
-                AvmString::new_utf8_bytes(activation.context.gc(), property_name),
+                AvmString::new_utf8_bytes(activation.gc(), property_name),
                 value.data.to_avm2_value(activation),
                 activation,
             )
@@ -65,7 +65,7 @@ impl<'gc> FlvValueAvm2Ext<'gc> for FlvValue<'_> {
             }
             FlvValue::StrictArray(values) => avm2_array_from_flv_values(activation, values),
             FlvValue::String(string_data) | FlvValue::LongString(string_data) => {
-                AvmString::new_utf8_bytes(activation.context.gc(), string_data).into()
+                AvmString::new_utf8_bytes(activation.gc(), string_data).into()
             }
             FlvValue::Date {
                 unix_time,

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -199,7 +199,7 @@ pub fn exec<'gc>(
             activation
                 .context
                 .avm2
-                .push_call(activation.context.gc_context, method, bound_class);
+                .push_call(activation.context.gc(), method, bound_class);
             (bm.method)(&mut activation, Value::Object(receiver), &arguments)
         }
         Method::Bytecode(bm) => {
@@ -242,14 +242,11 @@ pub fn exec<'gc>(
             activation
                 .context
                 .avm2
-                .push_call(activation.context.gc_context, method, bound_class);
+                .push_call(activation.context.gc(), method, bound_class);
             activation.run_actions(bm)
         }
     };
-    activation
-        .context
-        .avm2
-        .pop_call(activation.context.gc_context);
+    activation.context.avm2.pop_call(activation.context.gc());
     ret
 }
 

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -199,7 +199,7 @@ pub fn exec<'gc>(
             activation
                 .context
                 .avm2
-                .push_call(activation.context.gc(), method, bound_class);
+                .push_call(activation.gc(), method, bound_class);
             (bm.method)(&mut activation, Value::Object(receiver), &arguments)
         }
         Method::Bytecode(bm) => {
@@ -242,11 +242,11 @@ pub fn exec<'gc>(
             activation
                 .context
                 .avm2
-                .push_call(activation.context.gc(), method, bound_class);
+                .push_call(activation.gc(), method, bound_class);
             activation.run_actions(bm)
         }
     };
-    activation.context.avm2.pop_call(activation.context.gc());
+    activation.context.avm2.pop_call(activation.gc());
     ret
 }
 

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -422,7 +422,7 @@ fn dynamic_class<'gc>(
         .init_property(&name.into(), class_object.into(), activation)
         .expect("Should set property");
 
-    domain.export_definition(name, script, activation.context.gc_context)
+    domain.export_definition(name, script, activation.context.gc())
 }
 
 /// Add a class builtin to the global scope.
@@ -434,7 +434,7 @@ fn class<'gc>(
     script: Script<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<ClassObject<'gc>, Error<'gc>> {
-    let mc = activation.context.gc_context;
+    let mc = activation.context.gc();
     let (_, global, mut domain) = script.init();
 
     let super_class = if let Some(super_class) = class_def.super_class() {
@@ -467,7 +467,7 @@ fn vector_class<'gc>(
     script: Script<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<ClassObject<'gc>, Error<'gc>> {
-    let mc = activation.context.gc_context;
+    let mc = activation.context.gc();
     let namespaces = activation.avm2().namespaces;
     let (_, global, mut domain) = script.init();
 
@@ -512,7 +512,7 @@ pub fn load_player_globals<'gc>(
     activation: &mut Activation<'_, 'gc>,
     domain: Domain<'gc>,
 ) -> Result<(), Error<'gc>> {
-    let mc = activation.context.gc_context;
+    let mc = activation.context.gc();
 
     // Set the outer scope of this activation to the global scope.
 

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -422,7 +422,7 @@ fn dynamic_class<'gc>(
         .init_property(&name.into(), class_object.into(), activation)
         .expect("Should set property");
 
-    domain.export_definition(name, script, activation.context.gc())
+    domain.export_definition(name, script, activation.gc())
 }
 
 /// Add a class builtin to the global scope.
@@ -434,7 +434,7 @@ fn class<'gc>(
     script: Script<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<ClassObject<'gc>, Error<'gc>> {
-    let mc = activation.context.gc();
+    let mc = activation.gc();
     let (_, global, mut domain) = script.init();
 
     let super_class = if let Some(super_class) = class_def.super_class() {
@@ -467,7 +467,7 @@ fn vector_class<'gc>(
     script: Script<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<ClassObject<'gc>, Error<'gc>> {
-    let mc = activation.context.gc();
+    let mc = activation.gc();
     let namespaces = activation.avm2().namespaces;
     let (_, global, mut domain) = script.init();
 
@@ -512,7 +512,7 @@ pub fn load_player_globals<'gc>(
     activation: &mut Activation<'_, 'gc>,
     domain: Domain<'gc>,
 ) -> Result<(), Error<'gc>> {
-    let mc = activation.context.gc();
+    let mc = activation.gc();
 
     // Set the outer scope of this activation to the global scope.
 

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -73,7 +73,7 @@ pub fn instance_init<'gc>(
 
     activation.super_init(this, &[])?;
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.gc()) {
         if args.len() == 1 {
             if let Some(expected_len) = args.get(0).filter(|v| v.is_number()).map(|v| v.as_f64()) {
                 if expected_len < 0.0 || expected_len.is_nan() || expected_len.fract() != 0.0 {
@@ -122,7 +122,7 @@ pub fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc();
+    let gc_context = activation.gc();
     let this_class = this.as_class_object().unwrap();
     let array_proto = this_class.prototype();
 
@@ -169,7 +169,7 @@ pub fn set_length<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.gc()) {
         let size = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -230,7 +230,7 @@ pub fn resolve_array_hole<'gc>(
 
     if let Some(proto) = this.proto() {
         proto.get_public_property(
-            AvmString::new_utf8(activation.context.gc(), i.to_string()),
+            AvmString::new_utf8(activation.gc(), i.to_string()),
             activation,
         )
     } else {
@@ -267,7 +267,7 @@ where
         }
 
         return Ok(AvmString::new(
-            activation.context.gc(),
+            activation.gc(),
             crate::string::join(&accum, &string_separator),
         )
         .into());
@@ -382,7 +382,7 @@ impl<'gc> ArrayIter<'gc> {
             Some(
                 self.array_object
                     .get_public_property(
-                        AvmString::new_utf8(activation.context.gc(), i.to_string()),
+                        AvmString::new_utf8(activation.gc(), i.to_string()),
                         activation,
                     )
                     .map(|val| (i, val)),
@@ -408,7 +408,7 @@ impl<'gc> ArrayIter<'gc> {
             Some(
                 self.array_object
                     .get_public_property(
-                        AvmString::new_utf8(activation.context.gc(), i.to_string()),
+                        AvmString::new_utf8(activation.gc(), i.to_string()),
                         activation,
                     )
                     .map(|val| (i, val)),
@@ -610,7 +610,7 @@ pub fn pop<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.gc()) {
         return Ok(array.pop());
     }
 
@@ -625,7 +625,7 @@ pub fn push<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.gc()) {
         for arg in args {
             array.push(*arg)
         }
@@ -642,7 +642,7 @@ pub fn reverse<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.gc()) {
         let mut last_non_hole_index = None;
         for (i, val) in array.iter().enumerate() {
             if val.is_some() {
@@ -679,7 +679,7 @@ pub fn shift<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.gc()) {
         return Ok(array.shift());
     }
 
@@ -694,7 +694,7 @@ pub fn unshift<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.gc()) {
         for arg in args.iter().rev() {
             array.unshift(*arg)
         }
@@ -804,7 +804,7 @@ pub fn splice<'gc>(
 
             let mut resolved_array = ArrayStorage::from_args(&resolved[..]);
 
-            if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
+            if let Some(mut array) = this.as_array_storage_mut(activation.gc()) {
                 swap(&mut *array, &mut resolved_array)
             }
 
@@ -1068,7 +1068,7 @@ fn sort_postprocess<'gc>(
                 ),
             ));
         } else {
-            if let Some(mut old_array) = this.as_array_storage_mut(activation.context.gc()) {
+            if let Some(mut old_array) = this.as_array_storage_mut(activation.gc()) {
                 let new_vec = values
                     .iter()
                     .map(|(src, v)| {
@@ -1343,7 +1343,7 @@ pub fn remove_at<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.gc()) {
         let index = args
             .get(0)
             .cloned()
@@ -1358,7 +1358,7 @@ pub fn remove_at<'gc>(
 
 /// Construct `Array`'s class.
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc();
+    let mc = activation.gc();
     let class = Class::new(
         QName::new(activation.avm2().namespaces.public_all(), "Array"),
         Some(activation.avm2().class_defs().object),
@@ -1417,14 +1417,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         activation,
     );
 
-    class.mark_traits_loaded(activation.context.gc());
+    class.mark_traits_loaded(activation.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc());
+    c_class.mark_traits_loaded(activation.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -73,7 +73,7 @@ pub fn instance_init<'gc>(
 
     activation.super_init(this, &[])?;
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
         if args.len() == 1 {
             if let Some(expected_len) = args.get(0).filter(|v| v.is_number()).map(|v| v.as_f64()) {
                 if expected_len < 0.0 || expected_len.is_nan() || expected_len.fract() != 0.0 {
@@ -122,7 +122,7 @@ pub fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.context.gc();
     let this_class = this.as_class_object().unwrap();
     let array_proto = this_class.prototype();
 
@@ -169,7 +169,7 @@ pub fn set_length<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
         let size = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -230,7 +230,7 @@ pub fn resolve_array_hole<'gc>(
 
     if let Some(proto) = this.proto() {
         proto.get_public_property(
-            AvmString::new_utf8(activation.context.gc_context, i.to_string()),
+            AvmString::new_utf8(activation.context.gc(), i.to_string()),
             activation,
         )
     } else {
@@ -267,7 +267,7 @@ where
         }
 
         return Ok(AvmString::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             crate::string::join(&accum, &string_separator),
         )
         .into());
@@ -382,7 +382,7 @@ impl<'gc> ArrayIter<'gc> {
             Some(
                 self.array_object
                     .get_public_property(
-                        AvmString::new_utf8(activation.context.gc_context, i.to_string()),
+                        AvmString::new_utf8(activation.context.gc(), i.to_string()),
                         activation,
                     )
                     .map(|val| (i, val)),
@@ -408,7 +408,7 @@ impl<'gc> ArrayIter<'gc> {
             Some(
                 self.array_object
                     .get_public_property(
-                        AvmString::new_utf8(activation.context.gc_context, i.to_string()),
+                        AvmString::new_utf8(activation.context.gc(), i.to_string()),
                         activation,
                     )
                     .map(|val| (i, val)),
@@ -610,7 +610,7 @@ pub fn pop<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
         return Ok(array.pop());
     }
 
@@ -625,7 +625,7 @@ pub fn push<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
         for arg in args {
             array.push(*arg)
         }
@@ -642,7 +642,7 @@ pub fn reverse<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
         let mut last_non_hole_index = None;
         for (i, val) in array.iter().enumerate() {
             if val.is_some() {
@@ -679,7 +679,7 @@ pub fn shift<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
         return Ok(array.shift());
     }
 
@@ -694,7 +694,7 @@ pub fn unshift<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
         for arg in args.iter().rev() {
             array.unshift(*arg)
         }
@@ -804,7 +804,7 @@ pub fn splice<'gc>(
 
             let mut resolved_array = ArrayStorage::from_args(&resolved[..]);
 
-            if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+            if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
                 swap(&mut *array, &mut resolved_array)
             }
 
@@ -1068,7 +1068,7 @@ fn sort_postprocess<'gc>(
                 ),
             ));
         } else {
-            if let Some(mut old_array) = this.as_array_storage_mut(activation.context.gc_context) {
+            if let Some(mut old_array) = this.as_array_storage_mut(activation.context.gc()) {
                 let new_vec = values
                     .iter()
                     .map(|(src, v)| {
@@ -1343,7 +1343,7 @@ pub fn remove_at<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc()) {
         let index = args
             .get(0)
             .cloned()
@@ -1358,7 +1358,7 @@ pub fn remove_at<'gc>(
 
 /// Construct `Array`'s class.
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.context.gc();
     let class = Class::new(
         QName::new(activation.avm2().namespaces.public_all(), "Array"),
         Some(activation.avm2().class_defs().object),
@@ -1417,14 +1417,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         activation,
     );
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.mark_traits_loaded(activation.context.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc_context);
+    c_class.mark_traits_loaded(activation.context.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -34,8 +34,8 @@ pub fn describe_type_json<'gc>(
     }
 
     let qualified_name = used_class_def
-        .dollar_removed_name(activation.context.gc_context)
-        .to_qualified_name(activation.context.gc_context);
+        .dollar_removed_name(activation.context.gc())
+        .to_qualified_name(activation.context.gc());
 
     object.set_string_property_local("name", qualified_name.into(), activation)?;
 
@@ -435,7 +435,7 @@ fn write_params<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let params = ArrayObject::empty(activation);
     let mut params_array = params
-        .as_array_storage_mut(activation.context.gc_context)
+        .as_array_storage_mut(activation.context.gc())
         .unwrap();
     for param in method.signature() {
         let param_type_name = display_name(activation.strings(), param.param_type_name);
@@ -454,7 +454,7 @@ fn write_metadata<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<(), Error<'gc>> {
     let mut metadata_array = metadata_object
-        .as_array_storage_mut(activation.context.gc_context)
+        .as_array_storage_mut(activation.context.gc())
         .unwrap();
 
     for single_trait in trait_metadata.iter() {

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -34,8 +34,8 @@ pub fn describe_type_json<'gc>(
     }
 
     let qualified_name = used_class_def
-        .dollar_removed_name(activation.context.gc())
-        .to_qualified_name(activation.context.gc());
+        .dollar_removed_name(activation.gc())
+        .to_qualified_name(activation.gc());
 
     object.set_string_property_local("name", qualified_name.into(), activation)?;
 
@@ -434,9 +434,7 @@ fn write_params<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let params = ArrayObject::empty(activation);
-    let mut params_array = params
-        .as_array_storage_mut(activation.context.gc())
-        .unwrap();
+    let mut params_array = params.as_array_storage_mut(activation.gc()).unwrap();
     for param in method.signature() {
         let param_type_name = display_name(activation.strings(), param.param_type_name);
         let optional = param.default_value.is_some();
@@ -454,7 +452,7 @@ fn write_metadata<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<(), Error<'gc>> {
     let mut metadata_array = metadata_object
-        .as_array_storage_mut(activation.context.gc())
+        .as_array_storage_mut(activation.gc())
         .unwrap();
 
     for single_trait in trait_metadata.iter() {

--- a/core/src/avm2/globals/boolean.rs
+++ b/core/src/avm2/globals/boolean.rs
@@ -17,7 +17,7 @@ fn instance_init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc_context) {
+    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc()) {
         if matches!(*prim, Value::Undefined | Value::Null) {
             *prim = args
                 .get(0)
@@ -40,7 +40,7 @@ fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.context.gc();
     let this_class = this.as_class_object().unwrap();
     let boolean_proto = this_class.prototype();
 
@@ -156,14 +156,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     const CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
     class.define_constant_int_class_traits(namespaces.public_all(), CONSTANTS_INT, activation);
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.mark_traits_loaded(activation.context.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc_context);
+    c_class.mark_traits_loaded(activation.context.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/boolean.rs
+++ b/core/src/avm2/globals/boolean.rs
@@ -17,7 +17,7 @@ fn instance_init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc()) {
+    if let Some(mut prim) = this.as_primitive_mut(activation.gc()) {
         if matches!(*prim, Value::Undefined | Value::Null) {
             *prim = args
                 .get(0)
@@ -40,7 +40,7 @@ fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc();
+    let gc_context = activation.gc();
     let this_class = this.as_class_object().unwrap();
     let boolean_proto = this_class.prototype();
 
@@ -156,14 +156,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     const CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
     class.define_constant_int_class_traits(namespaces.public_all(), CONSTANTS_INT, activation);
 
-    class.mark_traits_loaded(activation.context.gc());
+    class.mark_traits_loaded(activation.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc());
+    c_class.mark_traits_loaded(activation.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/class.rs
+++ b/core/src/avm2/globals/class.rs
@@ -84,7 +84,7 @@ pub fn create_i_class<'gc>(
         PUBLIC_INSTANCE_PROPERTIES,
     );
 
-    class_i_class.mark_traits_loaded(activation.context.gc_context);
+    class_i_class.mark_traits_loaded(activation.context.gc());
     class_i_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
@@ -117,7 +117,7 @@ pub fn create_c_class<'gc>(
         activation,
     );
 
-    class_c_class.mark_traits_loaded(activation.context.gc_context);
+    class_c_class.mark_traits_loaded(activation.context.gc());
     class_c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/class.rs
+++ b/core/src/avm2/globals/class.rs
@@ -84,7 +84,7 @@ pub fn create_i_class<'gc>(
         PUBLIC_INSTANCE_PROPERTIES,
     );
 
-    class_i_class.mark_traits_loaded(activation.context.gc());
+    class_i_class.mark_traits_loaded(activation.gc());
     class_i_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
@@ -117,7 +117,7 @@ pub fn create_c_class<'gc>(
         activation,
     );
 
-    class_c_class.mark_traits_loaded(activation.context.gc());
+    class_c_class.mark_traits_loaded(activation.gc());
     class_c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -928,7 +928,7 @@ pub fn to_string<'gc>(
         .map(|date| date.with_timezone(&get_timezone()))
     {
         Ok(AvmString::new_utf8(
-            activation.context.gc(),
+            activation.gc(),
             date.format("%a %b %-d %T GMT%z %-Y").to_string(),
         )
         .into())
@@ -949,7 +949,7 @@ pub fn to_utc_string<'gc>(
 
     if let Some(date) = this.date_time() {
         Ok(AvmString::new_utf8(
-            activation.context.gc(),
+            activation.gc(),
             date.format("%a %b %-d %T %-Y UTC").to_string(),
         )
         .into())
@@ -973,7 +973,7 @@ pub fn to_locale_string<'gc>(
         .map(|date| date.with_timezone(&get_timezone()))
     {
         Ok(AvmString::new_utf8(
-            activation.context.gc(),
+            activation.gc(),
             date.format("%a %b %-d %-Y %T %p").to_string(),
         )
         .into())
@@ -996,10 +996,7 @@ pub fn to_time_string<'gc>(
         .date_time()
         .map(|date| date.with_timezone(&get_timezone()))
     {
-        Ok(
-            AvmString::new_utf8(activation.context.gc(), date.format("%T GMT%z").to_string())
-                .into(),
-        )
+        Ok(AvmString::new_utf8(activation.gc(), date.format("%T GMT%z").to_string()).into())
     } else {
         Ok("Invalid Date".into())
     }
@@ -1019,7 +1016,7 @@ pub fn to_locale_time_string<'gc>(
         .date_time()
         .map(|date| date.with_timezone(&get_timezone()))
     {
-        Ok(AvmString::new_utf8(activation.context.gc(), date.format("%T %p").to_string()).into())
+        Ok(AvmString::new_utf8(activation.gc(), date.format("%T %p").to_string()).into())
     } else {
         Ok("Invalid Date".into())
     }
@@ -1039,11 +1036,7 @@ pub fn to_date_string<'gc>(
         .date_time()
         .map(|date| date.with_timezone(&get_timezone()))
     {
-        Ok(AvmString::new_utf8(
-            activation.context.gc(),
-            date.format("%a %b %-d %-Y").to_string(),
-        )
-        .into())
+        Ok(AvmString::new_utf8(activation.gc(), date.format("%a %b %-d %-Y").to_string()).into())
     } else {
         Ok("Invalid Date".into())
     }

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -928,7 +928,7 @@ pub fn to_string<'gc>(
         .map(|date| date.with_timezone(&get_timezone()))
     {
         Ok(AvmString::new_utf8(
-            activation.context.gc_context,
+            activation.context.gc(),
             date.format("%a %b %-d %T GMT%z %-Y").to_string(),
         )
         .into())
@@ -949,7 +949,7 @@ pub fn to_utc_string<'gc>(
 
     if let Some(date) = this.date_time() {
         Ok(AvmString::new_utf8(
-            activation.context.gc_context,
+            activation.context.gc(),
             date.format("%a %b %-d %T %-Y UTC").to_string(),
         )
         .into())
@@ -973,7 +973,7 @@ pub fn to_locale_string<'gc>(
         .map(|date| date.with_timezone(&get_timezone()))
     {
         Ok(AvmString::new_utf8(
-            activation.context.gc_context,
+            activation.context.gc(),
             date.format("%a %b %-d %-Y %T %p").to_string(),
         )
         .into())
@@ -996,11 +996,10 @@ pub fn to_time_string<'gc>(
         .date_time()
         .map(|date| date.with_timezone(&get_timezone()))
     {
-        Ok(AvmString::new_utf8(
-            activation.context.gc_context,
-            date.format("%T GMT%z").to_string(),
+        Ok(
+            AvmString::new_utf8(activation.context.gc(), date.format("%T GMT%z").to_string())
+                .into(),
         )
-        .into())
     } else {
         Ok("Invalid Date".into())
     }
@@ -1020,11 +1019,7 @@ pub fn to_locale_time_string<'gc>(
         .date_time()
         .map(|date| date.with_timezone(&get_timezone()))
     {
-        Ok(AvmString::new_utf8(
-            activation.context.gc_context,
-            date.format("%T %p").to_string(),
-        )
-        .into())
+        Ok(AvmString::new_utf8(activation.context.gc(), date.format("%T %p").to_string()).into())
     } else {
         Ok("Invalid Date".into())
     }
@@ -1045,7 +1040,7 @@ pub fn to_date_string<'gc>(
         .map(|date| date.with_timezone(&get_timezone()))
     {
         Ok(AvmString::new_utf8(
-            activation.context.gc_context,
+            activation.context.gc(),
             date.format("%a %b %-d %-Y").to_string(),
         )
         .into())

--- a/core/src/avm2/globals/error.rs
+++ b/core/src/avm2/globals/error.rs
@@ -28,7 +28,7 @@ pub fn get_stack_trace<'gc>(
     if let Some(error) = this.as_error_object() {
         let call_stack = error.call_stack();
         if !call_stack.is_empty() {
-            return Ok(AvmString::new(activation.context.gc_context, error.display_full()?).into());
+            return Ok(AvmString::new(activation.context.gc(), error.display_full()?).into());
         }
     }
     Ok(Value::Null)

--- a/core/src/avm2/globals/error.rs
+++ b/core/src/avm2/globals/error.rs
@@ -28,7 +28,7 @@ pub fn get_stack_trace<'gc>(
     if let Some(error) = this.as_error_object() {
         let call_stack = error.call_stack();
         if !call_stack.is_empty() {
-            return Ok(AvmString::new(activation.context.gc(), error.display_full()?).into());
+            return Ok(AvmString::new(activation.gc(), error.display_full()?).into());
         }
     }
     Ok(Value::Null)

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -26,9 +26,9 @@ pub fn bitmap_allocator<'gc>(
     let orig_class = class;
     while let Some(class) = class_def {
         if class == bitmap_cls {
-            let bitmap_data = BitmapDataWrapper::dummy(activation.context.gc_context);
+            let bitmap_data = BitmapDataWrapper::dummy(activation.context.gc());
             let display_object = Bitmap::new_with_bitmap_data(
-                activation.context.gc_context,
+                activation.context.gc(),
                 0,
                 bitmap_data,
                 false,
@@ -65,7 +65,7 @@ pub fn bitmap_allocator<'gc>(
                 new_bitmap_data.init_object2(activation.gc(), bitmap_data_obj);
 
                 let child = Bitmap::new_with_bitmap_data(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     0,
                     new_bitmap_data,
                     false,
@@ -100,8 +100,8 @@ pub fn init<'gc>(
         if let Some(bitmap_data) = bitmap_data {
             bitmap.set_bitmap_data(activation.context, bitmap_data);
         }
-        bitmap.set_smoothing(activation.context.gc_context, smoothing);
-        bitmap.set_pixel_snapping(activation.context.gc_context, pixel_snapping);
+        bitmap.set_smoothing(activation.context.gc(), smoothing);
+        bitmap.set_pixel_snapping(activation.context.gc(), pixel_snapping);
     } else {
         unreachable!();
     }
@@ -181,7 +181,7 @@ pub fn set_pixel_snapping<'gc>(
         let Some(value) = PixelSnapping::from_wstr(&args.get_string(activation, 0)?) else {
             return Err(make_error_2008(activation, "pixelSnapping"));
         };
-        bitmap.set_pixel_snapping(activation.context.gc_context, value);
+        bitmap.set_pixel_snapping(activation.context.gc(), value);
     }
     Ok(Value::Undefined)
 }
@@ -211,7 +211,7 @@ pub fn set_smoothing<'gc>(
 
     if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
         let smoothing = args.get_bool(0);
-        bitmap.set_smoothing(activation.context.gc_context, smoothing);
+        bitmap.set_smoothing(activation.context.gc(), smoothing);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -26,9 +26,9 @@ pub fn bitmap_allocator<'gc>(
     let orig_class = class;
     while let Some(class) = class_def {
         if class == bitmap_cls {
-            let bitmap_data = BitmapDataWrapper::dummy(activation.context.gc());
+            let bitmap_data = BitmapDataWrapper::dummy(activation.gc());
             let display_object = Bitmap::new_with_bitmap_data(
-                activation.context.gc(),
+                activation.gc(),
                 0,
                 bitmap_data,
                 false,
@@ -65,7 +65,7 @@ pub fn bitmap_allocator<'gc>(
                 new_bitmap_data.init_object2(activation.gc(), bitmap_data_obj);
 
                 let child = Bitmap::new_with_bitmap_data(
-                    activation.context.gc(),
+                    activation.gc(),
                     0,
                     new_bitmap_data,
                     false,
@@ -100,8 +100,8 @@ pub fn init<'gc>(
         if let Some(bitmap_data) = bitmap_data {
             bitmap.set_bitmap_data(activation.context, bitmap_data);
         }
-        bitmap.set_smoothing(activation.context.gc(), smoothing);
-        bitmap.set_pixel_snapping(activation.context.gc(), pixel_snapping);
+        bitmap.set_smoothing(activation.gc(), smoothing);
+        bitmap.set_pixel_snapping(activation.gc(), pixel_snapping);
     } else {
         unreachable!();
     }
@@ -181,7 +181,7 @@ pub fn set_pixel_snapping<'gc>(
         let Some(value) = PixelSnapping::from_wstr(&args.get_string(activation, 0)?) else {
             return Err(make_error_2008(activation, "pixelSnapping"));
         };
-        bitmap.set_pixel_snapping(activation.context.gc(), value);
+        bitmap.set_pixel_snapping(activation.gc(), value);
     }
     Ok(Value::Undefined)
 }
@@ -211,7 +211,7 @@ pub fn set_smoothing<'gc>(
 
     if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
         let smoothing = args.get_bool(0);
-        bitmap.set_smoothing(activation.context.gc(), smoothing);
+        bitmap.set_smoothing(activation.gc(), smoothing);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -75,7 +75,7 @@ pub fn fill_bitmap_data_from_symbol<'gc>(
 ) -> BitmapDataWrapper<'gc> {
     let bitmap = bd.decode().expect("Failed to decode BitmapData");
     let new_bitmap_data = GcCell::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         BitmapData::new_with_pixels(
             bitmap.width(),
             bitmap.height(),
@@ -146,11 +146,11 @@ pub fn init<'gc>(
         }
 
         let new_bitmap_data = BitmapData::new(width, height, transparency, fill_color);
-        BitmapDataWrapper::new(GcCell::new(activation.context.gc_context, new_bitmap_data))
+        BitmapDataWrapper::new(GcCell::new(activation.context.gc(), new_bitmap_data))
     };
 
-    new_bitmap_data.init_object2(activation.context.gc_context, this);
-    this.init_bitmap_data(activation.context.gc_context, new_bitmap_data);
+    new_bitmap_data.init_object2(activation.context.gc(), this);
+    this.init_bitmap_data(activation.context.gc(), new_bitmap_data);
 
     Ok(Value::Undefined)
 }
@@ -217,7 +217,7 @@ pub fn scroll<'gc>(
         let y = args.get_i32(activation, 1)?;
 
         operations::scroll(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -452,7 +452,7 @@ pub fn set_pixel<'gc>(
         let y = args.get_u32(activation, 1)?;
         let color = args.get_u32(activation, 2)?;
         operations::set_pixel(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -480,7 +480,7 @@ pub fn set_pixel32<'gc>(
         let color = args.get_u32(activation, 2)?;
 
         operations::set_pixel32(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -511,7 +511,7 @@ pub fn set_pixels<'gc>(
             .expect("Parameter must be a bytearray");
 
         operations::set_pixels_from_byte_array(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -615,7 +615,7 @@ pub fn copy_channel<'gc>(
                 get_rectangle_x_y_width_height(activation, source_rect)?;
 
             operations::copy_channel(
-                activation.context.gc_context,
+                activation.context.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 (dest_x, dest_y),
@@ -643,7 +643,7 @@ pub fn flood_fill<'gc>(
             let color = args.get_u32(activation, 2)?;
 
             operations::flood_fill(
-                activation.context.gc_context,
+                activation.context.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 x,
@@ -675,7 +675,7 @@ pub fn noise<'gc>(
         bitmap_data.check_valid(activation)?;
         let random_seed = args.get_i32(activation, 0)?;
         operations::noise(
-            activation.context.gc_context,
+            activation.context.gc(),
             bitmap_data,
             random_seed,
             low,
@@ -713,7 +713,7 @@ pub fn color_transform<'gc>(
                 )?;
 
             operations::color_transform(
-                activation.context.gc_context,
+                activation.context.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 x_min,
@@ -1106,7 +1106,7 @@ pub fn fill_rect<'gc>(
         let (x, y, width, height) = get_rectangle_x_y_width_height(activation, rectangle)?;
 
         operations::fill_rect(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -1130,7 +1130,7 @@ pub fn dispose<'gc>(
     if let Some(bitmap_data) = this.as_bitmap_data() {
         // Don't check if we've already disposed this BitmapData - 'BitmapData.dispose()' can be called
         // multiple times
-        bitmap_data.dispose(activation.context.gc_context);
+        bitmap_data.dispose(activation.context.gc());
     }
     Ok(Value::Undefined)
 }
@@ -1256,7 +1256,7 @@ pub fn clone<'gc>(
             let class = activation.avm2().classes().bitmapdata;
             let new_bitmap_data_object = BitmapDataObject::from_bitmap_data_internal(
                 activation,
-                BitmapDataWrapper::new(GcCell::new(activation.context.gc_context, new_bitmap_data)),
+                BitmapDataWrapper::new(GcCell::new(activation.context.gc(), new_bitmap_data)),
                 class,
             )?;
 
@@ -1323,7 +1323,7 @@ pub fn palette_map<'gc>(
         let alpha_array = get_channel(6, 24)?;
 
         operations::palette_map(
-            activation.context.gc_context,
+            activation.context.gc(),
             activation.context.renderer,
             bitmap_data,
             source_bitmap,
@@ -1390,7 +1390,7 @@ pub fn perlin_noise<'gc>(
             let octave_offsets = octave_offsets?;
 
             operations::perlin_noise(
-                activation.context.gc_context,
+                activation.context.gc(),
                 bitmap_data,
                 (base_x, base_y),
                 num_octaves,
@@ -1456,7 +1456,7 @@ pub fn threshold<'gc>(
                 src_bitmap.check_valid(activation)?;
 
                 return Ok(operations::threshold(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     src_bitmap,
@@ -1539,7 +1539,7 @@ pub fn compare<'gc>(
             let class = activation.avm2().classes().bitmapdata;
             Ok(BitmapDataObject::from_bitmap_data_internal(
                 activation,
-                BitmapDataWrapper::new(GcCell::new(activation.context.gc_context, bitmap_data)),
+                BitmapDataWrapper::new(GcCell::new(activation.context.gc(), bitmap_data)),
                 class,
             )?
             .into())
@@ -1594,7 +1594,7 @@ pub fn pixel_dissolve<'gc>(
             src_bitmap_data.check_valid(activation)?;
 
             return Ok(operations::pixel_dissolve(
-                activation.context.gc_context,
+                activation.context.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 src_bitmap_data,
@@ -1650,7 +1650,7 @@ pub fn merge<'gc>(
             if let Some(src_bitmap) = src_bitmap.as_bitmap_data() {
                 if !src_bitmap.disposed() {
                     operations::merge(
-                        activation.context.gc_context,
+                        activation.context.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap,

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -75,7 +75,7 @@ pub fn fill_bitmap_data_from_symbol<'gc>(
 ) -> BitmapDataWrapper<'gc> {
     let bitmap = bd.decode().expect("Failed to decode BitmapData");
     let new_bitmap_data = GcCell::new(
-        activation.context.gc(),
+        activation.gc(),
         BitmapData::new_with_pixels(
             bitmap.width(),
             bitmap.height(),
@@ -146,11 +146,11 @@ pub fn init<'gc>(
         }
 
         let new_bitmap_data = BitmapData::new(width, height, transparency, fill_color);
-        BitmapDataWrapper::new(GcCell::new(activation.context.gc(), new_bitmap_data))
+        BitmapDataWrapper::new(GcCell::new(activation.gc(), new_bitmap_data))
     };
 
-    new_bitmap_data.init_object2(activation.context.gc(), this);
-    this.init_bitmap_data(activation.context.gc(), new_bitmap_data);
+    new_bitmap_data.init_object2(activation.gc(), this);
+    this.init_bitmap_data(activation.gc(), new_bitmap_data);
 
     Ok(Value::Undefined)
 }
@@ -217,7 +217,7 @@ pub fn scroll<'gc>(
         let y = args.get_i32(activation, 1)?;
 
         operations::scroll(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -452,7 +452,7 @@ pub fn set_pixel<'gc>(
         let y = args.get_u32(activation, 1)?;
         let color = args.get_u32(activation, 2)?;
         operations::set_pixel(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -480,7 +480,7 @@ pub fn set_pixel32<'gc>(
         let color = args.get_u32(activation, 2)?;
 
         operations::set_pixel32(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -511,7 +511,7 @@ pub fn set_pixels<'gc>(
             .expect("Parameter must be a bytearray");
 
         operations::set_pixels_from_byte_array(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -615,7 +615,7 @@ pub fn copy_channel<'gc>(
                 get_rectangle_x_y_width_height(activation, source_rect)?;
 
             operations::copy_channel(
-                activation.context.gc(),
+                activation.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 (dest_x, dest_y),
@@ -643,7 +643,7 @@ pub fn flood_fill<'gc>(
             let color = args.get_u32(activation, 2)?;
 
             operations::flood_fill(
-                activation.context.gc(),
+                activation.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 x,
@@ -675,7 +675,7 @@ pub fn noise<'gc>(
         bitmap_data.check_valid(activation)?;
         let random_seed = args.get_i32(activation, 0)?;
         operations::noise(
-            activation.context.gc(),
+            activation.gc(),
             bitmap_data,
             random_seed,
             low,
@@ -713,7 +713,7 @@ pub fn color_transform<'gc>(
                 )?;
 
             operations::color_transform(
-                activation.context.gc(),
+                activation.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 x_min,
@@ -1106,7 +1106,7 @@ pub fn fill_rect<'gc>(
         let (x, y, width, height) = get_rectangle_x_y_width_height(activation, rectangle)?;
 
         operations::fill_rect(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.renderer,
             bitmap_data,
             x,
@@ -1130,7 +1130,7 @@ pub fn dispose<'gc>(
     if let Some(bitmap_data) = this.as_bitmap_data() {
         // Don't check if we've already disposed this BitmapData - 'BitmapData.dispose()' can be called
         // multiple times
-        bitmap_data.dispose(activation.context.gc());
+        bitmap_data.dispose(activation.gc());
     }
     Ok(Value::Undefined)
 }
@@ -1256,7 +1256,7 @@ pub fn clone<'gc>(
             let class = activation.avm2().classes().bitmapdata;
             let new_bitmap_data_object = BitmapDataObject::from_bitmap_data_internal(
                 activation,
-                BitmapDataWrapper::new(GcCell::new(activation.context.gc(), new_bitmap_data)),
+                BitmapDataWrapper::new(GcCell::new(activation.gc(), new_bitmap_data)),
                 class,
             )?;
 
@@ -1323,7 +1323,7 @@ pub fn palette_map<'gc>(
         let alpha_array = get_channel(6, 24)?;
 
         operations::palette_map(
-            activation.context.gc(),
+            activation.gc(),
             activation.context.renderer,
             bitmap_data,
             source_bitmap,
@@ -1390,7 +1390,7 @@ pub fn perlin_noise<'gc>(
             let octave_offsets = octave_offsets?;
 
             operations::perlin_noise(
-                activation.context.gc(),
+                activation.gc(),
                 bitmap_data,
                 (base_x, base_y),
                 num_octaves,
@@ -1456,7 +1456,7 @@ pub fn threshold<'gc>(
                 src_bitmap.check_valid(activation)?;
 
                 return Ok(operations::threshold(
-                    activation.context.gc(),
+                    activation.gc(),
                     activation.context.renderer,
                     bitmap_data,
                     src_bitmap,
@@ -1539,7 +1539,7 @@ pub fn compare<'gc>(
             let class = activation.avm2().classes().bitmapdata;
             Ok(BitmapDataObject::from_bitmap_data_internal(
                 activation,
-                BitmapDataWrapper::new(GcCell::new(activation.context.gc(), bitmap_data)),
+                BitmapDataWrapper::new(GcCell::new(activation.gc(), bitmap_data)),
                 class,
             )?
             .into())
@@ -1594,7 +1594,7 @@ pub fn pixel_dissolve<'gc>(
             src_bitmap_data.check_valid(activation)?;
 
             return Ok(operations::pixel_dissolve(
-                activation.context.gc(),
+                activation.gc(),
                 activation.context.renderer,
                 bitmap_data,
                 src_bitmap_data,
@@ -1650,7 +1650,7 @@ pub fn merge<'gc>(
             if let Some(src_bitmap) = src_bitmap.as_bitmap_data() {
                 if !src_bitmap.disposed() {
                     operations::merge(
-                        activation.context.gc(),
+                        activation.gc(),
                         activation.context.renderer,
                         bitmap_data,
                         src_bitmap,

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -33,7 +33,7 @@ pub fn initialize_for_allocator<'gc>(
     class: ClassObject<'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let obj: StageObject = StageObject::for_display_object(activation, dobj, class)?;
-    dobj.set_placed_by_script(activation.context.gc(), true);
+    dobj.set_placed_by_script(activation.gc(), true);
     dobj.set_object2(activation.context, obj.into());
 
     // [NA] Should these run for everything?
@@ -45,7 +45,7 @@ pub fn initialize_for_allocator<'gc>(
     // and consequently are observed to have their currentFrame lag one
     // frame behind objects placed by the timeline (even if they were
     // both placed in the same frame to begin with).
-    dobj.base_mut(activation.context.gc())
+    dobj.base_mut(activation.gc())
         .set_skip_next_enter_frame(true);
     dobj.on_construction_complete(activation.context);
 
@@ -64,7 +64,7 @@ pub fn display_object_initializer<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         if let Some(clip) = dobj.as_movie_clip() {
-            clip.set_constructing_frame(true, activation.context.gc());
+            clip.set_constructing_frame(true, activation.gc());
         }
 
         if let Some(container) = dobj.as_container() {
@@ -74,7 +74,7 @@ pub fn display_object_initializer<'gc>(
         }
 
         if let Some(clip) = dobj.as_movie_clip() {
-            clip.set_constructing_frame(false, activation.context.gc());
+            clip.set_constructing_frame(false, activation.gc());
         }
     }
 
@@ -106,7 +106,7 @@ pub fn set_alpha<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let new_alpha = args.get_f64(activation, 0)?;
-        dobj.set_alpha(activation.context.gc(), new_alpha);
+        dobj.set_alpha(activation.gc(), new_alpha);
     }
 
     Ok(Value::Undefined)
@@ -181,7 +181,7 @@ pub fn set_scale9grid<'gc>(
             None => Rectangle::default(),
             Some(rect) => object_to_rectangle(activation, rect)?,
         };
-        dobj.set_scaling_grid(activation.context.gc(), rect);
+        dobj.set_scaling_grid(activation.gc(), rect);
     }
 
     Ok(Value::Undefined)
@@ -196,7 +196,7 @@ pub fn get_scale_y<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        return Ok(dobj.scale_y(activation.context.gc()).unit().into());
+        return Ok(dobj.scale_y(activation.gc()).unit().into());
     }
 
     Ok(Value::Undefined)
@@ -212,7 +212,7 @@ pub fn set_scale_y<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let new_scale = args.get_f64(activation, 0)?;
-        dobj.set_scale_y(activation.context.gc(), Percent::from_unit(new_scale));
+        dobj.set_scale_y(activation.gc(), Percent::from_unit(new_scale));
     }
 
     Ok(Value::Undefined)
@@ -260,7 +260,7 @@ pub fn get_scale_x<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        return Ok(dobj.scale_x(activation.context.gc()).unit().into());
+        return Ok(dobj.scale_x(activation.gc()).unit().into());
     }
 
     Ok(Value::Undefined)
@@ -276,7 +276,7 @@ pub fn set_scale_x<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let new_scale = args.get_f64(activation, 0)?;
-        dobj.set_scale_x(activation.context.gc(), Percent::from_unit(new_scale));
+        dobj.set_scale_x(activation.gc(), Percent::from_unit(new_scale));
     }
 
     Ok(Value::Undefined)
@@ -338,11 +338,11 @@ pub fn set_filters<'gc>(
                         filter_vec.push(Filter::from_avm2_object(activation, filter_object)?);
                     }
 
-                    dobj.set_filters(activation.context.gc(), filter_vec);
+                    dobj.set_filters(activation.gc(), filter_vec);
                 }
             }
         } else {
-            dobj.set_filters(activation.context.gc(), vec![]);
+            dobj.set_filters(activation.gc(), vec![]);
         }
     }
 
@@ -374,7 +374,7 @@ pub fn set_x<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let x = args.get_f64(activation, 0)?;
-        dobj.set_x(activation.context.gc(), Twips::from_pixels(x));
+        dobj.set_x(activation.gc(), Twips::from_pixels(x));
     }
 
     Ok(Value::Undefined)
@@ -405,7 +405,7 @@ pub fn set_y<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let y = args.get_f64(activation, 0)?;
-        dobj.set_y(activation.context.gc(), Twips::from_pixels(y));
+        dobj.set_y(activation.gc(), Twips::from_pixels(y));
     }
 
     Ok(Value::Undefined)
@@ -510,7 +510,7 @@ pub fn get_rotation<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        let rot: f64 = dobj.rotation(activation.context.gc()).into();
+        let rot: f64 = dobj.rotation(activation.gc()).into();
         let rem = rot % 360.0;
 
         if rem <= 180.0 {
@@ -534,7 +534,7 @@ pub fn set_rotation<'gc>(
     if let Some(dobj) = this.as_display_object() {
         let new_rotation = args.get_f64(activation, 0)?;
 
-        dobj.set_rotation(activation.context.gc(), Degrees::from(new_rotation));
+        dobj.set_rotation(activation.gc(), Degrees::from(new_rotation));
     }
 
     Ok(Value::Undefined)
@@ -574,7 +574,7 @@ pub fn set_name<'gc>(
             )?));
         }
 
-        dobj.set_name(activation.context.gc(), new_name);
+        dobj.set_name(activation.gc(), new_name);
     }
 
     Ok(Value::Undefined)
@@ -835,14 +835,14 @@ pub fn set_transform<'gc>(
     let color_transform = color_transform_from_transform_object(transform);
 
     let dobj = this.as_display_object().unwrap();
-    let mut write = dobj.base_mut(activation.context.gc());
+    let mut write = dobj.base_mut(activation.gc());
     write.set_matrix(matrix);
     write.set_color_transform(color_transform);
     drop(write);
     if let Some(parent) = dobj.parent() {
         // Self-transform changes are automatically handled,
         // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
-        parent.invalidate_cached_bitmap(activation.context.gc());
+        parent.invalidate_cached_bitmap(activation.gc());
     }
 
     Ok(Value::Undefined)
@@ -857,7 +857,7 @@ pub fn get_blend_mode<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        let mode = AvmString::new_utf8(activation.context.gc(), dobj.blend_mode().to_string());
+        let mode = AvmString::new_utf8(activation.gc(), dobj.blend_mode().to_string());
         return Ok(mode.into());
     }
     Ok(Value::Undefined)
@@ -875,7 +875,7 @@ pub fn set_blend_mode<'gc>(
         let mode = args.get_string(activation, 0)?;
 
         if let Ok(mode) = ExtendedBlendMode::from_str(&mode.to_string()) {
-            dobj.set_blend_mode(activation.context.gc(), mode);
+            dobj.set_blend_mode(activation.gc(), mode);
         } else {
             tracing::error!("Unknown blend mode {}", mode);
             return Err(make_error_2008(activation, "blendMode"));
@@ -959,14 +959,11 @@ pub fn set_scroll_rect<'gc>(
             // operate on a `next_scroll_rect` field. Just before we render a DisplayObject, we copy
             // its `next_scroll_rect` to the `scroll_rect` field used for both rendering and
             // `localToGlobal`.
-            dobj.set_next_scroll_rect(
-                activation.context.gc(),
-                object_to_rectangle(activation, rectangle)?,
-            );
+            dobj.set_next_scroll_rect(activation.gc(), object_to_rectangle(activation, rectangle)?);
 
-            dobj.set_has_scroll_rect(activation.context.gc(), true);
+            dobj.set_has_scroll_rect(activation.gc(), true);
         } else {
-            dobj.set_has_scroll_rect(activation.context.gc(), false);
+            dobj.set_has_scroll_rect(activation.gc(), false);
         }
     }
     Ok(Value::Undefined)
@@ -1108,10 +1105,10 @@ pub fn set_mask<'gc>(
                 format!("Mask is not a DisplayObject: {mask:?}").into()
             })?;
 
-            this.set_masker(activation.context.gc(), Some(mask), true);
-            mask.set_maskee(activation.context.gc(), Some(this), true);
+            this.set_masker(activation.gc(), Some(mask), true);
+            mask.set_maskee(activation.gc(), Some(this), true);
         } else {
-            this.set_masker(activation.context.gc(), None, true);
+            this.set_masker(activation.gc(), None, true);
         }
     }
     Ok(Value::Undefined)
@@ -1139,7 +1136,7 @@ pub fn set_cache_as_bitmap<'gc>(
 
     if let Some(this) = this.as_display_object() {
         let cache = args.get(0).unwrap_or(&Value::Undefined).coerce_to_boolean();
-        this.set_bitmap_cached_preference(activation.context.gc(), cache);
+        this.set_bitmap_cached_preference(activation.gc(), cache);
     }
     Ok(Value::Undefined)
 }
@@ -1176,7 +1173,7 @@ pub fn set_opaque_background<'gc>(
             Value::Null | Value::Undefined => None,
             value => Some(Color::from_rgb(value.coerce_to_u32(activation)?, 255)),
         };
-        dobj.set_opaque_background(activation.context.gc(), color);
+        dobj.set_opaque_background(activation.gc(), color);
     }
 
     Ok(Value::Undefined)
@@ -1204,7 +1201,7 @@ pub fn set_blend_shader<'gc>(
             .pixel_bender_shader()
             .expect("Missing compiled PixelBender shader");
 
-        dobj.set_blend_shader(activation.context.gc(), Some(shader_handle));
+        dobj.set_blend_shader(activation.gc(), Some(shader_handle));
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -33,7 +33,7 @@ pub fn initialize_for_allocator<'gc>(
     class: ClassObject<'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let obj: StageObject = StageObject::for_display_object(activation, dobj, class)?;
-    dobj.set_placed_by_script(activation.context.gc_context, true);
+    dobj.set_placed_by_script(activation.context.gc(), true);
     dobj.set_object2(activation.context, obj.into());
 
     // [NA] Should these run for everything?
@@ -45,7 +45,7 @@ pub fn initialize_for_allocator<'gc>(
     // and consequently are observed to have their currentFrame lag one
     // frame behind objects placed by the timeline (even if they were
     // both placed in the same frame to begin with).
-    dobj.base_mut(activation.context.gc_context)
+    dobj.base_mut(activation.context.gc())
         .set_skip_next_enter_frame(true);
     dobj.on_construction_complete(activation.context);
 
@@ -64,7 +64,7 @@ pub fn display_object_initializer<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         if let Some(clip) = dobj.as_movie_clip() {
-            clip.set_constructing_frame(true, activation.context.gc_context);
+            clip.set_constructing_frame(true, activation.context.gc());
         }
 
         if let Some(container) = dobj.as_container() {
@@ -74,7 +74,7 @@ pub fn display_object_initializer<'gc>(
         }
 
         if let Some(clip) = dobj.as_movie_clip() {
-            clip.set_constructing_frame(false, activation.context.gc_context);
+            clip.set_constructing_frame(false, activation.context.gc());
         }
     }
 
@@ -106,7 +106,7 @@ pub fn set_alpha<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let new_alpha = args.get_f64(activation, 0)?;
-        dobj.set_alpha(activation.context.gc_context, new_alpha);
+        dobj.set_alpha(activation.context.gc(), new_alpha);
     }
 
     Ok(Value::Undefined)
@@ -181,7 +181,7 @@ pub fn set_scale9grid<'gc>(
             None => Rectangle::default(),
             Some(rect) => object_to_rectangle(activation, rect)?,
         };
-        dobj.set_scaling_grid(activation.context.gc_context, rect);
+        dobj.set_scaling_grid(activation.context.gc(), rect);
     }
 
     Ok(Value::Undefined)
@@ -196,7 +196,7 @@ pub fn get_scale_y<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        return Ok(dobj.scale_y(activation.context.gc_context).unit().into());
+        return Ok(dobj.scale_y(activation.context.gc()).unit().into());
     }
 
     Ok(Value::Undefined)
@@ -212,7 +212,7 @@ pub fn set_scale_y<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let new_scale = args.get_f64(activation, 0)?;
-        dobj.set_scale_y(activation.context.gc_context, Percent::from_unit(new_scale));
+        dobj.set_scale_y(activation.context.gc(), Percent::from_unit(new_scale));
     }
 
     Ok(Value::Undefined)
@@ -260,7 +260,7 @@ pub fn get_scale_x<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        return Ok(dobj.scale_x(activation.context.gc_context).unit().into());
+        return Ok(dobj.scale_x(activation.context.gc()).unit().into());
     }
 
     Ok(Value::Undefined)
@@ -276,7 +276,7 @@ pub fn set_scale_x<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let new_scale = args.get_f64(activation, 0)?;
-        dobj.set_scale_x(activation.context.gc_context, Percent::from_unit(new_scale));
+        dobj.set_scale_x(activation.context.gc(), Percent::from_unit(new_scale));
     }
 
     Ok(Value::Undefined)
@@ -338,11 +338,11 @@ pub fn set_filters<'gc>(
                         filter_vec.push(Filter::from_avm2_object(activation, filter_object)?);
                     }
 
-                    dobj.set_filters(activation.context.gc_context, filter_vec);
+                    dobj.set_filters(activation.context.gc(), filter_vec);
                 }
             }
         } else {
-            dobj.set_filters(activation.context.gc_context, vec![]);
+            dobj.set_filters(activation.context.gc(), vec![]);
         }
     }
 
@@ -374,7 +374,7 @@ pub fn set_x<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let x = args.get_f64(activation, 0)?;
-        dobj.set_x(activation.context.gc_context, Twips::from_pixels(x));
+        dobj.set_x(activation.context.gc(), Twips::from_pixels(x));
     }
 
     Ok(Value::Undefined)
@@ -405,7 +405,7 @@ pub fn set_y<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         let y = args.get_f64(activation, 0)?;
-        dobj.set_y(activation.context.gc_context, Twips::from_pixels(y));
+        dobj.set_y(activation.context.gc(), Twips::from_pixels(y));
     }
 
     Ok(Value::Undefined)
@@ -510,7 +510,7 @@ pub fn get_rotation<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        let rot: f64 = dobj.rotation(activation.context.gc_context).into();
+        let rot: f64 = dobj.rotation(activation.context.gc()).into();
         let rem = rot % 360.0;
 
         if rem <= 180.0 {
@@ -534,7 +534,7 @@ pub fn set_rotation<'gc>(
     if let Some(dobj) = this.as_display_object() {
         let new_rotation = args.get_f64(activation, 0)?;
 
-        dobj.set_rotation(activation.context.gc_context, Degrees::from(new_rotation));
+        dobj.set_rotation(activation.context.gc(), Degrees::from(new_rotation));
     }
 
     Ok(Value::Undefined)
@@ -574,7 +574,7 @@ pub fn set_name<'gc>(
             )?));
         }
 
-        dobj.set_name(activation.context.gc_context, new_name);
+        dobj.set_name(activation.context.gc(), new_name);
     }
 
     Ok(Value::Undefined)
@@ -835,14 +835,14 @@ pub fn set_transform<'gc>(
     let color_transform = color_transform_from_transform_object(transform);
 
     let dobj = this.as_display_object().unwrap();
-    let mut write = dobj.base_mut(activation.context.gc_context);
+    let mut write = dobj.base_mut(activation.context.gc());
     write.set_matrix(matrix);
     write.set_color_transform(color_transform);
     drop(write);
     if let Some(parent) = dobj.parent() {
         // Self-transform changes are automatically handled,
         // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
-        parent.invalidate_cached_bitmap(activation.context.gc_context);
+        parent.invalidate_cached_bitmap(activation.context.gc());
     }
 
     Ok(Value::Undefined)
@@ -857,8 +857,7 @@ pub fn get_blend_mode<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        let mode =
-            AvmString::new_utf8(activation.context.gc_context, dobj.blend_mode().to_string());
+        let mode = AvmString::new_utf8(activation.context.gc(), dobj.blend_mode().to_string());
         return Ok(mode.into());
     }
     Ok(Value::Undefined)
@@ -876,7 +875,7 @@ pub fn set_blend_mode<'gc>(
         let mode = args.get_string(activation, 0)?;
 
         if let Ok(mode) = ExtendedBlendMode::from_str(&mode.to_string()) {
-            dobj.set_blend_mode(activation.context.gc_context, mode);
+            dobj.set_blend_mode(activation.context.gc(), mode);
         } else {
             tracing::error!("Unknown blend mode {}", mode);
             return Err(make_error_2008(activation, "blendMode"));
@@ -961,13 +960,13 @@ pub fn set_scroll_rect<'gc>(
             // its `next_scroll_rect` to the `scroll_rect` field used for both rendering and
             // `localToGlobal`.
             dobj.set_next_scroll_rect(
-                activation.context.gc_context,
+                activation.context.gc(),
                 object_to_rectangle(activation, rectangle)?,
             );
 
-            dobj.set_has_scroll_rect(activation.context.gc_context, true);
+            dobj.set_has_scroll_rect(activation.context.gc(), true);
         } else {
-            dobj.set_has_scroll_rect(activation.context.gc_context, false);
+            dobj.set_has_scroll_rect(activation.context.gc(), false);
         }
     }
     Ok(Value::Undefined)
@@ -1109,10 +1108,10 @@ pub fn set_mask<'gc>(
                 format!("Mask is not a DisplayObject: {mask:?}").into()
             })?;
 
-            this.set_masker(activation.context.gc_context, Some(mask), true);
-            mask.set_maskee(activation.context.gc_context, Some(this), true);
+            this.set_masker(activation.context.gc(), Some(mask), true);
+            mask.set_maskee(activation.context.gc(), Some(this), true);
         } else {
-            this.set_masker(activation.context.gc_context, None, true);
+            this.set_masker(activation.context.gc(), None, true);
         }
     }
     Ok(Value::Undefined)
@@ -1140,7 +1139,7 @@ pub fn set_cache_as_bitmap<'gc>(
 
     if let Some(this) = this.as_display_object() {
         let cache = args.get(0).unwrap_or(&Value::Undefined).coerce_to_boolean();
-        this.set_bitmap_cached_preference(activation.context.gc_context, cache);
+        this.set_bitmap_cached_preference(activation.context.gc(), cache);
     }
     Ok(Value::Undefined)
 }
@@ -1177,7 +1176,7 @@ pub fn set_opaque_background<'gc>(
             Value::Null | Value::Undefined => None,
             value => Some(Color::from_rgb(value.coerce_to_u32(activation)?, 255)),
         };
-        dobj.set_opaque_background(activation.context.gc_context, color);
+        dobj.set_opaque_background(activation.context.gc(), color);
     }
 
     Ok(Value::Undefined)
@@ -1205,7 +1204,7 @@ pub fn set_blend_shader<'gc>(
             .pixel_bender_shader()
             .expect("Missing compiled PixelBender shader");
 
-        dobj.set_blend_shader(activation.context.gc_context, Some(shader_handle));
+        dobj.set_blend_shader(activation.context.gc(), Some(shader_handle));
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/display/display_object_container.rs
+++ b/core/src/avm2/globals/flash/display/display_object_container.rs
@@ -348,7 +348,7 @@ pub fn remove_child_at<'gc>(
             }
 
             let child = ctr.child_by_index(target_child as usize).unwrap();
-            child.set_placed_by_script(activation.context.gc(), true);
+            child.set_placed_by_script(activation.gc(), true);
 
             ctr.remove_child(activation.context, child);
 
@@ -485,8 +485,8 @@ pub fn swap_children_at<'gc>(
             let child0 = ctr.child_by_index(index0 as usize).unwrap();
             let child1 = ctr.child_by_index(index1 as usize).unwrap();
 
-            child0.set_placed_by_script(activation.context.gc(), true);
-            child1.set_placed_by_script(activation.context.gc(), true);
+            child0.set_placed_by_script(activation.gc(), true);
+            child1.set_placed_by_script(activation.gc(), true);
 
             ctr.swap_at_index(activation.context, index0 as usize, index1 as usize);
         }
@@ -523,8 +523,8 @@ pub fn swap_children<'gc>(
                 .position(|a| DisplayObject::ptr_eq(a, child1))
                 .ok_or(make_error_2025(activation))?;
 
-            child0.set_placed_by_script(activation.context.gc(), true);
-            child1.set_placed_by_script(activation.context.gc(), true);
+            child0.set_placed_by_script(activation.gc(), true);
+            child1.set_placed_by_script(activation.gc(), true);
 
             ctr.swap_at_index(activation.context, index0, index1);
         }
@@ -649,7 +649,7 @@ pub fn set_mouse_children<'gc>(
     {
         let mouse_children = args.get_bool(0);
 
-        dobj.raw_container_mut(activation.context.gc())
+        dobj.raw_container_mut(activation.gc())
             .set_mouse_children(mouse_children);
     }
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/display_object_container.rs
+++ b/core/src/avm2/globals/flash/display/display_object_container.rs
@@ -109,7 +109,7 @@ fn validate_remove_operation<'gc>(
 fn remove_child_from_displaylist<'gc>(context: &mut UpdateContext<'gc>, child: DisplayObject<'gc>) {
     if let Some(parent) = child.parent() {
         if let Some(mut ctr) = parent.as_container() {
-            child.set_placed_by_script(context.gc_context, true);
+            child.set_placed_by_script(context.gc(), true);
             ctr.remove_child(context, child);
         }
     }
@@ -123,7 +123,7 @@ pub(super) fn add_child_to_displaylist<'gc>(
     index: usize,
 ) {
     if let Some(mut ctr) = parent.as_container() {
-        child.set_placed_by_script(context.gc_context, true);
+        child.set_placed_by_script(context.gc(), true);
         ctr.insert_at_index(context, child, index);
     }
 }
@@ -348,7 +348,7 @@ pub fn remove_child_at<'gc>(
             }
 
             let child = ctr.child_by_index(target_child as usize).unwrap();
-            child.set_placed_by_script(activation.context.gc_context, true);
+            child.set_placed_by_script(activation.context.gc(), true);
 
             ctr.remove_child(activation.context, child);
 
@@ -485,8 +485,8 @@ pub fn swap_children_at<'gc>(
             let child0 = ctr.child_by_index(index0 as usize).unwrap();
             let child1 = ctr.child_by_index(index1 as usize).unwrap();
 
-            child0.set_placed_by_script(activation.context.gc_context, true);
-            child1.set_placed_by_script(activation.context.gc_context, true);
+            child0.set_placed_by_script(activation.context.gc(), true);
+            child1.set_placed_by_script(activation.context.gc(), true);
 
             ctr.swap_at_index(activation.context, index0 as usize, index1 as usize);
         }
@@ -523,8 +523,8 @@ pub fn swap_children<'gc>(
                 .position(|a| DisplayObject::ptr_eq(a, child1))
                 .ok_or(make_error_2025(activation))?;
 
-            child0.set_placed_by_script(activation.context.gc_context, true);
-            child1.set_placed_by_script(activation.context.gc_context, true);
+            child0.set_placed_by_script(activation.context.gc(), true);
+            child1.set_placed_by_script(activation.context.gc(), true);
 
             ctr.swap_at_index(activation.context, index0, index1);
         }
@@ -649,7 +649,7 @@ pub fn set_mouse_children<'gc>(
     {
         let mouse_children = args.get_bool(0);
 
-        dobj.raw_container_mut(activation.context.gc_context)
+        dobj.raw_container_mut(activation.context.gc())
             .set_mouse_children(mouse_children);
     }
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -46,7 +46,7 @@ pub fn begin_fill<'gc>(
         let color = args.get_u32(activation, 0)?;
         let alpha = args.get_f64(activation, 1)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw.set_fill_style(Some(FillStyle::Color(color_from_args(color, alpha))));
         }
     }
@@ -136,7 +136,7 @@ pub fn begin_gradient_fill<'gc>(
         let interpolation = parse_interpolation_method(interpolation?);
         let focal_point = args.get_f64(activation, 7)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             match gradient_type {
                 GradientType::Linear => {
                     draw.set_fill_style(Some(FillStyle::LinearGradient(Gradient {
@@ -261,7 +261,7 @@ pub fn clear<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(this) = this.as_display_object() {
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw.clear()
         }
     }
@@ -283,7 +283,7 @@ pub fn curve_to<'gc>(
         let anchor_x = args.get_f64(activation, 2)?;
         let anchor_y = args.get_f64(activation, 3)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw.draw_command(DrawCommand::QuadraticCurveTo {
                 control: Point::from_pixels(control_x, control_y),
                 anchor: Point::from_pixels(anchor_x, anchor_y),
@@ -303,7 +303,7 @@ pub fn end_fill<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(this) = this.as_display_object() {
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw.set_fill_style(None);
         }
     }
@@ -363,7 +363,7 @@ pub fn line_style<'gc>(
         let thickness = args.get_f64(activation, 0)?;
 
         if thickness.is_nan() {
-            if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+            if let Some(mut draw) = this.as_drawing(activation.gc()) {
                 draw.set_line_style(None);
             }
         } else {
@@ -391,7 +391,7 @@ pub fn line_style<'gc>(
                 .with_is_pixel_hinted(is_pixel_hinted)
                 .with_allow_close(false);
 
-            if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+            if let Some(mut draw) = this.as_drawing(activation.gc()) {
                 draw.set_line_style(Some(line_style));
             }
         }
@@ -412,7 +412,7 @@ pub fn line_to<'gc>(
         let x = Twips::from_pixels(args.get_f64(activation, 0)?);
         let y = Twips::from_pixels(args.get_f64(activation, 1)?);
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw.draw_command(DrawCommand::LineTo(Point::new(x, y)));
         }
     }
@@ -432,7 +432,7 @@ pub fn move_to<'gc>(
         let x = Twips::from_pixels(args.get_f64(activation, 0)?);
         let y = Twips::from_pixels(args.get_f64(activation, 1)?);
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw.draw_command(DrawCommand::MoveTo(Point::new(x, y)));
         }
     }
@@ -454,7 +454,7 @@ pub fn draw_rect<'gc>(
         let width = Twips::from_pixels(args.get_f64(activation, 2)?);
         let height = Twips::from_pixels(args.get_f64(activation, 3)?);
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw.draw_command(DrawCommand::MoveTo(Point::new(x, y)));
             draw.draw_command(DrawCommand::LineTo(Point::new(x + width, y)));
             draw.draw_command(DrawCommand::LineTo(Point::new(x + width, y + height)));
@@ -748,7 +748,7 @@ pub fn draw_round_rect<'gc>(
             ellipse_height = ellipse_width;
         }
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw_round_rect_internal(
                 &mut draw,
                 x,
@@ -788,7 +788,7 @@ pub fn draw_round_rect_complex<'gc>(
         let bottom_left = args.get_f64(activation, 6)?;
         let bottom_right = args.get_f64(activation, 7)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw_round_rect_internal(
                 &mut draw,
                 x,
@@ -823,7 +823,7 @@ pub fn draw_circle<'gc>(
         let y = args.get_f64(activation, 1)?;
         let radius = args.get_f64(activation, 2)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw_round_rect_internal(
                 &mut draw,
                 x - radius,
@@ -859,7 +859,7 @@ pub fn draw_ellipse<'gc>(
         let width = args.get_f64(activation, 2)?;
         let height = args.get_f64(activation, 3)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw_round_rect_internal(
                 &mut draw,
                 x,
@@ -914,7 +914,7 @@ pub fn line_gradient_style<'gc>(
         let interpolation = parse_interpolation_method(interpolation?);
         let focal_point = args.get_f64(activation, 7)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             match gradient_type {
                 GradientType::Linear => {
                     draw.set_line_fill_style(FillStyle::LinearGradient(Gradient {
@@ -963,7 +963,7 @@ pub fn cubic_curve_to<'gc>(
         let anchor_x = args.get_f64(activation, 4)?;
         let anchor_y = args.get_f64(activation, 5)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             draw.draw_command(DrawCommand::CubicCurveTo {
                 control_a: Point::from_pixels(control_a_x, control_a_y),
                 control_b: Point::from_pixels(control_b_x, control_b_y),
@@ -990,11 +990,11 @@ pub fn copy_from<'gc>(
             .expect("Bad sourceGraphics");
 
         let source = source
-            .as_drawing(activation.context.gc())
+            .as_drawing(activation.gc())
             .expect("Missing drawing for sourceGraphics");
 
         let mut target_drawing = this
-            .as_drawing(activation.context.gc())
+            .as_drawing(activation.gc())
             .expect("Missing drawing for target");
 
         target_drawing.copy_from(&source);
@@ -1011,7 +1011,7 @@ pub fn draw_path<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_display_object().unwrap();
-    let mut drawing = this.as_drawing(activation.context.gc()).unwrap();
+    let mut drawing = this.as_drawing(activation.gc()).unwrap();
     let commands = args.get_object(activation, 0, "commands")?;
     let data = args.get_object(activation, 1, "data")?;
     let winding = args.get_string(activation, 2)?;
@@ -1052,7 +1052,7 @@ pub fn draw_triangles<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(this) = this.as_display_object() {
-        if let Some(mut drawing) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut drawing) = this.as_drawing(activation.gc()) {
             let vertices = args.get_object(activation, 0, "vertices")?;
 
             let indices = args.try_get_object(activation, 1);
@@ -1286,7 +1286,7 @@ pub fn draw_graphics_data<'gc>(
     {
         let this = this.as_display_object().expect("Bad this");
 
-        if let Some(mut drawing) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut drawing) = this.as_drawing(activation.gc()) {
             for elem in vector.iter() {
                 if let Some(obj) = elem.as_object() {
                     handle_igraphics_data(activation, &mut drawing, &obj)?;
@@ -1320,7 +1320,7 @@ pub fn line_bitmap_style<'gc>(
         let is_repeating = args.get_bool(2);
         let is_smoothed = args.get_bool(3);
 
-        let handle = bitmap.bitmap_handle(activation.context.gc(), activation.context.renderer);
+        let handle = bitmap.bitmap_handle(activation.gc(), activation.context.renderer);
 
         let bitmap = ruffle_render::bitmap::BitmapInfo {
             handle,
@@ -1332,7 +1332,7 @@ pub fn line_bitmap_style<'gc>(
             Fixed16::from_f64(bitmap.height as f64),
         );
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
+        if let Some(mut draw) = this.as_drawing(activation.gc()) {
             let id = draw.add_bitmap(bitmap);
             draw.set_line_fill_style(FillStyle::Bitmap {
                 id,
@@ -1787,7 +1787,7 @@ fn handle_bitmap_fill<'gc>(
         .get_slot(graphics_bitmap_fill_slots::SMOOTH)
         .coerce_to_boolean();
 
-    let handle = bitmap_data.bitmap_handle(activation.context.gc(), activation.context.renderer);
+    let handle = bitmap_data.bitmap_handle(activation.gc(), activation.context.renderer);
 
     let bitmap = ruffle_render::bitmap::BitmapInfo {
         handle,

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -46,7 +46,7 @@ pub fn begin_fill<'gc>(
         let color = args.get_u32(activation, 0)?;
         let alpha = args.get_f64(activation, 1)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw.set_fill_style(Some(FillStyle::Color(color_from_args(color, alpha))));
         }
     }
@@ -136,7 +136,7 @@ pub fn begin_gradient_fill<'gc>(
         let interpolation = parse_interpolation_method(interpolation?);
         let focal_point = args.get_f64(activation, 7)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             match gradient_type {
                 GradientType::Linear => {
                     draw.set_fill_style(Some(FillStyle::LinearGradient(Gradient {
@@ -261,7 +261,7 @@ pub fn clear<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(this) = this.as_display_object() {
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw.clear()
         }
     }
@@ -283,7 +283,7 @@ pub fn curve_to<'gc>(
         let anchor_x = args.get_f64(activation, 2)?;
         let anchor_y = args.get_f64(activation, 3)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw.draw_command(DrawCommand::QuadraticCurveTo {
                 control: Point::from_pixels(control_x, control_y),
                 anchor: Point::from_pixels(anchor_x, anchor_y),
@@ -303,7 +303,7 @@ pub fn end_fill<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(this) = this.as_display_object() {
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw.set_fill_style(None);
         }
     }
@@ -363,7 +363,7 @@ pub fn line_style<'gc>(
         let thickness = args.get_f64(activation, 0)?;
 
         if thickness.is_nan() {
-            if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+            if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
                 draw.set_line_style(None);
             }
         } else {
@@ -391,7 +391,7 @@ pub fn line_style<'gc>(
                 .with_is_pixel_hinted(is_pixel_hinted)
                 .with_allow_close(false);
 
-            if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+            if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
                 draw.set_line_style(Some(line_style));
             }
         }
@@ -412,7 +412,7 @@ pub fn line_to<'gc>(
         let x = Twips::from_pixels(args.get_f64(activation, 0)?);
         let y = Twips::from_pixels(args.get_f64(activation, 1)?);
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw.draw_command(DrawCommand::LineTo(Point::new(x, y)));
         }
     }
@@ -432,7 +432,7 @@ pub fn move_to<'gc>(
         let x = Twips::from_pixels(args.get_f64(activation, 0)?);
         let y = Twips::from_pixels(args.get_f64(activation, 1)?);
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw.draw_command(DrawCommand::MoveTo(Point::new(x, y)));
         }
     }
@@ -454,7 +454,7 @@ pub fn draw_rect<'gc>(
         let width = Twips::from_pixels(args.get_f64(activation, 2)?);
         let height = Twips::from_pixels(args.get_f64(activation, 3)?);
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw.draw_command(DrawCommand::MoveTo(Point::new(x, y)));
             draw.draw_command(DrawCommand::LineTo(Point::new(x + width, y)));
             draw.draw_command(DrawCommand::LineTo(Point::new(x + width, y + height)));
@@ -748,7 +748,7 @@ pub fn draw_round_rect<'gc>(
             ellipse_height = ellipse_width;
         }
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw_round_rect_internal(
                 &mut draw,
                 x,
@@ -788,7 +788,7 @@ pub fn draw_round_rect_complex<'gc>(
         let bottom_left = args.get_f64(activation, 6)?;
         let bottom_right = args.get_f64(activation, 7)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw_round_rect_internal(
                 &mut draw,
                 x,
@@ -823,7 +823,7 @@ pub fn draw_circle<'gc>(
         let y = args.get_f64(activation, 1)?;
         let radius = args.get_f64(activation, 2)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw_round_rect_internal(
                 &mut draw,
                 x - radius,
@@ -859,7 +859,7 @@ pub fn draw_ellipse<'gc>(
         let width = args.get_f64(activation, 2)?;
         let height = args.get_f64(activation, 3)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw_round_rect_internal(
                 &mut draw,
                 x,
@@ -914,7 +914,7 @@ pub fn line_gradient_style<'gc>(
         let interpolation = parse_interpolation_method(interpolation?);
         let focal_point = args.get_f64(activation, 7)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             match gradient_type {
                 GradientType::Linear => {
                     draw.set_line_fill_style(FillStyle::LinearGradient(Gradient {
@@ -963,7 +963,7 @@ pub fn cubic_curve_to<'gc>(
         let anchor_x = args.get_f64(activation, 4)?;
         let anchor_y = args.get_f64(activation, 5)?;
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             draw.draw_command(DrawCommand::CubicCurveTo {
                 control_a: Point::from_pixels(control_a_x, control_a_y),
                 control_b: Point::from_pixels(control_b_x, control_b_y),
@@ -990,11 +990,11 @@ pub fn copy_from<'gc>(
             .expect("Bad sourceGraphics");
 
         let source = source
-            .as_drawing(activation.context.gc_context)
+            .as_drawing(activation.context.gc())
             .expect("Missing drawing for sourceGraphics");
 
         let mut target_drawing = this
-            .as_drawing(activation.context.gc_context)
+            .as_drawing(activation.context.gc())
             .expect("Missing drawing for target");
 
         target_drawing.copy_from(&source);
@@ -1011,7 +1011,7 @@ pub fn draw_path<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_display_object().unwrap();
-    let mut drawing = this.as_drawing(activation.context.gc_context).unwrap();
+    let mut drawing = this.as_drawing(activation.context.gc()).unwrap();
     let commands = args.get_object(activation, 0, "commands")?;
     let data = args.get_object(activation, 1, "data")?;
     let winding = args.get_string(activation, 2)?;
@@ -1052,7 +1052,7 @@ pub fn draw_triangles<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(this) = this.as_display_object() {
-        if let Some(mut drawing) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut drawing) = this.as_drawing(activation.context.gc()) {
             let vertices = args.get_object(activation, 0, "vertices")?;
 
             let indices = args.try_get_object(activation, 1);
@@ -1286,7 +1286,7 @@ pub fn draw_graphics_data<'gc>(
     {
         let this = this.as_display_object().expect("Bad this");
 
-        if let Some(mut drawing) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut drawing) = this.as_drawing(activation.context.gc()) {
             for elem in vector.iter() {
                 if let Some(obj) = elem.as_object() {
                     handle_igraphics_data(activation, &mut drawing, &obj)?;
@@ -1320,8 +1320,7 @@ pub fn line_bitmap_style<'gc>(
         let is_repeating = args.get_bool(2);
         let is_smoothed = args.get_bool(3);
 
-        let handle =
-            bitmap.bitmap_handle(activation.context.gc_context, activation.context.renderer);
+        let handle = bitmap.bitmap_handle(activation.context.gc(), activation.context.renderer);
 
         let bitmap = ruffle_render::bitmap::BitmapInfo {
             handle,
@@ -1333,7 +1332,7 @@ pub fn line_bitmap_style<'gc>(
             Fixed16::from_f64(bitmap.height as f64),
         );
 
-        if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
+        if let Some(mut draw) = this.as_drawing(activation.context.gc()) {
             let id = draw.add_bitmap(bitmap);
             draw.set_line_fill_style(FillStyle::Bitmap {
                 id,
@@ -1788,8 +1787,7 @@ fn handle_bitmap_fill<'gc>(
         .get_slot(graphics_bitmap_fill_slots::SMOOTH)
         .coerce_to_boolean();
 
-    let handle =
-        bitmap_data.bitmap_handle(activation.context.gc_context, activation.context.renderer);
+    let handle = bitmap_data.bitmap_handle(activation.context.gc(), activation.context.renderer);
 
     let bitmap = ruffle_render::bitmap::BitmapInfo {
         handle,

--- a/core/src/avm2/globals/flash/display/interactive_object.rs
+++ b/core/src/avm2/globals/flash/display/interactive_object.rs
@@ -39,7 +39,7 @@ pub fn set_mouse_enabled<'gc>(
         .and_then(|dobj| dobj.as_interactive())
     {
         let value = args.get_bool(0);
-        int.set_mouse_enabled(activation.context.gc(), value);
+        int.set_mouse_enabled(activation.gc(), value);
     }
 
     Ok(Value::Undefined)
@@ -76,7 +76,7 @@ pub fn set_double_click_enabled<'gc>(
         .and_then(|dobj| dobj.as_interactive())
     {
         let value = args.get_bool(0);
-        int.set_double_click_enabled(activation.context.gc(), value);
+        int.set_double_click_enabled(activation.gc(), value);
     }
 
     Ok(Value::Undefined)
@@ -113,7 +113,7 @@ pub fn set_context_menu<'gc>(
         .and_then(|dobj| dobj.as_interactive())
     {
         let value = args.get_value(0);
-        int.set_context_menu(activation.context.gc(), value);
+        int.set_context_menu(activation.gc(), value);
     }
 
     Ok(Value::Undefined)
@@ -219,7 +219,7 @@ pub fn set_focus_rect<'gc>(
             // everything else sets focusRect to false
             _ => Some(false),
         };
-        obj.set_focus_rect(activation.context.gc(), value);
+        obj.set_focus_rect(activation.gc(), value);
     }
 
     Ok(Value::Null)

--- a/core/src/avm2/globals/flash/display/interactive_object.rs
+++ b/core/src/avm2/globals/flash/display/interactive_object.rs
@@ -39,7 +39,7 @@ pub fn set_mouse_enabled<'gc>(
         .and_then(|dobj| dobj.as_interactive())
     {
         let value = args.get_bool(0);
-        int.set_mouse_enabled(activation.context.gc_context, value);
+        int.set_mouse_enabled(activation.context.gc(), value);
     }
 
     Ok(Value::Undefined)
@@ -76,7 +76,7 @@ pub fn set_double_click_enabled<'gc>(
         .and_then(|dobj| dobj.as_interactive())
     {
         let value = args.get_bool(0);
-        int.set_double_click_enabled(activation.context.gc_context, value);
+        int.set_double_click_enabled(activation.context.gc(), value);
     }
 
     Ok(Value::Undefined)
@@ -113,7 +113,7 @@ pub fn set_context_menu<'gc>(
         .and_then(|dobj| dobj.as_interactive())
     {
         let value = args.get_value(0);
-        int.set_context_menu(activation.context.gc_context, value);
+        int.set_context_menu(activation.context.gc(), value);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -88,7 +88,7 @@ pub fn load<'gc>(
     // This is a dummy MovieClip, which will get overwritten in `Loader`
     let content = MovieClip::new(
         Arc::new(SwfMovie::empty(activation.context.swf.version())),
-        activation.context.gc_context,
+        activation.context.gc(),
     );
 
     // Update the LoaderStream - we still have a fake SwfMovie, but we now have the real target clip.
@@ -98,7 +98,7 @@ pub fn load<'gc>(
             Some(content.into()),
             false,
         ),
-        activation.context.gc_context,
+        activation.context.gc(),
     );
 
     let request = request_from_url_request(activation, url_request)?;
@@ -247,7 +247,7 @@ pub fn load_bytes<'gc>(
     // This is a dummy MovieClip, which will get overwritten in `Loader`
     let content = MovieClip::new(
         Arc::new(SwfMovie::empty(activation.context.swf.version())),
-        activation.context.gc_context,
+        activation.context.gc(),
     );
 
     let default_domain = activation

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -88,7 +88,7 @@ pub fn load<'gc>(
     // This is a dummy MovieClip, which will get overwritten in `Loader`
     let content = MovieClip::new(
         Arc::new(SwfMovie::empty(activation.context.swf.version())),
-        activation.context.gc(),
+        activation.gc(),
     );
 
     // Update the LoaderStream - we still have a fake SwfMovie, but we now have the real target clip.
@@ -98,7 +98,7 @@ pub fn load<'gc>(
             Some(content.into()),
             false,
         ),
-        activation.context.gc(),
+        activation.gc(),
     );
 
     let request = request_from_url_request(activation, url_request)?;
@@ -247,7 +247,7 @@ pub fn load_bytes<'gc>(
     // This is a dummy MovieClip, which will get overwritten in `Loader`
     let content = MovieClip::new(
         Arc::new(SwfMovie::empty(activation.context.swf.version())),
-        activation.context.gc(),
+        activation.gc(),
     );
 
     let default_domain = activation

--- a/core/src/avm2/globals/flash/display/loader_info.rs
+++ b/core/src/avm2/globals/flash/display/loader_info.rs
@@ -373,7 +373,7 @@ pub fn get_url<'gc>(
             let root = match &*loader_stream {
                 LoaderStream::NotYetLoaded(root, _, _) | LoaderStream::Swf(root, _) => root,
             };
-            return Ok(AvmString::new_utf8(activation.context.gc_context, root.url()).into());
+            return Ok(AvmString::new_utf8(activation.context.gc(), root.url()).into());
         }
     }
 
@@ -519,7 +519,7 @@ pub fn get_loader_url<'gc>(
         };
 
         let loader_url = root.loader_url().unwrap_or_else(|| root.url());
-        return Ok(AvmString::new_utf8(activation.context.gc_context, loader_url).into());
+        return Ok(AvmString::new_utf8(activation.context.gc(), loader_url).into());
     }
 
     Ok(Value::Undefined)
@@ -546,8 +546,8 @@ pub fn get_parameters<'gc>(
         let parameters = root.parameters();
 
         for (k, v) in parameters.iter() {
-            let avm_k = AvmString::new_utf8(activation.context.gc_context, k);
-            let avm_v = AvmString::new_utf8(activation.context.gc_context, v);
+            let avm_k = AvmString::new_utf8(activation.context.gc(), k);
+            let avm_v = AvmString::new_utf8(activation.context.gc(), v);
             params_obj.set_string_property_local(avm_k, avm_v.into(), activation)?;
         }
 

--- a/core/src/avm2/globals/flash/display/loader_info.rs
+++ b/core/src/avm2/globals/flash/display/loader_info.rs
@@ -373,7 +373,7 @@ pub fn get_url<'gc>(
             let root = match &*loader_stream {
                 LoaderStream::NotYetLoaded(root, _, _) | LoaderStream::Swf(root, _) => root,
             };
-            return Ok(AvmString::new_utf8(activation.context.gc(), root.url()).into());
+            return Ok(AvmString::new_utf8(activation.gc(), root.url()).into());
         }
     }
 
@@ -519,7 +519,7 @@ pub fn get_loader_url<'gc>(
         };
 
         let loader_url = root.loader_url().unwrap_or_else(|| root.url());
-        return Ok(AvmString::new_utf8(activation.context.gc(), loader_url).into());
+        return Ok(AvmString::new_utf8(activation.gc(), loader_url).into());
     }
 
     Ok(Value::Undefined)
@@ -546,8 +546,8 @@ pub fn get_parameters<'gc>(
         let parameters = root.parameters();
 
         for (k, v) in parameters.iter() {
-            let avm_k = AvmString::new_utf8(activation.context.gc(), k);
-            let avm_v = AvmString::new_utf8(activation.context.gc(), v);
+            let avm_k = AvmString::new_utf8(activation.gc(), k);
+            let avm_v = AvmString::new_utf8(activation.gc(), v);
             params_obj.set_string_property_local(avm_k, avm_v.into(), activation)?;
         }
 

--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -81,7 +81,7 @@ pub fn get_current_frame_label<'gc>(
                 if start_frame < mc.current_frame() {
                     None
                 } else {
-                    Some(AvmString::new(activation.context.gc_context, label).into())
+                    Some(AvmString::new(activation.context.gc(), label).into())
                 }
             })
             .unwrap_or(Value::Null));
@@ -104,9 +104,7 @@ pub fn get_current_label<'gc>(
     {
         return Ok(mc
             .current_label()
-            .map(|(label, _start_frame)| {
-                AvmString::new(activation.context.gc_context, label).into()
-            })
+            .map(|(label, _start_frame)| AvmString::new(activation.context.gc(), label).into())
             .unwrap_or(Value::Null));
     }
 
@@ -132,7 +130,7 @@ fn labels_for_scene<'gc>(
     let mut frame_labels = Vec::with_capacity(labels.len());
 
     for (name, frame) in labels {
-        let name: Value<'gc> = AvmString::new(activation.context.gc_context, name).into();
+        let name: Value<'gc> = AvmString::new(activation.context.gc(), name).into();
         let local_frame = frame - scene_start + 1;
         let args = [name, local_frame.into()];
         let frame_label = frame_label_class.construct(activation, &args)?;
@@ -190,7 +188,7 @@ pub fn get_current_scene<'gc>(
         let (scene_name, scene_length, scene_labels) = labels_for_scene(activation, mc, &scene)?;
         let scene_class = activation.context.avm2.classes().scene;
         let args = [
-            AvmString::new_utf8(activation.context.gc_context, scene_name).into(),
+            AvmString::new_utf8(activation.context.gc(), scene_name).into(),
             scene_labels.into(),
             scene_length.into(),
         ];
@@ -266,7 +264,7 @@ pub fn get_scenes<'gc>(
                 labels_for_scene(activation, mc, &scene)?;
             let scene_class = activation.context.avm2.classes().scene;
             let args = [
-                AvmString::new_utf8(activation.context.gc_context, scene_name).into(),
+                AvmString::new_utf8(activation.context.gc(), scene_name).into(),
                 scene_labels.into(),
                 scene_length.into(),
             ];
@@ -352,7 +350,7 @@ pub fn goto_and_play<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
-        mc.set_programmatically_played(activation.context.gc_context);
+        mc.set_programmatically_played(activation.context.gc());
         goto_frame(activation, mc, args, false)?;
     }
 
@@ -472,7 +470,7 @@ pub fn play<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
-        mc.set_programmatically_played(activation.context.gc_context);
+        mc.set_programmatically_played(activation.context.gc());
         mc.play(activation.context);
     }
 

--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -81,7 +81,7 @@ pub fn get_current_frame_label<'gc>(
                 if start_frame < mc.current_frame() {
                     None
                 } else {
-                    Some(AvmString::new(activation.context.gc(), label).into())
+                    Some(AvmString::new(activation.gc(), label).into())
                 }
             })
             .unwrap_or(Value::Null));
@@ -104,7 +104,7 @@ pub fn get_current_label<'gc>(
     {
         return Ok(mc
             .current_label()
-            .map(|(label, _start_frame)| AvmString::new(activation.context.gc(), label).into())
+            .map(|(label, _start_frame)| AvmString::new(activation.gc(), label).into())
             .unwrap_or(Value::Null));
     }
 
@@ -130,7 +130,7 @@ fn labels_for_scene<'gc>(
     let mut frame_labels = Vec::with_capacity(labels.len());
 
     for (name, frame) in labels {
-        let name: Value<'gc> = AvmString::new(activation.context.gc(), name).into();
+        let name: Value<'gc> = AvmString::new(activation.gc(), name).into();
         let local_frame = frame - scene_start + 1;
         let args = [name, local_frame.into()];
         let frame_label = frame_label_class.construct(activation, &args)?;
@@ -188,7 +188,7 @@ pub fn get_current_scene<'gc>(
         let (scene_name, scene_length, scene_labels) = labels_for_scene(activation, mc, &scene)?;
         let scene_class = activation.context.avm2.classes().scene;
         let args = [
-            AvmString::new_utf8(activation.context.gc(), scene_name).into(),
+            AvmString::new_utf8(activation.gc(), scene_name).into(),
             scene_labels.into(),
             scene_length.into(),
         ];
@@ -264,7 +264,7 @@ pub fn get_scenes<'gc>(
                 labels_for_scene(activation, mc, &scene)?;
             let scene_class = activation.context.avm2.classes().scene;
             let args = [
-                AvmString::new_utf8(activation.context.gc(), scene_name).into(),
+                AvmString::new_utf8(activation.gc(), scene_name).into(),
                 scene_labels.into(),
                 scene_length.into(),
             ];
@@ -350,7 +350,7 @@ pub fn goto_and_play<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
-        mc.set_programmatically_played(activation.context.gc());
+        mc.set_programmatically_played(activation.gc());
         goto_frame(activation, mc, args, false)?;
     }
 
@@ -470,7 +470,7 @@ pub fn play<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
-        mc.set_programmatically_played(activation.context.gc());
+        mc.set_programmatically_played(activation.gc());
         mc.play(activation.context);
     }
 

--- a/core/src/avm2/globals/flash/display/shader_data.rs
+++ b/core/src/avm2/globals/flash/display/shader_data.rs
@@ -24,7 +24,7 @@ pub fn init<'gc>(
     let shader = parse_shader(bytecode.bytes()).expect("Failed to parse PixelBender");
 
     for meta in &shader.metadata {
-        let name = AvmString::new_utf8(activation.context.gc_context, &meta.key);
+        let name = AvmString::new_utf8(activation.context.gc(), &meta.key);
         // Top-level metadata appears to turn `TInt` into a plain integer value,
         // rather than a single-element array.
         let value = meta.value.as_avm2_value(activation, true)?;
@@ -32,7 +32,7 @@ pub fn init<'gc>(
     }
     this.set_string_property_local(
         "name",
-        AvmString::new_utf8(activation.context.gc_context, &shader.name).into(),
+        AvmString::new_utf8(activation.context.gc(), &shader.name).into(),
         activation,
     )?;
 
@@ -60,7 +60,7 @@ pub fn init<'gc>(
             }
         };
 
-        let name = AvmString::new_utf8(activation.context.gc_context, name);
+        let name = AvmString::new_utf8(activation.context.gc(), name);
         let param_obj = make_shader_parameter(activation, param, index)?;
         this.set_string_property_local(name, param_obj, activation)?;
     }

--- a/core/src/avm2/globals/flash/display/shader_data.rs
+++ b/core/src/avm2/globals/flash/display/shader_data.rs
@@ -24,7 +24,7 @@ pub fn init<'gc>(
     let shader = parse_shader(bytecode.bytes()).expect("Failed to parse PixelBender");
 
     for meta in &shader.metadata {
-        let name = AvmString::new_utf8(activation.context.gc(), &meta.key);
+        let name = AvmString::new_utf8(activation.gc(), &meta.key);
         // Top-level metadata appears to turn `TInt` into a plain integer value,
         // rather than a single-element array.
         let value = meta.value.as_avm2_value(activation, true)?;
@@ -32,7 +32,7 @@ pub fn init<'gc>(
     }
     this.set_string_property_local(
         "name",
-        AvmString::new_utf8(activation.context.gc(), &shader.name).into(),
+        AvmString::new_utf8(activation.gc(), &shader.name).into(),
         activation,
     )?;
 
@@ -60,7 +60,7 @@ pub fn init<'gc>(
             }
         };
 
-        let name = AvmString::new_utf8(activation.context.gc(), name);
+        let name = AvmString::new_utf8(activation.gc(), name);
         let param_obj = make_shader_parameter(activation, param, index)?;
         this.set_string_property_local(name, param_obj, activation)?;
     }

--- a/core/src/avm2/globals/flash/display/shader_job.rs
+++ b/core/src/avm2/globals/flash/display/shader_job.rs
@@ -68,7 +68,7 @@ pub fn get_shader_args<'gc>(
                     }
                     let shader_param = shader_data
                         .get_string_property_local(
-                            AvmString::new_utf8(activation.context.gc(), name),
+                            AvmString::new_utf8(activation.gc(), name),
                             activation,
                         )
                         .expect("Missing normal property");
@@ -104,7 +104,7 @@ pub fn get_shader_args<'gc>(
                 } => {
                     let shader_input = shader_data
                         .get_string_property_local(
-                            AvmString::new_utf8(activation.context.gc(), name),
+                            AvmString::new_utf8(activation.gc(), name),
                             activation,
                         )
                         .expect("Missing property")
@@ -134,10 +134,9 @@ pub fn get_shader_args<'gc>(
 
                     let texture = if let Some(input) = input.as_object() {
                         let input_texture = if let Some(bitmap) = input.as_bitmap_data() {
-                            ImageInputTexture::Bitmap(bitmap.bitmap_handle(
-                                activation.context.gc(),
-                                activation.context.renderer,
-                            ))
+                            ImageInputTexture::Bitmap(
+                                bitmap.bitmap_handle(activation.gc(), activation.context.renderer),
+                            )
                         } else if let Some(byte_array) = input.as_bytearray() {
                             let expected_len = (width * height * input_channels) as usize
                                 * std::mem::size_of::<f32>();
@@ -220,7 +219,7 @@ pub fn start<'gc>(
         let target_bitmap = bitmap.sync(activation.context.renderer);
         // Perform both a GPU->CPU and CPU->GPU sync before writing to it.
         // FIXME - are both necessary?
-        let mut target_bitmap_data = target_bitmap.write(activation.context.gc());
+        let mut target_bitmap_data = target_bitmap.write(activation.gc());
         target_bitmap_data.update_dirty_texture(activation.context.renderer);
 
         PixelBenderTarget::Bitmap(
@@ -247,11 +246,11 @@ pub fn start<'gc>(
                 .as_bitmap_data()
                 .unwrap()
                 .sync(activation.context.renderer);
-            let mut target_bitmap_data = target_bitmap.write(activation.context.gc());
+            let mut target_bitmap_data = target_bitmap.write(activation.gc());
             let width = target_bitmap_data.width();
             let height = target_bitmap_data.height();
             target_bitmap_data.set_gpu_dirty(
-                activation.context.gc(),
+                activation.gc(),
                 sync_handle,
                 PixelRegion::for_whole_size(width, height),
             );
@@ -259,7 +258,7 @@ pub fn start<'gc>(
         PixelBenderOutput::Bytes(pixels) => {
             if let Some(mut bytearray) = target.as_bytearray_mut() {
                 bytearray.write_at(&pixels, 0).unwrap();
-            } else if let Some(mut vector) = target.as_vector_storage_mut(activation.context.gc()) {
+            } else if let Some(mut vector) = target.as_vector_storage_mut(activation.gc()) {
                 let new_storage: Vec<_> = bytemuck::cast_slice::<u8, f32>(&pixels)
                     .iter()
                     .map(|p| Value::from(*p as f64))

--- a/core/src/avm2/globals/flash/display/shader_job.rs
+++ b/core/src/avm2/globals/flash/display/shader_job.rs
@@ -68,7 +68,7 @@ pub fn get_shader_args<'gc>(
                     }
                     let shader_param = shader_data
                         .get_string_property_local(
-                            AvmString::new_utf8(activation.context.gc_context, name),
+                            AvmString::new_utf8(activation.context.gc(), name),
                             activation,
                         )
                         .expect("Missing normal property");
@@ -104,7 +104,7 @@ pub fn get_shader_args<'gc>(
                 } => {
                     let shader_input = shader_data
                         .get_string_property_local(
-                            AvmString::new_utf8(activation.context.gc_context, name),
+                            AvmString::new_utf8(activation.context.gc(), name),
                             activation,
                         )
                         .expect("Missing property")
@@ -135,7 +135,7 @@ pub fn get_shader_args<'gc>(
                     let texture = if let Some(input) = input.as_object() {
                         let input_texture = if let Some(bitmap) = input.as_bitmap_data() {
                             ImageInputTexture::Bitmap(bitmap.bitmap_handle(
-                                activation.context.gc_context,
+                                activation.context.gc(),
                                 activation.context.renderer,
                             ))
                         } else if let Some(byte_array) = input.as_bytearray() {
@@ -220,7 +220,7 @@ pub fn start<'gc>(
         let target_bitmap = bitmap.sync(activation.context.renderer);
         // Perform both a GPU->CPU and CPU->GPU sync before writing to it.
         // FIXME - are both necessary?
-        let mut target_bitmap_data = target_bitmap.write(activation.context.gc_context);
+        let mut target_bitmap_data = target_bitmap.write(activation.context.gc());
         target_bitmap_data.update_dirty_texture(activation.context.renderer);
 
         PixelBenderTarget::Bitmap(
@@ -247,11 +247,11 @@ pub fn start<'gc>(
                 .as_bitmap_data()
                 .unwrap()
                 .sync(activation.context.renderer);
-            let mut target_bitmap_data = target_bitmap.write(activation.context.gc_context);
+            let mut target_bitmap_data = target_bitmap.write(activation.context.gc());
             let width = target_bitmap_data.width();
             let height = target_bitmap_data.height();
             target_bitmap_data.set_gpu_dirty(
-                activation.context.gc_context,
+                activation.context.gc(),
                 sync_handle,
                 PixelRegion::for_whole_size(width, height),
             );
@@ -259,9 +259,7 @@ pub fn start<'gc>(
         PixelBenderOutput::Bytes(pixels) => {
             if let Some(mut bytearray) = target.as_bytearray_mut() {
                 bytearray.write_at(&pixels, 0).unwrap();
-            } else if let Some(mut vector) =
-                target.as_vector_storage_mut(activation.context.gc_context)
-            {
+            } else if let Some(mut vector) = target.as_vector_storage_mut(activation.context.gc()) {
                 let new_storage: Vec<_> = bytemuck::cast_slice::<u8, f32>(&pixels)
                     .iter()
                     .map(|p| Value::from(*p as f64))

--- a/core/src/avm2/globals/flash/display/shader_parameter.rs
+++ b/core/src/avm2/globals/flash/display/shader_parameter.rs
@@ -24,13 +24,12 @@ pub fn make_shader_parameter<'gc>(
                 .classes()
                 .shaderparameter
                 .construct(activation, &[])?;
-            let type_name =
-                AvmString::new_utf8(activation.context.gc_context, param_type.to_string());
+            let type_name = AvmString::new_utf8(activation.context.gc(), param_type.to_string());
 
             obj.set_slot(parameter_slots::_INDEX, index.into(), activation)?;
             obj.set_slot(parameter_slots::_TYPE, type_name.into(), activation)?;
             for meta in metadata {
-                let name = AvmString::new_utf8(activation.context.gc_context, &meta.key);
+                let name = AvmString::new_utf8(activation.context.gc(), &meta.key);
                 let value = meta.value.clone().as_avm2_value(activation, false)?;
                 obj.set_public_property(name, value, activation)?;
 
@@ -40,7 +39,7 @@ pub fn make_shader_parameter<'gc>(
             }
             obj.set_string_property_local(
                 "name",
-                AvmString::new_utf8(activation.context.gc_context, name).into(),
+                AvmString::new_utf8(activation.context.gc(), name).into(),
                 activation,
             )?;
             Ok(obj.into())
@@ -55,7 +54,7 @@ pub fn make_shader_parameter<'gc>(
             obj.set_slot(input_slots::_INDEX, index.into(), activation)?;
             obj.set_string_property_local(
                 "name",
-                AvmString::new_utf8(activation.context.gc_context, name).into(),
+                AvmString::new_utf8(activation.context.gc(), name).into(),
                 activation,
             )?;
             Ok(obj.into())

--- a/core/src/avm2/globals/flash/display/shader_parameter.rs
+++ b/core/src/avm2/globals/flash/display/shader_parameter.rs
@@ -24,12 +24,12 @@ pub fn make_shader_parameter<'gc>(
                 .classes()
                 .shaderparameter
                 .construct(activation, &[])?;
-            let type_name = AvmString::new_utf8(activation.context.gc(), param_type.to_string());
+            let type_name = AvmString::new_utf8(activation.gc(), param_type.to_string());
 
             obj.set_slot(parameter_slots::_INDEX, index.into(), activation)?;
             obj.set_slot(parameter_slots::_TYPE, type_name.into(), activation)?;
             for meta in metadata {
-                let name = AvmString::new_utf8(activation.context.gc(), &meta.key);
+                let name = AvmString::new_utf8(activation.gc(), &meta.key);
                 let value = meta.value.clone().as_avm2_value(activation, false)?;
                 obj.set_public_property(name, value, activation)?;
 
@@ -39,7 +39,7 @@ pub fn make_shader_parameter<'gc>(
             }
             obj.set_string_property_local(
                 "name",
-                AvmString::new_utf8(activation.context.gc(), name).into(),
+                AvmString::new_utf8(activation.gc(), name).into(),
                 activation,
             )?;
             Ok(obj.into())
@@ -54,7 +54,7 @@ pub fn make_shader_parameter<'gc>(
             obj.set_slot(input_slots::_INDEX, index.into(), activation)?;
             obj.set_string_property_local(
                 "name",
-                AvmString::new_utf8(activation.context.gc(), name).into(),
+                AvmString::new_utf8(activation.gc(), name).into(),
                 activation,
             )?;
             Ok(obj.into())

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -23,7 +23,7 @@ pub fn sprite_allocator<'gc>(
     while let Some(class) = class_def {
         if class == sprite_cls {
             let movie = activation.caller_movie_or_root();
-            let display_object = MovieClip::new(movie, activation.context.gc()).into();
+            let display_object = MovieClip::new(movie, activation.gc()).into();
             return initialize_for_allocator(activation, display_object, orig_class);
         }
 

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -23,7 +23,7 @@ pub fn sprite_allocator<'gc>(
     while let Some(class) = class_def {
         if class == sprite_cls {
             let movie = activation.caller_movie_or_root();
-            let display_object = MovieClip::new(movie, activation.context.gc_context).into();
+            let display_object = MovieClip::new(movie, activation.context.gc()).into();
             return initialize_for_allocator(activation, display_object, orig_class);
         }
 

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -39,7 +39,7 @@ pub fn get_align<'gc>(
     if align.contains(StageAlign::RIGHT) {
         s.push_byte(b'R');
     }
-    let align = AvmString::new(activation.context.gc(), s);
+    let align = AvmString::new(activation.gc(), s);
     Ok(align.into())
 }
 
@@ -107,7 +107,7 @@ pub fn set_color<'gc>(
 
     if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         let color = Color::from_rgb(args.get_u32(activation, 0)?, 255);
-        dobj.set_background_color(activation.context.gc(), Some(color));
+        dobj.set_background_color(activation.gc(), Some(color));
     }
 
     Ok(Value::Undefined)
@@ -144,7 +144,7 @@ pub fn get_display_state<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let display_state = AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.stage.display_state().to_string(),
     );
     Ok(display_state.into())
@@ -265,7 +265,7 @@ pub fn get_scale_mode<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let scale_mode = AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         activation.context.stage.scale_mode().to_string(),
     );
     Ok(scale_mode.into())
@@ -313,7 +313,7 @@ pub fn set_stage_focus_rect<'gc>(
 
     if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         let rf = args.get_bool(0);
-        dobj.set_stage_focus_rect(activation.context.gc(), rf);
+        dobj.set_stage_focus_rect(activation.gc(), rf);
     }
 
     Ok(Value::Undefined)
@@ -452,7 +452,7 @@ pub fn invalidate<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(stage) = this.as_display_object().and_then(|this| this.as_stage()) {
-        stage.set_invalidated(activation.context.gc(), true);
+        stage.set_invalidated(activation.gc(), true);
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -39,7 +39,7 @@ pub fn get_align<'gc>(
     if align.contains(StageAlign::RIGHT) {
         s.push_byte(b'R');
     }
-    let align = AvmString::new(activation.context.gc_context, s);
+    let align = AvmString::new(activation.context.gc(), s);
     Ok(align.into())
 }
 
@@ -107,7 +107,7 @@ pub fn set_color<'gc>(
 
     if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         let color = Color::from_rgb(args.get_u32(activation, 0)?, 255);
-        dobj.set_background_color(activation.context.gc_context, Some(color));
+        dobj.set_background_color(activation.context.gc(), Some(color));
     }
 
     Ok(Value::Undefined)
@@ -144,7 +144,7 @@ pub fn get_display_state<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let display_state = AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.stage.display_state().to_string(),
     );
     Ok(display_state.into())
@@ -265,7 +265,7 @@ pub fn get_scale_mode<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let scale_mode = AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         activation.context.stage.scale_mode().to_string(),
     );
     Ok(scale_mode.into())
@@ -313,7 +313,7 @@ pub fn set_stage_focus_rect<'gc>(
 
     if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         let rf = args.get_bool(0);
-        dobj.set_stage_focus_rect(activation.context.gc_context, rf);
+        dobj.set_stage_focus_rect(activation.context.gc(), rf);
     }
 
     Ok(Value::Undefined)
@@ -452,7 +452,7 @@ pub fn invalidate<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(stage) = this.as_display_object().and_then(|this| this.as_stage()) {
-        stage.set_invalidated(activation.context.gc_context, true);
+        stage.set_invalidated(activation.context.gc(), true);
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/display/stage_3d.rs
+++ b/core/src/avm2/globals/flash/display/stage_3d.rs
@@ -60,7 +60,7 @@ pub fn request_context3d_internal<'gc>(
     if this_stage3d.context3d().is_none() {
         let context = activation.context.renderer.create_context3d(profile)?;
         let context3d_obj = Context3DObject::from_context(activation, context, this_stage3d)?;
-        this_stage3d.set_context3d(Some(context3d_obj), activation.context.gc());
+        this_stage3d.set_context3d(Some(context3d_obj), activation.gc());
 
         let event = activation
             .avm2()

--- a/core/src/avm2/globals/flash/display/stage_3d.rs
+++ b/core/src/avm2/globals/flash/display/stage_3d.rs
@@ -60,7 +60,7 @@ pub fn request_context3d_internal<'gc>(
     if this_stage3d.context3d().is_none() {
         let context = activation.context.renderer.create_context3d(profile)?;
         let context3d_obj = Context3DObject::from_context(activation, context, this_stage3d)?;
-        this_stage3d.set_context3d(Some(context3d_obj), activation.context.gc_context);
+        this_stage3d.set_context3d(Some(context3d_obj), activation.context.gc());
 
         let event = activation
             .avm2()

--- a/core/src/avm2/globals/flash/display3D/context_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/context_3d.rs
@@ -797,6 +797,6 @@ pub fn dispose<'gc>(
     this.as_context_3d()
         .unwrap()
         .stage3d()
-        .set_context3d(None, activation.context.gc_context);
+        .set_context3d(None, activation.context.gc());
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/display3D/context_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/context_3d.rs
@@ -797,6 +797,6 @@ pub fn dispose<'gc>(
     this.as_context_3d()
         .unwrap()
         .stage3d()
-        .set_context3d(None, activation.context.gc());
+        .set_context3d(None, activation.gc());
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/display3D/textures/texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/texture.rs
@@ -52,7 +52,7 @@ pub fn do_copy<'gc>(
                 .collect();
 
             let bitmap_data = BitmapData::new_with_pixels(width, height, true, colors);
-            BitmapDataWrapper::new(GcCell::new(activation.context.gc_context, bitmap_data))
+            BitmapDataWrapper::new(GcCell::new(activation.context.gc(), bitmap_data))
         }
         _ => {
             tracing::warn!(

--- a/core/src/avm2/globals/flash/display3D/textures/texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/texture.rs
@@ -52,7 +52,7 @@ pub fn do_copy<'gc>(
                 .collect();
 
             let bitmap_data = BitmapData::new_with_pixels(width, height, true, colors);
-            BitmapDataWrapper::new(GcCell::new(activation.context.gc(), bitmap_data))
+            BitmapDataWrapper::new(GcCell::new(activation.gc(), bitmap_data))
         }
         _ => {
             tracing::warn!(

--- a/core/src/avm2/globals/flash/events/event.rs
+++ b/core/src/avm2/globals/flash/events/event.rs
@@ -15,7 +15,7 @@ pub fn init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    let mut evt = this.as_event_mut(activation.context.gc()).unwrap();
+    let mut evt = this.as_event_mut(activation.gc()).unwrap();
     evt.set_event_type(args.get_string(activation, 0)?);
     evt.set_bubbles(args.get_bool(1));
     evt.set_cancelable(args.get_bool(2));
@@ -139,7 +139,7 @@ pub fn prevent_default<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut evt) = this.as_event_mut(activation.context.gc()) {
+    if let Some(mut evt) = this.as_event_mut(activation.gc()) {
         evt.cancel();
     }
 
@@ -154,7 +154,7 @@ pub fn stop_propagation<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut evt) = this.as_event_mut(activation.context.gc()) {
+    if let Some(mut evt) = this.as_event_mut(activation.gc()) {
         evt.stop_propagation();
     }
 
@@ -169,7 +169,7 @@ pub fn stop_immediate_propagation<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut evt) = this.as_event_mut(activation.context.gc()) {
+    if let Some(mut evt) = this.as_event_mut(activation.gc()) {
         evt.stop_immediate_propagation();
     }
 

--- a/core/src/avm2/globals/flash/events/event.rs
+++ b/core/src/avm2/globals/flash/events/event.rs
@@ -15,7 +15,7 @@ pub fn init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    let mut evt = this.as_event_mut(activation.context.gc_context).unwrap();
+    let mut evt = this.as_event_mut(activation.context.gc()).unwrap();
     evt.set_event_type(args.get_string(activation, 0)?);
     evt.set_bubbles(args.get_bool(1));
     evt.set_cancelable(args.get_bool(2));
@@ -139,7 +139,7 @@ pub fn prevent_default<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut evt) = this.as_event_mut(activation.context.gc_context) {
+    if let Some(mut evt) = this.as_event_mut(activation.context.gc()) {
         evt.cancel();
     }
 
@@ -154,7 +154,7 @@ pub fn stop_propagation<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut evt) = this.as_event_mut(activation.context.gc_context) {
+    if let Some(mut evt) = this.as_event_mut(activation.context.gc()) {
         evt.stop_propagation();
     }
 
@@ -169,7 +169,7 @@ pub fn stop_immediate_propagation<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut evt) = this.as_event_mut(activation.context.gc_context) {
+    if let Some(mut evt) = this.as_event_mut(activation.context.gc()) {
         evt.stop_immediate_propagation();
     }
 

--- a/core/src/avm2/globals/flash/events/event_dispatcher.rs
+++ b/core/src/avm2/globals/flash/events/event_dispatcher.rs
@@ -40,7 +40,7 @@ pub fn add_event_listener<'gc>(
 
     //TODO: If we ever get weak GC references, we should respect `useWeakReference`.
     dispatch_list
-        .as_dispatch_mut(activation.context.gc())
+        .as_dispatch_mut(activation.gc())
         .expect("Internal properties should have what I put in them")
         .add_event_listener(event_type, priority, listener, use_capture);
 
@@ -63,7 +63,7 @@ pub fn remove_event_listener<'gc>(
     let use_capture = args.get_bool(2);
 
     dispatch_list
-        .as_dispatch_mut(activation.context.gc())
+        .as_dispatch_mut(activation.gc())
         .expect("Internal properties should have what I put in them")
         .remove_event_listener(event_type, listener, use_capture);
 
@@ -82,7 +82,7 @@ pub fn has_event_listener<'gc>(
     let event_type = args.get_string(activation, 0)?;
 
     let does_have = dispatch_list
-        .as_dispatch_mut(activation.context.gc())
+        .as_dispatch_mut(activation.gc())
         .expect("Internal properties should have what I put in them")
         .has_event_listener(event_type)
         .into();
@@ -102,7 +102,7 @@ pub fn will_trigger<'gc>(
     let event_type = args.get_string(activation, 0)?;
 
     if dispatch_list
-        .as_dispatch_mut(activation.context.gc())
+        .as_dispatch_mut(activation.gc())
         .expect("Internal properties should have what I put in them")
         .has_event_listener(event_type)
     {

--- a/core/src/avm2/globals/flash/events/event_dispatcher.rs
+++ b/core/src/avm2/globals/flash/events/event_dispatcher.rs
@@ -40,7 +40,7 @@ pub fn add_event_listener<'gc>(
 
     //TODO: If we ever get weak GC references, we should respect `useWeakReference`.
     dispatch_list
-        .as_dispatch_mut(activation.context.gc_context)
+        .as_dispatch_mut(activation.context.gc())
         .expect("Internal properties should have what I put in them")
         .add_event_listener(event_type, priority, listener, use_capture);
 
@@ -63,7 +63,7 @@ pub fn remove_event_listener<'gc>(
     let use_capture = args.get_bool(2);
 
     dispatch_list
-        .as_dispatch_mut(activation.context.gc_context)
+        .as_dispatch_mut(activation.context.gc())
         .expect("Internal properties should have what I put in them")
         .remove_event_listener(event_type, listener, use_capture);
 
@@ -82,7 +82,7 @@ pub fn has_event_listener<'gc>(
     let event_type = args.get_string(activation, 0)?;
 
     let does_have = dispatch_list
-        .as_dispatch_mut(activation.context.gc_context)
+        .as_dispatch_mut(activation.context.gc())
         .expect("Internal properties should have what I put in them")
         .has_event_listener(event_type)
         .into();
@@ -102,7 +102,7 @@ pub fn will_trigger<'gc>(
     let event_type = args.get_string(activation, 0)?;
 
     if dispatch_list
-        .as_dispatch_mut(activation.context.gc_context)
+        .as_dispatch_mut(activation.context.gc())
         .expect("Internal properties should have what I put in them")
         .has_event_listener(event_type)
     {

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -40,9 +40,9 @@ pub fn set_color_transform<'gc>(
         activation,
     )?;
     let dobj = get_display_object(this);
-    dobj.set_color_transform(activation.context.gc_context, ct);
+    dobj.set_color_transform(activation.context.gc(), ct);
     if let Some(parent) = dobj.parent() {
-        parent.invalidate_cached_bitmap(activation.context.gc_context);
+        parent.invalidate_cached_bitmap(activation.context.gc());
     }
     Ok(Value::Undefined)
 }
@@ -70,11 +70,11 @@ pub fn set_matrix<'gc>(
     // remain its previous non-null value.
     let matrix = object_to_matrix(args.get_object(activation, 0, "value")?, activation)?;
     let dobj = get_display_object(this);
-    dobj.set_matrix(activation.context.gc_context, matrix);
+    dobj.set_matrix(activation.context.gc(), matrix);
     if let Some(parent) = dobj.parent() {
         // Self-transform changes are automatically handled,
         // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
-        parent.invalidate_cached_bitmap(activation.context.gc_context);
+        parent.invalidate_cached_bitmap(activation.context.gc());
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -40,9 +40,9 @@ pub fn set_color_transform<'gc>(
         activation,
     )?;
     let dobj = get_display_object(this);
-    dobj.set_color_transform(activation.context.gc(), ct);
+    dobj.set_color_transform(activation.gc(), ct);
     if let Some(parent) = dobj.parent() {
-        parent.invalidate_cached_bitmap(activation.context.gc());
+        parent.invalidate_cached_bitmap(activation.gc());
     }
     Ok(Value::Undefined)
 }
@@ -70,11 +70,11 @@ pub fn set_matrix<'gc>(
     // remain its previous non-null value.
     let matrix = object_to_matrix(args.get_object(activation, 0, "value")?, activation)?;
     let dobj = get_display_object(this);
-    dobj.set_matrix(activation.context.gc(), matrix);
+    dobj.set_matrix(activation.gc(), matrix);
     if let Some(parent) = dobj.parent() {
         // Self-transform changes are automatically handled,
         // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
-        parent.invalidate_cached_bitmap(activation.context.gc());
+        parent.invalidate_cached_bitmap(activation.gc());
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -13,7 +13,7 @@ pub fn video_allocator<'gc>(
     while let Some(target) = target_class {
         if target == video_class {
             let movie = activation.caller_movie_or_root();
-            let new_do = Video::new(activation.context.gc_context, movie, 0, 0, None);
+            let new_do = Video::new(activation.context.gc(), movie, 0, 0, None);
             return initialize_for_allocator(activation, new_do.into(), class);
         }
 
@@ -50,7 +50,7 @@ pub fn init<'gc>(
         let width = args.get_i32(activation, 0)?;
         let height = args.get_i32(activation, 1)?;
 
-        video.set_size(activation.context.gc_context, width, height);
+        video.set_size(activation.context.gc(), width, height);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -13,7 +13,7 @@ pub fn video_allocator<'gc>(
     while let Some(target) = target_class {
         if target == video_class {
             let movie = activation.caller_movie_or_root();
-            let new_do = Video::new(activation.context.gc(), movie, 0, 0, None);
+            let new_do = Video::new(activation.gc(), movie, 0, 0, None);
             return initialize_for_allocator(activation, new_do.into(), class);
         }
 
@@ -50,7 +50,7 @@ pub fn init<'gc>(
         let width = args.get_i32(activation, 0)?;
         let height = args.get_i32(activation, 1)?;
 
-        video.set_size(activation.context.gc(), width, height);
+        video.set_size(activation.gc(), width, height);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/net/file_reference.rs
+++ b/core/src/avm2/globals/flash/net/file_reference.rs
@@ -89,7 +89,7 @@ pub fn get_name<'gc>(
         FileReference::None => return Err(make_error_2037(activation)),
         FileReference::FileDialogResult(ref dialog_result) => {
             let name = dialog_result.file_name().unwrap_or_default();
-            AvmString::new_utf8(activation.context.gc(), name).into()
+            AvmString::new_utf8(activation.gc(), name).into()
         }
     };
 
@@ -126,7 +126,7 @@ pub fn get_type<'gc>(
         FileReference::None => return Err(make_error_2037(activation)),
         FileReference::FileDialogResult(ref dialog_result) => {
             let type_ = dialog_result.file_type().unwrap_or_default();
-            AvmString::new_utf8(activation.context.gc(), type_).into()
+            AvmString::new_utf8(activation.gc(), type_).into()
         }
     };
 

--- a/core/src/avm2/globals/flash/net/file_reference.rs
+++ b/core/src/avm2/globals/flash/net/file_reference.rs
@@ -89,7 +89,7 @@ pub fn get_name<'gc>(
         FileReference::None => return Err(make_error_2037(activation)),
         FileReference::FileDialogResult(ref dialog_result) => {
             let name = dialog_result.file_name().unwrap_or_default();
-            AvmString::new_utf8(activation.context.gc_context, name).into()
+            AvmString::new_utf8(activation.context.gc(), name).into()
         }
     };
 
@@ -126,7 +126,7 @@ pub fn get_type<'gc>(
         FileReference::None => return Err(make_error_2037(activation)),
         FileReference::FileDialogResult(ref dialog_result) => {
             let type_ = dialog_result.file_type().unwrap_or_default();
-            AvmString::new_utf8(activation.context.gc_context, type_).into()
+            AvmString::new_utf8(activation.context.gc(), type_).into()
         }
     };
 

--- a/core/src/avm2/globals/flash/net/local_connection.rs
+++ b/core/src/avm2/globals/flash/net/local_connection.rs
@@ -19,7 +19,7 @@ pub fn get_domain<'gc>(
     let domain = LocalConnections::get_domain(movie.url());
 
     Ok(Value::String(AvmString::new_utf8(
-        activation.context.gc_context,
+        activation.context.gc(),
         domain,
     )))
 }

--- a/core/src/avm2/globals/flash/net/local_connection.rs
+++ b/core/src/avm2/globals/flash/net/local_connection.rs
@@ -18,10 +18,7 @@ pub fn get_domain<'gc>(
     let movie = &activation.context.swf;
     let domain = LocalConnections::get_domain(movie.url());
 
-    Ok(Value::String(AvmString::new_utf8(
-        activation.context.gc(),
-        domain,
-    )))
+    Ok(Value::String(AvmString::new_utf8(activation.gc(), domain)))
 }
 
 /// Implements `LocalConnection.send`

--- a/core/src/avm2/globals/flash/net/net_connection.rs
+++ b/core/src/avm2/globals/flash/net/net_connection.rs
@@ -233,7 +233,7 @@ pub fn get_uri<'gc>(
         .handle()
         .and_then(|handle| activation.context.net_connections.get_uri(handle))
     {
-        return Ok(AvmString::new_utf8(activation.context.gc_context, result).into());
+        return Ok(AvmString::new_utf8(activation.context.gc(), result).into());
     }
 
     Ok(Value::Null)

--- a/core/src/avm2/globals/flash/net/net_connection.rs
+++ b/core/src/avm2/globals/flash/net/net_connection.rs
@@ -233,7 +233,7 @@ pub fn get_uri<'gc>(
         .handle()
         .and_then(|handle| activation.context.net_connections.get_uri(handle))
     {
-        return Ok(AvmString::new_utf8(activation.context.gc(), result).into());
+        return Ok(AvmString::new_utf8(activation.gc(), result).into());
     }
 
     Ok(Value::Null)

--- a/core/src/avm2/globals/flash/net/net_stream.rs
+++ b/core/src/avm2/globals/flash/net/net_stream.rs
@@ -120,7 +120,7 @@ pub fn set_client<'gc>(
 
     if let Some(client) = client {
         if let Some(ns) = this.as_netstream() {
-            ns.set_client(activation.context.gc(), client);
+            ns.set_client(activation.gc(), client);
         }
     } else {
         return Err(make_error_2004(activation, Error2004Type::TypeError));

--- a/core/src/avm2/globals/flash/net/net_stream.rs
+++ b/core/src/avm2/globals/flash/net/net_stream.rs
@@ -120,7 +120,7 @@ pub fn set_client<'gc>(
 
     if let Some(client) = client {
         if let Some(ns) = this.as_netstream() {
-            ns.set_client(activation.context.gc_context, client);
+            ns.set_client(activation.context.gc(), client);
         }
     } else {
         return Err(make_error_2004(activation, Error2004Type::TypeError));

--- a/core/src/avm2/globals/flash/net/responder.rs
+++ b/core/src/avm2/globals/flash/net/responder.rs
@@ -16,7 +16,7 @@ pub fn init<'gc>(
     let status = args.try_get_object(activation, 1);
 
     responder.set_callbacks(
-        activation.context.gc(),
+        activation.gc(),
         result.as_function_object(),
         status.and_then(|o| o.as_function_object()),
     );

--- a/core/src/avm2/globals/flash/net/responder.rs
+++ b/core/src/avm2/globals/flash/net/responder.rs
@@ -16,7 +16,7 @@ pub fn init<'gc>(
     let status = args.try_get_object(activation, 1);
 
     responder.set_callbacks(
-        activation.context.gc_context,
+        activation.context.gc(),
         result.as_function_object(),
         status.and_then(|o| o.as_function_object()),
     );

--- a/core/src/avm2/globals/flash/net/xml_socket.rs
+++ b/core/src/avm2/globals/flash/net/xml_socket.rs
@@ -15,7 +15,7 @@ pub fn get_domain<'gc>(
         if url.scheme() == "file" {
             "localhost".into()
         } else if let Some(domain) = url.domain() {
-            AvmString::new_utf8(activation.context.gc(), domain)
+            AvmString::new_utf8(activation.gc(), domain)
         } else {
             // no domain?
             "localhost".into()

--- a/core/src/avm2/globals/flash/net/xml_socket.rs
+++ b/core/src/avm2/globals/flash/net/xml_socket.rs
@@ -15,7 +15,7 @@ pub fn get_domain<'gc>(
         if url.scheme() == "file" {
             "localhost".into()
         } else if let Some(domain) = url.domain() {
-            AvmString::new_utf8(activation.context.gc_context, domain)
+            AvmString::new_utf8(activation.context.gc(), domain)
         } else {
             // no domain?
             "localhost".into()

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -26,7 +26,7 @@ pub fn init<'gc>(
             .expect("Invalid parent domain")
     };
     let fresh_domain = Domain::movie_domain(activation, parent_domain);
-    this.init_application_domain(activation.context.gc_context, fresh_domain);
+    this.init_application_domain(activation.context.gc(), fresh_domain);
 
     Ok(Value::Undefined)
 }
@@ -128,7 +128,7 @@ pub fn get_qualified_definition_names<'gc>(
                 .get_defined_names()
                 .iter()
                 .filter(|name| !name.namespace().is_private())
-                .map(|name| Value::String(name.to_qualified_name(activation.context.gc_context)))
+                .map(|name| Value::String(name.to_qualified_name(activation.context.gc())))
                 .collect(),
             false,
             Some(activation.avm2().class_defs().string),

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -26,7 +26,7 @@ pub fn init<'gc>(
             .expect("Invalid parent domain")
     };
     let fresh_domain = Domain::movie_domain(activation, parent_domain);
-    this.init_application_domain(activation.context.gc(), fresh_domain);
+    this.init_application_domain(activation.gc(), fresh_domain);
 
     Ok(Value::Undefined)
 }
@@ -128,7 +128,7 @@ pub fn get_qualified_definition_names<'gc>(
                 .get_defined_names()
                 .iter()
                 .filter(|name| !name.namespace().is_private())
-                .map(|name| Value::String(name.to_qualified_name(activation.context.gc())))
+                .map(|name| Value::String(name.to_qualified_name(activation.gc())))
                 .collect(),
             false,
             Some(activation.avm2().class_defs().string),

--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -67,7 +67,7 @@ pub fn get_player_type<'gc>(
         }
     };
 
-    Ok(AvmString::new_utf8(activation.context.gc_context, player_type).into())
+    Ok(AvmString::new_utf8(activation.context.gc(), player_type).into())
 }
 
 /// Implements `flash.system.Capabilities.screenResolutionX`

--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -67,7 +67,7 @@ pub fn get_player_type<'gc>(
         }
     };
 
-    Ok(AvmString::new_utf8(activation.context.gc(), player_type).into())
+    Ok(AvmString::new_utf8(activation.gc(), player_type).into())
 }
 
 /// Implements `flash.system.Capabilities.screenResolutionX`

--- a/core/src/avm2/globals/flash/system/security.rs
+++ b/core/src/avm2/globals/flash/system/security.rs
@@ -26,7 +26,7 @@ pub fn get_page_domain<'gc>(
 
         let mut domain = url.origin().ascii_serialization();
         domain.push('/'); // Add trailing slash that is used by Flash, but isn't part of a standard origin.
-        Ok(AvmString::new_utf8(activation.context.gc_context, domain).into())
+        Ok(AvmString::new_utf8(activation.context.gc(), domain).into())
     } else {
         tracing::warn!("flash.system.Security.pageDomain: No page-url available");
         Ok(Value::Null)
@@ -48,7 +48,7 @@ pub fn get_sandbox_type<'gc>(
         SandboxType::LocalTrusted => "localTrusted",
         SandboxType::Application => "application",
     };
-    Ok(AvmString::new_utf8(activation.context.gc_context, sandbox_type).into())
+    Ok(AvmString::new_utf8(activation.context.gc(), sandbox_type).into())
 }
 
 pub fn allow_domain<'gc>(

--- a/core/src/avm2/globals/flash/system/security.rs
+++ b/core/src/avm2/globals/flash/system/security.rs
@@ -26,7 +26,7 @@ pub fn get_page_domain<'gc>(
 
         let mut domain = url.origin().ascii_serialization();
         domain.push('/'); // Add trailing slash that is used by Flash, but isn't part of a standard origin.
-        Ok(AvmString::new_utf8(activation.context.gc(), domain).into())
+        Ok(AvmString::new_utf8(activation.gc(), domain).into())
     } else {
         tracing::warn!("flash.system.Security.pageDomain: No page-url available");
         Ok(Value::Null)
@@ -48,7 +48,7 @@ pub fn get_sandbox_type<'gc>(
         SandboxType::LocalTrusted => "localTrusted",
         SandboxType::Application => "application",
     };
-    Ok(AvmString::new_utf8(activation.context.gc(), sandbox_type).into())
+    Ok(AvmString::new_utf8(activation.gc(), sandbox_type).into())
 }
 
 pub fn allow_domain<'gc>(

--- a/core/src/avm2/globals/flash/text/font.rs
+++ b/core/src/avm2/globals/flash/text/font.rs
@@ -22,7 +22,7 @@ pub fn get_font_name<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(font) = this.as_font() {
-        return Ok(AvmString::new_utf8(activation.context.gc(), font.descriptor().name()).into());
+        return Ok(AvmString::new_utf8(activation.gc(), font.descriptor().name()).into());
     }
 
     Ok(Value::Null)
@@ -104,7 +104,7 @@ pub fn enumerate_fonts<'gc>(
     }
 
     for font in activation.context.library.global_fonts() {
-        storage.push(FontObject::for_font(activation.context.gc(), font_class, font).into());
+        storage.push(FontObject::for_font(activation.gc(), font_class, font).into());
     }
 
     if let Some(library) = activation
@@ -116,8 +116,7 @@ pub fn enumerate_fonts<'gc>(
             // TODO: EmbeddedCFF isn't supposed to show until it's been used (some kind of internal initialization method?)
             // Device is only supposed to show when arg0 is true - but that's supposed to be "all known" device fonts, not just loaded ones
             if font.font_type() == FontType::Embedded {
-                storage
-                    .push(FontObject::for_font(activation.context.gc(), font_class, font).into());
+                storage.push(FontObject::for_font(activation.gc(), font_class, font).into());
             }
         }
     }

--- a/core/src/avm2/globals/flash/text/font.rs
+++ b/core/src/avm2/globals/flash/text/font.rs
@@ -22,9 +22,7 @@ pub fn get_font_name<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(font) = this.as_font() {
-        return Ok(
-            AvmString::new_utf8(activation.context.gc_context, font.descriptor().name()).into(),
-        );
+        return Ok(AvmString::new_utf8(activation.context.gc(), font.descriptor().name()).into());
     }
 
     Ok(Value::Null)
@@ -106,7 +104,7 @@ pub fn enumerate_fonts<'gc>(
     }
 
     for font in activation.context.library.global_fonts() {
-        storage.push(FontObject::for_font(activation.context.gc_context, font_class, font).into());
+        storage.push(FontObject::for_font(activation.context.gc(), font_class, font).into());
     }
 
     if let Some(library) = activation
@@ -118,9 +116,8 @@ pub fn enumerate_fonts<'gc>(
             // TODO: EmbeddedCFF isn't supposed to show until it's been used (some kind of internal initialization method?)
             // Device is only supposed to show when arg0 is true - but that's supposed to be "all known" device fonts, not just loaded ones
             if font.font_type() == FontType::Embedded {
-                storage.push(
-                    FontObject::for_font(activation.context.gc_context, font_class, font).into(),
-                );
+                storage
+                    .push(FontObject::for_font(activation.context.gc(), font_class, font).into());
             }
         }
     }

--- a/core/src/avm2/globals/flash/text/static_text.rs
+++ b/core/src/avm2/globals/flash/text/static_text.rs
@@ -26,7 +26,7 @@ pub fn get_text<'gc>(
         .and_then(|this| this.as_text())
     {
         let text = this.text(activation.context);
-        return Ok(AvmString::new(activation.context.gc(), text).into());
+        return Ok(AvmString::new(activation.gc(), text).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -143,7 +143,7 @@ pub fn set_background<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         let has_background = args.get_bool(0);
-        this.set_has_background(activation.context.gc(), has_background);
+        this.set_has_background(activation.gc(), has_background);
     }
 
     Ok(Value::Undefined)
@@ -179,7 +179,7 @@ pub fn set_background_color<'gc>(
     {
         let rgb = args.get_u32(activation, 0)?;
         let color = Color::from_rgb(rgb, 255);
-        this.set_background_color(activation.context.gc(), color);
+        this.set_background_color(activation.gc(), color);
     }
 
     Ok(Value::Undefined)
@@ -214,7 +214,7 @@ pub fn set_border<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         let border = args.get_bool(0);
-        this.set_has_border(activation.context.gc(), border);
+        this.set_has_border(activation.gc(), border);
     }
 
     Ok(Value::Undefined)
@@ -250,7 +250,7 @@ pub fn set_border_color<'gc>(
     {
         let rgb = args.get_u32(activation, 0)?;
         let color = Color::from_rgb(rgb, 255);
-        this.set_border_color(activation.context.gc(), color);
+        this.set_border_color(activation.gc(), color);
     }
 
     Ok(Value::Undefined)
@@ -414,7 +414,7 @@ pub fn get_html_text<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        return Ok(AvmString::new(activation.context.gc(), this.html_text()).into());
+        return Ok(AvmString::new(activation.gc(), this.html_text()).into());
     }
 
     Ok(Value::Undefined)
@@ -540,7 +540,7 @@ pub fn get_text<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        return Ok(AvmString::new(activation.context.gc(), this.text()).into());
+        return Ok(AvmString::new(activation.gc(), this.text()).into());
     }
 
     Ok(Value::Undefined)
@@ -949,7 +949,7 @@ pub fn set_selection<'gc>(
                 begin_index as usize,
                 end_index as usize,
             )),
-            activation.context.gc(),
+            activation.gc(),
         );
     }
 
@@ -1044,15 +1044,9 @@ pub fn set_anti_alias_type<'gc>(
         let new_type = args.get_string_non_null(activation, 0, "antiAliasType")?;
 
         if &new_type == b"advanced" {
-            this.set_render_settings(
-                activation.context.gc(),
-                old_settings.with_advanced_rendering(),
-            );
+            this.set_render_settings(activation.gc(), old_settings.with_advanced_rendering());
         } else if &new_type == b"normal" {
-            this.set_render_settings(
-                activation.context.gc(),
-                old_settings.with_normal_rendering(),
-            );
+            this.set_render_settings(activation.gc(), old_settings.with_normal_rendering());
         }
     }
     Ok(Value::Undefined)
@@ -1095,18 +1089,18 @@ pub fn set_grid_fit_type<'gc>(
 
         if &new_type == b"pixel" {
             this.set_render_settings(
-                activation.context.gc(),
+                activation.gc(),
                 old_settings.with_grid_fit(swf::TextGridFit::Pixel),
             );
         } else if &new_type == b"subpixel" {
             this.set_render_settings(
-                activation.context.gc(),
+                activation.gc(),
                 old_settings.with_grid_fit(swf::TextGridFit::SubPixel),
             );
         } else {
             //NOTE: In AS3 invalid values are treated as None.
             this.set_render_settings(
-                activation.context.gc(),
+                activation.gc(),
                 old_settings.with_grid_fit(swf::TextGridFit::None),
             );
         }
@@ -1153,7 +1147,7 @@ pub fn set_thickness<'gc>(
         new_thickness = new_thickness.clamp(-200.0, 200.0);
 
         this.set_render_settings(
-            activation.context.gc(),
+            activation.gc(),
             old_settings.with_thickness(new_thickness as f32),
         );
     }
@@ -1200,7 +1194,7 @@ pub fn set_sharpness<'gc>(
         new_sharpness = new_sharpness.clamp(-400.0, 400.0);
 
         this.set_render_settings(
-            activation.context.gc(),
+            activation.gc(),
             old_settings.with_sharpness(new_sharpness as f32),
         );
     }
@@ -1542,7 +1536,7 @@ pub fn get_restrict<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         return match this.restrict() {
-            Some(value) => Ok(AvmString::new(activation.context.gc(), value).into()),
+            Some(value) => Ok(AvmString::new(activation.gc(), value).into()),
             None => Ok(Value::Null),
         };
     }
@@ -1589,7 +1583,7 @@ pub fn get_selected_text<'gc>(
         let start_index = selection.start();
         let end_index = selection.end();
 
-        return Ok(AvmString::new(activation.context.gc(), &text[start_index..end_index]).into());
+        return Ok(AvmString::new(activation.gc(), &text[start_index..end_index]).into());
     }
     Ok(activation.strings().empty().into())
 }

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -143,7 +143,7 @@ pub fn set_background<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         let has_background = args.get_bool(0);
-        this.set_has_background(activation.context.gc_context, has_background);
+        this.set_has_background(activation.context.gc(), has_background);
     }
 
     Ok(Value::Undefined)
@@ -179,7 +179,7 @@ pub fn set_background_color<'gc>(
     {
         let rgb = args.get_u32(activation, 0)?;
         let color = Color::from_rgb(rgb, 255);
-        this.set_background_color(activation.context.gc_context, color);
+        this.set_background_color(activation.context.gc(), color);
     }
 
     Ok(Value::Undefined)
@@ -214,7 +214,7 @@ pub fn set_border<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         let border = args.get_bool(0);
-        this.set_has_border(activation.context.gc_context, border);
+        this.set_has_border(activation.context.gc(), border);
     }
 
     Ok(Value::Undefined)
@@ -250,7 +250,7 @@ pub fn set_border_color<'gc>(
     {
         let rgb = args.get_u32(activation, 0)?;
         let color = Color::from_rgb(rgb, 255);
-        this.set_border_color(activation.context.gc_context, color);
+        this.set_border_color(activation.context.gc(), color);
     }
 
     Ok(Value::Undefined)
@@ -414,7 +414,7 @@ pub fn get_html_text<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        return Ok(AvmString::new(activation.context.gc_context, this.html_text()).into());
+        return Ok(AvmString::new(activation.context.gc(), this.html_text()).into());
     }
 
     Ok(Value::Undefined)
@@ -540,7 +540,7 @@ pub fn get_text<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        return Ok(AvmString::new(activation.context.gc_context, this.text()).into());
+        return Ok(AvmString::new(activation.context.gc(), this.text()).into());
     }
 
     Ok(Value::Undefined)
@@ -949,7 +949,7 @@ pub fn set_selection<'gc>(
                 begin_index as usize,
                 end_index as usize,
             )),
-            activation.context.gc_context,
+            activation.context.gc(),
         );
     }
 
@@ -1045,12 +1045,12 @@ pub fn set_anti_alias_type<'gc>(
 
         if &new_type == b"advanced" {
             this.set_render_settings(
-                activation.context.gc_context,
+                activation.context.gc(),
                 old_settings.with_advanced_rendering(),
             );
         } else if &new_type == b"normal" {
             this.set_render_settings(
-                activation.context.gc_context,
+                activation.context.gc(),
                 old_settings.with_normal_rendering(),
             );
         }
@@ -1095,18 +1095,18 @@ pub fn set_grid_fit_type<'gc>(
 
         if &new_type == b"pixel" {
             this.set_render_settings(
-                activation.context.gc_context,
+                activation.context.gc(),
                 old_settings.with_grid_fit(swf::TextGridFit::Pixel),
             );
         } else if &new_type == b"subpixel" {
             this.set_render_settings(
-                activation.context.gc_context,
+                activation.context.gc(),
                 old_settings.with_grid_fit(swf::TextGridFit::SubPixel),
             );
         } else {
             //NOTE: In AS3 invalid values are treated as None.
             this.set_render_settings(
-                activation.context.gc_context,
+                activation.context.gc(),
                 old_settings.with_grid_fit(swf::TextGridFit::None),
             );
         }
@@ -1153,7 +1153,7 @@ pub fn set_thickness<'gc>(
         new_thickness = new_thickness.clamp(-200.0, 200.0);
 
         this.set_render_settings(
-            activation.context.gc_context,
+            activation.context.gc(),
             old_settings.with_thickness(new_thickness as f32),
         );
     }
@@ -1200,7 +1200,7 @@ pub fn set_sharpness<'gc>(
         new_sharpness = new_sharpness.clamp(-400.0, 400.0);
 
         this.set_render_settings(
-            activation.context.gc_context,
+            activation.context.gc(),
             old_settings.with_sharpness(new_sharpness as f32),
         );
     }
@@ -1542,7 +1542,7 @@ pub fn get_restrict<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         return match this.restrict() {
-            Some(value) => Ok(AvmString::new(activation.context.gc_context, value).into()),
+            Some(value) => Ok(AvmString::new(activation.context.gc(), value).into()),
             None => Ok(Value::Null),
         };
     }

--- a/core/src/avm2/globals/flash/text/text_format.rs
+++ b/core/src/avm2/globals/flash/text/text_format.rs
@@ -267,7 +267,7 @@ pub fn get_font<'gc>(
 
     if let Some(text_format) = this.as_text_format() {
         return Ok(text_format.font.as_ref().map_or(Value::Null, |font| {
-            AvmString::new(activation.context.gc_context, font.as_wstr()).into()
+            AvmString::new(activation.context.gc(), font.as_wstr()).into()
         }));
     }
 
@@ -631,7 +631,7 @@ pub fn get_target<'gc>(
 
     if let Some(text_format) = this.as_text_format() {
         return Ok(text_format.target.as_ref().map_or(Value::Null, |target| {
-            AvmString::new(activation.context.gc_context, target.as_wstr()).into()
+            AvmString::new(activation.context.gc(), target.as_wstr()).into()
         }));
     }
 
@@ -700,7 +700,7 @@ pub fn get_url<'gc>(
 
     if let Some(text_format) = this.as_text_format() {
         return Ok(text_format.url.as_ref().map_or(Value::Null, |url| {
-            AvmString::new(activation.context.gc_context, url.as_wstr()).into()
+            AvmString::new(activation.context.gc(), url.as_wstr()).into()
         }));
     }
 

--- a/core/src/avm2/globals/flash/text/text_format.rs
+++ b/core/src/avm2/globals/flash/text/text_format.rs
@@ -267,7 +267,7 @@ pub fn get_font<'gc>(
 
     if let Some(text_format) = this.as_text_format() {
         return Ok(text_format.font.as_ref().map_or(Value::Null, |font| {
-            AvmString::new(activation.context.gc(), font.as_wstr()).into()
+            AvmString::new(activation.gc(), font.as_wstr()).into()
         }));
     }
 
@@ -631,7 +631,7 @@ pub fn get_target<'gc>(
 
     if let Some(text_format) = this.as_text_format() {
         return Ok(text_format.target.as_ref().map_or(Value::Null, |target| {
-            AvmString::new(activation.context.gc(), target.as_wstr()).into()
+            AvmString::new(activation.gc(), target.as_wstr()).into()
         }));
     }
 
@@ -700,7 +700,7 @@ pub fn get_url<'gc>(
 
     if let Some(text_format) = this.as_text_format() {
         return Ok(text_format.url.as_ref().map_or(Value::Null, |url| {
-            AvmString::new(activation.context.gc(), url.as_wstr()).into()
+            AvmString::new(activation.gc(), url.as_wstr()).into()
         }));
     }
 

--- a/core/src/avm2/globals/flash/ui/keyboard.rs
+++ b/core/src/avm2/globals/flash/ui/keyboard.rs
@@ -39,7 +39,7 @@ pub fn get_physical_keyboard_type<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.ui.Keyboard", "physicalKeyboardType");
-    Ok(AvmString::new_utf8(activation.context.gc(), "alphanumeric").into())
+    Ok(AvmString::new_utf8(activation.gc(), "alphanumeric").into())
 }
 
 pub fn is_accessible<'gc>(

--- a/core/src/avm2/globals/flash/ui/keyboard.rs
+++ b/core/src/avm2/globals/flash/ui/keyboard.rs
@@ -39,7 +39,7 @@ pub fn get_physical_keyboard_type<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.ui.Keyboard", "physicalKeyboardType");
-    Ok(AvmString::new_utf8(activation.context.gc_context, "alphanumeric").into())
+    Ok(AvmString::new_utf8(activation.context.gc(), "alphanumeric").into())
 }
 
 pub fn is_accessible<'gc>(

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -135,7 +135,7 @@ pub fn escape_multi_byte<'gc>(
             let _ = write!(&mut result, "%{byte:02X}");
         }
     }
-    Ok(AvmString::new(activation.context.gc(), result).into())
+    Ok(AvmString::new(activation.gc(), result).into())
 }
 
 fn handle_percent<I>(chars: &mut I) -> Option<u8>
@@ -182,7 +182,7 @@ pub fn unescape_multi_byte<'gc>(
 
         buf.push_char(c);
     }
-    let v = AvmString::new(activation.context.gc(), buf);
+    let v = AvmString::new(activation.gc(), buf);
     Ok(v.into())
 }
 
@@ -213,10 +213,7 @@ pub fn get_qualified_superclass_name<'gc>(
     };
 
     if let Some(super_class) = class.super_class() {
-        Ok(super_class
-            .name()
-            .to_qualified_name(activation.context.gc())
-            .into())
+        Ok(super_class.name().to_qualified_name(activation.gc()).into())
     } else {
         Ok(Value::Null)
     }

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -135,7 +135,7 @@ pub fn escape_multi_byte<'gc>(
             let _ = write!(&mut result, "%{byte:02X}");
         }
     }
-    Ok(AvmString::new(activation.context.gc_context, result).into())
+    Ok(AvmString::new(activation.context.gc(), result).into())
 }
 
 fn handle_percent<I>(chars: &mut I) -> Option<u8>
@@ -182,7 +182,7 @@ pub fn unescape_multi_byte<'gc>(
 
         buf.push_char(c);
     }
-    let v = AvmString::new(activation.context.gc_context, buf);
+    let v = AvmString::new(activation.context.gc(), buf);
     Ok(v.into())
 }
 
@@ -215,7 +215,7 @@ pub fn get_qualified_superclass_name<'gc>(
     if let Some(super_class) = class.super_class() {
         Ok(super_class
             .name()
-            .to_qualified_name(activation.context.gc_context)
+            .to_qualified_name(activation.context.gc())
             .into())
     } else {
         Ok(Value::Null)

--- a/core/src/avm2/globals/flash/utils/byte_array.rs
+++ b/core/src/avm2/globals/flash/utils/byte_array.rs
@@ -169,7 +169,7 @@ pub fn read_utf<'gc>(
 
     if let Some(bytearray) = this.as_bytearray() {
         return Ok(AvmString::new_utf8_bytes(
-            activation.context.gc(),
+            activation.gc(),
             bytearray.read_utf().map_err(|e| e.to_avm(activation))?,
         )
         .into());
@@ -188,17 +188,17 @@ pub fn strip_bom<'gc>(activation: &mut Activation<'_, 'gc>, mut bytes: &[u8]) ->
             .chunks_exact(2)
             .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
             .collect();
-        return AvmString::new(activation.context.gc(), WString::from_buf(utf16_bytes));
+        return AvmString::new(activation.gc(), WString::from_buf(utf16_bytes));
     // Big-endian UTF-16 BOM
     } else if let Some(without_bom) = bytes.strip_prefix(&[0xFE, 0xFF]) {
         let utf16_bytes: Vec<_> = without_bom
             .chunks_exact(2)
             .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
             .collect();
-        return AvmString::new(activation.context.gc(), WString::from_buf(utf16_bytes));
+        return AvmString::new(activation.gc(), WString::from_buf(utf16_bytes));
     }
 
-    AvmString::new_utf8_bytes(activation.context.gc(), bytes)
+    AvmString::new_utf8_bytes(activation.gc(), bytes)
 }
 
 pub fn to_string<'gc>(
@@ -498,7 +498,7 @@ pub fn read_utf_bytes<'gc>(
             .unwrap_or(&Value::Undefined)
             .coerce_to_u32(activation)?;
         return Ok(AvmString::new_utf8(
-            activation.context.gc(),
+            activation.gc(),
             String::from_utf8_lossy(
                 bytearray
                     .read_utf_bytes(len as usize)
@@ -700,7 +700,7 @@ pub fn read_multi_byte<'gc>(
         let encoder =
             Encoding::for_label(charset_label.to_utf8_lossy().as_bytes()).unwrap_or(UTF_8);
         let (decoded_str, _, _) = encoder.decode(bytes);
-        return Ok(AvmString::new_utf8(activation.context.gc(), decoded_str).into());
+        return Ok(AvmString::new_utf8(activation.gc(), decoded_str).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/utils/byte_array.rs
+++ b/core/src/avm2/globals/flash/utils/byte_array.rs
@@ -169,7 +169,7 @@ pub fn read_utf<'gc>(
 
     if let Some(bytearray) = this.as_bytearray() {
         return Ok(AvmString::new_utf8_bytes(
-            activation.context.gc_context,
+            activation.context.gc(),
             bytearray.read_utf().map_err(|e| e.to_avm(activation))?,
         )
         .into());
@@ -188,23 +188,17 @@ pub fn strip_bom<'gc>(activation: &mut Activation<'_, 'gc>, mut bytes: &[u8]) ->
             .chunks_exact(2)
             .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
             .collect();
-        return AvmString::new(
-            activation.context.gc_context,
-            WString::from_buf(utf16_bytes),
-        );
+        return AvmString::new(activation.context.gc(), WString::from_buf(utf16_bytes));
     // Big-endian UTF-16 BOM
     } else if let Some(without_bom) = bytes.strip_prefix(&[0xFE, 0xFF]) {
         let utf16_bytes: Vec<_> = without_bom
             .chunks_exact(2)
             .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
             .collect();
-        return AvmString::new(
-            activation.context.gc_context,
-            WString::from_buf(utf16_bytes),
-        );
+        return AvmString::new(activation.context.gc(), WString::from_buf(utf16_bytes));
     }
 
-    AvmString::new_utf8_bytes(activation.context.gc_context, bytes)
+    AvmString::new_utf8_bytes(activation.context.gc(), bytes)
 }
 
 pub fn to_string<'gc>(
@@ -504,7 +498,7 @@ pub fn read_utf_bytes<'gc>(
             .unwrap_or(&Value::Undefined)
             .coerce_to_u32(activation)?;
         return Ok(AvmString::new_utf8(
-            activation.context.gc_context,
+            activation.context.gc(),
             String::from_utf8_lossy(
                 bytearray
                     .read_utf_bytes(len as usize)
@@ -706,7 +700,7 @@ pub fn read_multi_byte<'gc>(
         let encoder =
             Encoding::for_label(charset_label.to_utf8_lossy().as_bytes()).unwrap_or(UTF_8);
         let (decoded_str, _, _) = encoder.decode(bytes);
-        return Ok(AvmString::new_utf8(activation.context.gc_context, decoded_str).into());
+        return Ok(AvmString::new_utf8(activation.context.gc(), decoded_str).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/xml/xml_node.rs
+++ b/core/src/avm2/globals/flash/xml/xml_node.rs
@@ -29,7 +29,7 @@ pub fn _escape_xml<'gc>(
             .replace(gt.as_ref(), from_utf8("&gt;").as_ref())
             .replace(quote.as_ref(), from_utf8("&quot;").as_ref())
             .replace(apos.as_ref(), from_utf8("&apos;").as_ref());
-        Ok(AvmString::new(activation.context.gc_context, result).into())
+        Ok(AvmString::new(activation.context.gc(), result).into())
     } else {
         // Save the allocation, just return input
         Ok(input.into())

--- a/core/src/avm2/globals/flash/xml/xml_node.rs
+++ b/core/src/avm2/globals/flash/xml/xml_node.rs
@@ -29,7 +29,7 @@ pub fn _escape_xml<'gc>(
             .replace(gt.as_ref(), from_utf8("&gt;").as_ref())
             .replace(quote.as_ref(), from_utf8("&quot;").as_ref())
             .replace(apos.as_ref(), from_utf8("&apos;").as_ref());
-        Ok(AvmString::new(activation.context.gc(), result).into())
+        Ok(AvmString::new(activation.gc(), result).into())
     } else {
         // Save the allocation, just return input
         Ok(input.into())

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -60,7 +60,7 @@ pub fn class_init<'gc>(
         "call",
         FunctionObject::from_method(
             activation,
-            Method::from_builtin(call, "call", activation.context.gc_context),
+            Method::from_builtin(call, "call", activation.context.gc()),
             scope,
             None,
             None,
@@ -73,7 +73,7 @@ pub fn class_init<'gc>(
         "apply",
         FunctionObject::from_method(
             activation,
-            Method::from_builtin(apply, "apply", activation.context.gc_context),
+            Method::from_builtin(apply, "apply", activation.context.gc()),
             scope,
             None,
             None,
@@ -86,7 +86,7 @@ pub fn class_init<'gc>(
         "toString",
         FunctionObject::from_method(
             activation,
-            Method::from_builtin(to_string, "toString", activation.context.gc_context),
+            Method::from_builtin(to_string, "toString", activation.context.gc()),
             scope,
             None,
             None,
@@ -99,7 +99,7 @@ pub fn class_init<'gc>(
         "toLocaleString",
         FunctionObject::from_method(
             activation,
-            Method::from_builtin(to_string, "toLocaleString", activation.context.gc_context),
+            Method::from_builtin(to_string, "toLocaleString", activation.context.gc()),
             scope,
             None,
             None,
@@ -108,23 +108,15 @@ pub fn class_init<'gc>(
         .into(),
         activation,
     )?;
+    function_proto.set_local_property_is_enumerable(activation.context.gc(), "call".into(), false);
+    function_proto.set_local_property_is_enumerable(activation.context.gc(), "apply".into(), false);
     function_proto.set_local_property_is_enumerable(
-        activation.context.gc_context,
-        "call".into(),
-        false,
-    );
-    function_proto.set_local_property_is_enumerable(
-        activation.context.gc_context,
-        "apply".into(),
-        false,
-    );
-    function_proto.set_local_property_is_enumerable(
-        activation.context.gc_context,
+        activation.context.gc(),
         "toString".into(),
         false,
     );
     function_proto.set_local_property_is_enumerable(
-        activation.context.gc_context,
+        activation.context.gc(),
         "toLocaleString".into(),
         false,
     );
@@ -231,7 +223,7 @@ fn set_prototype<'gc>(
 
     if let Some(function) = this.as_function_object() {
         let new_proto = args.get(0).unwrap_or(&Value::Undefined).as_object();
-        function.set_prototype(new_proto, activation.context.gc_context);
+        function.set_prototype(new_proto, activation.context.gc());
     }
 
     Ok(Value::Undefined)
@@ -299,12 +291,12 @@ pub fn create_class<'gc>(
         Method::from_builtin(class_call, "<Function call handler>", gc_context),
     );
 
-    function_i_class.mark_traits_loaded(activation.context.gc_context);
+    function_i_class.mark_traits_loaded(activation.context.gc());
     function_i_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
-    function_c_class.mark_traits_loaded(activation.context.gc_context);
+    function_c_class.mark_traits_loaded(activation.context.gc());
     function_c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -60,7 +60,7 @@ pub fn class_init<'gc>(
         "call",
         FunctionObject::from_method(
             activation,
-            Method::from_builtin(call, "call", activation.context.gc()),
+            Method::from_builtin(call, "call", activation.gc()),
             scope,
             None,
             None,
@@ -73,7 +73,7 @@ pub fn class_init<'gc>(
         "apply",
         FunctionObject::from_method(
             activation,
-            Method::from_builtin(apply, "apply", activation.context.gc()),
+            Method::from_builtin(apply, "apply", activation.gc()),
             scope,
             None,
             None,
@@ -86,7 +86,7 @@ pub fn class_init<'gc>(
         "toString",
         FunctionObject::from_method(
             activation,
-            Method::from_builtin(to_string, "toString", activation.context.gc()),
+            Method::from_builtin(to_string, "toString", activation.gc()),
             scope,
             None,
             None,
@@ -99,7 +99,7 @@ pub fn class_init<'gc>(
         "toLocaleString",
         FunctionObject::from_method(
             activation,
-            Method::from_builtin(to_string, "toLocaleString", activation.context.gc()),
+            Method::from_builtin(to_string, "toLocaleString", activation.gc()),
             scope,
             None,
             None,
@@ -108,15 +108,11 @@ pub fn class_init<'gc>(
         .into(),
         activation,
     )?;
-    function_proto.set_local_property_is_enumerable(activation.context.gc(), "call".into(), false);
-    function_proto.set_local_property_is_enumerable(activation.context.gc(), "apply".into(), false);
+    function_proto.set_local_property_is_enumerable(activation.gc(), "call".into(), false);
+    function_proto.set_local_property_is_enumerable(activation.gc(), "apply".into(), false);
+    function_proto.set_local_property_is_enumerable(activation.gc(), "toString".into(), false);
     function_proto.set_local_property_is_enumerable(
-        activation.context.gc(),
-        "toString".into(),
-        false,
-    );
-    function_proto.set_local_property_is_enumerable(
-        activation.context.gc(),
+        activation.gc(),
         "toLocaleString".into(),
         false,
     );
@@ -223,7 +219,7 @@ fn set_prototype<'gc>(
 
     if let Some(function) = this.as_function_object() {
         let new_proto = args.get(0).unwrap_or(&Value::Undefined).as_object();
-        function.set_prototype(new_proto, activation.context.gc());
+        function.set_prototype(new_proto, activation.gc());
     }
 
     Ok(Value::Undefined)
@@ -291,12 +287,12 @@ pub fn create_class<'gc>(
         Method::from_builtin(class_call, "<Function call handler>", gc_context),
     );
 
-    function_i_class.mark_traits_loaded(activation.context.gc());
+    function_i_class.mark_traits_loaded(activation.gc());
     function_i_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
-    function_c_class.mark_traits_loaded(activation.context.gc());
+    function_c_class.mark_traits_loaded(activation.gc());
     function_c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -26,7 +26,7 @@ pub fn create_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
     traits: Vec<Trait<'gc>>,
 ) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.context.gc();
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), "global"),
         Some(activation.avm2().class_defs().object),

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -26,7 +26,7 @@ pub fn create_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
     traits: Vec<Trait<'gc>>,
 ) -> Class<'gc> {
-    let mc = activation.context.gc();
+    let mc = activation.gc();
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), "global"),
         Some(activation.avm2().class_defs().object),

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -17,7 +17,7 @@ fn instance_init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc()) {
+    if let Some(mut prim) = this.as_primitive_mut(activation.gc()) {
         if matches!(*prim, Value::Undefined | Value::Null) {
             *prim = args
                 .get(0)
@@ -40,7 +40,7 @@ fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc();
+    let gc_context = activation.gc();
     let this_class = this.as_class_object().unwrap();
     let int_proto = this_class.prototype();
 
@@ -227,7 +227,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             instance_init,
             "<int instance initializer>",
             vec![ParamConfig {
-                param_name: AvmString::new_utf8(activation.context.gc(), "value"),
+                param_name: AvmString::new_utf8(activation.gc(), "value"),
                 param_type_name: None,
                 default_value: Some(Value::Integer(0)),
             }],
@@ -265,14 +265,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     ];
     class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
-    class.mark_traits_loaded(activation.context.gc());
+    class.mark_traits_loaded(activation.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc());
+    c_class.mark_traits_loaded(activation.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -17,7 +17,7 @@ fn instance_init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc_context) {
+    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc()) {
         if matches!(*prim, Value::Undefined | Value::Null) {
             *prim = args
                 .get(0)
@@ -40,7 +40,7 @@ fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.context.gc();
     let this_class = this.as_class_object().unwrap();
     let int_proto = this_class.prototype();
 
@@ -227,7 +227,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             instance_init,
             "<int instance initializer>",
             vec![ParamConfig {
-                param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
+                param_name: AvmString::new_utf8(activation.context.gc(), "value"),
                 param_type_name: None,
                 default_value: Some(Value::Integer(0)),
             }],
@@ -265,14 +265,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     ];
     class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.mark_traits_loaded(activation.context.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc_context);
+    c_class.mark_traits_loaded(activation.context.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/json.rs
+++ b/core/src/avm2/globals/json.rs
@@ -22,7 +22,7 @@ fn deserialize_json_inner<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(match json {
         JsonValue::Null => Value::Null,
-        JsonValue::String(s) => AvmString::new_utf8(activation.context.gc_context, s).into(),
+        JsonValue::String(s) => AvmString::new_utf8(activation.context.gc(), s).into(),
         JsonValue::Bool(b) => b.into(),
         JsonValue::Number(number) => {
             let number = number.as_f64().unwrap();
@@ -35,7 +35,7 @@ fn deserialize_json_inner<'gc>(
         JsonValue::Object(js_obj) => {
             let obj = ScriptObject::new_object(activation);
             for entry in js_obj.iter() {
-                let key = AvmString::new_utf8(activation.context.gc_context, entry.0);
+                let key = AvmString::new_utf8(activation.context.gc(), entry.0);
                 let val = deserialize_json_inner(activation, entry.1.clone(), reviver)?;
                 let mapped_val = match reviver {
                     None => val,
@@ -204,7 +204,7 @@ impl<'gc> AvmSerializer<'gc> {
         let mut iter = ArrayIter::new(activation, iterable)?;
         while let Some(r) = iter.next(activation) {
             let (i, item) = r?;
-            let mc = activation.context.gc_context;
+            let mc = activation.context.gc();
             let mapped =
                 self.map_value(activation, || AvmString::new_utf8(mc, i.to_string()), item)?;
             js_arr.push(self.serialize_value(activation, mapped)?);
@@ -357,5 +357,5 @@ pub fn stringify<'gc>(
         }
         None => serde_json::to_vec(&json).expect("JSON serialization cannot fail"),
     };
-    Ok(AvmString::new_utf8_bytes(activation.context.gc_context, &result).into())
+    Ok(AvmString::new_utf8_bytes(activation.context.gc(), &result).into())
 }

--- a/core/src/avm2/globals/json.rs
+++ b/core/src/avm2/globals/json.rs
@@ -22,7 +22,7 @@ fn deserialize_json_inner<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(match json {
         JsonValue::Null => Value::Null,
-        JsonValue::String(s) => AvmString::new_utf8(activation.context.gc(), s).into(),
+        JsonValue::String(s) => AvmString::new_utf8(activation.gc(), s).into(),
         JsonValue::Bool(b) => b.into(),
         JsonValue::Number(number) => {
             let number = number.as_f64().unwrap();
@@ -35,7 +35,7 @@ fn deserialize_json_inner<'gc>(
         JsonValue::Object(js_obj) => {
             let obj = ScriptObject::new_object(activation);
             for entry in js_obj.iter() {
-                let key = AvmString::new_utf8(activation.context.gc(), entry.0);
+                let key = AvmString::new_utf8(activation.gc(), entry.0);
                 let val = deserialize_json_inner(activation, entry.1.clone(), reviver)?;
                 let mapped_val = match reviver {
                     None => val,
@@ -204,7 +204,7 @@ impl<'gc> AvmSerializer<'gc> {
         let mut iter = ArrayIter::new(activation, iterable)?;
         while let Some(r) = iter.next(activation) {
             let (i, item) = r?;
-            let mc = activation.context.gc();
+            let mc = activation.gc();
             let mapped =
                 self.map_value(activation, || AvmString::new_utf8(mc, i.to_string()), item)?;
             js_arr.push(self.serialize_value(activation, mapped)?);
@@ -357,5 +357,5 @@ pub fn stringify<'gc>(
         }
         None => serde_json::to_vec(&json).expect("JSON serialization cannot fail"),
     };
-    Ok(AvmString::new_utf8_bytes(activation.context.gc(), &result).into())
+    Ok(AvmString::new_utf8_bytes(activation.gc(), &result).into())
 }

--- a/core/src/avm2/globals/null.rs
+++ b/core/src/avm2/globals/null.rs
@@ -14,7 +14,7 @@ fn null_init<'gc>(
 }
 
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc();
+    let mc = activation.gc();
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), "null"),
         None,
@@ -23,7 +23,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     );
     class.set_attributes(mc, ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    class.mark_traits_loaded(activation.context.gc());
+    class.mark_traits_loaded(activation.gc());
 
     class
 }

--- a/core/src/avm2/globals/null.rs
+++ b/core/src/avm2/globals/null.rs
@@ -14,7 +14,7 @@ fn null_init<'gc>(
 }
 
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.context.gc();
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), "null"),
         None,
@@ -23,7 +23,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     );
     class.set_attributes(mc, ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.mark_traits_loaded(activation.context.gc());
 
     class
 }

--- a/core/src/avm2/globals/number.rs
+++ b/core/src/avm2/globals/number.rs
@@ -17,7 +17,7 @@ fn instance_init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc()) {
+    if let Some(mut prim) = this.as_primitive_mut(activation.gc()) {
         if matches!(*prim, Value::Undefined | Value::Null) {
             *prim = args
                 .get(0)
@@ -40,7 +40,7 @@ fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc();
+    let gc_context = activation.gc();
     let this_class = this.as_class_object().unwrap();
     let number_proto = this_class.prototype();
 
@@ -166,7 +166,7 @@ pub fn to_exponential<'gc>(
     let digits = digits as usize;
 
     Ok(AvmString::new_utf8(
-        activation.context.gc(),
+        activation.gc(),
         format!("{number:.digits$e}")
             .replace('e', "e+")
             .replace("e+-", "e-")
@@ -193,11 +193,7 @@ pub fn to_fixed<'gc>(
         return Err(make_error_1002(activation));
     }
 
-    Ok(AvmString::new_utf8(
-        activation.context.gc(),
-        format!("{0:.1$}", number, digits as usize),
-    )
-    .into())
+    Ok(AvmString::new_utf8(activation.gc(), format!("{0:.1$}", number, digits as usize)).into())
 }
 
 pub fn print_with_precision<'gc>(
@@ -215,7 +211,7 @@ pub fn print_with_precision<'gc>(
 
     if (wanted_digits as f64) <= available_digits {
         Ok(AvmString::new_utf8(
-            activation.context.gc(),
+            activation.gc(),
             format!(
                 "{}e{}{}",
                 precision / 10.0_f64.powf(available_digits),
@@ -224,10 +220,7 @@ pub fn print_with_precision<'gc>(
             ),
         ))
     } else {
-        Ok(AvmString::new_utf8(
-            activation.context.gc(),
-            format!("{precision}"),
-        ))
+        Ok(AvmString::new_utf8(activation.gc(), format!("{precision}")))
     }
 }
 
@@ -302,7 +295,7 @@ pub fn print_with_radix<'gc>(
 
     let formatted: String = digits.into_iter().rev().collect();
 
-    Ok(AvmString::new_utf8(activation.context.gc(), formatted))
+    Ok(AvmString::new_utf8(activation.gc(), formatted))
 }
 
 /// Implements `Number.prototype.toString`
@@ -425,14 +418,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     ];
     class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
-    class.mark_traits_loaded(activation.context.gc());
+    class.mark_traits_loaded(activation.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc());
+    c_class.mark_traits_loaded(activation.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -44,7 +44,7 @@ pub fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.context.gc();
     let this_class = this.as_class_object().unwrap();
     let object_proto = this_class.prototype();
 
@@ -256,7 +256,7 @@ pub fn set_property_is_enumerable<'gc>(
     let name = name?.coerce_to_string(activation)?;
 
     if let Some(Value::Bool(is_enum)) = args.get(1) {
-        this.set_local_property_is_enumerable(activation.context.gc_context, name, *is_enum);
+        this.set_local_property_is_enumerable(activation.context.gc(), name, *is_enum);
     }
 
     Ok(Value::Undefined)
@@ -316,7 +316,7 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         as3_instance_methods,
     );
 
-    object_i_class.mark_traits_loaded(activation.context.gc_context);
+    object_i_class.mark_traits_loaded(activation.context.gc());
     object_i_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
@@ -356,7 +356,7 @@ pub fn create_c_class<'gc>(
         INTERNAL_INIT_METHOD,
     );
 
-    object_c_class.mark_traits_loaded(activation.context.gc_context);
+    object_c_class.mark_traits_loaded(activation.context.gc());
     object_c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -44,7 +44,7 @@ pub fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc();
+    let gc_context = activation.gc();
     let this_class = this.as_class_object().unwrap();
     let object_proto = this_class.prototype();
 
@@ -256,7 +256,7 @@ pub fn set_property_is_enumerable<'gc>(
     let name = name?.coerce_to_string(activation)?;
 
     if let Some(Value::Bool(is_enum)) = args.get(1) {
-        this.set_local_property_is_enumerable(activation.context.gc(), name, *is_enum);
+        this.set_local_property_is_enumerable(activation.gc(), name, *is_enum);
     }
 
     Ok(Value::Undefined)
@@ -316,7 +316,7 @@ pub fn create_i_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
         as3_instance_methods,
     );
 
-    object_i_class.mark_traits_loaded(activation.context.gc());
+    object_i_class.mark_traits_loaded(activation.gc());
     object_i_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
@@ -356,7 +356,7 @@ pub fn create_c_class<'gc>(
         INTERNAL_INIT_METHOD,
     );
 
-    object_c_class.mark_traits_loaded(activation.context.gc());
+    object_c_class.mark_traits_loaded(activation.gc());
     object_c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/q_name.rs
+++ b/core/src/avm2/globals/q_name.rs
@@ -66,19 +66,16 @@ pub fn q_name_constructor<'gc>(
         };
 
         if let Value::Object(Object::QNameObject(qname)) = local_arg {
-            this.set_local_name(activation.context.gc(), qname.local_name());
+            this.set_local_name(activation.gc(), qname.local_name());
         } else {
-            this.set_local_name(
-                activation.context.gc(),
-                local_arg.coerce_to_string(activation)?,
-            );
+            this.set_local_name(activation.gc(), local_arg.coerce_to_string(activation)?);
         }
 
         namespace
     } else {
         let qname_arg = args.get(0).copied().unwrap_or(Value::Undefined);
         if let Value::Object(Object::QNameObject(qname_obj)) = qname_arg {
-            this.init_name(activation.context.gc(), qname_obj.name().clone());
+            this.init_name(activation.gc(), qname_obj.name().clone());
             return Ok(this.into());
         }
 
@@ -89,7 +86,7 @@ pub fn q_name_constructor<'gc>(
         };
 
         if &*local != b"*" {
-            this.set_local_name(activation.context.gc(), local);
+            this.set_local_name(activation.gc(), local);
             Some(activation.avm2().find_public_namespace())
         } else {
             None
@@ -97,8 +94,8 @@ pub fn q_name_constructor<'gc>(
     };
 
     if let Some(namespace) = namespace {
-        this.set_namespace(activation.context.gc(), namespace);
-        this.set_is_qname(activation.context.gc(), true);
+        this.set_namespace(activation.gc(), namespace);
+        this.set_is_qname(activation.gc(), true);
     }
 
     Ok(this.into())

--- a/core/src/avm2/globals/q_name.rs
+++ b/core/src/avm2/globals/q_name.rs
@@ -66,10 +66,10 @@ pub fn q_name_constructor<'gc>(
         };
 
         if let Value::Object(Object::QNameObject(qname)) = local_arg {
-            this.set_local_name(activation.context.gc_context, qname.local_name());
+            this.set_local_name(activation.context.gc(), qname.local_name());
         } else {
             this.set_local_name(
-                activation.context.gc_context,
+                activation.context.gc(),
                 local_arg.coerce_to_string(activation)?,
             );
         }
@@ -78,7 +78,7 @@ pub fn q_name_constructor<'gc>(
     } else {
         let qname_arg = args.get(0).copied().unwrap_or(Value::Undefined);
         if let Value::Object(Object::QNameObject(qname_obj)) = qname_arg {
-            this.init_name(activation.context.gc_context, qname_obj.name().clone());
+            this.init_name(activation.context.gc(), qname_obj.name().clone());
             return Ok(this.into());
         }
 
@@ -89,7 +89,7 @@ pub fn q_name_constructor<'gc>(
         };
 
         if &*local != b"*" {
-            this.set_local_name(activation.context.gc_context, local);
+            this.set_local_name(activation.context.gc(), local);
             Some(activation.avm2().find_public_namespace())
         } else {
             None
@@ -97,8 +97,8 @@ pub fn q_name_constructor<'gc>(
     };
 
     if let Some(namespace) = namespace {
-        this.set_namespace(activation.context.gc_context, namespace);
-        this.set_is_qname(activation.context.gc_context, true);
+        this.set_namespace(activation.context.gc(), namespace);
+        this.set_is_qname(activation.context.gc(), true);
     }
 
     Ok(this.into())

--- a/core/src/avm2/globals/reg_exp.rs
+++ b/core/src/avm2/globals/reg_exp.rs
@@ -18,7 +18,7 @@ pub fn init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut regexp) = this.as_regexp_mut(activation.context.gc_context) {
+    if let Some(mut regexp) = this.as_regexp_mut(activation.context.gc()) {
         let source: AvmString<'gc> = match args.get(0) {
             Some(Value::Undefined) => activation.strings().empty(),
             Some(Value::Object(Object::RegExpObject(o))) => {
@@ -177,7 +177,7 @@ pub fn set_last_index<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut re) = this.as_regexp_mut(activation.context.gc_context) {
+    if let Some(mut re) = this.as_regexp_mut(activation.context.gc()) {
         let i = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -211,7 +211,7 @@ pub fn exec<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut re) = this.as_regexp_mut(activation.context.gc_context) {
+    if let Some(mut re) = this.as_regexp_mut(activation.context.gc()) {
         let text = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -225,7 +225,7 @@ pub fn exec<'gc>(
 
                 let storage = ArrayStorage::from_iter(substrings.map(|s| match s {
                     None => Value::Undefined,
-                    Some(s) => AvmString::new(activation.context.gc_context, s).into(),
+                    Some(s) => AvmString::new(activation.context.gc(), s).into(),
                 }));
 
                 (storage, matched.start())
@@ -253,7 +253,7 @@ pub fn test<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut re) = this.as_regexp_mut(activation.context.gc_context) {
+    if let Some(mut re) = this.as_regexp_mut(activation.context.gc()) {
         let text = args
             .get(0)
             .unwrap_or(&Value::Undefined)

--- a/core/src/avm2/globals/reg_exp.rs
+++ b/core/src/avm2/globals/reg_exp.rs
@@ -18,7 +18,7 @@ pub fn init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut regexp) = this.as_regexp_mut(activation.context.gc()) {
+    if let Some(mut regexp) = this.as_regexp_mut(activation.gc()) {
         let source: AvmString<'gc> = match args.get(0) {
             Some(Value::Undefined) => activation.strings().empty(),
             Some(Value::Object(Object::RegExpObject(o))) => {
@@ -177,7 +177,7 @@ pub fn set_last_index<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut re) = this.as_regexp_mut(activation.context.gc()) {
+    if let Some(mut re) = this.as_regexp_mut(activation.gc()) {
         let i = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -211,7 +211,7 @@ pub fn exec<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut re) = this.as_regexp_mut(activation.context.gc()) {
+    if let Some(mut re) = this.as_regexp_mut(activation.gc()) {
         let text = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -225,7 +225,7 @@ pub fn exec<'gc>(
 
                 let storage = ArrayStorage::from_iter(substrings.map(|s| match s {
                     None => Value::Undefined,
-                    Some(s) => AvmString::new(activation.context.gc(), s).into(),
+                    Some(s) => AvmString::new(activation.gc(), s).into(),
                 }));
 
                 (storage, matched.start())
@@ -253,7 +253,7 @@ pub fn test<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut re) = this.as_regexp_mut(activation.context.gc()) {
+    if let Some(mut re) = this.as_regexp_mut(activation.gc()) {
         let text = args
             .get(0)
             .unwrap_or(&Value::Undefined)

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -46,7 +46,7 @@ pub fn instance_init<'gc>(
 
     activation.super_init(this, &[])?;
 
-    if let Some(mut value) = this.as_primitive_mut(activation.context.gc_context) {
+    if let Some(mut value) = this.as_primitive_mut(activation.context.gc()) {
         if !matches!(*value, Value::String(_)) {
             *value = match args.get(0) {
                 Some(arg) => arg.coerce_to_string(activation)?.into(),
@@ -67,7 +67,7 @@ pub fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.context.gc();
     let this_class = this.as_class_object().unwrap();
     let proto = this_class.prototype();
 
@@ -182,7 +182,7 @@ fn concat<'gc>(
 
     for arg in args {
         let s = arg.coerce_to_string(activation)?;
-        ret = AvmString::concat(activation.context.gc_context, ret, s);
+        ret = AvmString::concat(activation.context.gc(), ret, s);
     }
 
     Ok(ret.into())
@@ -199,7 +199,7 @@ fn from_char_code<'gc>(
         let i = arg.coerce_to_u32(activation)? as u16;
         out.push(i);
     }
-    Ok(AvmString::new(activation.context.gc_context, out).into())
+    Ok(AvmString::new(activation.context.gc(), out).into())
 }
 
 /// Implements `String.indexOf`
@@ -306,7 +306,7 @@ fn match_s<'gc>(
             .expect("Regexp objects must be Value::Object")
     };
 
-    if let Some(mut regexp) = pattern.as_regexp_mut(activation.context.gc_context) {
+    if let Some(mut regexp) = pattern.as_regexp_mut(activation.context.gc()) {
         let mut storage = ArrayStorage::new(0);
         if regexp.flags().contains(RegExpFlags::GLOBAL) {
             let mut last = regexp.last_index();
@@ -316,9 +316,7 @@ fn match_s<'gc>(
                 if regexp.last_index() == last {
                     break;
                 }
-                storage.push(
-                    AvmString::new(activation.context.gc_context, &this[result.range()]).into(),
-                );
+                storage.push(AvmString::new(activation.context.gc(), &this[result.range()]).into());
                 last = regexp.last_index();
             }
             regexp.set_last_index(0);
@@ -335,7 +333,7 @@ fn match_s<'gc>(
 
                 let mut storage = ArrayStorage::new(0);
                 for substring in substrings {
-                    storage.push(AvmString::new(activation.context.gc_context, substring).into());
+                    storage.push(AvmString::new(activation.context.gc(), substring).into());
                 }
                 regexp.set_last_index(old);
 
@@ -391,7 +389,7 @@ fn replace<'gc>(
         }
         ret.push_str(&this[position + pattern.len()..]);
 
-        Ok(AvmString::new(activation.context.gc_context, ret).into())
+        Ok(AvmString::new(activation.context.gc(), ret).into())
     } else {
         Ok(this.into())
     }
@@ -417,7 +415,7 @@ fn search<'gc>(
             .expect("Regexp objects must be Value::Object")
     };
 
-    if let Some(mut regexp) = pattern.as_regexp_mut(activation.context.gc_context) {
+    if let Some(mut regexp) = pattern.as_regexp_mut(activation.context.gc()) {
         let old = regexp.last_index();
         regexp.set_last_index(0);
         if let Some(result) = regexp.exec(this) {
@@ -487,7 +485,7 @@ fn split<'gc>(
     if let Some(mut regexp) = delimiter
         .as_object()
         .as_ref()
-        .and_then(|o| o.as_regexp_mut(activation.context.gc_context))
+        .and_then(|o| o.as_regexp_mut(activation.context.gc()))
     {
         return Ok(regexp.split(activation, this, limit)?.into());
     }
@@ -505,7 +503,7 @@ fn split<'gc>(
     } else {
         this.split(&delimiter)
             .take(limit)
-            .map(|c| Value::from(AvmString::new(activation.context.gc_context, c)))
+            .map(|c| Value::from(AvmString::new(activation.context.gc(), c)))
             .collect()
     };
 
@@ -611,7 +609,7 @@ fn to_lower_case<'gc>(
     let this = this.coerce_to_string(activation)?;
 
     Ok(AvmString::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         this.iter()
             .map(crate::string::utils::swf_to_lowercase)
             .collect::<WString>(),
@@ -661,7 +659,7 @@ fn to_upper_case<'gc>(
     let this = this.coerce_to_string(activation)?;
 
     Ok(AvmString::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         this.iter()
             .map(crate::string::utils::swf_to_uppercase)
             .collect::<WString>(),
@@ -732,14 +730,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     class.define_builtin_class_methods(mc, namespaces.as3, AS3_CLASS_METHODS);
     class.define_builtin_class_methods(mc, namespaces.public_all(), PUBLIC_CLASS_METHODS);
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.mark_traits_loaded(activation.context.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc_context);
+    c_class.mark_traits_loaded(activation.context.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/toplevel.rs
+++ b/core/src/avm2/globals/toplevel.rs
@@ -122,7 +122,7 @@ pub fn escape<'gc>(
         }
     }
 
-    Ok(AvmString::new(activation.context.gc_context, output).into())
+    Ok(AvmString::new(activation.context.gc(), output).into())
 }
 
 pub fn unescape<'gc>(
@@ -165,7 +165,7 @@ pub fn unescape<'gc>(
             index = prev_index;
         }
     }
-    Ok(AvmString::new(activation.context.gc_context, output).into())
+    Ok(AvmString::new(activation.context.gc(), output).into())
 }
 
 pub fn encode_uri<'gc>(
@@ -224,7 +224,7 @@ fn encode_utf8_with_exclusions<'gc>(
         }
     }
 
-    Ok(AvmString::new_utf8(activation.context.gc_context, output).into())
+    Ok(AvmString::new_utf8(activation.context.gc(), output).into())
 }
 
 pub fn decode_uri<'gc>(
@@ -351,5 +351,5 @@ fn decode<'gc>(
         }
     }
 
-    Ok(AvmString::new(activation.context.gc_context, output).into())
+    Ok(AvmString::new(activation.context.gc(), output).into())
 }

--- a/core/src/avm2/globals/toplevel.rs
+++ b/core/src/avm2/globals/toplevel.rs
@@ -122,7 +122,7 @@ pub fn escape<'gc>(
         }
     }
 
-    Ok(AvmString::new(activation.context.gc(), output).into())
+    Ok(AvmString::new(activation.gc(), output).into())
 }
 
 pub fn unescape<'gc>(
@@ -165,7 +165,7 @@ pub fn unescape<'gc>(
             index = prev_index;
         }
     }
-    Ok(AvmString::new(activation.context.gc(), output).into())
+    Ok(AvmString::new(activation.gc(), output).into())
 }
 
 pub fn encode_uri<'gc>(
@@ -224,7 +224,7 @@ fn encode_utf8_with_exclusions<'gc>(
         }
     }
 
-    Ok(AvmString::new_utf8(activation.context.gc(), output).into())
+    Ok(AvmString::new_utf8(activation.gc(), output).into())
 }
 
 pub fn decode_uri<'gc>(
@@ -351,5 +351,5 @@ fn decode<'gc>(
         }
     }
 
-    Ok(AvmString::new(activation.context.gc(), output).into())
+    Ok(AvmString::new(activation.gc(), output).into())
 }

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -17,7 +17,7 @@ fn instance_init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc_context) {
+    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc()) {
         if matches!(*prim, Value::Undefined | Value::Null) {
             *prim = args
                 .get(0)
@@ -40,7 +40,7 @@ fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc_context;
+    let gc_context = activation.context.gc();
     let this_class = this.as_class_object().unwrap();
     let uint_proto = this_class.prototype();
 
@@ -228,7 +228,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             instance_init,
             "<uint instance initializer>",
             vec![ParamConfig {
-                param_name: AvmString::new_utf8(activation.context.gc_context, "value"),
+                param_name: AvmString::new_utf8(activation.context.gc(), "value"),
                 param_type_name: None,
                 default_value: Some(Value::Integer(0)),
             }],
@@ -272,14 +272,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     ];
     class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.mark_traits_loaded(activation.context.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc_context);
+    c_class.mark_traits_loaded(activation.context.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -17,7 +17,7 @@ fn instance_init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc()) {
+    if let Some(mut prim) = this.as_primitive_mut(activation.gc()) {
         if matches!(*prim, Value::Undefined | Value::Null) {
             *prim = args
                 .get(0)
@@ -40,7 +40,7 @@ fn class_init<'gc>(
     let this = this.as_object().unwrap();
 
     let scope = activation.create_scopechain();
-    let gc_context = activation.context.gc();
+    let gc_context = activation.gc();
     let this_class = this.as_class_object().unwrap();
     let uint_proto = this_class.prototype();
 
@@ -228,7 +228,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
             instance_init,
             "<uint instance initializer>",
             vec![ParamConfig {
-                param_name: AvmString::new_utf8(activation.context.gc(), "value"),
+                param_name: AvmString::new_utf8(activation.gc(), "value"),
                 param_type_name: None,
                 default_value: Some(Value::Integer(0)),
             }],
@@ -272,14 +272,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     ];
     class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
-    class.mark_traits_loaded(activation.context.gc());
+    class.mark_traits_loaded(activation.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc());
+    c_class.mark_traits_loaded(activation.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -39,7 +39,7 @@ pub fn instance_init<'gc>(
 
     activation.super_init(this, &[])?;
 
-    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vector) = this.as_vector_storage_mut(activation.gc()) {
         let length = args
             .get(0)
             .cloned()
@@ -155,7 +155,7 @@ fn class_init<'gc>(
             *pubname,
             FunctionObject::from_method(
                 activation,
-                Method::from_builtin(*func, pubname, activation.context.gc()),
+                Method::from_builtin(*func, pubname, activation.gc()),
                 scope,
                 None,
                 None,
@@ -164,7 +164,7 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        proto.set_local_property_is_enumerable(activation.context.gc(), (*pubname).into(), false);
+        proto.set_local_property_is_enumerable(activation.gc(), (*pubname).into(), false);
     }
 
     Ok(Value::Undefined)
@@ -193,7 +193,7 @@ pub fn set_length<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vector) = this.as_vector_storage_mut(activation.gc()) {
         let new_length = args
             .get(0)
             .cloned()
@@ -229,7 +229,7 @@ pub fn set_fixed<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vector) = this.as_vector_storage_mut(activation.gc()) {
         let new_fixed = args
             .get(0)
             .cloned()
@@ -273,13 +273,13 @@ pub fn concat<'gc>(
         if !arg.is_of_type(activation, my_base_vector_class) {
             let base_vector_name = my_base_vector_class
                 .name()
-                .to_qualified_name_err_message(activation.context.gc());
+                .to_qualified_name_err_message(activation.gc());
 
             return Err(Error::AvmError(type_error(
                 activation,
                 &format!(
                     "Error #1034: Type Coercion failed: cannot convert {}@00000000000 to {}.",
-                    arg_obj.instance_of_class_name(activation.context.gc()),
+                    arg_obj.instance_of_class_name(activation.gc()),
                     base_vector_name,
                 ),
                 1034,
@@ -337,7 +337,7 @@ where
         }
 
         return Ok(AvmString::new(
-            activation.context.gc(),
+            activation.gc(),
             crate::string::join(&accum, &string_separator),
         )
         .into());
@@ -604,7 +604,7 @@ pub fn pop<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.gc()) {
         return vs.pop(activation);
     }
 
@@ -619,7 +619,7 @@ pub fn push<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.gc()) {
         let value_type = vs.value_type_for_coercion(activation);
 
         // Pushing nothing will still throw if the Vector is fixed.
@@ -645,7 +645,7 @@ pub fn shift<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.gc()) {
         return vs.shift(activation);
     }
 
@@ -660,7 +660,7 @@ pub fn unshift<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.gc()) {
         let value_type = vs.value_type_for_coercion(activation);
 
         for arg in args.iter().rev() {
@@ -683,7 +683,7 @@ pub fn insert_at<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.gc()) {
         let index = args
             .get(0)
             .cloned()
@@ -712,7 +712,7 @@ pub fn remove_at<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.gc()) {
         let index = args
             .get(0)
             .cloned()
@@ -733,7 +733,7 @@ pub fn reverse<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.gc()) {
         vs.reverse();
 
         return Ok(this.into());
@@ -750,7 +750,7 @@ pub fn slice<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(vs) = this.as_vector_storage_mut(activation.gc()) {
         let from = args
             .get(0)
             .cloned()
@@ -792,7 +792,7 @@ pub fn sort<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(vs) = this.as_vector_storage_mut(activation.gc()) {
         let fn_or_options = args.get(0).cloned().unwrap_or(Value::Undefined);
 
         let (compare_fnc, options) = if let Some(callable) = fn_or_options
@@ -853,7 +853,7 @@ pub fn sort<'gc>(
         }
 
         if !options.contains(SortOptions::UNIQUE_SORT) || unique_sort_satisfied {
-            let mut vs = this.as_vector_storage_mut(activation.context.gc()).unwrap();
+            let mut vs = this.as_vector_storage_mut(activation.gc()).unwrap();
             vs.replace_storage(values.into_iter().collect());
         }
 
@@ -871,7 +871,7 @@ pub fn splice<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.gc()) {
         let start_len = args
             .get(0)
             .cloned()
@@ -915,7 +915,7 @@ pub fn splice<'gc>(
 
 /// Construct `Vector`'s class.
 pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc();
+    let mc = activation.gc();
     let class = Class::new(
         QName::new(activation.avm2().namespaces.vector_public, "Vector"),
         Some(activation.avm2().class_defs().object),
@@ -928,14 +928,14 @@ pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<
     class.set_attributes(mc, ClassAttributes::GENERIC | ClassAttributes::FINAL);
     class.set_instance_allocator(mc, generic_vector_allocator);
 
-    class.mark_traits_loaded(activation.context.gc());
+    class.mark_traits_loaded(activation.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc());
+    c_class.mark_traits_loaded(activation.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
@@ -1020,14 +1020,14 @@ pub fn create_builtin_class<'gc>(
     ];
     class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
-    class.mark_traits_loaded(activation.context.gc());
+    class.mark_traits_loaded(activation.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc());
+    c_class.mark_traits_loaded(activation.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -39,7 +39,7 @@ pub fn instance_init<'gc>(
 
     activation.super_init(this, &[])?;
 
-    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc()) {
         let length = args
             .get(0)
             .cloned()
@@ -155,7 +155,7 @@ fn class_init<'gc>(
             *pubname,
             FunctionObject::from_method(
                 activation,
-                Method::from_builtin(*func, pubname, activation.context.gc_context),
+                Method::from_builtin(*func, pubname, activation.context.gc()),
                 scope,
                 None,
                 None,
@@ -164,11 +164,7 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        proto.set_local_property_is_enumerable(
-            activation.context.gc_context,
-            (*pubname).into(),
-            false,
-        );
+        proto.set_local_property_is_enumerable(activation.context.gc(), (*pubname).into(), false);
     }
 
     Ok(Value::Undefined)
@@ -197,7 +193,7 @@ pub fn set_length<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc()) {
         let new_length = args
             .get(0)
             .cloned()
@@ -233,7 +229,7 @@ pub fn set_fixed<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc()) {
         let new_fixed = args
             .get(0)
             .cloned()
@@ -277,13 +273,13 @@ pub fn concat<'gc>(
         if !arg.is_of_type(activation, my_base_vector_class) {
             let base_vector_name = my_base_vector_class
                 .name()
-                .to_qualified_name_err_message(activation.context.gc_context);
+                .to_qualified_name_err_message(activation.context.gc());
 
             return Err(Error::AvmError(type_error(
                 activation,
                 &format!(
                     "Error #1034: Type Coercion failed: cannot convert {}@00000000000 to {}.",
-                    arg_obj.instance_of_class_name(activation.context.gc_context),
+                    arg_obj.instance_of_class_name(activation.context.gc()),
                     base_vector_name,
                 ),
                 1034,
@@ -341,7 +337,7 @@ where
         }
 
         return Ok(AvmString::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             crate::string::join(&accum, &string_separator),
         )
         .into());
@@ -608,7 +604,7 @@ pub fn pop<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
         return vs.pop(activation);
     }
 
@@ -623,7 +619,7 @@ pub fn push<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
         let value_type = vs.value_type_for_coercion(activation);
 
         // Pushing nothing will still throw if the Vector is fixed.
@@ -649,7 +645,7 @@ pub fn shift<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
         return vs.shift(activation);
     }
 
@@ -664,7 +660,7 @@ pub fn unshift<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
         let value_type = vs.value_type_for_coercion(activation);
 
         for arg in args.iter().rev() {
@@ -687,7 +683,7 @@ pub fn insert_at<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
         let index = args
             .get(0)
             .cloned()
@@ -716,7 +712,7 @@ pub fn remove_at<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
         let index = args
             .get(0)
             .cloned()
@@ -737,7 +733,7 @@ pub fn reverse<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
         vs.reverse();
 
         return Ok(this.into());
@@ -754,7 +750,7 @@ pub fn slice<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(vs) = this.as_vector_storage_mut(activation.context.gc()) {
         let from = args
             .get(0)
             .cloned()
@@ -796,7 +792,7 @@ pub fn sort<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(vs) = this.as_vector_storage_mut(activation.context.gc()) {
         let fn_or_options = args.get(0).cloned().unwrap_or(Value::Undefined);
 
         let (compare_fnc, options) = if let Some(callable) = fn_or_options
@@ -857,9 +853,7 @@ pub fn sort<'gc>(
         }
 
         if !options.contains(SortOptions::UNIQUE_SORT) || unique_sort_satisfied {
-            let mut vs = this
-                .as_vector_storage_mut(activation.context.gc_context)
-                .unwrap();
+            let mut vs = this.as_vector_storage_mut(activation.context.gc()).unwrap();
             vs.replace_storage(values.into_iter().collect());
         }
 
@@ -877,7 +871,7 @@ pub fn splice<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
-    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc()) {
         let start_len = args
             .get(0)
             .cloned()
@@ -921,7 +915,7 @@ pub fn splice<'gc>(
 
 /// Construct `Vector`'s class.
 pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.context.gc();
     let class = Class::new(
         QName::new(activation.avm2().namespaces.vector_public, "Vector"),
         Some(activation.avm2().class_defs().object),
@@ -934,14 +928,14 @@ pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<
     class.set_attributes(mc, ClassAttributes::GENERIC | ClassAttributes::FINAL);
     class.set_instance_allocator(mc, generic_vector_allocator);
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.mark_traits_loaded(activation.context.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc_context);
+    c_class.mark_traits_loaded(activation.context.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
@@ -1026,14 +1020,14 @@ pub fn create_builtin_class<'gc>(
     ];
     class.define_builtin_instance_methods(mc, namespaces.as3, AS3_INSTANCE_METHODS);
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.mark_traits_loaded(activation.context.gc());
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
     let c_class = class.c_class().expect("Class::new returns an i_class");
 
-    c_class.mark_traits_loaded(activation.context.gc_context);
+    c_class.mark_traits_loaded(activation.context.gc());
     c_class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/globals/void.rs
+++ b/core/src/avm2/globals/void.rs
@@ -14,7 +14,7 @@ fn void_init<'gc>(
 }
 
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc();
+    let mc = activation.gc();
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), "void"),
         None,
@@ -23,7 +23,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     );
     class.set_attributes(mc, ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    class.mark_traits_loaded(activation.context.gc());
+    class.mark_traits_loaded(activation.gc());
 
     class
 }

--- a/core/src/avm2/globals/void.rs
+++ b/core/src/avm2/globals/void.rs
@@ -14,7 +14,7 @@ fn void_init<'gc>(
 }
 
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
-    let mc = activation.context.gc_context;
+    let mc = activation.context.gc();
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), "void"),
         None,
@@ -23,7 +23,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     );
     class.set_attributes(mc, ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    class.mark_traits_loaded(activation.context.gc_context);
+    class.mark_traits_loaded(activation.context.gc());
 
     class
 }

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -54,7 +54,7 @@ pub fn init<'gc>(
 
     let node = match nodes.as_slice() {
         // XML defaults to an empty text node when nothing was parsed
-        [] => E4XNode::text(activation.context.gc_context, AvmString::default(), None),
+        [] => E4XNode::text(activation.context.gc(), AvmString::default(), None),
         [node] => *node,
         nodes => {
             let mut single_element_node = None;
@@ -97,7 +97,7 @@ pub fn init<'gc>(
             }
         }
     };
-    this.set_node(activation.context.gc_context, node);
+    this.set_node(activation.context.gc(), node);
 
     Ok(Value::Undefined)
 }
@@ -733,7 +733,7 @@ pub fn call_handler<'gc>(
             // This re-uses the XML object stored in the list
             if let Some(xml_list) = obj.as_xml_list_object() {
                 if xml_list.length() == 1 {
-                    return Ok(xml_list.children_mut(activation.context.gc_context)[0]
+                    return Ok(xml_list.children_mut(activation.context.gc())[0]
                         .get_or_create_xml(activation)
                         .into());
                 }
@@ -794,7 +794,7 @@ pub fn append_child<'gc>(
     let length = xml_list.length();
     let name = Multiname::new(
         namespaces.public_all(),
-        AvmString::new_utf8(activation.context.gc_context, length.to_string()),
+        AvmString::new_utf8(activation.context.gc(), length.to_string()),
     );
     xml_list.set_property_local(&name, child, activation)?;
 
@@ -1231,7 +1231,7 @@ pub fn set_notification<'gc>(
     let fun = args.try_get_object(activation, 0);
     node.set_notification(
         fun.and_then(|f| f.as_function_object()),
-        activation.context.gc_context,
+        activation.context.gc(),
     );
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -54,7 +54,7 @@ pub fn init<'gc>(
 
     let node = match nodes.as_slice() {
         // XML defaults to an empty text node when nothing was parsed
-        [] => E4XNode::text(activation.context.gc(), AvmString::default(), None),
+        [] => E4XNode::text(activation.gc(), AvmString::default(), None),
         [node] => *node,
         nodes => {
             let mut single_element_node = None;
@@ -97,7 +97,7 @@ pub fn init<'gc>(
             }
         }
     };
-    this.set_node(activation.context.gc(), node);
+    this.set_node(activation.gc(), node);
 
     Ok(Value::Undefined)
 }
@@ -733,7 +733,7 @@ pub fn call_handler<'gc>(
             // This re-uses the XML object stored in the list
             if let Some(xml_list) = obj.as_xml_list_object() {
                 if xml_list.length() == 1 {
-                    return Ok(xml_list.children_mut(activation.context.gc())[0]
+                    return Ok(xml_list.children_mut(activation.gc())[0]
                         .get_or_create_xml(activation)
                         .into());
                 }
@@ -794,7 +794,7 @@ pub fn append_child<'gc>(
     let length = xml_list.length();
     let name = Multiname::new(
         namespaces.public_all(),
-        AvmString::new_utf8(activation.context.gc(), length.to_string()),
+        AvmString::new_utf8(activation.gc(), length.to_string()),
     );
     xml_list.set_property_local(&name, child, activation)?;
 
@@ -1229,10 +1229,7 @@ pub fn set_notification<'gc>(
     let xml = this.as_xml_object().unwrap();
     let node = xml.node();
     let fun = args.try_get_object(activation, 0);
-    node.set_notification(
-        fun.and_then(|f| f.as_function_object()),
-        activation.context.gc(),
-    );
+    node.set_notification(fun.and_then(|f| f.as_function_object()), activation.gc());
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -46,7 +46,7 @@ pub fn init<'gc>(
             // `this[0] === xmlObjArg` true.
             // This logic does *not* go in `E4XNode::parse`, as it does not apply
             // to the `XML` constructor: `new XML(xmlObj) === xmlObj` is false.
-            this.set_children(activation.context.gc(), vec![E4XOrXml::Xml(xml)]);
+            this.set_children(activation.gc(), vec![E4XOrXml::Xml(xml)]);
             return Ok(Value::Undefined);
         }
     }
@@ -60,7 +60,7 @@ pub fn init<'gc>(
     ) {
         Ok(nodes) => {
             this.set_children(
-                activation.context.gc(),
+                activation.gc(),
                 nodes.into_iter().map(E4XOrXml::E4X).collect(),
             );
         }
@@ -590,7 +590,7 @@ macro_rules! define_xml_proxy {
                 let namespaces = activation.avm2().namespaces;
                 let list = this.as_xml_list_object().unwrap();
 
-                let mut children = list.children_mut(activation.context.gc());
+                let mut children = list.children_mut(activation.gc());
                 match &mut children[..] {
                     [child] => {
                         child
@@ -635,7 +635,7 @@ pub fn namespace_internal_impl<'gc>(
 
     let list = this.as_xml_list_object().unwrap();
     let namespaces = activation.avm2().namespaces;
-    let mut children = list.children_mut(activation.context.gc());
+    let mut children = list.children_mut(activation.gc());
 
     let args = if args[0] == Value::Bool(true) {
         &args[1..]

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -46,7 +46,7 @@ pub fn init<'gc>(
             // `this[0] === xmlObjArg` true.
             // This logic does *not* go in `E4XNode::parse`, as it does not apply
             // to the `XML` constructor: `new XML(xmlObj) === xmlObj` is false.
-            this.set_children(activation.context.gc_context, vec![E4XOrXml::Xml(xml)]);
+            this.set_children(activation.context.gc(), vec![E4XOrXml::Xml(xml)]);
             return Ok(Value::Undefined);
         }
     }
@@ -60,7 +60,7 @@ pub fn init<'gc>(
     ) {
         Ok(nodes) => {
             this.set_children(
-                activation.context.gc_context,
+                activation.context.gc(),
                 nodes.into_iter().map(E4XOrXml::E4X).collect(),
             );
         }
@@ -590,7 +590,7 @@ macro_rules! define_xml_proxy {
                 let namespaces = activation.avm2().namespaces;
                 let list = this.as_xml_list_object().unwrap();
 
-                let mut children = list.children_mut(activation.context.gc_context);
+                let mut children = list.children_mut(activation.context.gc());
                 match &mut children[..] {
                     [child] => {
                         child
@@ -635,7 +635,7 @@ pub fn namespace_internal_impl<'gc>(
 
     let list = this.as_xml_list_object().unwrap();
     let namespaces = activation.avm2().namespaces;
-    let mut children = list.children_mut(activation.context.gc_context);
+    let mut children = list.children_mut(activation.context.gc());
 
     let args = if args[0] == Value::Bool(true) {
         &args[1..]

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -231,7 +231,7 @@ impl<'gc> BytecodeMethod<'gc> {
         // TODO: avmplus seems to eaglerly verify some methods
 
         *unlock!(
-            Gc::write(activation.context.gc_context, this),
+            Gc::write(activation.context.gc(), this),
             BytecodeMethod,
             verified_info
         )
@@ -349,7 +349,7 @@ impl<'gc> NativeMethod<'gc> {
         &self,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        *self.resolved_signature.write(activation.context.gc_context) =
+        *self.resolved_signature.write(activation.context.gc()) =
             Some(resolve_param_config(activation, &self.signature)?);
 
         Ok(())

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -231,7 +231,7 @@ impl<'gc> BytecodeMethod<'gc> {
         // TODO: avmplus seems to eaglerly verify some methods
 
         *unlock!(
-            Gc::write(activation.context.gc(), this),
+            Gc::write(activation.gc(), this),
             BytecodeMethod,
             verified_info
         )
@@ -349,7 +349,7 @@ impl<'gc> NativeMethod<'gc> {
         &self,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        *self.resolved_signature.write(activation.context.gc()) =
+        *self.resolved_signature.write(activation.gc()) =
             Some(resolve_param_config(activation, &self.signature)?);
 
         Ok(())

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -482,7 +482,7 @@ impl<'gc> Multiname<'gc> {
         if self.is_any_name() {
             context.ascii_char(b'*')
         } else {
-            self.to_qualified_name(context.gc_context)
+            self.to_qualified_name(context.gc())
         }
     }
 

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -230,7 +230,7 @@ impl<'gc> Namespace<'gc> {
     ) -> Self {
         let atom = context.intern(package_name.into());
         Self(Some(Gc::new(
-            context.gc_context,
+            context.gc(),
             NamespaceData::Namespace(atom, api_version),
         )))
     }
@@ -242,7 +242,7 @@ impl<'gc> Namespace<'gc> {
     ) -> Self {
         let atom = context.intern(package_name.into());
         Self(Some(Gc::new(
-            context.gc_context,
+            context.gc(),
             NamespaceData::PackageInternal(atom),
         )))
     }

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -281,7 +281,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     .make_bound_method(activation, self.into(), disp_id)
                     .ok_or_else(|| format!("Method not found with id {disp_id}"))?;
 
-                self.install_bound_method(activation.context.gc_context, disp_id, bound_method);
+                self.install_bound_method(activation.context.gc(), disp_id, bound_method);
 
                 Ok(bound_method.into())
             }
@@ -368,7 +368,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     .coerce_trait_value(slot_id, value, activation)?;
 
                 self.base()
-                    .set_slot(slot_id, value, activation.context.gc_context);
+                    .set_slot(slot_id, value, activation.context.gc());
 
                 Ok(())
             }
@@ -451,7 +451,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     .coerce_trait_value(slot_id, value, activation)?;
 
                 self.base()
-                    .set_slot(slot_id, value, activation.context.gc_context);
+                    .set_slot(slot_id, value, activation.context.gc());
 
                 Ok(())
             }
@@ -619,7 +619,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
         let bound_method = VTable::bind_method(activation, self.into(), full_method);
 
-        self.install_bound_method(activation.context.gc_context, id, bound_method);
+        self.install_bound_method(activation.context.gc(), id, bound_method);
 
         bound_method.call(activation, Value::from(self.into()), arguments)
     }
@@ -937,11 +937,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     ) -> Result<Value<'gc>, Error<'gc>> {
         let class_name = self.instance_class().name().local_name();
 
-        Ok(AvmString::new_utf8(
-            activation.context.gc_context,
-            format!("[object {class_name}]"),
-        )
-        .into())
+        Ok(AvmString::new_utf8(activation.context.gc(), format!("[object {class_name}]")).into())
     }
 
     /// Implement the result of calling `Object.prototype.valueOf` on this

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -281,7 +281,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     .make_bound_method(activation, self.into(), disp_id)
                     .ok_or_else(|| format!("Method not found with id {disp_id}"))?;
 
-                self.install_bound_method(activation.context.gc(), disp_id, bound_method);
+                self.install_bound_method(activation.gc(), disp_id, bound_method);
 
                 Ok(bound_method.into())
             }
@@ -367,8 +367,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     .vtable()
                     .coerce_trait_value(slot_id, value, activation)?;
 
-                self.base()
-                    .set_slot(slot_id, value, activation.context.gc());
+                self.base().set_slot(slot_id, value, activation.gc());
 
                 Ok(())
             }
@@ -450,8 +449,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     .vtable()
                     .coerce_trait_value(slot_id, value, activation)?;
 
-                self.base()
-                    .set_slot(slot_id, value, activation.context.gc());
+                self.base().set_slot(slot_id, value, activation.gc());
 
                 Ok(())
             }
@@ -619,7 +617,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
         let bound_method = VTable::bind_method(activation, self.into(), full_method);
 
-        self.install_bound_method(activation.context.gc(), id, bound_method);
+        self.install_bound_method(activation.gc(), id, bound_method);
 
         bound_method.call(activation, Value::from(self.into()), arguments)
     }
@@ -937,7 +935,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     ) -> Result<Value<'gc>, Error<'gc>> {
         let class_name = self.instance_class().name().local_name();
 
-        Ok(AvmString::new_utf8(activation.context.gc(), format!("[object {class_name}]")).into())
+        Ok(AvmString::new_utf8(activation.gc(), format!("[object {class_name}]")).into())
     }
 
     /// Implement the result of calling `Object.prototype.valueOf` on this

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -21,7 +21,7 @@ pub fn array_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(ArrayObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         ArrayObjectData {
             base,
             array: RefLock::new(ArrayStorage::new(0)),
@@ -79,7 +79,7 @@ impl<'gc> ArrayObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         ArrayObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             ArrayObjectData {
                 base,
                 array: RefLock::new(array),
@@ -130,7 +130,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mc = activation.context.gc_context;
+        let mc = activation.context.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {
@@ -153,7 +153,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mc = activation.context.gc_context;
+        let mc = activation.context.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {
@@ -175,7 +175,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         name: &Multiname<'gc>,
     ) -> Result<bool, Error<'gc>> {
-        let mc = activation.context.gc_context;
+        let mc = activation.context.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -21,7 +21,7 @@ pub fn array_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(ArrayObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         ArrayObjectData {
             base,
             array: RefLock::new(ArrayStorage::new(0)),
@@ -79,7 +79,7 @@ impl<'gc> ArrayObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         ArrayObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             ArrayObjectData {
                 base,
                 array: RefLock::new(array),
@@ -130,7 +130,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mc = activation.context.gc();
+        let mc = activation.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {
@@ -153,7 +153,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mc = activation.context.gc();
+        let mc = activation.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {
@@ -175,7 +175,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         name: &Multiname<'gc>,
     ) -> Result<bool, Error<'gc>> {
-        let mc = activation.context.gc();
+        let mc = activation.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -17,7 +17,7 @@ pub fn bitmap_data_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(BitmapDataObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         BitmapDataObjectData {
             base,
             // This always starts out as a dummy (invalid) BitmapDataWrapper, so
@@ -76,7 +76,7 @@ impl<'gc> BitmapDataObject<'gc> {
         class: ClassObject<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let instance: Object<'gc> = Self(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             BitmapDataObjectData {
                 base: ScriptObjectData::new(class),
                 bitmap_data: Lock::new(bitmap_data),
@@ -84,7 +84,7 @@ impl<'gc> BitmapDataObject<'gc> {
         ))
         .into();
 
-        bitmap_data.init_object2(activation.context.gc_context, instance);
+        bitmap_data.init_object2(activation.context.gc(), instance);
 
         // We call the custom BitmapData class with width and height...
         // but, it always seems to be 1 in Flash Player when constructed from timeline?

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -17,7 +17,7 @@ pub fn bitmap_data_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(BitmapDataObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         BitmapDataObjectData {
             base,
             // This always starts out as a dummy (invalid) BitmapDataWrapper, so
@@ -76,7 +76,7 @@ impl<'gc> BitmapDataObject<'gc> {
         class: ClassObject<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let instance: Object<'gc> = Self(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             BitmapDataObjectData {
                 base: ScriptObjectData::new(class),
                 bitmap_data: Lock::new(bitmap_data),
@@ -84,7 +84,7 @@ impl<'gc> BitmapDataObject<'gc> {
         ))
         .into();
 
-        bitmap_data.init_object2(activation.context.gc(), instance);
+        bitmap_data.init_object2(activation.gc(), instance);
 
         // We call the custom BitmapData class with width and height...
         // but, it always seems to be 1 in Flash Player when constructed from timeline?

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -41,7 +41,7 @@ pub fn byte_array_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(ByteArrayObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         ByteArrayObjectData {
             base,
             storage: RefCell::new(storage),
@@ -90,7 +90,7 @@ impl<'gc> ByteArrayObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let instance: Object<'gc> = ByteArrayObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             ByteArrayObjectData {
                 base,
                 storage: RefCell::new(bytes),

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -41,7 +41,7 @@ pub fn byte_array_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(ByteArrayObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         ByteArrayObjectData {
             base,
             storage: RefCell::new(storage),
@@ -90,7 +90,7 @@ impl<'gc> ByteArrayObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let instance: Object<'gc> = ByteArrayObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             ByteArrayObjectData {
                 base,
                 storage: RefCell::new(bytes),

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -98,7 +98,7 @@ impl<'gc> ClassObject<'gc> {
 
         if let Some(superclass_object) = superclass_object {
             let base_proto = superclass_object.prototype();
-            proto.set_proto(activation.context.gc_context, base_proto);
+            proto.set_proto(activation.context.gc(), base_proto);
         }
         Ok(proto)
     }
@@ -123,7 +123,7 @@ impl<'gc> ClassObject<'gc> {
         class_object.link_prototype(activation, class_proto)?;
 
         let class_class_proto = activation.avm2().classes().class.prototype();
-        class_object.link_type(activation.context.gc_context, class_class_proto);
+        class_object.link_type(activation.context.gc(), class_class_proto);
 
         class_object.into_finished_class(activation)
     }
@@ -168,10 +168,10 @@ impl<'gc> ClassObject<'gc> {
             }
         }
 
-        let mc = activation.context.gc_context;
+        let mc = activation.context.gc();
 
         let class_object = ClassObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             ClassObjectData {
                 // We pass `custom_new` the temporary vtable of the class object
                 // because we don't have the full vtable created yet. We'll
@@ -198,7 +198,7 @@ impl<'gc> ClassObject<'gc> {
         .set(instance_scope);
         class_object.init_instance_vtable(activation)?;
 
-        class.add_class_object(activation.context.gc_context, class_object);
+        class.add_class_object(activation.context.gc(), class_object);
 
         Ok(class_object)
     }
@@ -213,7 +213,7 @@ impl<'gc> ClassObject<'gc> {
             self.superclass_object(),
             Some(self.instance_scope()),
             self.superclass_object().map(|cls| cls.instance_vtable()),
-            activation.context.gc_context,
+            activation.context.gc(),
         );
 
         self.link_interfaces(activation)?;
@@ -249,16 +249,16 @@ impl<'gc> ClassObject<'gc> {
         let class_classobject = activation.avm2().classes().class;
 
         // class vtable == class traits + Class instance traits
-        let class_vtable = VTable::empty(activation.context.gc_context);
+        let class_vtable = VTable::empty(activation.context.gc());
         class_vtable.init_vtable(
             c_class,
             Some(class_classobject),
             Some(self.class_scope()),
             Some(class_classobject.instance_vtable()),
-            activation.context.gc_context,
+            activation.context.gc(),
         );
 
-        self.set_vtable(activation.context.gc_context, class_vtable);
+        self.set_vtable(activation.context.gc(), class_vtable);
 
         self.run_class_initializer(activation)?;
 
@@ -271,7 +271,7 @@ impl<'gc> ClassObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         class_proto: Object<'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mc = activation.context.gc_context;
+        let mc = activation.context.gc();
 
         unlock!(Gc::write(mc, self.0), ClassObjectData, prototype).set(Some(class_proto));
         class_proto.set_string_property_local("constructor", self.into(), activation)?;
@@ -298,7 +298,7 @@ impl<'gc> ClassObject<'gc> {
                 if !interface_trait.name().namespace().is_public() {
                     let public_name = QName::new(internal_ns, interface_trait.name().local_name());
                     self.instance_vtable().copy_property_for_interface(
-                        activation.context.gc_context,
+                        activation.context.gc(),
                         public_name,
                         interface_trait.name(),
                     );
@@ -405,7 +405,7 @@ impl<'gc> ClassObject<'gc> {
             let qualified_class_name = self
                 .inner_class_definition()
                 .name()
-                .to_qualified_name_err_message(activation.context.gc_context);
+                .to_qualified_name_err_message(activation.context.gc());
 
             return Err(Error::AvmError(reference_error(
                 activation,
@@ -624,7 +624,7 @@ impl<'gc> ClassObject<'gc> {
             Self::from_class(activation, parameterized_class, Some(vector_star_cls))?;
 
         unlock!(
-            Gc::write(activation.context.gc_context, self.0),
+            Gc::write(activation.context.gc(), self.0),
             ClassObjectData,
             applications
         )
@@ -765,7 +765,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
 
     fn to_string(&self, activation: &mut Activation<'_, 'gc>) -> Result<Value<'gc>, Error<'gc>> {
         Ok(AvmString::new_utf8(
-            activation.context.gc_context,
+            activation.context.gc(),
             format!("[class {}]", self.0.class.name().local_name()),
         )
         .into())
@@ -797,7 +797,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
             let class_name = self
                 .inner_class_definition()
                 .name()
-                .to_qualified_name(activation.context.gc_context);
+                .to_qualified_name(activation.context.gc());
 
             return Err(Error::AvmError(type_error(
                 activation,

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -48,7 +48,7 @@ impl<'gc> DateObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let instance: Object<'gc> = DateObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             DateObjectData {
                 base,
                 date_time: Cell::new(Some(date_time)),

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -48,7 +48,7 @@ impl<'gc> DateObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let instance: Object<'gc> = DateObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             DateObjectData {
                 base,
                 date_time: Cell::new(Some(date_time)),

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -17,11 +17,7 @@ pub fn dictionary_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    Ok(DictionaryObject(Gc::new(
-        activation.context.gc(),
-        DictionaryObjectData { base },
-    ))
-    .into())
+    Ok(DictionaryObject(Gc::new(activation.gc(), DictionaryObjectData { base })).into())
 }
 
 /// An object that allows associations between objects and values.

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -18,7 +18,7 @@ pub fn dictionary_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(DictionaryObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         DictionaryObjectData { base },
     ))
     .into())

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -71,7 +71,7 @@ impl<'gc> DispatchObject<'gc> {
         let base = ScriptObjectData::new(activation.avm2().classes().object);
 
         DispatchObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             DispatchObjectData {
                 base,
                 dispatch: RefLock::new(DispatchList::new()),

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -71,7 +71,7 @@ impl<'gc> DispatchObject<'gc> {
         let base = ScriptObjectData::new(activation.avm2().classes().object);
 
         DispatchObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             DispatchObjectData {
                 base,
                 dispatch: RefLock::new(DispatchList::new()),

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -18,7 +18,7 @@ pub fn application_domain_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(DomainObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         DomainObjectData {
             base,
             domain: Lock::new(domain),
@@ -70,7 +70,7 @@ impl<'gc> DomainObject<'gc> {
         let class = activation.avm2().classes().application_domain;
         let base = ScriptObjectData::new(class);
         let this: Object<'gc> = DomainObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             DomainObjectData {
                 base,
                 domain: Lock::new(domain),

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -18,7 +18,7 @@ pub fn application_domain_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(DomainObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         DomainObjectData {
             base,
             domain: Lock::new(domain),
@@ -70,7 +70,7 @@ impl<'gc> DomainObject<'gc> {
         let class = activation.avm2().classes().application_domain;
         let base = ScriptObjectData::new(class);
         let this: Object<'gc> = DomainObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             DomainObjectData {
                 base,
                 domain: Lock::new(domain),

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -24,7 +24,7 @@ pub fn error_allocator<'gc>(
         .unwrap_or_default();
 
     Ok(ErrorObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         ErrorObjectData { base, call_stack },
     ))
     .into())

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -24,7 +24,7 @@ pub fn error_allocator<'gc>(
         .unwrap_or_default();
 
     Ok(ErrorObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         ErrorObjectData { base, call_stack },
     ))
     .into())

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -24,7 +24,7 @@ pub fn event_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(EventObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         EventObjectData {
             base,
             event: RefLock::new(Event::new(activation.strings().empty())),

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -24,7 +24,7 @@ pub fn event_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(EventObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         EventObjectData {
             base,
             event: RefLock::new(Event::new(activation.strings().empty())),
@@ -88,7 +88,7 @@ impl<'gc> EventObject<'gc> {
         event.set_cancelable(cancelable);
 
         let event_object = EventObject(Gc::new(
-            context.gc_context,
+            context.gc(),
             EventObjectData {
                 base,
                 event: RefLock::new(event),

--- a/core/src/avm2/object/file_reference_object.rs
+++ b/core/src/avm2/object/file_reference_object.rs
@@ -14,7 +14,7 @@ pub fn file_reference_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(FileReferenceObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         FileReferenceObjectData {
             base,
             reference: RefCell::new(FileReference::None),

--- a/core/src/avm2/object/font_object.rs
+++ b/core/src/avm2/object/font_object.rs
@@ -33,7 +33,7 @@ pub fn font_allocator<'gc>(
     };
 
     Ok(FontObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         FontObjectData { base, font },
     ))
     .into())

--- a/core/src/avm2/object/font_object.rs
+++ b/core/src/avm2/object/font_object.rs
@@ -32,11 +32,7 @@ pub fn font_allocator<'gc>(
         None
     };
 
-    Ok(FontObject(Gc::new(
-        activation.context.gc(),
-        FontObjectData { base, font },
-    ))
-    .into())
+    Ok(FontObject(Gc::new(activation.gc(), FontObjectData { base, font })).into())
 }
 
 #[derive(Clone, Collect, Copy)]

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -126,7 +126,7 @@ impl<'gc> FunctionObject<'gc> {
         let es3_proto = ScriptObject::new_object(activation);
 
         FunctionObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             FunctionObjectData {
                 base: ScriptObjectData::new(fn_class),
                 exec: RefLock::new(exec),
@@ -163,7 +163,7 @@ impl<'gc> FunctionObject<'gc> {
         };
 
         let instance = ScriptObject::custom_object(
-            activation.context.gc_context,
+            activation.context.gc(),
             object_class.inner_class_definition(),
             Some(prototype),
             object_class.instance_vtable(),

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -126,7 +126,7 @@ impl<'gc> FunctionObject<'gc> {
         let es3_proto = ScriptObject::new_object(activation);
 
         FunctionObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             FunctionObjectData {
                 base: ScriptObjectData::new(fn_class),
                 exec: RefLock::new(exec),
@@ -163,7 +163,7 @@ impl<'gc> FunctionObject<'gc> {
         };
 
         let instance = ScriptObject::custom_object(
-            activation.context.gc(),
+            activation.gc(),
             object_class.inner_class_definition(),
             Some(prototype),
             object_class.instance_vtable(),

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -122,7 +122,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         let loaded_stream = LoaderStream::Swf(movie, root);
 
         let this: Object<'gc> = LoaderInfoObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             LoaderInfoObjectData {
                 base,
                 loaded_stream: RefLock::new(loaded_stream),
@@ -169,7 +169,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let this: Object<'gc> = LoaderInfoObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             LoaderInfoObjectData {
                 base,
                 loaded_stream: RefLock::new(LoaderStream::NotYetLoaded(movie, root_clip, is_stage)),
@@ -347,7 +347,7 @@ impl<'gc> LoaderInfoObject<'gc> {
                 .expect("Native init should succeed");
 
             unlock!(
-                Gc::write(activation.context.gc_context, self.0),
+                Gc::write(activation.context.gc(), self.0),
                 LoaderInfoObjectData,
                 cached_avm1movie
             )
@@ -361,7 +361,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         // Reset properties
         let empty_swf = Arc::new(SwfMovie::empty(activation.context.swf.version()));
         let loader_stream = LoaderStream::NotYetLoaded(empty_swf, None, false);
-        self.set_loader_stream(loader_stream, activation.context.gc_context);
+        self.set_loader_stream(loader_stream, activation.context.gc());
         self.set_errored(false);
         self.reset_init_and_complete_events();
 

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -122,7 +122,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         let loaded_stream = LoaderStream::Swf(movie, root);
 
         let this: Object<'gc> = LoaderInfoObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             LoaderInfoObjectData {
                 base,
                 loaded_stream: RefLock::new(loaded_stream),
@@ -169,7 +169,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let this: Object<'gc> = LoaderInfoObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             LoaderInfoObjectData {
                 base,
                 loaded_stream: RefLock::new(LoaderStream::NotYetLoaded(movie, root_clip, is_stage)),
@@ -347,7 +347,7 @@ impl<'gc> LoaderInfoObject<'gc> {
                 .expect("Native init should succeed");
 
             unlock!(
-                Gc::write(activation.context.gc(), self.0),
+                Gc::write(activation.gc(), self.0),
                 LoaderInfoObjectData,
                 cached_avm1movie
             )
@@ -361,7 +361,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         // Reset properties
         let empty_swf = Arc::new(SwfMovie::empty(activation.context.swf.version()));
         let loader_stream = LoaderStream::NotYetLoaded(empty_swf, None, false);
-        self.set_loader_stream(loader_stream, activation.context.gc());
+        self.set_loader_stream(loader_stream, activation.gc());
         self.set_errored(false);
         self.reset_init_and_complete_events();
 

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -21,7 +21,7 @@ pub fn local_connection_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     let object = LocalConnectionObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         LocalConnectionObjectData {
             base,
             connection_handle: RefCell::new(None),

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -21,7 +21,7 @@ pub fn local_connection_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     let object = LocalConnectionObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         LocalConnectionObjectData {
             base,
             connection_handle: RefCell::new(None),

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -56,7 +56,7 @@ impl<'gc> NamespaceObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         NamespaceObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             NamespaceObjectData {
                 base,
                 namespace,
@@ -71,7 +71,7 @@ impl<'gc> NamespaceObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         NamespaceObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             NamespaceObjectData {
                 base,
                 namespace,

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -56,7 +56,7 @@ impl<'gc> NamespaceObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         NamespaceObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             NamespaceObjectData {
                 base,
                 namespace,
@@ -71,7 +71,7 @@ impl<'gc> NamespaceObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         NamespaceObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             NamespaceObjectData {
                 base,
                 namespace,

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -16,7 +16,7 @@ pub fn net_connection_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
     let this: Object<'gc> = NetConnectionObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         NetConnectionObjectData {
             base,
             handle: Cell::new(None),

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -16,7 +16,7 @@ pub fn net_connection_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
     let this: Object<'gc> = NetConnectionObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         NetConnectionObjectData {
             base,
             handle: Cell::new(None),

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -14,16 +14,13 @@ pub fn netstream_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    let ns = NetStream::new(activation.context.gc(), None);
-    let this: Object<'gc> = NetStreamObject(Gc::new(
-        activation.context.gc(),
-        NetStreamObjectData { base, ns },
-    ))
-    .into();
+    let ns = NetStream::new(activation.gc(), None);
+    let this: Object<'gc> =
+        NetStreamObject(Gc::new(activation.gc(), NetStreamObjectData { base, ns })).into();
 
-    ns.set_avm_object(activation.context.gc(), this.into());
+    ns.set_avm_object(activation.gc(), this.into());
 
-    ns.set_client(activation.context.gc(), this);
+    ns.set_client(activation.gc(), this);
 
     Ok(this)
 }

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -14,16 +14,16 @@ pub fn netstream_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    let ns = NetStream::new(activation.context.gc_context, None);
+    let ns = NetStream::new(activation.context.gc(), None);
     let this: Object<'gc> = NetStreamObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         NetStreamObjectData { base, ns },
     ))
     .into();
 
-    ns.set_avm_object(activation.context.gc_context, this.into());
+    ns.set_avm_object(activation.context.gc(), this.into());
 
-    ns.set_client(activation.context.gc_context, this);
+    ns.set_client(activation.context.gc(), this);
 
     Ok(this)
 }

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -20,7 +20,7 @@ pub fn primitive_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(PrimitiveObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         PrimitiveObjectData {
             base,
             primitive: RefLock::new(Value::Undefined),
@@ -94,7 +94,7 @@ impl<'gc> PrimitiveObject<'gc> {
 
         let base = ScriptObjectData::new(class);
         let this: Object<'gc> = PrimitiveObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             PrimitiveObjectData {
                 base,
                 primitive: RefLock::new(primitive),
@@ -133,10 +133,7 @@ impl<'gc> TObject<'gc> for PrimitiveObject<'gc> {
             _ => {
                 let class_name = self.instance_class().name().local_name();
 
-                Ok(
-                    AvmString::new_utf8(activation.context.gc(), format!("[object {class_name}]"))
-                        .into(),
-                )
+                Ok(AvmString::new_utf8(activation.gc(), format!("[object {class_name}]")).into())
             }
         }
     }

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -20,7 +20,7 @@ pub fn primitive_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(PrimitiveObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         PrimitiveObjectData {
             base,
             primitive: RefLock::new(Value::Undefined),
@@ -94,7 +94,7 @@ impl<'gc> PrimitiveObject<'gc> {
 
         let base = ScriptObjectData::new(class);
         let this: Object<'gc> = PrimitiveObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             PrimitiveObjectData {
                 base,
                 primitive: RefLock::new(primitive),
@@ -133,11 +133,10 @@ impl<'gc> TObject<'gc> for PrimitiveObject<'gc> {
             _ => {
                 let class_name = self.instance_class().name().local_name();
 
-                Ok(AvmString::new_utf8(
-                    activation.context.gc_context,
-                    format!("[object {class_name}]"),
+                Ok(
+                    AvmString::new_utf8(activation.context.gc(), format!("[object {class_name}]"))
+                        .into(),
                 )
-                .into())
             }
         }
     }

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -17,7 +17,7 @@ pub fn proxy_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    Ok(ProxyObject(Gc::new(activation.context.gc(), ProxyObjectData { base })).into())
+    Ok(ProxyObject(Gc::new(activation.gc(), ProxyObjectData { base })).into())
 }
 
 #[derive(Clone, Collect, Copy)]

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -17,11 +17,7 @@ pub fn proxy_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    Ok(ProxyObject(Gc::new(
-        activation.context.gc_context,
-        ProxyObjectData { base },
-    ))
-    .into())
+    Ok(ProxyObject(Gc::new(activation.context.gc(), ProxyObjectData { base })).into())
 }
 
 #[derive(Clone, Collect, Copy)]

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -20,7 +20,7 @@ pub fn reg_exp_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(RegExpObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         RegExpObjectData {
             base,
             regexp: RefLock::new(RegExp::new(activation.strings().empty())),
@@ -68,7 +68,7 @@ impl<'gc> RegExpObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let this: Object<'gc> = RegExpObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             RegExpObjectData {
                 base,
                 regexp: RefLock::new(regexp),

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -20,7 +20,7 @@ pub fn reg_exp_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(RegExpObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         RegExpObjectData {
             base,
             regexp: RefLock::new(RegExp::new(activation.strings().empty())),
@@ -68,7 +68,7 @@ impl<'gc> RegExpObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let this: Object<'gc> = RegExpObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             RegExpObjectData {
                 base,
                 regexp: RefLock::new(regexp),

--- a/core/src/avm2/object/responder_object.rs
+++ b/core/src/avm2/object/responder_object.rs
@@ -16,7 +16,7 @@ pub fn responder_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(ResponderObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         ResponderObjectData {
             base,
             result: Lock::new(None),

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -25,7 +25,7 @@ pub fn scriptobject_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    Ok(ScriptObject(Gc::new(activation.context.gc(), base)).into())
+    Ok(ScriptObject(Gc::new(activation.gc(), base)).into())
 }
 
 /// Default implementation of `avm2::Object`.
@@ -126,7 +126,7 @@ impl<'gc> ScriptObject<'gc> {
     /// A special case for `newcatch` implementation. Basically a variable (q)name
     /// which maps to slot 1.
     pub fn catch_scope(activation: &mut Activation<'_, 'gc>, qname: &QName<'gc>) -> Object<'gc> {
-        let mc = activation.context.gc();
+        let mc = activation.gc();
 
         let vt = VTable::newcatch(mc, qname);
 

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -25,7 +25,7 @@ pub fn scriptobject_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    Ok(ScriptObject(Gc::new(activation.context.gc_context, base)).into())
+    Ok(ScriptObject(Gc::new(activation.context.gc(), base)).into())
 }
 
 /// Default implementation of `avm2::Object`.
@@ -126,7 +126,7 @@ impl<'gc> ScriptObject<'gc> {
     /// A special case for `newcatch` implementation. Basically a variable (q)name
     /// which maps to slot 1.
     pub fn catch_scope(activation: &mut Activation<'_, 'gc>, qname: &QName<'gc>) -> Object<'gc> {
-        let mc = activation.context.gc_context;
+        let mc = activation.context.gc();
 
         let vt = VTable::newcatch(mc, qname);
 

--- a/core/src/avm2/object/shared_object_object.rs
+++ b/core/src/avm2/object/shared_object_object.rs
@@ -60,7 +60,7 @@ impl<'gc> SharedObjectObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         SharedObjectObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             SharedObjectObjectData {
                 base,
                 data: Lock::new(data),

--- a/core/src/avm2/object/shared_object_object.rs
+++ b/core/src/avm2/object/shared_object_object.rs
@@ -60,7 +60,7 @@ impl<'gc> SharedObjectObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         SharedObjectObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             SharedObjectObjectData {
                 base,
                 data: Lock::new(data),

--- a/core/src/avm2/object/socket_object.rs
+++ b/core/src/avm2/object/socket_object.rs
@@ -16,7 +16,7 @@ pub fn socket_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(SocketObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         SocketObjectData {
             base,
             // Default endianness is Big.

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -31,7 +31,7 @@ pub fn sound_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(SoundObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         SoundObjectData {
             base,
             sound_data: RefLock::new(SoundData::NotLoaded {
@@ -116,7 +116,7 @@ impl<'gc> SoundObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<bool, Error<'gc>> {
         let mut sound_data = unlock!(
-            Gc::write(activation.context.gc_context, self.0),
+            Gc::write(activation.context.gc(), self.0),
             SoundObjectData,
             sound_data
         )
@@ -142,12 +142,8 @@ impl<'gc> SoundObject<'gc> {
         context: &mut UpdateContext<'gc>,
         sound: SoundHandle,
     ) -> Result<(), Error<'gc>> {
-        let mut sound_data = unlock!(
-            Gc::write(context.gc_context, self.0),
-            SoundObjectData,
-            sound_data
-        )
-        .borrow_mut();
+        let mut sound_data =
+            unlock!(Gc::write(context.gc(), self.0), SoundObjectData, sound_data).borrow_mut();
         let mut activation = Activation::from_nothing(context);
         match &mut *sound_data {
             SoundData::NotLoaded { queued_plays } => {
@@ -237,7 +233,7 @@ impl<'gc> SoundObject<'gc> {
                 .expect("slot is typed String");
             }
         }
-        self.set_id3(activation.context.gc_context, Some(id3));
+        self.set_id3(activation.context.gc(), Some(id3));
         if tag.is_ok() {
             let id3_evt = EventObject::bare_default_event(activation.context, "id3");
             Avm2::dispatch_event(activation.context, id3_evt, self.into());

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -31,7 +31,7 @@ pub fn sound_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(SoundObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         SoundObjectData {
             base,
             sound_data: RefLock::new(SoundData::NotLoaded {
@@ -116,7 +116,7 @@ impl<'gc> SoundObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<bool, Error<'gc>> {
         let mut sound_data = unlock!(
-            Gc::write(activation.context.gc(), self.0),
+            Gc::write(activation.gc(), self.0),
             SoundObjectData,
             sound_data
         )
@@ -233,7 +233,7 @@ impl<'gc> SoundObject<'gc> {
                 .expect("slot is typed String");
             }
         }
-        self.set_id3(activation.context.gc(), Some(id3));
+        self.set_id3(activation.gc(), Some(id3));
         if tag.is_ok() {
             let id3_evt = EventObject::bare_default_event(activation.context, "id3");
             Avm2::dispatch_event(activation.context, id3_evt, self.into());

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -20,7 +20,7 @@ pub fn sound_channel_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(SoundChannelObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         SoundChannelObjectData {
             base,
             sound_channel_data: RefCell::new(SoundChannelData::NotLoaded {
@@ -85,7 +85,7 @@ impl<'gc> SoundChannelObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let sound_object = SoundChannelObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             SoundChannelObjectData {
                 base,
                 sound_channel_data: RefCell::new(SoundChannelData::NotLoaded {

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -20,7 +20,7 @@ pub fn sound_channel_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(SoundChannelObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         SoundChannelObjectData {
             base,
             sound_channel_data: RefCell::new(SoundChannelData::NotLoaded {
@@ -85,7 +85,7 @@ impl<'gc> SoundChannelObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         let sound_object = SoundChannelObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             SoundChannelObjectData {
                 base,
                 sound_channel_data: RefCell::new(SoundChannelData::NotLoaded {

--- a/core/src/avm2/object/soundtransform_object.rs
+++ b/core/src/avm2/object/soundtransform_object.rs
@@ -14,7 +14,7 @@ pub fn sound_transform_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(SoundTransformObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         SoundTransformObjectData {
             base,
             left_to_left: Cell::new(0.0),

--- a/core/src/avm2/object/soundtransform_object.rs
+++ b/core/src/avm2/object/soundtransform_object.rs
@@ -14,7 +14,7 @@ pub fn sound_transform_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(SoundTransformObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         SoundTransformObjectData {
             base,
             left_to_left: Cell::new(0.0),

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -49,7 +49,7 @@ impl<'gc> StageObject<'gc> {
         class: ClassObject<'gc>,
     ) -> Result<Self, Error<'gc>> {
         let instance = Self(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             StageObjectData {
                 base: ScriptObjectData::new(class),
                 display_object,
@@ -98,7 +98,7 @@ impl<'gc> StageObject<'gc> {
     ) -> Result<Self, Error<'gc>> {
         let class = activation.avm2().classes().graphics;
         let this = Self(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             StageObjectData {
                 base: ScriptObjectData::new(class),
                 display_object,

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -49,7 +49,7 @@ impl<'gc> StageObject<'gc> {
         class: ClassObject<'gc>,
     ) -> Result<Self, Error<'gc>> {
         let instance = Self(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             StageObjectData {
                 base: ScriptObjectData::new(class),
                 display_object,
@@ -98,7 +98,7 @@ impl<'gc> StageObject<'gc> {
     ) -> Result<Self, Error<'gc>> {
         let class = activation.avm2().classes().graphics;
         let this = Self(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             StageObjectData {
                 base: ScriptObjectData::new(class),
                 display_object,

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -25,7 +25,7 @@ pub fn vector_allocator<'gc>(
         .ok_or("Cannot convert to unparametrized Vector")?;
 
     Ok(VectorObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         VectorObjectData {
             base,
             vector: RefLock::new(VectorStorage::new(0, false, param_type, activation)),
@@ -78,7 +78,7 @@ impl<'gc> VectorObject<'gc> {
         let applied_class = vector_class.parametrize(activation, value_type)?;
 
         let object: Object<'gc> = VectorObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             VectorObjectData {
                 base: ScriptObjectData::new(applied_class),
                 vector: RefLock::new(vector),
@@ -129,7 +129,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mc = activation.context.gc_context;
+        let mc = activation.context.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {
@@ -159,7 +159,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mc = activation.context.gc_context;
+        let mc = activation.context.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {
@@ -188,7 +188,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         name: &Multiname<'gc>,
     ) -> Result<bool, Error<'gc>> {
-        let mc = activation.context.gc_context;
+        let mc = activation.context.gc();
 
         if name.contains_public_namespace()
             && name.local_name().is_some()

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -25,7 +25,7 @@ pub fn vector_allocator<'gc>(
         .ok_or("Cannot convert to unparametrized Vector")?;
 
     Ok(VectorObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         VectorObjectData {
             base,
             vector: RefLock::new(VectorStorage::new(0, false, param_type, activation)),
@@ -78,7 +78,7 @@ impl<'gc> VectorObject<'gc> {
         let applied_class = vector_class.parametrize(activation, value_type)?;
 
         let object: Object<'gc> = VectorObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             VectorObjectData {
                 base: ScriptObjectData::new(applied_class),
                 vector: RefLock::new(vector),
@@ -129,7 +129,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mc = activation.context.gc();
+        let mc = activation.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {
@@ -159,7 +159,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let mc = activation.context.gc();
+        let mc = activation.gc();
 
         if name.contains_public_namespace() {
             if let Some(name) = name.local_name() {
@@ -188,7 +188,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         name: &Multiname<'gc>,
     ) -> Result<bool, Error<'gc>> {
-        let mc = activation.context.gc();
+        let mc = activation.gc();
 
         if name.contains_public_namespace()
             && name.local_name().is_some()

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -26,7 +26,7 @@ pub fn xml_list_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(XmlListObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         XmlListObjectData {
             base,
             children: RefLock::new(Vec::new()),
@@ -73,7 +73,7 @@ impl<'gc> XmlListObject<'gc> {
     ) -> XmlListObject<'gc> {
         let base = ScriptObjectData::new(activation.context.avm2.classes().xml_list);
         XmlListObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             XmlListObjectData {
                 base,
                 children: RefLock::new(children),
@@ -135,7 +135,7 @@ impl<'gc> XmlListObject<'gc> {
         let children = self
             .children()
             .iter()
-            .map(|child| E4XOrXml::E4X(child.node().deep_copy(activation.context.gc_context)))
+            .map(|child| E4XOrXml::E4X(child.node().deep_copy(activation.context.gc())))
             .collect();
         XmlListObject::new_with_children(
             activation,
@@ -1097,10 +1097,9 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                         let removed_node = removed.node();
                         if let Some(parent) = removed_node.parent() {
                             if removed_node.is_attribute() {
-                                parent
-                                    .remove_attribute(activation.context.gc_context, &removed_node);
+                                parent.remove_attribute(activation.context.gc(), &removed_node);
                             } else {
-                                parent.remove_child(activation.context.gc_context, &removed_node);
+                                parent.remove_child(activation.context.gc(), &removed_node);
                             }
                         }
                     }

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -26,7 +26,7 @@ pub fn xml_list_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(XmlListObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         XmlListObjectData {
             base,
             children: RefLock::new(Vec::new()),
@@ -73,7 +73,7 @@ impl<'gc> XmlListObject<'gc> {
     ) -> XmlListObject<'gc> {
         let base = ScriptObjectData::new(activation.context.avm2.classes().xml_list);
         XmlListObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             XmlListObjectData {
                 base,
                 children: RefLock::new(children),
@@ -135,7 +135,7 @@ impl<'gc> XmlListObject<'gc> {
         let children = self
             .children()
             .iter()
-            .map(|child| E4XOrXml::E4X(child.node().deep_copy(activation.context.gc())))
+            .map(|child| E4XOrXml::E4X(child.node().deep_copy(activation.gc())))
             .collect();
         XmlListObject::new_with_children(
             activation,
@@ -1097,9 +1097,9 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                         let removed_node = removed.node();
                         if let Some(parent) = removed_node.parent() {
                             if removed_node.is_attribute() {
-                                parent.remove_attribute(activation.context.gc(), &removed_node);
+                                parent.remove_attribute(activation.gc(), &removed_node);
                             } else {
-                                parent.remove_child(activation.context.gc(), &removed_node);
+                                parent.remove_child(activation.gc(), &removed_node);
                             }
                         }
                     }

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -27,10 +27,10 @@ pub fn xml_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(XmlObject(Gc::new(
-        activation.context.gc(),
+        activation.gc(),
         XmlObjectData {
             base,
-            node: Lock::new(E4XNode::dummy(activation.context.gc())),
+            node: Lock::new(E4XNode::dummy(activation.gc())),
         },
     ))
     .into())
@@ -69,7 +69,7 @@ const _: () =
 impl<'gc> XmlObject<'gc> {
     pub fn new(node: E4XNode<'gc>, activation: &mut Activation<'_, 'gc>) -> Self {
         XmlObject(Gc::new(
-            activation.context.gc(),
+            activation.gc(),
             XmlObjectData {
                 base: ScriptObjectData::new(activation.context.avm2.classes().xml),
                 node: Lock::new(node),
@@ -500,7 +500,7 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
                 value.coerce_to_string(activation)?
             };
 
-            let mc = activation.context.gc();
+            let mc = activation.gc();
             self.delete_property_local(activation, &name)?;
             let Some(local_name) = name.local_name() else {
                 return Err(format!("Cannot set attribute {:?} without a local name", name).into());

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -27,10 +27,10 @@ pub fn xml_allocator<'gc>(
     let base = ScriptObjectData::new(class);
 
     Ok(XmlObject(Gc::new(
-        activation.context.gc_context,
+        activation.context.gc(),
         XmlObjectData {
             base,
-            node: Lock::new(E4XNode::dummy(activation.context.gc_context)),
+            node: Lock::new(E4XNode::dummy(activation.context.gc())),
         },
     ))
     .into())
@@ -69,7 +69,7 @@ const _: () =
 impl<'gc> XmlObject<'gc> {
     pub fn new(node: E4XNode<'gc>, activation: &mut Activation<'_, 'gc>) -> Self {
         XmlObject(Gc::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             XmlObjectData {
                 base: ScriptObjectData::new(activation.context.avm2.classes().xml),
                 node: Lock::new(node),
@@ -500,7 +500,7 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
                 value.coerce_to_string(activation)?
             };
 
-            let mc = activation.context.gc_context;
+            let mc = activation.context.gc();
             self.delete_property_local(activation, &name)?;
             let Some(local_name) = name.local_name() else {
                 return Err(format!("Cannot set attribute {:?} without a local name", name).into());

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -1281,11 +1281,7 @@ pub fn optimize<'gc>(
                             }
 
                             drop(slot_classes);
-                            vtable.set_slot_class(
-                                activation.context.gc(),
-                                *slot_id as usize,
-                                value_class,
-                            );
+                            vtable.set_slot_class(activation.gc(), *slot_id as usize, value_class);
                         }
                     }
 
@@ -1322,7 +1318,7 @@ pub fn optimize<'gc>(
                                     }
 
                                     vtable.set_slot_class(
-                                        activation.context.gc(),
+                                        activation.gc(),
                                         slot_id as usize,
                                         value_class,
                                     );
@@ -1731,7 +1727,7 @@ pub fn optimize<'gc>(
                         }
 
                         class.vtable().set_slot_class(
-                            activation.context.gc(),
+                            activation.gc(),
                             *slot_id as usize,
                             value_class,
                         );

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -1282,7 +1282,7 @@ pub fn optimize<'gc>(
 
                             drop(slot_classes);
                             vtable.set_slot_class(
-                                activation.context.gc_context,
+                                activation.context.gc(),
                                 *slot_id as usize,
                                 value_class,
                             );
@@ -1322,7 +1322,7 @@ pub fn optimize<'gc>(
                                     }
 
                                     vtable.set_slot_class(
-                                        activation.context.gc_context,
+                                        activation.context.gc(),
                                         slot_id as usize,
                                         value_class,
                                     );
@@ -1731,7 +1731,7 @@ pub fn optimize<'gc>(
                         }
 
                         class.vtable().set_slot_class(
-                            activation.context.gc_context,
+                            activation.context.gc(),
                             *slot_id as usize,
                             value_class,
                         );

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -114,7 +114,7 @@ impl<'gc> PropertyClass<'gc> {
 
     pub fn get_name(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         match self {
-            PropertyClass::Class(class) => class.name().to_qualified_name(context.gc_context),
+            PropertyClass::Class(class) => class.name().to_qualified_name(context.gc()),
             PropertyClass::Name(name, _) => name.to_qualified_name_or_star(context),
             PropertyClass::Any => context.ascii_char(b'*'),
         }

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -237,7 +237,7 @@ impl<'gc> RegExp<'gc> {
             let args = std::iter::once(Some(&m.range))
                 .chain((m.captures.iter()).map(|x| x.as_ref()))
                 .map(|o| match o {
-                    Some(r) => AvmString::new(activation.context.gc(), &txt[r.start..r.end]).into(),
+                    Some(r) => AvmString::new(activation.gc(), &txt[r.start..r.end]).into(),
                     None => activation.strings().empty().into(),
                 })
                 .chain(std::iter::once(m.range.start.into()))
@@ -324,7 +324,7 @@ impl<'gc> RegExp<'gc> {
         }
 
         ret.push_str(&text[start..]);
-        Ok(AvmString::new(activation.context.gc(), ret))
+        Ok(AvmString::new(activation.gc(), ret))
     }
 
     pub fn split(
@@ -338,7 +338,7 @@ impl<'gc> RegExp<'gc> {
         if self.source.is_empty() {
             let mut it = text.chars().take(limit);
             while let Some(Ok(c)) = it.next() {
-                storage.push(AvmString::new(activation.context.gc(), WString::from_char(c)).into());
+                storage.push(AvmString::new(activation.gc(), WString::from_char(c)).into());
             }
             return Ok(ArrayObject::from_storage(activation, storage));
         }
@@ -348,13 +348,12 @@ impl<'gc> RegExp<'gc> {
             if m.range.end == start {
                 break;
             }
-            storage
-                .push(AvmString::new(activation.context.gc(), &text[start..m.range.start]).into());
+            storage.push(AvmString::new(activation.gc(), &text[start..m.range.start]).into());
             if storage.length() >= limit {
                 break;
             }
             for c in m.captures.iter().filter_map(Option::as_ref) {
-                storage.push(AvmString::new(activation.context.gc(), &text[c.start..c.end]).into());
+                storage.push(AvmString::new(activation.gc(), &text[c.start..c.end]).into());
                 if storage.length() >= limit {
                     break; // Intentional bug to match Flash.
                            // Causes adding parts past limit.
@@ -365,7 +364,7 @@ impl<'gc> RegExp<'gc> {
         }
 
         if storage.length() < limit {
-            storage.push(AvmString::new(activation.context.gc(), &text[start..]).into());
+            storage.push(AvmString::new(activation.gc(), &text[start..]).into());
         }
 
         Ok(ArrayObject::from_storage(activation, storage))

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -237,9 +237,7 @@ impl<'gc> RegExp<'gc> {
             let args = std::iter::once(Some(&m.range))
                 .chain((m.captures.iter()).map(|x| x.as_ref()))
                 .map(|o| match o {
-                    Some(r) => {
-                        AvmString::new(activation.context.gc_context, &txt[r.start..r.end]).into()
-                    }
+                    Some(r) => AvmString::new(activation.context.gc(), &txt[r.start..r.end]).into(),
                     None => activation.strings().empty().into(),
                 })
                 .chain(std::iter::once(m.range.start.into()))
@@ -326,7 +324,7 @@ impl<'gc> RegExp<'gc> {
         }
 
         ret.push_str(&text[start..]);
-        Ok(AvmString::new(activation.context.gc_context, ret))
+        Ok(AvmString::new(activation.context.gc(), ret))
     }
 
     pub fn split(
@@ -340,9 +338,7 @@ impl<'gc> RegExp<'gc> {
         if self.source.is_empty() {
             let mut it = text.chars().take(limit);
             while let Some(Ok(c)) = it.next() {
-                storage.push(
-                    AvmString::new(activation.context.gc_context, WString::from_char(c)).into(),
-                );
+                storage.push(AvmString::new(activation.context.gc(), WString::from_char(c)).into());
             }
             return Ok(ArrayObject::from_storage(activation, storage));
         }
@@ -352,16 +348,13 @@ impl<'gc> RegExp<'gc> {
             if m.range.end == start {
                 break;
             }
-            storage.push(
-                AvmString::new(activation.context.gc_context, &text[start..m.range.start]).into(),
-            );
+            storage
+                .push(AvmString::new(activation.context.gc(), &text[start..m.range.start]).into());
             if storage.length() >= limit {
                 break;
             }
             for c in m.captures.iter().filter_map(Option::as_ref) {
-                storage.push(
-                    AvmString::new(activation.context.gc_context, &text[c.start..c.end]).into(),
-                );
+                storage.push(AvmString::new(activation.context.gc(), &text[c.start..c.end]).into());
                 if storage.length() >= limit {
                     break; // Intentional bug to match Flash.
                            // Causes adding parts past limit.
@@ -372,7 +365,7 @@ impl<'gc> RegExp<'gc> {
         }
 
         if storage.length() < limit {
-            storage.push(AvmString::new(activation.context.gc_context, &text[start..]).into());
+            storage.push(AvmString::new(activation.context.gc(), &text[start..]).into());
         }
 
         Ok(ArrayObject::from_storage(activation, storage))

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -127,7 +127,7 @@ impl<'gc> TranslationUnit<'gc> {
             // and how it's exported again when it is encountered in a trait (see `Script::load_traits`).
             // We currently don't handle them and just export it in the domain in both cases.
             self.domain()
-                .export_class(class.name(), class, activation.context.gc());
+                .export_class(class.name(), class, activation.gc());
         }
 
         Ok(())
@@ -200,14 +200,14 @@ impl<'gc> TranslationUnit<'gc> {
                         bc_method.signature,
                         bc_method.return_type,
                         variadic,
-                        activation.context.gc(),
+                        activation.gc(),
                     );
                 }
             }
-            Gc::new(activation.context.gc(), bc_method).into()
+            Gc::new(activation.gc(), bc_method).into()
         })();
 
-        self.0.write(activation.context.gc()).methods[method_index.0 as usize] = Some(method);
+        self.0.write(activation.gc()).methods[method_index.0 as usize] = Some(method);
 
         Ok(method)
     }
@@ -226,7 +226,7 @@ impl<'gc> TranslationUnit<'gc> {
         drop(read);
 
         let class = Class::from_abc_index(self, class_index, activation)?;
-        self.0.write(activation.context.gc()).classes[class_index as usize] = Some(class);
+        self.0.write(activation.gc()).classes[class_index as usize] = Some(class);
 
         class.load_traits(activation, self, class_index)?;
 
@@ -255,7 +255,7 @@ impl<'gc> TranslationUnit<'gc> {
         drop(read);
 
         let script = Script::from_abc_index(self, script_index, domain, activation)?;
-        self.0.write(activation.context.gc()).scripts[script_index as usize] = Some(script);
+        self.0.write(activation.gc()).scripts[script_index as usize] = Some(script);
 
         script.load_traits(self, script_index, activation)?;
 
@@ -482,7 +482,7 @@ impl<'gc> Script<'gc> {
         let init = unit.load_method(script.init_method, false, activation)?;
 
         Ok(Self(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             ScriptData {
                 globals: None,
                 domain,

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -306,7 +306,7 @@ impl Definition {
             let name = match key {
                 DynamicKey::String(name) => *name,
                 DynamicKey::Uint(key) => {
-                    AvmString::new_utf8(activation.context.gc_context, key.to_string())
+                    AvmString::new_utf8(activation.context.gc(), key.to_string())
                 }
                 DynamicKey::Object(object) => {
                     Value::Object(*object).coerce_to_string(activation).unwrap()
@@ -492,7 +492,7 @@ pub fn capture_specification(context: &mut UpdateContext, output: &Path) {
                 let class_name = class
                     .inner_class_definition()
                     .name()
-                    .to_qualified_name_err_message(activation.context.gc_context)
+                    .to_qualified_name_err_message(activation.context.gc())
                     .to_string();
                 let class_stubs = ClassStubs::for_class(&class_name, &stubs);
                 definitions.insert(

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -305,9 +305,7 @@ impl Definition {
         for (key, value) in prototype_values.as_hashmap().iter() {
             let name = match key {
                 DynamicKey::String(name) => *name,
-                DynamicKey::Uint(key) => {
-                    AvmString::new_utf8(activation.context.gc(), key.to_string())
-                }
+                DynamicKey::Uint(key) => AvmString::new_utf8(activation.gc(), key.to_string()),
                 DynamicKey::Object(object) => {
                     Value::Object(*object).coerce_to_string(activation).unwrap()
                 }
@@ -492,7 +490,7 @@ pub fn capture_specification(context: &mut UpdateContext, output: &Path) {
                 let class_name = class
                     .inner_class_definition()
                     .name()
-                    .to_qualified_name_err_message(activation.context.gc())
+                    .to_qualified_name_err_message(activation.gc())
                     .to_string();
                 let class_stubs = ClassStubs::for_class(&class_name, &stubs);
                 definitions.insert(

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -651,7 +651,7 @@ impl<'gc> Value<'gc> {
                     activation,
                     &format!(
                         "Error #1050: Cannot convert {} to primitive.",
-                        o.instance_of_class_name(activation.context.gc())
+                        o.instance_of_class_name(activation.gc())
                     ),
                     1050,
                 )?))
@@ -673,7 +673,7 @@ impl<'gc> Value<'gc> {
                     activation,
                     &format!(
                         "Error #1050: Cannot convert {} to primitive.",
-                        o.instance_of_class_name(activation.context.gc())
+                        o.instance_of_class_name(activation.gc())
                     ),
                     1050,
                 )?))
@@ -790,7 +790,7 @@ impl<'gc> Value<'gc> {
             Value::Number(n) if n.is_nan() => "NaN".into(),
             Value::Number(n) if *n == 0.0 => "0".into(),
             Value::Number(n) if *n < 0.0 => AvmString::new_utf8(
-                activation.context.gc(),
+                activation.gc(),
                 format!("-{}", Value::Number(-n).coerce_to_string(activation)?),
             ),
             Value::Number(n) if n.is_infinite() => "Infinity".into(),
@@ -804,7 +804,7 @@ impl<'gc> Value<'gc> {
 
                 if digits < Self::MIN_DIGITS || digits >= Self::MAX_DIGITS {
                     AvmString::new_utf8(
-                        activation.context.gc(),
+                        activation.gc(),
                         format!(
                             "{}e{}{}",
                             precision / 10.0_f64.powf(digits),
@@ -813,14 +813,14 @@ impl<'gc> Value<'gc> {
                         ),
                     )
                 } else {
-                    AvmString::new_utf8(activation.context.gc(), n.to_string())
+                    AvmString::new_utf8(activation.gc(), n.to_string())
                 }
             }
             Value::Integer(i) => {
                 if *i >= 0 && *i < 10 {
                     activation.strings().make_char('0' as u16 + *i as u16)
                 } else {
-                    AvmString::new_utf8(activation.context.gc(), i.to_string())
+                    AvmString::new_utf8(activation.gc(), i.to_string())
                 }
             }
             Value::String(s) => *s,
@@ -841,7 +841,7 @@ impl<'gc> Value<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         Ok(match self {
-            Value::String(s) => AvmString::new_utf8(activation.context.gc(), format!("\"{s}\"")),
+            Value::String(s) => AvmString::new_utf8(activation.gc(), format!("\"{s}\"")),
             Value::Object(_) => self
                 .coerce_to_primitive(Some(Hint::String), activation)?
                 .coerce_to_debug_string(activation)?,
@@ -1002,9 +1002,7 @@ impl<'gc> Value<'gc> {
             }
         }
 
-        let name = class
-            .name()
-            .to_qualified_name_err_message(activation.context.gc());
+        let name = class.name().to_qualified_name_err_message(activation.gc());
 
         let debug_str = match self {
             Value::Object(obj) if obj.as_primitive().is_none() => {
@@ -1014,7 +1012,7 @@ impl<'gc> Value<'gc> {
                 // application is trying to parse the error message.
                 format!(
                     "{}@00000000000",
-                    obj.instance_of_class_name(activation.context.gc())
+                    obj.instance_of_class_name(activation.gc())
                 )
             }
             _ => self.coerce_to_debug_string(activation)?.to_string(),

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -651,7 +651,7 @@ impl<'gc> Value<'gc> {
                     activation,
                     &format!(
                         "Error #1050: Cannot convert {} to primitive.",
-                        o.instance_of_class_name(activation.context.gc_context)
+                        o.instance_of_class_name(activation.context.gc())
                     ),
                     1050,
                 )?))
@@ -673,7 +673,7 @@ impl<'gc> Value<'gc> {
                     activation,
                     &format!(
                         "Error #1050: Cannot convert {} to primitive.",
-                        o.instance_of_class_name(activation.context.gc_context)
+                        o.instance_of_class_name(activation.context.gc())
                     ),
                     1050,
                 )?))
@@ -790,7 +790,7 @@ impl<'gc> Value<'gc> {
             Value::Number(n) if n.is_nan() => "NaN".into(),
             Value::Number(n) if *n == 0.0 => "0".into(),
             Value::Number(n) if *n < 0.0 => AvmString::new_utf8(
-                activation.context.gc_context,
+                activation.context.gc(),
                 format!("-{}", Value::Number(-n).coerce_to_string(activation)?),
             ),
             Value::Number(n) if n.is_infinite() => "Infinity".into(),
@@ -804,7 +804,7 @@ impl<'gc> Value<'gc> {
 
                 if digits < Self::MIN_DIGITS || digits >= Self::MAX_DIGITS {
                     AvmString::new_utf8(
-                        activation.context.gc_context,
+                        activation.context.gc(),
                         format!(
                             "{}e{}{}",
                             precision / 10.0_f64.powf(digits),
@@ -813,14 +813,14 @@ impl<'gc> Value<'gc> {
                         ),
                     )
                 } else {
-                    AvmString::new_utf8(activation.context.gc_context, n.to_string())
+                    AvmString::new_utf8(activation.context.gc(), n.to_string())
                 }
             }
             Value::Integer(i) => {
                 if *i >= 0 && *i < 10 {
                     activation.strings().make_char('0' as u16 + *i as u16)
                 } else {
-                    AvmString::new_utf8(activation.context.gc_context, i.to_string())
+                    AvmString::new_utf8(activation.context.gc(), i.to_string())
                 }
             }
             Value::String(s) => *s,
@@ -841,9 +841,7 @@ impl<'gc> Value<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         Ok(match self {
-            Value::String(s) => {
-                AvmString::new_utf8(activation.context.gc_context, format!("\"{s}\""))
-            }
+            Value::String(s) => AvmString::new_utf8(activation.context.gc(), format!("\"{s}\"")),
             Value::Object(_) => self
                 .coerce_to_primitive(Some(Hint::String), activation)?
                 .coerce_to_debug_string(activation)?,
@@ -1006,7 +1004,7 @@ impl<'gc> Value<'gc> {
 
         let name = class
             .name()
-            .to_qualified_name_err_message(activation.context.gc_context);
+            .to_qualified_name_err_message(activation.context.gc());
 
         let debug_str = match self {
             Value::Object(obj) if obj.as_primitive().is_none() => {
@@ -1016,7 +1014,7 @@ impl<'gc> Value<'gc> {
                 // application is trying to parse the error message.
                 format!(
                     "{}@00000000000",
-                    obj.instance_of_class_name(activation.context.gc_context)
+                    obj.instance_of_class_name(activation.context.gc())
                 )
             }
             _ => self.coerce_to_debug_string(activation)?.to_string(),

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -443,7 +443,7 @@ pub fn verify_method<'gc>(
                     make_error_1014(
                         activation,
                         Error1014Type::VerifyError,
-                        pooled_type_name.to_qualified_name(activation.context.gc()),
+                        pooled_type_name.to_qualified_name(activation.gc()),
                     )
                 })?;
 

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -443,7 +443,7 @@ pub fn verify_method<'gc>(
                     make_error_1014(
                         activation,
                         Error1014Type::VerifyError,
-                        pooled_type_name.to_qualified_name(activation.context.gc_context),
+                        pooled_type_name.to_qualified_name(activation.context.gc()),
                     )
                 })?;
 

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -164,7 +164,7 @@ impl<'gc> VTable<'gc> {
         // Calling coerce modified `PropertyClass` to cache the class lookup,
         // so store the new value back in the vtable.
         if changed {
-            self.0.write(activation.context.gc_context).slot_classes[slot_id as usize] = slot_class;
+            self.0.write(activation.context.gc()).slot_classes[slot_id as usize] = slot_class;
         }
         Ok(value)
     }

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -164,7 +164,7 @@ impl<'gc> VTable<'gc> {
         // Calling coerce modified `PropertyClass` to cache the class lookup,
         // so store the new value back in the vtable.
         if changed {
-            self.0.write(activation.context.gc()).slot_classes[slot_id as usize] = slot_class;
+            self.0.write(activation.gc()).slot_classes[slot_id as usize] = slot_class;
         }
         Ok(value)
     }

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -492,7 +492,7 @@ mod wrapper {
             context: &mut RenderContext<'_, 'gc>,
             pixel_snapping: PixelSnapping,
         ) {
-            let mut inner_bitmap_data = self.0.write(context.gc_context);
+            let mut inner_bitmap_data = self.0.write(context.gc());
             if inner_bitmap_data.disposed() {
                 return;
             }

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -1659,10 +1659,10 @@ pub fn set_vector<'gc>(
     let region = PixelRegion::for_region(x_min, y_min, width as u32, height as u32);
 
     let bitmap_data = target.sync(activation.context.renderer);
-    let mut bitmap_data = bitmap_data.write(activation.context.gc());
+    let mut bitmap_data = bitmap_data.write(activation.gc());
     let transparency = bitmap_data.transparency();
     let mut iter = vector.iter();
-    bitmap_data.set_cpu_dirty(activation.context.gc(), region);
+    bitmap_data.set_cpu_dirty(activation.gc(), region);
     for y in region.y_min..region.y_max {
         for x in region.x_min..region.x_max {
             let color = iter

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -380,7 +380,7 @@ impl<'gc> UpdateContext<'gc> {
         activation
             .context
             .stage
-            .set_loader_info(activation.context.gc(), stage_loader_info);
+            .set_loader_info(activation.gc(), stage_loader_info);
 
         drop(activation);
 
@@ -413,9 +413,9 @@ impl<'gc> UpdateContext<'gc> {
             .system
             .get_version_string(activation.context.avm1);
         object.define_value(
-            activation.context.gc(),
+            activation.gc(),
             "$version",
-            AvmString::new_utf8(activation.context.gc(), version_string).into(),
+            AvmString::new_utf8(activation.gc(), version_string).into(),
             Attribute::empty(),
         );
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -58,7 +58,7 @@ use web_time::Instant;
 pub struct UpdateContext<'gc> {
     /// The mutation context to allocate and mutate `Gc` pointers.
     ///
-    /// NOTE: This is redundant with `strings.gc_context`, but is used by
+    /// NOTE: This is redundant with `strings.gc()`, but is used by
     /// too much code to remove.
     pub gc_context: &'gc Mutation<'gc>,
 
@@ -347,11 +347,11 @@ impl<'gc> UpdateContext<'gc> {
         }
 
         self.stage.set_movie_size(
-            self.gc_context,
+            self.gc(),
             self.swf.width().to_pixels() as u32,
             self.swf.height().to_pixels() as u32,
         );
-        self.stage.set_movie(self.gc_context, self.swf.clone());
+        self.stage.set_movie(self.gc(), self.swf.clone());
 
         let stage_domain = self.avm2.stage_domain();
         let mut activation = Avm2Activation::from_domain(self, stage_domain);
@@ -380,18 +380,18 @@ impl<'gc> UpdateContext<'gc> {
         activation
             .context
             .stage
-            .set_loader_info(activation.context.gc_context, stage_loader_info);
+            .set_loader_info(activation.context.gc(), stage_loader_info);
 
         drop(activation);
 
-        root.set_depth(self.gc_context, 0);
+        root.set_depth(self.gc(), 0);
         let flashvars = if !self.swf.parameters().is_empty() {
-            let object = ScriptObject::new(self.gc_context, None);
+            let object = ScriptObject::new(self.gc(), None);
             for (key, value) in self.swf.parameters().iter() {
                 object.define_value(
-                    self.gc_context,
-                    AvmString::new_utf8(self.gc_context, key),
-                    AvmString::new_utf8(self.gc_context, value).into(),
+                    self.gc(),
+                    AvmString::new_utf8(self.gc(), key),
+                    AvmString::new_utf8(self.gc(), value).into(),
                     Attribute::empty(),
                 );
             }
@@ -413,9 +413,9 @@ impl<'gc> UpdateContext<'gc> {
             .system
             .get_version_string(activation.context.avm1);
         object.define_value(
-            activation.context.gc_context,
+            activation.context.gc(),
             "$version",
-            AvmString::new_utf8(activation.context.gc_context, version_string).into(),
+            AvmString::new_utf8(activation.context.gc(), version_string).into(),
             Attribute::empty(),
         );
 
@@ -523,7 +523,7 @@ impl Default for ActionQueue<'_> {
 /// `Player` creates this when it renders a frame and passes it down to display objects.
 ///
 /// As a convenience, this type can be deref-coerced to `Mutation<'gc>`, but note that explicitly
-/// writing `context.gc_context` can be sometimes necessary to satisfy the borrow checker.
+/// writing `context.gc()` can be sometimes necessary to satisfy the borrow checker.
 pub struct RenderContext<'a, 'gc> {
     /// The renderer, used by the display objects to register themselves.
     pub renderer: &'a mut dyn RenderBackend,

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -48,7 +48,7 @@ impl Avm2ObjectWindow {
         let mut keep_open = true;
         let domain = context.avm2.stage_domain();
         let mut activation = Activation::from_domain(context, domain);
-        Window::new(object_name(activation.context.gc_context, object))
+        Window::new(object_name(activation.context.gc(), object))
             .id(Id::new(object.as_ptr()))
             .open(&mut keep_open)
             .scroll([true, true])
@@ -270,7 +270,7 @@ impl Avm2ObjectWindow {
                         ui.text_edit_singleline(
                             &mut interface
                                 .name()
-                                .to_qualified_name_err_message(activation.context.gc_context)
+                                .to_qualified_name_err_message(activation.context.gc())
                                 .to_string()
                                 .as_str(),
                         );
@@ -424,7 +424,7 @@ impl ValueWidget {
             Value::String(value) => ValueWidget::String(value.to_string()),
             Value::Object(value) => ValueWidget::Object(
                 AVM2ObjectHandle::new(context, value),
-                object_name(context.gc_context, value),
+                object_name(context.gc(), value),
             ),
         }
     }

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -48,7 +48,7 @@ impl Avm2ObjectWindow {
         let mut keep_open = true;
         let domain = context.avm2.stage_domain();
         let mut activation = Activation::from_domain(context, domain);
-        Window::new(object_name(activation.context.gc(), object))
+        Window::new(object_name(activation.gc(), object))
             .id(Id::new(object.as_ptr()))
             .open(&mut keep_open)
             .scroll([true, true])
@@ -270,7 +270,7 @@ impl Avm2ObjectWindow {
                         ui.text_edit_singleline(
                             &mut interface
                                 .name()
-                                .to_qualified_name_err_message(activation.context.gc())
+                                .to_qualified_name_err_message(activation.gc())
                                 .to_string()
                                 .as_str(),
                         );

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -205,7 +205,7 @@ impl DisplayObjectWindow {
                     let mut enabled = object.mouse_enabled();
                     Checkbox::new(&mut enabled, "Enabled").ui(ui);
                     if enabled != object.mouse_enabled() {
-                        object.set_mouse_enabled(context.gc_context, enabled);
+                        object.set_mouse_enabled(context.gc(), enabled);
                     }
                 });
                 ui.end_row();
@@ -215,7 +215,7 @@ impl DisplayObjectWindow {
                     let mut enabled = object.double_click_enabled();
                     Checkbox::new(&mut enabled, "Enabled").ui(ui);
                     if enabled != object.double_click_enabled() {
-                        object.set_double_click_enabled(context.gc_context, enabled);
+                        object.set_double_click_enabled(context.gc(), enabled);
                     }
                 });
                 ui.end_row();
@@ -986,13 +986,13 @@ impl DisplayObjectWindow {
                         let mut enabled = object.is_bitmap_cached_preference();
                         Checkbox::new(&mut enabled, "Enabled").ui(ui);
                         if enabled != object.is_bitmap_cached_preference() {
-                            object.set_bitmap_cached_preference(context.gc_context, enabled);
+                            object.set_bitmap_cached_preference(context.gc(), enabled);
                         }
                     } else {
                         ui.label("Forced due to filters");
                     }
                     if ui.button("Invalidate").clicked() {
-                        object.invalidate_cached_bitmap(context.gc_context);
+                        object.invalidate_cached_bitmap(context.gc());
                     }
                 });
                 ui.end_row();
@@ -1025,7 +1025,7 @@ impl DisplayObjectWindow {
                     });
                 ui.end_row();
                 if new_blend != old_blend {
-                    object.set_blend_mode(context.gc_context, new_blend);
+                    object.set_blend_mode(context.gc(), new_blend);
                 }
 
                 let color_transform = *object.base().color_transform();
@@ -1039,7 +1039,7 @@ impl DisplayObjectWindow {
                         let mut enabled = obj.raw_container().mouse_children();
                         Checkbox::new(&mut enabled, "Enabled").ui(ui);
                         if enabled != obj.raw_container().mouse_children() {
-                            obj.raw_container_mut(context.gc_context)
+                            obj.raw_container_mut(context.gc())
                                 .set_mouse_children(enabled);
                         }
                     });

--- a/core/src/debug_ui/domain.rs
+++ b/core/src/debug_ui/domain.rs
@@ -57,7 +57,7 @@ impl DomainListWindow {
                 classes.sort_by_key(|(name, _, _)| *name);
 
                 for (_, _, class) in classes {
-                    let class_name = class.name().to_qualified_name(context.gc_context);
+                    let class_name = class.name().to_qualified_name(context.gc());
                     if !class_name.to_string().to_ascii_lowercase().contains(search) {
                         continue;
                     }
@@ -78,7 +78,7 @@ impl DomainListWindow {
                 }
                 drop(class_props);
 
-                for child_domain in domain.children(context.gc_context) {
+                for child_domain in domain.children(context.gc()) {
                     self.show_domain(ui, context, child_domain, messages, search);
                 }
             });

--- a/core/src/debug_ui/handle.rs
+++ b/core/src/debug_ui/handle.rs
@@ -20,7 +20,7 @@ impl DisplayObjectHandle {
     ) -> Self {
         let object = object.into();
         Self {
-            root: context.dynamic_root.stash(context.gc_context, object),
+            root: context.dynamic_root.stash(context.gc(), object),
             ptr: object.as_ptr(),
         }
     }
@@ -66,7 +66,7 @@ pub struct AVM1ObjectHandle {
 impl AVM1ObjectHandle {
     pub fn new<'gc>(context: &mut UpdateContext<'gc>, object: crate::avm1::Object<'gc>) -> Self {
         Self {
-            root: context.dynamic_root.stash(context.gc_context, object),
+            root: context.dynamic_root.stash(context.gc(), object),
             ptr: object.as_ptr(),
         }
     }
@@ -106,7 +106,7 @@ pub struct AVM2ObjectHandle {
 impl AVM2ObjectHandle {
     pub fn new<'gc>(context: &mut UpdateContext<'gc>, object: crate::avm2::Object<'gc>) -> Self {
         Self {
-            root: context.dynamic_root.stash(context.gc_context, object),
+            root: context.dynamic_root.stash(context.gc(), object),
             ptr: object.as_ptr(),
         }
     }
@@ -148,7 +148,7 @@ pub struct DomainHandle {
 impl DomainHandle {
     pub fn new<'gc>(context: &mut UpdateContext<'gc>, domain: crate::avm2::Domain<'gc>) -> Self {
         Self {
-            root: context.dynamic_root.stash(context.gc_context, domain),
+            root: context.dynamic_root.stash(context.gc(), domain),
             ptr: domain.as_ptr(),
         }
     }

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -277,9 +277,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         self.set_default_instance_name(context);
 
         if !self.movie().is_action_script_3() {
-            context
-                .avm1
-                .add_to_exec_list(context.gc_context, (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), (*self).into());
         }
 
         if self.0.object.get().is_none() {

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -337,7 +337,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
                     .avm2_bitmapdata_class()
                     .unwrap_or_else(|| activation.context.avm2.classes().bitmapdata);
 
-                let mc = activation.context.gc();
+                let mc = activation.gc();
 
                 let bitmap = Avm2StageObject::for_display_object_childless(
                     &mut activation,

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -243,11 +243,11 @@ impl<'gc> Bitmap<'gc> {
         bitmap_data: BitmapDataWrapper<'gc>,
     ) {
         let weak_self = DisplayObjectWeak::Bitmap(self.downgrade());
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
 
         write
             .bitmap_data
-            .remove_display_object(context.gc_context, weak_self);
+            .remove_display_object(context.gc(), weak_self);
 
         // Refresh our cached values, even if we're writing the same BitmapData
         // that we currently have stored. This will update them to '0' if the
@@ -256,7 +256,7 @@ impl<'gc> Bitmap<'gc> {
         write.height = bitmap_data.height();
         write.bitmap_data = bitmap_data;
 
-        bitmap_data.add_display_object(context.gc_context, weak_self);
+        bitmap_data.add_display_object(context.gc(), weak_self);
     }
 
     pub fn avm2_bitmapdata_class(self) -> Option<Avm2ClassObject<'gc>> {
@@ -337,7 +337,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
                     .avm2_bitmapdata_class()
                     .unwrap_or_else(|| activation.context.avm2.classes().bitmapdata);
 
-                let mc = activation.context.gc_context;
+                let mc = activation.context.gc();
 
                 let bitmap = Avm2StageObject::for_display_object_childless(
                     &mut activation,
@@ -365,9 +365,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
 
             self.on_construction_complete(context);
         } else {
-            context
-                .avm1
-                .add_to_exec_list(context.gc_context, (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), (*self).into());
 
             if run_frame {
                 self.run_frame_avm1(context);
@@ -396,7 +394,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
     }
 
     fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
-        self.0.write(context.gc_context).avm2_object = Some(to);
+        self.0.write(context.gc()).avm2_object = Some(to);
     }
 
     fn as_bitmap(self) -> Option<Bitmap<'gc>> {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -295,12 +295,12 @@ impl<'gc> EditText<'gc> {
         };
 
         let et = EditText(GcCell::new(
-            context.gc_context,
+            context.gc(),
             EditTextData {
                 base: InteractiveObjectBase::default(),
                 text_spans,
                 static_data: Gc::new(
-                    context.gc_context,
+                    context.gc(),
                     EditTextStatic {
                         swf: swf_movie,
                         id: swf_tag.id(),
@@ -366,7 +366,7 @@ impl<'gc> EditText<'gc> {
 
         // Set position.
         {
-            let mut base = text_field.base_mut(context.gc_context);
+            let mut base = text_field.base_mut(context.gc());
             let matrix = base.matrix_mut();
             matrix.tx = Twips::from_pixels(x);
             matrix.ty = Twips::from_pixels(y);
@@ -385,7 +385,7 @@ impl<'gc> EditText<'gc> {
         height: f64,
     ) -> Self {
         let text = Self::new(context, swf_movie, x, y, width, height);
-        text.set_is_tlf(context.gc_context, true);
+        text.set_is_tlf(context.gc(), true);
         text.set_selectable(false, context);
 
         text
@@ -396,7 +396,7 @@ impl<'gc> EditText<'gc> {
     }
 
     pub fn set_text(self, text: &WStr, context: &mut UpdateContext<'gc>) {
-        let mut edit_text = self.0.write(context.gc_context);
+        let mut edit_text = self.0.write(context.gc());
         let default_format = edit_text.text_spans.default_format().clone();
         edit_text.text_spans = FormatSpans::from_text(text.into(), default_format);
         drop(edit_text);
@@ -415,7 +415,7 @@ impl<'gc> EditText<'gc> {
 
     pub fn set_html_text(self, text: &WStr, context: &mut UpdateContext<'gc>) {
         if self.is_html() {
-            let mut write = self.0.write(context.gc_context);
+            let mut write = self.0.write(context.gc());
             let default_format = write.text_spans.default_format().clone();
             write.text_spans = FormatSpans::from_html(
                 text,
@@ -441,10 +441,7 @@ impl<'gc> EditText<'gc> {
     }
 
     pub fn set_new_text_format(self, tf: TextFormat, context: &mut UpdateContext<'gc>) {
-        self.0
-            .write(context.gc_context)
-            .text_spans
-            .set_default_format(tf);
+        self.0.write(context.gc()).text_spans.set_default_format(tf);
     }
 
     pub fn text_format(self, from: usize, to: usize) -> TextFormat {
@@ -461,7 +458,7 @@ impl<'gc> EditText<'gc> {
     ) {
         // TODO: Convert to byte indices
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .text_spans
             .set_text_format(from, to, &tf);
         self.relayout(context);
@@ -477,7 +474,7 @@ impl<'gc> EditText<'gc> {
 
     pub fn set_editable(self, is_editable: bool, context: &mut UpdateContext<'gc>) {
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .flags
             .set(EditTextFlag::READ_ONLY, !is_editable);
     }
@@ -487,7 +484,7 @@ impl<'gc> EditText<'gc> {
     }
 
     pub fn set_mouse_wheel_enabled(self, is_enabled: bool, context: &mut UpdateContext<'gc>) {
-        self.0.write(context.gc_context).mouse_wheel_enabled = is_enabled;
+        self.0.write(context.gc()).mouse_wheel_enabled = is_enabled;
     }
 
     pub fn is_multiline(self) -> bool {
@@ -500,7 +497,7 @@ impl<'gc> EditText<'gc> {
 
     pub fn set_password(self, is_password: bool, context: &mut UpdateContext<'gc>) {
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .flags
             .set(EditTextFlag::PASSWORD, is_password);
         self.relayout(context);
@@ -511,12 +508,12 @@ impl<'gc> EditText<'gc> {
     }
 
     pub fn set_restrict(self, text: Option<&WStr>, context: &mut UpdateContext<'gc>) {
-        self.0.write(context.gc_context).restrict = EditTextRestrict::from(text);
+        self.0.write(context.gc()).restrict = EditTextRestrict::from(text);
     }
 
     pub fn set_multiline(self, is_multiline: bool, context: &mut UpdateContext<'gc>) {
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .flags
             .set(EditTextFlag::MULTILINE, is_multiline);
         self.relayout(context);
@@ -528,7 +525,7 @@ impl<'gc> EditText<'gc> {
 
     pub fn set_selectable(self, is_selectable: bool, context: &mut UpdateContext<'gc>) {
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .flags
             .set(EditTextFlag::NO_SELECT, !is_selectable);
     }
@@ -539,7 +536,7 @@ impl<'gc> EditText<'gc> {
 
     pub fn set_word_wrap(self, is_word_wrap: bool, context: &mut UpdateContext<'gc>) {
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .flags
             .set(EditTextFlag::WORD_WRAP, is_word_wrap);
         self.relayout(context);
@@ -550,7 +547,7 @@ impl<'gc> EditText<'gc> {
     }
 
     pub fn set_autosize(self, asm: AutoSizeMode, context: &mut UpdateContext<'gc>) {
-        self.0.write(context.gc_context).autosize = asm;
+        self.0.write(context.gc()).autosize = asm;
         self.relayout(context);
     }
 
@@ -627,7 +624,7 @@ impl<'gc> EditText<'gc> {
 
     pub fn set_is_device_font(self, context: &mut UpdateContext<'gc>, is_device_font: bool) {
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .flags
             .set(EditTextFlag::USE_OUTLINES, !is_device_font);
         self.relayout(context);
@@ -643,7 +640,7 @@ impl<'gc> EditText<'gc> {
 
     pub fn set_is_html(self, context: &mut UpdateContext<'gc>, is_html: bool) {
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .flags
             .set(EditTextFlag::HTML, is_html);
     }
@@ -702,7 +699,7 @@ impl<'gc> EditText<'gc> {
         context: &mut UpdateContext<'gc>,
     ) {
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .text_spans
             .replace_text(from, to, text);
         self.relayout(context);
@@ -740,11 +737,11 @@ impl<'gc> EditText<'gc> {
         // Clear previous binding.
         if let Some(stage_object) = self
             .0
-            .write(activation.context.gc_context)
+            .write(activation.context.gc())
             .bound_stage_object
             .take()
         {
-            stage_object.clear_text_field_binding(activation.context.gc_context, self);
+            stage_object.clear_text_field_binding(activation.context.gc(), self);
         } else {
             activation
                 .context
@@ -762,7 +759,7 @@ impl<'gc> EditText<'gc> {
             .unwrap_or_default();
         self.set_text(&text, activation.context);
 
-        self.0.write(activation.context.gc_context).variable = variable;
+        self.0.write(activation.context.gc()).variable = variable;
         self.try_bind_text_field_variable(activation, true);
     }
 
@@ -773,7 +770,7 @@ impl<'gc> EditText<'gc> {
     /// have already been calculated and applied to HTML trees lowered into the
     /// text-span representation.
     pub fn relayout(self, context: &mut UpdateContext<'gc>) {
-        let mut edit_text = self.0.write(context.gc_context);
+        let mut edit_text = self.0.write(context.gc());
         let autosize = edit_text.autosize;
         let is_word_wrap = edit_text.flags.contains(EditTextFlag::WORD_WRAP);
         let movie = edit_text.static_data.swf.clone();
@@ -848,7 +845,7 @@ impl<'gc> EditText<'gc> {
             edit_text.bounds.set_height(height);
         }
         drop(edit_text);
-        self.invalidate_cached_bitmap(context.gc_context);
+        self.invalidate_cached_bitmap(context.gc());
     }
 
     /// Measure the width and height of the `EditText`'s current text load.
@@ -1252,7 +1249,7 @@ impl<'gc> EditText<'gc> {
                     if let Ok(Some((object, property))) =
                         activation.resolve_variable_path(parent, &variable_path)
                     {
-                        let property = AvmString::new(activation.context.gc_context, property);
+                        let property = AvmString::new(activation.context.gc(), property);
 
                         // If this text field was just created, we immediately propagate the text to the variable (or vice versa).
                         if set_initial_value {
@@ -1270,8 +1267,7 @@ impl<'gc> EditText<'gc> {
                                 if !text.is_empty() {
                                     let _ = object.set(
                                         property,
-                                        AvmString::new(activation.context.gc_context, self.text())
-                                            .into(),
+                                        AvmString::new(activation.context.gc(), self.text()).into(),
                                         activation,
                                     );
                                 }
@@ -1279,11 +1275,10 @@ impl<'gc> EditText<'gc> {
                         }
 
                         if let Some(stage_object) = object.as_stage_object() {
-                            self.0
-                                .write(activation.context.gc_context)
-                                .bound_stage_object = Some(stage_object);
+                            self.0.write(activation.context.gc()).bound_stage_object =
+                                Some(stage_object);
                             stage_object.register_text_field_binding(
-                                activation.context.gc_context,
+                                activation.context.gc(),
                                 self,
                                 property,
                             );
@@ -1303,7 +1298,7 @@ impl<'gc> EditText<'gc> {
     /// Does not change the unbound text field list.
     /// Caller is responsible for adding this text field to the unbound list, if necessary.
     pub fn clear_bound_stage_object(self, context: &mut UpdateContext<'gc>) {
-        self.0.write(context.gc_context).bound_stage_object = None;
+        self.0.write(context.gc()).bound_stage_object = None;
     }
 
     /// Propagates a text change to the bound display object.
@@ -1315,8 +1310,7 @@ impl<'gc> EditText<'gc> {
             .flags
             .contains(EditTextFlag::FIRING_VARIABLE_BINDING)
         {
-            self.0.write(activation.context.gc_context).flags |=
-                EditTextFlag::FIRING_VARIABLE_BINDING;
+            self.0.write(activation.context.gc()).flags |= EditTextFlag::FIRING_VARIABLE_BINDING;
             if let Some(variable) = self.variable() {
                 // Avoid double-borrows by copying the string.
                 // TODO: Can we avoid this somehow? Maybe when we have a better string type.
@@ -1333,19 +1327,17 @@ impl<'gc> EditText<'gc> {
                         self.avm1_parent().unwrap(),
                         self.movie().version(),
                         |activation| {
-                            let property = AvmString::new(activation.context.gc_context, property);
+                            let property = AvmString::new(activation.context.gc(), property);
                             let _ = object.set(
                                 property,
-                                AvmString::new(activation.context.gc_context, self.html_text())
-                                    .into(),
+                                AvmString::new(activation.context.gc(), self.html_text()).into(),
                                 activation,
                             );
                         },
                     );
                 }
             }
-            self.0.write(activation.context.gc_context).flags -=
-                EditTextFlag::FIRING_VARIABLE_BINDING;
+            self.0.write(activation.context.gc()).flags -= EditTextFlag::FIRING_VARIABLE_BINDING;
         }
     }
 
@@ -1410,7 +1402,7 @@ impl<'gc> EditText<'gc> {
     }
 
     pub fn set_hscroll(self, hscroll: f64, context: &mut UpdateContext<'gc>) {
-        self.0.write(context.gc_context).hscroll = hscroll;
+        self.0.write(context.gc()).hscroll = hscroll;
         self.invalidate_cached_bitmap(context.gc());
     }
 
@@ -1437,7 +1429,7 @@ impl<'gc> EditText<'gc> {
     }
 
     pub fn set_max_chars(self, value: i32, context: &mut UpdateContext<'gc>) {
-        self.0.write(context.gc_context).max_chars = value;
+        self.0.write(context.gc()).max_chars = value;
     }
 
     pub fn screen_position_to_index(self, position: Point<Twips>) -> Option<usize> {
@@ -1579,10 +1571,7 @@ impl<'gc> EditText<'gc> {
                 } else {
                     selection.start()
                 };
-                self.set_selection(
-                    Some(TextSelection::for_position(new_pos)),
-                    context.gc_context,
-                );
+                self.set_selection(Some(TextSelection::for_position(new_pos)), context.gc());
             }
             TextControlCode::MoveRight
             | TextControlCode::MoveRightWord
@@ -1593,10 +1582,7 @@ impl<'gc> EditText<'gc> {
                 } else {
                     selection.end()
                 };
-                self.set_selection(
-                    Some(TextSelection::for_position(new_pos)),
-                    context.gc_context,
-                );
+                self.set_selection(Some(TextSelection::for_position(new_pos)), context.gc());
             }
             TextControlCode::SelectLeft
             | TextControlCode::SelectLeftWord
@@ -1606,7 +1592,7 @@ impl<'gc> EditText<'gc> {
                     let new_pos = self.find_new_position(control_code, selection.to);
                     self.set_selection(
                         Some(TextSelection::for_range(selection.from, new_pos)),
-                        context.gc_context,
+                        context.gc(),
                     );
                 }
             }
@@ -1618,14 +1604,14 @@ impl<'gc> EditText<'gc> {
                     let new_pos = self.find_new_position(control_code, selection.to);
                     self.set_selection(
                         Some(TextSelection::for_range(selection.from, new_pos)),
-                        context.gc_context,
+                        context.gc(),
                     )
                 }
             }
             TextControlCode::SelectAll => {
                 self.set_selection(
                     Some(TextSelection::for_range(0, self.text().len())),
-                    context.gc_context,
+                    context.gc(),
                 );
             }
             TextControlCode::Copy => {
@@ -1656,12 +1642,12 @@ impl<'gc> EditText<'gc> {
                     if is_selectable {
                         self.set_selection(
                             Some(TextSelection::for_position(new_pos)),
-                            context.gc_context,
+                            context.gc(),
                         );
                     } else {
                         self.set_selection(
                             Some(TextSelection::for_position(self.text().len())),
-                            context.gc_context,
+                            context.gc(),
                         );
                     }
                     changed = true;
@@ -1675,12 +1661,12 @@ impl<'gc> EditText<'gc> {
                 if is_selectable {
                     self.set_selection(
                         Some(TextSelection::for_position(selection.start())),
-                        context.gc_context,
+                        context.gc(),
                     );
                 } else {
                     self.set_selection(
                         Some(TextSelection::for_position(self.text().len())),
-                        context.gc_context,
+                        context.gc(),
                     );
                 }
                 changed = true;
@@ -1695,7 +1681,7 @@ impl<'gc> EditText<'gc> {
                 self.replace_text(selection.start(), selection.end(), WStr::empty(), context);
                 self.set_selection(
                     Some(TextSelection::for_position(selection.start())),
-                    context.gc_context,
+                    context.gc(),
                 );
                 changed = true;
             }
@@ -1705,10 +1691,7 @@ impl<'gc> EditText<'gc> {
                     // Delete previous character(s)
                     let start = self.find_new_position(control_code, selection.start());
                     self.replace_text(start, selection.start(), WStr::empty(), context);
-                    self.set_selection(
-                        Some(TextSelection::for_position(start)),
-                        context.gc_context,
-                    );
+                    self.set_selection(Some(TextSelection::for_position(start)), context.gc());
                     changed = true;
                 }
             }
@@ -1719,7 +1702,7 @@ impl<'gc> EditText<'gc> {
                     let end = self.find_new_position(control_code, selection.start());
                     self.replace_text(selection.start(), end, WStr::empty(), context);
                     // No need to change selection, reset it to prevent caret from blinking
-                    self.reset_selection_blinking(context.gc_context);
+                    self.reset_selection_blinking(context.gc());
                     changed = true;
                 }
             }
@@ -1866,7 +1849,7 @@ impl<'gc> EditText<'gc> {
         };
 
         if let Avm2Value::Object(target) = self.object2() {
-            let character_string = AvmString::new_utf8(context.gc_context, character.to_string());
+            let character_string = AvmString::new_utf8(context.gc(), character.to_string());
 
             let mut activation = Avm2Activation::from_nothing(context);
             let text_evt = Avm2EventObject::text_event(
@@ -1890,10 +1873,7 @@ impl<'gc> EditText<'gc> {
             context,
         );
         let new_pos = selection.start() + character.len_utf8();
-        self.set_selection(
-            Some(TextSelection::for_position(new_pos)),
-            context.gc_context,
-        );
+        self.set_selection(Some(TextSelection::for_position(new_pos)), context.gc());
 
         let mut activation = Avm1Activation::from_nothing(
             context,
@@ -1907,7 +1887,7 @@ impl<'gc> EditText<'gc> {
     fn initialize_as_broadcaster(&self, activation: &mut Avm1Activation<'_, 'gc>) {
         if let Avm1Value::Object(object) = self.object() {
             activation.context.avm1.broadcaster_functions().initialize(
-                activation.context.gc_context,
+                activation.context.gc(),
                 object,
                 activation.context.avm1.prototypes().array,
             );
@@ -1958,10 +1938,10 @@ impl<'gc> EditText<'gc> {
 
     /// Construct the text field's AVM1 representation.
     fn construct_as_avm1_object(&self, context: &mut UpdateContext<'gc>, run_frame: bool) {
-        let mut text = self.0.write(context.gc_context);
+        let mut text = self.0.write(context.gc());
         if text.object.is_none() {
             let object: Avm1Object<'gc> = Avm1StageObject::for_display_object(
-                context.gc_context,
+                context.gc(),
                 (*self).into(),
                 context.avm1.prototypes().text_field,
             )
@@ -2190,12 +2170,12 @@ impl<'gc> EditText<'gc> {
         let this = parent.object().coerce_to_object(&mut activation);
 
         if let Some((name, args)) = address.split_once(b',') {
-            let name = AvmString::new(activation.context.gc_context, name);
-            let args = AvmString::new(activation.context.gc_context, args);
+            let name = AvmString::new(activation.context.gc(), name);
+            let args = AvmString::new(activation.context.gc(), args);
             let function = activation.get_variable(name)?;
             function.call_with_default_this(this, name, &mut activation, &[args.into()])?;
         } else {
-            let name = AvmString::new(activation.context.gc_context, address);
+            let name = AvmString::new(activation.context.gc(), address);
             let function = activation.get_variable(name)?;
             function.call_with_default_this(this, name, &mut activation, &[])?;
         }
@@ -2210,7 +2190,7 @@ impl<'gc> EditText<'gc> {
         } else if let Some(address) = url.strip_prefix(WStr::from_units(b"event:")) {
             if let Avm2Value::Object(object) = self.object2() {
                 let mut activation = Avm2Activation::from_nothing(context);
-                let text = AvmString::new(activation.context.gc_context, address);
+                let text = AvmString::new(activation.context.gc(), address);
                 let event = Avm2EventObject::text_event(&mut activation, "link", text, true, false);
 
                 Avm2::dispatch_event(activation.context, event, object);
@@ -2339,9 +2319,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.set_default_instance_name(context);
 
         if !self.movie().is_action_script_3() {
-            context
-                .avm1
-                .add_to_exec_list(context.gc_context, (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), (*self).into());
             self.construct_as_avm1_object(context, run_frame);
         }
     }
@@ -2365,7 +2343,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
-        self.0.write(context.gc_context).object = Some(to.into());
+        self.0.write(context.gc()).object = Some(to.into());
     }
 
     fn self_bounds(&self) -> Rectangle<Twips> {
@@ -2409,7 +2387,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     fn set_width(&self, context: &mut UpdateContext<'gc>, value: f64) {
-        let mut edit_text = self.0.write(context.gc_context);
+        let mut edit_text = self.0.write(context.gc());
         edit_text.requested_width = Twips::from_pixels(value);
         edit_text.base.base.set_transformed_by_script(true);
         drop(edit_text);
@@ -2424,7 +2402,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     fn set_height(&self, context: &mut UpdateContext<'gc>, value: f64) {
-        let mut edit_text = self.0.write(context.gc_context);
+        let mut edit_text = self.0.write(context.gc());
         edit_text.requested_height = Twips::from_pixels(value);
         edit_text.base.base.set_transformed_by_script(true);
         drop(edit_text);
@@ -2520,14 +2498,14 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.drop_focus(context);
 
         if let Some(node) = self.maskee() {
-            node.set_masker(context.gc_context, None, true);
+            node.set_masker(context.gc(), None, true);
         } else if let Some(node) = self.masker() {
-            node.set_maskee(context.gc_context, None, true);
+            node.set_maskee(context.gc(), None, true);
         }
 
         // Unbind any display objects bound to this text.
-        if let Some(stage_object) = self.0.write(context.gc_context).bound_stage_object.take() {
-            stage_object.clear_text_field_binding(context.gc_context, *self);
+        if let Some(stage_object) = self.0.write(context.gc()).bound_stage_object.take() {
+            stage_object.clear_text_field_binding(context.gc(), *self);
         }
 
         // Unregister any text fields that may be bound to *this* text field.
@@ -2542,7 +2520,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
                 .retain(|&text_field| !DisplayObject::ptr_eq(text_field.into(), (*self).into()));
         }
 
-        self.set_avm1_removed(context.gc_context, true);
+        self.set_avm1_removed(context.gc(), true);
     }
 }
 
@@ -2842,7 +2820,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
     ) {
         let is_avm1 = !self.movie().is_action_script_3();
         if !focused && is_avm1 {
-            self.set_selection(None, context.gc_context);
+            self.set_selection(None, context.gc());
         }
     }
 

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -161,9 +161,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
                 (*self).into(),
                 class_object,
             ) {
-                Ok(object) => {
-                    self.0.write(activation.context.gc()).avm2_object = Some(object.into())
-                }
+                Ok(object) => self.0.write(activation.gc()).avm2_object = Some(object.into()),
                 Err(e) => {
                     tracing::error!("Got error when constructing AVM2 side of shape: {}", e)
                 }

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -62,10 +62,10 @@ impl<'gc> Graphic<'gc> {
         };
 
         Graphic(GcCell::new(
-            context.gc_context,
+            context.gc(),
             GraphicData {
                 base: Default::default(),
-                static_data: gc_arena::Gc::new(context.gc_context, static_data),
+                static_data: gc_arena::Gc::new(context.gc(), static_data),
                 class: None,
                 avm2_object: None,
                 drawing: None,
@@ -95,10 +95,10 @@ impl<'gc> Graphic<'gc> {
         };
 
         Graphic(GcCell::new(
-            context.gc_context,
+            context.gc(),
             GraphicData {
                 base: Default::default(),
-                static_data: gc_arena::Gc::new(context.gc_context, static_data),
+                static_data: gc_arena::Gc::new(context.gc(), static_data),
                 class: None,
                 avm2_object: None,
                 drawing: None,
@@ -162,7 +162,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
                 class_object,
             ) {
                 Ok(object) => {
-                    self.0.write(activation.context.gc_context).avm2_object = Some(object.into())
+                    self.0.write(activation.context.gc()).avm2_object = Some(object.into())
                 }
                 Err(e) => {
                     tracing::error!("Got error when constructing AVM2 side of shape: {}", e)
@@ -181,11 +181,11 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
             .library_for_movie_mut(self.movie())
             .get_graphic(id)
         {
-            self.0.write(context.gc_context).static_data = new_graphic.0.read().static_data;
+            self.0.write(context.gc()).static_data = new_graphic.0.read().static_data;
         } else {
             tracing::warn!("PlaceObject: expected Graphic at character ID {}", id);
         }
-        self.invalidate_cached_bitmap(context.gc_context);
+        self.invalidate_cached_bitmap(context.gc());
     }
 
     fn run_frame_avm1(&self, _context: &mut UpdateContext) {
@@ -244,9 +244,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         if self.movie().is_action_script_3() {
             self.set_default_instance_name(context);
         } else {
-            context
-                .avm1
-                .add_to_exec_list(context.gc_context, (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), (*self).into());
 
             if run_frame {
                 self.run_frame_avm1(context);
@@ -267,7 +265,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 
     fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
-        self.0.write(context.gc_context).avm2_object = Some(to);
+        self.0.write(context.gc()).avm2_object = Some(to);
     }
 
     fn as_drawing(&self, gc_context: &Mutation<'gc>) -> Option<RefMut<'_, Drawing>> {

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -43,7 +43,7 @@ pub struct LoaderDisplayData<'gc> {
 impl<'gc> LoaderDisplay<'gc> {
     pub fn empty(activation: &mut Activation<'_, 'gc>, movie: Arc<SwfMovie>) -> Self {
         let obj = LoaderDisplay(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             LoaderDisplayData {
                 base: Default::default(),
                 container: ChildContainer::new(movie.clone()),
@@ -52,7 +52,7 @@ impl<'gc> LoaderDisplay<'gc> {
             },
         ));
 
-        obj.set_placed_by_script(activation.context.gc(), true);
+        obj.set_placed_by_script(activation.gc(), true);
         activation.context.avm2.add_orphan_obj(obj.into());
         obj
     }

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -43,7 +43,7 @@ pub struct LoaderDisplayData<'gc> {
 impl<'gc> LoaderDisplay<'gc> {
     pub fn empty(activation: &mut Activation<'_, 'gc>, movie: Arc<SwfMovie>) -> Self {
         let obj = LoaderDisplay(GcCell::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             LoaderDisplayData {
                 base: Default::default(),
                 container: ChildContainer::new(movie.clone()),
@@ -52,7 +52,7 @@ impl<'gc> LoaderDisplay<'gc> {
             },
         ));
 
-        obj.set_placed_by_script(activation.context.gc_context, true);
+        obj.set_placed_by_script(activation.context.gc(), true);
         activation.context.avm2.add_orphan_obj(obj.into());
         obj
     }
@@ -100,7 +100,7 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
     }
 
     fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
-        self.0.write(context.gc_context).avm2_object = Some(to);
+        self.0.write(context.gc()).avm2_object = Some(to);
     }
 
     fn as_container(self) -> Option<DisplayObjectContainer<'gc>> {
@@ -116,14 +116,11 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
         for child in self.iter_render_list() {
             // See MovieClip::enter_frame for an explanation of this.
             if skip_frame {
-                child
-                    .base_mut(context.gc_context)
-                    .set_skip_next_enter_frame(true);
+                child.base_mut(context.gc()).set_skip_next_enter_frame(true);
             }
             child.enter_frame(context);
         }
-        self.base_mut(context.gc_context)
-            .set_skip_next_enter_frame(false);
+        self.base_mut(context.gc()).set_skip_next_enter_frame(false);
     }
 
     fn construct_frame(&self, context: &mut UpdateContext<'gc>) {

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -95,11 +95,11 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
             .library_for_movie_mut(self.movie())
             .get_morph_shape(id)
         {
-            self.0.write(context.gc_context).static_data = new_morph_shape.0.read().static_data;
+            self.0.write(context.gc()).static_data = new_morph_shape.0.read().static_data;
         } else {
             tracing::warn!("PlaceObject: expected morph shape at character ID {}", id);
         }
-        self.invalidate_cached_bitmap(context.gc_context);
+        self.invalidate_cached_bitmap(context.gc());
     }
 
     fn run_frame_avm1(&self, _context: &mut UpdateContext) {
@@ -115,7 +115,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
     }
 
     fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
-        self.0.write(context.gc_context).object = Some(to);
+        self.0.write(context.gc()).object = Some(to);
     }
 
     /// Construct objects placed on this frame.
@@ -128,7 +128,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
                 (*self).into(),
                 class,
             ) {
-                Ok(object) => self.0.write(context.gc_context).object = Some(object.into()),
+                Ok(object) => self.0.write(context.gc()).object = Some(object.into()),
                 Err(e) => tracing::error!("Got {} when constructing AVM2 side of MorphShape", e),
             };
             self.on_construction_complete(context);

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -333,17 +333,17 @@ impl<'gc> MovieClip<'gc> {
         let loader_info = None;
 
         let mc = MovieClip(GcCell::new(
-            context.gc_context,
+            context.gc(),
             MovieClipData {
                 base: Default::default(),
                 static_data: Gc::new(
-                    context.gc_context,
+                    context.gc(),
                     MovieClipStatic::with_data(
                         0,
                         movie.clone().into(),
                         num_frames,
                         loader_info,
-                        context.gc_context,
+                        context.gc(),
                     ),
                 ),
                 tag_stream_pos: 0,
@@ -399,17 +399,17 @@ impl<'gc> MovieClip<'gc> {
         };
 
         let mc = MovieClip(GcCell::new(
-            activation.context.gc_context,
+            activation.context.gc(),
             MovieClipData {
                 base: Default::default(),
                 static_data: Gc::new(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     MovieClipStatic::with_data(
                         0,
                         movie.clone().into(),
                         num_frames,
                         loader_info,
-                        activation.context.gc_context,
+                        activation.context.gc(),
                     ),
                 ),
                 tag_stream_pos: 0,
@@ -448,12 +448,10 @@ impl<'gc> MovieClip<'gc> {
                 .unwrap()
                 .as_loader_info_object()
                 .unwrap();
-            loader_info.set_loader_stream(
-                LoaderStream::Swf(movie, mc.into()),
-                activation.context.gc_context,
-            );
+            loader_info
+                .set_loader_stream(LoaderStream::Swf(movie, mc.into()), activation.context.gc());
         }
-        mc.set_is_root(activation.context.gc_context, true);
+        mc.set_is_root(activation.context.gc(), true);
         mc
     }
 
@@ -472,7 +470,7 @@ impl<'gc> MovieClip<'gc> {
         is_root: bool,
         loader_info: Option<LoaderInfoObject<'gc>>,
     ) {
-        let mut mc = self.0.write(context.gc_context);
+        let mut mc = self.0.write(context.gc());
         let movie = movie.unwrap_or_else(|| Arc::new(SwfMovie::empty(mc.movie().version())));
         let total_frames = movie.num_frames();
         assert_eq!(
@@ -482,13 +480,13 @@ impl<'gc> MovieClip<'gc> {
 
         mc.base.base.reset_for_movie_load();
         mc.static_data = Gc::new(
-            context.gc_context,
+            context.gc(),
             MovieClipStatic::with_data(
                 0,
                 movie.clone().into(),
                 total_frames,
                 loader_info.map(|l| l.into()),
-                context.gc_context,
+                context.gc(),
             ),
         );
         mc.tag_stream_pos = 0;
@@ -571,7 +569,7 @@ impl<'gc> MovieClip<'gc> {
                     if sub_preload_done {
                         static_data
                             .preload_progress
-                            .write(context.gc_context)
+                            .write(context.gc())
                             .cur_preload_symbol = None;
                     }
                 }
@@ -584,7 +582,7 @@ impl<'gc> MovieClip<'gc> {
 
                     static_data
                         .preload_progress
-                        .write(context.gc_context)
+                        .write(context.gc())
                         .cur_preload_symbol = None;
                 }
                 None => {
@@ -595,7 +593,7 @@ impl<'gc> MovieClip<'gc> {
 
                     static_data
                         .preload_progress
-                        .write(context.gc_context)
+                        .write(context.gc())
                         .cur_preload_symbol = None;
                 }
             }
@@ -612,139 +610,100 @@ impl<'gc> MovieClip<'gc> {
             match tag_code {
                 TagCode::CsmTextSettings => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .csm_text_settings(context, reader),
-                TagCode::DefineBits => self
-                    .0
-                    .write(context.gc_context)
-                    .define_bits(context, reader),
+                TagCode::DefineBits => self.0.write(context.gc()).define_bits(context, reader),
                 TagCode::DefineBitsJpeg2 => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_bits_jpeg_2(context, reader),
                 TagCode::DefineBitsJpeg3 => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_bits_jpeg_3_or_4(context, reader, 3),
                 TagCode::DefineBitsJpeg4 => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_bits_jpeg_3_or_4(context, reader, 4),
                 TagCode::DefineBitsLossless => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_bits_lossless(context, reader, 1),
                 TagCode::DefineBitsLossless2 => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_bits_lossless(context, reader, 2),
-                TagCode::DefineButton => self
-                    .0
-                    .write(context.gc_context)
-                    .define_button_1(context, reader),
-                TagCode::DefineButton2 => self
-                    .0
-                    .write(context.gc_context)
-                    .define_button_2(context, reader),
+                TagCode::DefineButton => {
+                    self.0.write(context.gc()).define_button_1(context, reader)
+                }
+                TagCode::DefineButton2 => {
+                    self.0.write(context.gc()).define_button_2(context, reader)
+                }
                 TagCode::DefineButtonCxform => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_button_cxform(context, reader),
                 TagCode::DefineButtonSound => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_button_sound(context, reader),
-                TagCode::DefineEditText => self
-                    .0
-                    .write(context.gc_context)
-                    .define_edit_text(context, reader),
-                TagCode::DefineFont => self
-                    .0
-                    .write(context.gc_context)
-                    .define_font_1(context, reader),
-                TagCode::DefineFont2 => self
-                    .0
-                    .write(context.gc_context)
-                    .define_font_2(context, reader),
-                TagCode::DefineFont3 => self
-                    .0
-                    .write(context.gc_context)
-                    .define_font_3(context, reader),
-                TagCode::DefineFont4 => self
-                    .0
-                    .write(context.gc_context)
-                    .define_font_4(context, reader),
+                TagCode::DefineEditText => {
+                    self.0.write(context.gc()).define_edit_text(context, reader)
+                }
+                TagCode::DefineFont => self.0.write(context.gc()).define_font_1(context, reader),
+                TagCode::DefineFont2 => self.0.write(context.gc()).define_font_2(context, reader),
+                TagCode::DefineFont3 => self.0.write(context.gc()).define_font_3(context, reader),
+                TagCode::DefineFont4 => self.0.write(context.gc()).define_font_4(context, reader),
                 TagCode::DefineMorphShape => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_morph_shape(context, reader, 1),
                 TagCode::DefineMorphShape2 => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_morph_shape(context, reader, 2),
                 TagCode::DefineScalingGrid => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_scaling_grid(context, reader),
-                TagCode::DefineShape => self
-                    .0
-                    .write(context.gc_context)
-                    .define_shape(context, reader, 1),
-                TagCode::DefineShape2 => self
-                    .0
-                    .write(context.gc_context)
-                    .define_shape(context, reader, 2),
-                TagCode::DefineShape3 => self
-                    .0
-                    .write(context.gc_context)
-                    .define_shape(context, reader, 3),
-                TagCode::DefineShape4 => self
-                    .0
-                    .write(context.gc_context)
-                    .define_shape(context, reader, 4),
-                TagCode::DefineSound => self
-                    .0
-                    .write(context.gc_context)
-                    .define_sound(context, reader),
+                TagCode::DefineShape => self.0.write(context.gc()).define_shape(context, reader, 1),
+                TagCode::DefineShape2 => {
+                    self.0.write(context.gc()).define_shape(context, reader, 2)
+                }
+                TagCode::DefineShape3 => {
+                    self.0.write(context.gc()).define_shape(context, reader, 3)
+                }
+                TagCode::DefineShape4 => {
+                    self.0.write(context.gc()).define_shape(context, reader, 4)
+                }
+                TagCode::DefineSound => self.0.write(context.gc()).define_sound(context, reader),
                 TagCode::DefineVideoStream => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_video_stream(context, reader),
                 TagCode::DefineSprite => {
-                    return self.0.write(context.gc_context).define_sprite(
+                    return self.0.write(context.gc()).define_sprite(
                         context,
                         reader,
                         tag_len,
                         chunk_limit,
                     )
                 }
-                TagCode::DefineText => self
-                    .0
-                    .write(context.gc_context)
-                    .define_text(context, reader, 1),
-                TagCode::DefineText2 => self
-                    .0
-                    .write(context.gc_context)
-                    .define_text(context, reader, 2),
+                TagCode::DefineText => self.0.write(context.gc()).define_text(context, reader, 1),
+                TagCode::DefineText2 => self.0.write(context.gc()).define_text(context, reader, 2),
                 TagCode::DoInitAction => self.do_init_action(context, reader, tag_len),
                 TagCode::DefineSceneAndFrameLabelData => {
                     self.scene_and_frame_labels(reader, &mut static_data)
                 }
-                TagCode::ExportAssets => self
-                    .0
-                    .write(context.gc_context)
-                    .export_assets(context, reader),
-                TagCode::FrameLabel => self.0.write(context.gc_context).frame_label(
+                TagCode::ExportAssets => self.0.write(context.gc()).export_assets(context, reader),
+                TagCode::FrameLabel => self.0.write(context.gc()).frame_label(
                     reader,
                     cur_frame,
                     &mut static_data,
                     context,
                 ),
-                TagCode::JpegTables => self
-                    .0
-                    .write(context.gc_context)
-                    .jpeg_tables(context, reader),
-                TagCode::ShowFrame => self.0.write(context.gc_context).show_frame(
+                TagCode::JpegTables => self.0.write(context.gc()).jpeg_tables(context, reader),
+                TagCode::ShowFrame => self.0.write(context.gc()).show_frame(
                     reader,
                     tag_len,
                     &mut cur_frame,
@@ -752,34 +711,34 @@ impl<'gc> MovieClip<'gc> {
                 ),
                 TagCode::ScriptLimits => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .script_limits(reader, context.avm1),
                 TagCode::SoundStreamHead => {
                     self.0
-                        .write(context.gc_context)
+                        .write(context.gc())
                         .sound_stream_head(reader, &mut static_data, 1)
                 }
                 TagCode::SoundStreamHead2 => {
                     self.0
-                        .write(context.gc_context)
+                        .write(context.gc())
                         .sound_stream_head(reader, &mut static_data, 2)
                 }
                 TagCode::VideoFrame => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .preload_video_frame(context, reader),
                 TagCode::DefineBinaryData => self
                     .0
-                    .write(context.gc_context)
+                    .write(context.gc())
                     .define_binary_data(context, reader),
                 TagCode::ImportAssets => {
                     self.0
-                        .write(context.gc_context)
+                        .write(context.gc())
                         .import_assets(context, reader, chunk_limit)
                 }
                 TagCode::ImportAssets2 => {
                     self.0
-                        .write(context.gc_context)
+                        .write(context.gc())
                         .import_assets_2(context, reader, chunk_limit)
                 }
                 TagCode::DoAbc | TagCode::DoAbc2 => self.preload_bytecode_tag(
@@ -815,13 +774,13 @@ impl<'gc> MovieClip<'gc> {
         let is_finished = end_tag_found || result.is_err() || !result.unwrap_or_default();
 
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .import_exports_of_importer(context);
 
         // These variables will be persisted to be picked back up in the next
         // chunk.
         {
-            let mut write = static_data.preload_progress.write(context.gc_context);
+            let mut write = static_data.preload_progress.write(context.gc());
 
             write.next_preload_chunk = if is_finished {
                 // Flag the movie as fully preloaded when we hit the end of the
@@ -843,12 +802,12 @@ impl<'gc> MovieClip<'gc> {
         if is_finished {
             // End-of-clip should be treated as ShowFrame
             self.0
-                .write(context.gc_context)
+                .write(context.gc())
                 .show_frame(&mut reader, 0, &mut cur_frame, &mut start_pos)
                 .unwrap();
         }
 
-        self.0.write(context.gc_context).static_data = Gc::new(context.gc_context, static_data);
+        self.0.write(context.gc()).static_data = Gc::new(context.gc(), static_data);
 
         is_finished
     }
@@ -937,7 +896,7 @@ impl<'gc> MovieClip<'gc> {
         if !do_abc.data.is_empty() {
             let movie = self.movie();
             let domain = context.library.library_for_movie_mut(movie).avm2_domain();
-            let name = AvmString::new(context.gc_context, do_abc.name.decode(reader.encoding()));
+            let name = AvmString::new(context.gc(), do_abc.name.decode(reader.encoding()));
 
             match Avm2::do_abc(
                 context,
@@ -1040,7 +999,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn play(self, context: &mut UpdateContext<'gc>) {
-        self.0.write(context.gc_context).play()
+        self.0.write(context.gc()).play()
     }
 
     pub fn prev_frame(self, context: &mut UpdateContext<'gc>) {
@@ -1054,7 +1013,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn stop(self, context: &mut UpdateContext<'gc>) {
-        self.0.write(context.gc_context).stop(context)
+        self.0.write(context.gc()).stop(context)
     }
 
     /// Does this clip have a unload handler
@@ -1093,7 +1052,7 @@ impl<'gc> MovieClip<'gc> {
             {
                 // AVM2 does not allow a clip to see while it is executing a frame script.
                 // The goto is instead queued and run once the frame script is completed.
-                self.0.write(context.gc_context).queued_goto_frame = Some(frame);
+                self.0.write(context.gc()).queued_goto_frame = Some(frame);
             } else {
                 self.run_goto(context, frame, false);
             }
@@ -1509,7 +1468,7 @@ impl<'gc> MovieClip<'gc> {
         let next_frame = self.determine_next_frame();
         match next_frame {
             NextFrame::Next => {
-                let mut write = self.0.write(context.gc_context);
+                let mut write = self.0.write(context.gc());
                 if (write.current_frame + 1)
                     >= write.static_data.preload_progress.read().cur_preload_frame
                 {
@@ -1604,7 +1563,7 @@ impl<'gc> MovieClip<'gc> {
 
         // It is now safe to update the tag position and frame number.
         // TODO: Determine if explicit gotos override these or not.
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
 
         write.tag_stream_pos = reader.get_ref().as_ptr() as u64 - tag_stream_start;
 
@@ -1645,21 +1604,21 @@ impl<'gc> MovieClip<'gc> {
                 let prev_child = self.replace_at_depth(context, child, depth);
                 {
                     // Set initial properties for child.
-                    child.set_instantiated_by_timeline(context.gc_context, true);
-                    child.set_depth(context.gc_context, depth);
+                    child.set_instantiated_by_timeline(context.gc(), true);
+                    child.set_depth(context.gc(), depth);
                     child.set_parent(context, Some(self.into()));
-                    child.set_place_frame(context.gc_context, self.current_frame());
+                    child.set_place_frame(context.gc(), self.current_frame());
 
                     // Apply PlaceObject parameters.
                     child.apply_place_object(context, place_object);
                     if let Some(name) = &place_object.name {
                         let encoding = swf::SwfStr::encoding_for_version(self.swf_version());
-                        let name = AvmString::new(context.gc_context, name.decode(encoding));
-                        child.set_name(context.gc_context, name);
-                        child.set_has_explicit_name(context.gc_context, true);
+                        let name = AvmString::new(context.gc(), name.decode(encoding));
+                        child.set_name(context.gc(), name);
+                        child.set_has_explicit_name(context.gc(), true);
                     }
                     if let Some(clip_depth) = place_object.clip_depth {
-                        child.set_clip_depth(context.gc_context, clip_depth.into());
+                        child.set_clip_depth(context.gc(), clip_depth.into());
                     }
                     // Clip events only apply to movie clips.
                     if let (Some(clip_actions), Some(clip)) =
@@ -1667,7 +1626,7 @@ impl<'gc> MovieClip<'gc> {
                     {
                         // Convert from `swf::ClipAction` to Ruffle's `ClipEventHandler`.
                         clip.set_clip_event_handlers(
-                            context.gc_context,
+                            context.gc(),
                             clip_actions
                                 .iter()
                                 .cloned()
@@ -1748,7 +1707,7 @@ impl<'gc> MovieClip<'gc> {
         } else {
             // Of course, the target frame desync absolutely will break our
             // other asserts, so fix them up here.
-            let mut write = self.0.write(context.gc_context);
+            let mut write = self.0.write(context.gc());
 
             if let Some((_, end)) = write
                 .tag_frame_boundaries
@@ -1778,8 +1737,7 @@ impl<'gc> MovieClip<'gc> {
         }
 
         let frame_before_rewind = self.current_frame();
-        self.base_mut(context.gc_context)
-            .set_skip_next_enter_frame(false);
+        self.base_mut(context.gc()).set_skip_next_enter_frame(false);
 
         // Flash gotos are tricky:
         // 1) Conceptually, a goto should act like the playhead is advancing forward or
@@ -1798,14 +1756,14 @@ impl<'gc> MovieClip<'gc> {
         // TODO: Move this to UpdateContext to avoid allocations.
         let mut goto_commands: Vec<GotoPlaceObject<'_>> = vec![];
 
-        self.0.write(context.gc_context).stop_audio_stream(context);
+        self.0.write(context.gc()).stop_audio_stream(context);
 
         let is_rewind = if frame <= self.current_frame() {
             // Because we can only step forward, we have to start at frame 1
             // when rewinding. We don't actually remove children yet because
             // otherwise AS3 can observe byproducts of the rewinding process.
-            self.0.write(context.gc_context).tag_stream_pos = 0;
-            self.0.write(context.gc_context).current_frame = 0;
+            self.0.write(context.gc()).tag_stream_pos = 0;
+            self.0.write(context.gc()).current_frame = 0;
 
             true
         } else {
@@ -1817,7 +1775,7 @@ impl<'gc> MovieClip<'gc> {
         // Explicit gotos in the middle of an AS3 loop cancel the loop's queued
         // tags. The rest of the goto machinery can handle the side effects of
         // a half-executed loop.
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
         if write.loop_queued() {
             write.queued_tags = HashMap::new();
         }
@@ -1842,29 +1800,29 @@ impl<'gc> MovieClip<'gc> {
 
         let mut reader = data.read_from(frame_pos);
         while self.current_frame() < clamped_frame && !reader.get_ref().is_empty() {
-            self.0.write(context.gc_context).current_frame += 1;
+            self.0.write(context.gc()).current_frame += 1;
             frame_pos = reader.get_ref().as_ptr() as u64 - tag_stream_start;
 
             let tag_callback = |reader: &mut _, tag_code, _tag_len| {
                 match tag_code {
                     TagCode::PlaceObject => {
                         index += 1;
-                        let mut mc = self.0.write(context.gc_context);
+                        let mut mc = self.0.write(context.gc());
                         mc.goto_place_object(reader, 1, &mut goto_commands, is_rewind, index)
                     }
                     TagCode::PlaceObject2 => {
                         index += 1;
-                        let mut mc = self.0.write(context.gc_context);
+                        let mut mc = self.0.write(context.gc());
                         mc.goto_place_object(reader, 2, &mut goto_commands, is_rewind, index)
                     }
                     TagCode::PlaceObject3 => {
                         index += 1;
-                        let mut mc = self.0.write(context.gc_context);
+                        let mut mc = self.0.write(context.gc());
                         mc.goto_place_object(reader, 3, &mut goto_commands, is_rewind, index)
                     }
                     TagCode::PlaceObject4 => {
                         index += 1;
-                        let mut mc = self.0.write(context.gc_context);
+                        let mut mc = self.0.write(context.gc());
                         mc.goto_place_object(reader, 4, &mut goto_commands, is_rewind, index)
                     }
                     TagCode::RemoveObject => self.goto_remove_object(
@@ -1934,7 +1892,7 @@ impl<'gc> MovieClip<'gc> {
                 //
                 // TODO: We can only queue *new* object placement, existing
                 // objects still get updated too early.
-                let mut write = self.0.write(context.gc_context);
+                let mut write = self.0.write(context.gc());
                 let new_tag = QueuedTag {
                     tag_type: QueuedTagAction::Place(params.version),
                     tag_start: params.tag_start,
@@ -1963,7 +1921,7 @@ impl<'gc> MovieClip<'gc> {
                 (swf::PlaceObjectAction::Replace(id), Some(prev_child), _) => {
                     prev_child.replace_with(context, id);
                     prev_child.apply_place_object(context, &params.place_object);
-                    prev_child.set_place_frame(context.gc_context, params.frame);
+                    prev_child.set_place_frame(context.gc(), params.frame);
                 }
                 (PlaceObjectAction::Place(id), _, _)
                 | (swf::PlaceObjectAction::Replace(id), _, _) => {
@@ -1971,7 +1929,7 @@ impl<'gc> MovieClip<'gc> {
                         clip.instantiate_child(context, id, params.depth(), &params.place_object)
                     {
                         // Set the place frame to the frame where the object *would* have been placed.
-                        child.set_place_frame(context.gc_context, params.frame);
+                        child.set_place_frame(context.gc(), params.frame);
                     }
                 }
                 _ => {
@@ -2002,8 +1960,8 @@ impl<'gc> MovieClip<'gc> {
         // Note that this only happens if the frame exists and is loaded;
         // e.g. gotoAndStop(9999) displays the final frame, but actions don't run!
         if hit_target_frame {
-            self.0.write(context.gc_context).current_frame -= 1;
-            self.0.write(context.gc_context).tag_stream_pos = frame_pos;
+            self.0.write(context.gc()).current_frame -= 1;
+            self.0.write(context.gc()).tag_stream_pos = frame_pos;
             // If we changed frames, then trigger any sounds in our target frame.
             // However, if we executed a 'no-op goto' (start and end frames are the same),
             // then do *not* run sounds. Some SWFS (e.g. 'This is the only level too')
@@ -2015,7 +1973,7 @@ impl<'gc> MovieClip<'gc> {
                 self.movie().is_action_script_3(),
             );
         } else {
-            self.0.write(context.gc_context).current_frame = clamped_frame;
+            self.0.write(context.gc()).current_frame = clamped_frame;
         }
 
         // Finally, run frames for children that are placed on this frame.
@@ -2062,12 +2020,12 @@ impl<'gc> MovieClip<'gc> {
                     .map(|v| v.coerce_to_object(&mut activation))
                 {
                     let object: Avm1Object<'gc> = StageObject::for_display_object(
-                        activation.context.gc_context,
+                        activation.context.gc(),
                         self.into(),
                         prototype,
                     )
                     .into();
-                    self.0.write(activation.context.gc_context).object = Some(object.into());
+                    self.0.write(activation.context.gc()).object = Some(object.into());
 
                     if run_frame {
                         self.run_frame_avm1(activation.context);
@@ -2093,12 +2051,12 @@ impl<'gc> MovieClip<'gc> {
             }
 
             let object: Avm1Object<'gc> = StageObject::for_display_object(
-                context.gc_context,
+                context.gc(),
                 self.into(),
                 context.avm1.prototypes().movie_clip,
             )
             .into();
-            self.0.write(context.gc_context).object = Some(object.into());
+            self.0.write(context.gc()).object = Some(object.into());
 
             if run_frame {
                 self.run_frame_avm1(context);
@@ -2120,12 +2078,7 @@ impl<'gc> MovieClip<'gc> {
 
             let mut events = Vec::new();
 
-            for event_handler in self
-                .0
-                .write(context.gc_context)
-                .clip_event_handlers()
-                .iter()
-            {
+            for event_handler in self.0.write(context.gc()).clip_event_handlers().iter() {
                 if event_handler.events.contains(ClipEventFlag::INITIALIZE) {
                     context.action_queue.queue_action(
                         self.into(),
@@ -2225,7 +2178,7 @@ impl<'gc> MovieClip<'gc> {
                     class_object
                         .inner_class_definition()
                         .name()
-                        .to_qualified_name(context.gc_context)
+                        .to_qualified_name(context.gc())
                 );
             }
         }
@@ -2237,7 +2190,7 @@ impl<'gc> MovieClip<'gc> {
         callable: Option<Avm2Object<'gc>>,
         context: &mut UpdateContext<'gc>,
     ) {
-        let frame_scripts = &mut self.0.write(context.gc_context).frame_scripts;
+        let frame_scripts = &mut self.0.write(context.gc()).frame_scripts;
 
         let index = frame_id as usize;
         if let Some(callable) = callable {
@@ -2281,7 +2234,7 @@ impl<'gc> MovieClip<'gc> {
             //
             // We also have to reset the frame number as this emits AS3 events.
             let to_frame = self.current_frame();
-            self.0.write(context.gc_context).current_frame = from_frame;
+            self.0.write(context.gc()).current_frame = from_frame;
 
             let child = self.child_by_depth(depth);
             if let Some(child) = child {
@@ -2294,7 +2247,7 @@ impl<'gc> MovieClip<'gc> {
                 removed_frame_scripts.push(child);
             }
 
-            self.0.write(context.gc_context).current_frame = to_frame;
+            self.0.write(context.gc()).current_frame = to_frame;
         }
         Ok(())
     }
@@ -2312,7 +2265,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn set_avm2_enabled(self, context: &mut UpdateContext<'gc>, enabled: bool) {
-        self.0.write(context.gc_context).avm2_enabled = enabled;
+        self.0.write(context.gc()).avm2_enabled = enabled;
     }
 
     fn use_hand_cursor(self, context: &mut UpdateContext<'gc>) -> bool {
@@ -2328,7 +2281,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn set_avm2_use_hand_cursor(self, context: &mut UpdateContext<'gc>, use_hand_cursor: bool) {
-        self.0.write(context.gc_context).avm2_use_hand_cursor = use_hand_cursor;
+        self.0.write(context.gc()).avm2_use_hand_cursor = use_hand_cursor;
     }
 
     pub fn hit_area(self) -> Option<DisplayObject<'gc>> {
@@ -2340,7 +2293,7 @@ impl<'gc> MovieClip<'gc> {
         context: &mut UpdateContext<'gc>,
         hit_area: Option<DisplayObject<'gc>>,
     ) {
-        self.0.write(context.gc_context).hit_area = hit_area;
+        self.0.write(context.gc()).hit_area = hit_area;
     }
 
     pub fn tag_stream_len(&self) -> usize {
@@ -2352,7 +2305,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn set_forced_button_mode(self, context: &mut UpdateContext<'gc>, button_mode: bool) {
-        self.0.write(context.gc_context).button_mode = button_mode;
+        self.0.write(context.gc()).button_mode = button_mode;
     }
 
     pub fn drawing_mut(&self, gc_context: &Mutation<'gc>) -> RefMut<'_, Drawing> {
@@ -2400,7 +2353,7 @@ impl<'gc> MovieClip<'gc> {
 
     /// Remove all `PlaceObject` tags off the internal tag queue.
     fn unqueue_adds(&self, context: &mut UpdateContext<'gc>) -> Vec<(Depth, QueuedTag)> {
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
         let mut unqueued: Vec<_> = write
             .queued_tags
             .iter_mut()
@@ -2420,7 +2373,7 @@ impl<'gc> MovieClip<'gc> {
 
     /// Remove all `RemoveObject` tags off the internal tag queue.
     fn unqueue_removes(&self, context: &mut UpdateContext<'gc>) -> Vec<(Depth, QueuedTag)> {
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
         let mut unqueued: Vec<_> = write
             .queued_tags
             .iter_mut()
@@ -2521,7 +2474,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn attach_audio(self, context: &mut UpdateContext<'gc>, netstream: Option<NetStream<'gc>>) {
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
         if netstream != write.attached_audio {
             if let Some(old_netstream) = write.attached_audio {
                 old_netstream.was_detached(context);
@@ -2576,16 +2529,13 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                 // executing parent can add a child that should have its first frame skipped.
 
                 // FIXME - does this propagate through non-movie-clip children (Loader/Button)?
-                child
-                    .base_mut(context.gc_context)
-                    .set_skip_next_enter_frame(true);
+                child.base_mut(context.gc()).set_skip_next_enter_frame(true);
             }
             child.enter_frame(context);
         }
 
         if skip_frame {
-            self.base_mut(context.gc_context)
-                .set_skip_next_enter_frame(false);
+            self.base_mut(context.gc()).set_skip_next_enter_frame(false);
             return;
         }
 
@@ -2631,7 +2581,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                 false
             };
 
-            self.0.write(context.gc_context).unset_loop_queued();
+            self.0.write(context.gc()).unset_loop_queued();
 
             if needs_construction {
                 self.construct_as_avm2_object(context);
@@ -2667,7 +2617,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             let is_load_frame = !self.0.read().flags.contains(MovieClipFlags::INITIALIZED);
             if is_load_frame {
                 self.event_dispatch(context, ClipEvent::Load);
-                self.0.write(context.gc_context).set_initialized(true);
+                self.0.write(context.gc()).set_initialized(true);
             } else {
                 self.event_dispatch(context, ClipEvent::EnterFrame);
             }
@@ -2681,7 +2631,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn run_frame_scripts(self, context: &mut UpdateContext<'gc>) {
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
         let avm2_object = write.object.and_then(|o| o.as_avm2_object());
 
         if let Some(avm2_object) = avm2_object {
@@ -2730,7 +2680,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                                     e
                                 );
                             }
-                            write = self.0.write(context.gc_context);
+                            write = self.0.write(context.gc());
 
                             write
                                 .flags
@@ -2850,7 +2800,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     ) {
         if self
             .0
-            .write(context.gc_context)
+            .write(context.gc())
             .flags
             .contains(MovieClipFlags::POST_INSTANTIATED)
         {
@@ -2858,16 +2808,14 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             return;
         }
         self.0
-            .write(context.gc_context)
+            .write(context.gc())
             .flags
             .insert(MovieClipFlags::POST_INSTANTIATED);
 
         self.set_default_instance_name(context);
 
         if !self.movie().is_action_script_3() {
-            context
-                .avm1
-                .add_to_exec_list(context.gc_context, (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), (*self).into());
 
             self.construct_as_avm1_object(context, init_object, instantiated_by, run_frame);
         }
@@ -2892,7 +2840,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
-        self.0.write(context.gc_context).object = Some(to.into());
+        self.0.write(context.gc()).object = Some(to.into());
         if self.parent().is_none() {
             context.avm2.add_orphan_obj((*self).into());
         }
@@ -2910,9 +2858,9 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
 
         if let Some(node) = self.maskee() {
-            node.set_masker(context.gc_context, None, true);
+            node.set_masker(context.gc(), None, true);
         } else if let Some(node) = self.masker() {
-            node.set_maskee(context.gc_context, None, true);
+            node.set_maskee(context.gc(), None, true);
         }
 
         // Unregister any text field variable bindings.
@@ -2925,7 +2873,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         self.drop_focus(context);
 
         {
-            let mut mc = self.0.write(context.gc_context);
+            let mut mc = self.0.write(context.gc());
             mc.stop_audio_stream(context);
         }
 
@@ -2940,7 +2888,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             self.event_dispatch(context, ClipEvent::Unload);
         }
 
-        self.set_avm1_removed(context.gc_context, true);
+        self.set_avm1_removed(context.gc(), true);
     }
 
     fn loader_info(&self) -> Option<Avm2Object<'gc>> {
@@ -3580,7 +3528,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let movie = self.movie();
         let tag = reader.read_define_morph_shape(version)?;
         let id = tag.id;
-        let morph_shape = MorphShape::from_swf_tag(context.gc_context, tag, movie.clone());
+        let morph_shape = MorphShape::from_swf_tag(context.gc(), tag, movie.clone());
         context
             .library
             .library_for_movie_mut(movie)
@@ -3626,10 +3574,10 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let library = context.library.library_for_movie_mut(self.movie());
         match library.character_by_id(settings.id) {
             Some(Character::Text(text)) => {
-                text.set_render_settings(context.gc_context, settings.into());
+                text.set_render_settings(context.gc(), settings.into());
             }
             Some(Character::EditText(edit_text)) => {
-                edit_text.set_render_settings(context.gc_context, settings.into());
+                edit_text.set_render_settings(context.gc(), settings.into());
             }
             Some(_) => {
                 tracing::warn!(
@@ -3801,7 +3749,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
             Character::Avm1Button(Avm1Button::from_swf_tag(
                 &swf_button,
                 &self.static_data.swf,
-                context.gc_context,
+                context.gc(),
             ))
         };
         let library = context.library.library_for_movie_mut(movie);
@@ -3919,7 +3867,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
             flags: swf::FontFlag::empty(),
         };
         let font_object = Font::from_swf_tag(
-            context.gc_context,
+            context.gc(),
             context.renderer,
             font,
             reader.encoding(),
@@ -3941,7 +3889,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let font = reader.read_define_font_2(2)?;
         let font_id = font.id;
         let font_object = Font::from_swf_tag(
-            context.gc_context,
+            context.gc(),
             context.renderer,
             font,
             reader.encoding(),
@@ -3963,7 +3911,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let font = reader.read_define_font_2(3)?;
         let font_id = font.id;
         let font_object = Font::from_swf_tag(
-            context.gc_context,
+            context.gc(),
             context.renderer,
             font,
             reader.encoding(),
@@ -3985,7 +3933,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
     ) -> Result<(), Error> {
         let font = reader.read_define_font_4()?;
         let font_id = font.id;
-        let font_object = Font::from_font4_tag(context.gc_context, font, reader.encoding())?;
+        let font_object = Font::from_font4_tag(context.gc(), font, reader.encoding())?;
         context
             .library
             .library_for_movie_mut(self.movie())
@@ -4022,7 +3970,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
     ) -> Result<(), Error> {
         let streamdef = reader.read_define_video_stream()?;
         let id = streamdef.id;
-        let video = Video::from_swf_tag(self.movie(), streamdef, context.gc_context);
+        let video = Video::from_swf_tag(self.movie(), streamdef, context.gc());
         context
             .library
             .library_for_movie_mut(self.movie())
@@ -4043,7 +3991,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let num_read = reader.pos(start);
 
         let movie_clip = MovieClip::new_with_data(
-            context.gc_context,
+            context.gc(),
             id,
             self.static_data
                 .swf
@@ -4058,7 +4006,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
 
         self.static_data
             .preload_progress
-            .write(context.gc_context)
+            .write(context.gc())
             .cur_preload_symbol = Some(id);
 
         let should_exit = chunk_limit.did_ops_breach_limit(context, 4);
@@ -4069,7 +4017,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         if movie_clip.preload(context, chunk_limit) {
             self.static_data
                 .preload_progress
-                .write(context.gc_context)
+                .write(context.gc())
                 .cur_preload_symbol = None;
 
             Ok(ControlFlow::Continue)
@@ -4281,7 +4229,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let exports = reader.read_export_assets()?;
         for export in exports {
             let name = export.name.decode(reader.encoding());
-            let name = AvmString::new(context.gc_context, name);
+            let name = AvmString::new(context.gc(), name);
 
             if let Some(character) = self.get_registered_character_by_id(context, export.id) {
                 self.register_export(context, export.id, &name, self.movie());
@@ -4449,7 +4397,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         // (for any instance of this MovieClip) in `run_eager_script_and_symbol`
         static_data
             .abc_tags
-            .write(context.gc_context)
+            .write(context.gc())
             .entry(cur_frame)
             .or_default()
             .push(AbcCodeAndTag { tag_code, abc });
@@ -4463,16 +4411,14 @@ impl<'gc, 'a> MovieClip<'gc> {
         cur_frame: FrameNumber,
         static_data: &mut MovieClipStatic<'gc>,
     ) -> Result<(), Error> {
-        let mut symbolclass_names = static_data.symbolclass_names.write(context.gc_context);
+        let mut symbolclass_names = static_data.symbolclass_names.write(context.gc());
         let symbolclass_names = symbolclass_names.entry(cur_frame).or_default();
         let num_symbols = reader.read_u16()?;
 
         for _ in 0..num_symbols {
             let id = reader.read_u16()?;
-            let class_name = AvmString::new(
-                context.gc_context,
-                reader.read_str()?.decode(reader.encoding()),
-            );
+            let class_name =
+                AvmString::new(context.gc(), reader.read_str()?.decode(reader.encoding()));
 
             let name =
                 Avm2QName::from_qualified_name(class_name, context.avm2.root_api_version, context);
@@ -4506,7 +4452,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         let tags = read
             .static_data
             .abc_tags
-            .write(context.gc_context)
+            .write(context.gc())
             .remove(&current_frame);
         let mut eager_scripts = Vec::new();
         if let Some(tags) = tags {
@@ -4526,7 +4472,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         if let Some(symbols) = read
             .static_data
             .symbolclass_names
-            .write(context.gc_context)
+            .write(context.gc())
             .remove(&current_frame)
         {
             let mut activation = Avm2Activation::from_nothing(context);
@@ -4558,16 +4504,17 @@ impl<'gc, 'a> MovieClip<'gc> {
                             .library_for_movie_mut(movie.clone());
 
                         match library.character_by_id(id) {
-                            Some(Character::EditText(edit_text)) => edit_text
-                                .set_avm2_class(activation.context.gc_context, class_object),
+                            Some(Character::EditText(edit_text)) => {
+                                edit_text.set_avm2_class(activation.context.gc(), class_object)
+                            }
                             Some(Character::Graphic(graphic)) => {
-                                graphic.set_avm2_class(activation.context.gc_context, class_object)
+                                graphic.set_avm2_class(activation.context.gc(), class_object)
                             }
                             Some(Character::MovieClip(mc)) => {
-                                mc.set_avm2_class(activation.context.gc_context, Some(class_object))
+                                mc.set_avm2_class(activation.context.gc(), Some(class_object))
                             }
                             Some(Character::Avm2Button(btn)) => {
-                                btn.set_avm2_class(activation.context.gc_context, class_object)
+                                btn.set_avm2_class(activation.context.gc(), class_object)
                             }
                             Some(Character::BinaryData(_)) => {}
                             Some(Character::Font(_)) => {}
@@ -4599,7 +4546,7 @@ impl<'gc, 'a> MovieClip<'gc> {
                                 // Most SWFs use id 0 here, but some obfuscated SWFs can use other invalid IDs.
                                 if self.avm2_class().is_none() {
                                     self.set_avm2_class(
-                                        activation.context.gc_context,
+                                        activation.context.gc(),
                                         Some(class_object),
                                     );
                                 }
@@ -4631,7 +4578,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         reader: &mut SwfStream<'a>,
         version: u8,
     ) -> Result<(), Error> {
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
         let tag_start =
             reader.get_ref().as_ptr() as u64 - write.static_data.swf.as_ref().as_ptr() as u64;
         let place_object = if version == 1 {
@@ -4674,7 +4621,7 @@ impl<'gc, 'a> MovieClip<'gc> {
                 if let Some(child) = self.child_by_depth(place_object.depth.into()) {
                     child.replace_with(context, id);
                     child.apply_place_object(context, &place_object);
-                    child.set_place_frame(context.gc_context, self.current_frame());
+                    child.set_place_frame(context.gc(), self.current_frame());
                 }
             }
             PlaceObjectAction::Modify => {
@@ -4718,7 +4665,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         reader: &mut SwfStream<'a>,
         version: u8,
     ) -> Result<(), Error> {
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
         let tag_start =
             reader.get_ref().as_ptr() as u64 - write.static_data.swf.as_ref().as_ptr() as u64;
         let remove_object = if version == 1 {
@@ -4755,7 +4702,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         if context.stage.background_color().is_none() {
             context
                 .stage
-                .set_background_color(context.gc_context, Some(background_color));
+                .set_background_color(context.gc(), Some(background_color));
         }
         Ok(())
     }
@@ -4777,7 +4724,7 @@ impl<'gc, 'a> MovieClip<'gc> {
                 let audio_stream =
                     context.start_stream(self, mc.current_frame(), slice, stream_info);
                 drop(mc);
-                self.0.write(context.gc_context).audio_stream = audio_stream;
+                self.0.write(context.gc()).audio_stream = audio_stream;
             }
         }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -399,17 +399,17 @@ impl<'gc> MovieClip<'gc> {
         };
 
         let mc = MovieClip(GcCell::new(
-            activation.context.gc(),
+            activation.gc(),
             MovieClipData {
                 base: Default::default(),
                 static_data: Gc::new(
-                    activation.context.gc(),
+                    activation.gc(),
                     MovieClipStatic::with_data(
                         0,
                         movie.clone().into(),
                         num_frames,
                         loader_info,
-                        activation.context.gc(),
+                        activation.gc(),
                     ),
                 ),
                 tag_stream_pos: 0,
@@ -448,10 +448,9 @@ impl<'gc> MovieClip<'gc> {
                 .unwrap()
                 .as_loader_info_object()
                 .unwrap();
-            loader_info
-                .set_loader_stream(LoaderStream::Swf(movie, mc.into()), activation.context.gc());
+            loader_info.set_loader_stream(LoaderStream::Swf(movie, mc.into()), activation.gc());
         }
-        mc.set_is_root(activation.context.gc(), true);
+        mc.set_is_root(activation.gc(), true);
         mc
     }
 
@@ -2019,13 +2018,10 @@ impl<'gc> MovieClip<'gc> {
                     .get("prototype", &mut activation)
                     .map(|v| v.coerce_to_object(&mut activation))
                 {
-                    let object: Avm1Object<'gc> = StageObject::for_display_object(
-                        activation.context.gc(),
-                        self.into(),
-                        prototype,
-                    )
-                    .into();
-                    self.0.write(activation.context.gc()).object = Some(object.into());
+                    let object: Avm1Object<'gc> =
+                        StageObject::for_display_object(activation.gc(), self.into(), prototype)
+                            .into();
+                    self.0.write(activation.gc()).object = Some(object.into());
 
                     if run_frame {
                         self.run_frame_avm1(activation.context);
@@ -4505,16 +4501,16 @@ impl<'gc, 'a> MovieClip<'gc> {
 
                         match library.character_by_id(id) {
                             Some(Character::EditText(edit_text)) => {
-                                edit_text.set_avm2_class(activation.context.gc(), class_object)
+                                edit_text.set_avm2_class(activation.gc(), class_object)
                             }
                             Some(Character::Graphic(graphic)) => {
-                                graphic.set_avm2_class(activation.context.gc(), class_object)
+                                graphic.set_avm2_class(activation.gc(), class_object)
                             }
                             Some(Character::MovieClip(mc)) => {
-                                mc.set_avm2_class(activation.context.gc(), Some(class_object))
+                                mc.set_avm2_class(activation.gc(), Some(class_object))
                             }
                             Some(Character::Avm2Button(btn)) => {
-                                btn.set_avm2_class(activation.context.gc(), class_object)
+                                btn.set_avm2_class(activation.gc(), class_object)
                             }
                             Some(Character::BinaryData(_)) => {}
                             Some(Character::Font(_)) => {}
@@ -4545,10 +4541,7 @@ impl<'gc, 'a> MovieClip<'gc> {
                             None => {
                                 // Most SWFs use id 0 here, but some obfuscated SWFs can use other invalid IDs.
                                 if self.avm2_class().is_none() {
-                                    self.set_avm2_class(
-                                        activation.context.gc(),
-                                        Some(class_object),
-                                    );
+                                    self.set_avm2_class(activation.gc(), Some(class_object));
                                 }
                             }
                             _ => {

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -793,7 +793,7 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
 
         match avm2_stage {
             Ok(avm2_stage) => {
-                let mut write = self.0.write(activation.context.gc());
+                let mut write = self.0.write(activation.gc());
                 write.avm2_object = Some(avm2_stage.into());
                 write.stage3ds = vec![stage3d];
             }

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -270,7 +270,7 @@ impl<'gc> Stage<'gc> {
     /// This setting is currently ignored in Ruffle.
     /// Used by AVM1 `stage.quality` and AVM2 `Stage.quality` properties.
     pub fn set_quality(self, context: &mut UpdateContext<'gc>, quality: StageQuality) {
-        let mut this = self.0.write(context.gc_context);
+        let mut this = self.0.write(context.gc());
         this.quality = quality;
         this.use_bitmap_downsampling = matches!(
             quality,
@@ -324,7 +324,7 @@ impl<'gc> Stage<'gc> {
             return;
         }
 
-        self.0.write(context.gc_context).scale_mode = scale_mode;
+        self.0.write(context.gc()).scale_mode = scale_mode;
         self.build_matrices(context);
     }
 
@@ -335,7 +335,7 @@ impl<'gc> Stage<'gc> {
 
     /// Set whether movies are prevented from changing the stage scale mode.
     pub fn set_forced_scale_mode(self, context: &mut UpdateContext<'gc>, force: bool) {
-        self.0.write(context.gc_context).forced_scale_mode = force;
+        self.0.write(context.gc()).forced_scale_mode = force;
     }
 
     /// Get whether the Stage's display state can be changed.
@@ -345,7 +345,7 @@ impl<'gc> Stage<'gc> {
 
     /// Set whether the Stage's display state can be changed.
     pub fn set_allow_fullscreen(self, context: &mut UpdateContext<'gc>, allow: bool) {
-        self.0.write(context.gc_context).allow_fullscreen = allow;
+        self.0.write(context.gc()).allow_fullscreen = allow;
     }
 
     fn is_fullscreen_state(display_state: StageDisplayState) -> bool {
@@ -396,7 +396,7 @@ impl<'gc> Stage<'gc> {
         };
 
         if result.is_ok() {
-            self.0.write(context.gc_context).display_state = display_state;
+            self.0.write(context.gc()).display_state = display_state;
             self.fire_fullscreen_event(context);
         }
     }
@@ -410,7 +410,7 @@ impl<'gc> Stage<'gc> {
     /// This only has an effect if the scale mode is not `StageScaleMode::ExactFit`.
     pub fn set_align(self, context: &mut UpdateContext<'gc>, align: StageAlign) {
         if !self.forced_align() {
-            self.0.write(context.gc_context).align = align;
+            self.0.write(context.gc()).align = align;
             self.build_matrices(context);
         }
     }
@@ -422,7 +422,7 @@ impl<'gc> Stage<'gc> {
 
     /// Set whether movies are prevented from changing the stage alignment.
     pub fn set_forced_align(self, context: &mut UpdateContext<'gc>, force: bool) {
-        self.0.write(context.gc_context).forced_align = force;
+        self.0.write(context.gc()).forced_align = force;
     }
 
     /// Returns whether bitmaps will use high quality downsampling when scaled down.
@@ -446,7 +446,7 @@ impl<'gc> Stage<'gc> {
 
     /// Sets the window mode.
     pub fn set_window_mode(self, context: &mut UpdateContext<'gc>, window_mode: WindowMode) {
-        self.0.write(context.gc_context).window_mode = window_mode;
+        self.0.write(context.gc()).window_mode = window_mode;
     }
 
     pub fn view_bounds(self) -> Rectangle<Twips> {
@@ -458,7 +458,7 @@ impl<'gc> Stage<'gc> {
     }
 
     pub fn set_show_menu(self, context: &mut UpdateContext<'gc>, show_menu: bool) {
-        let mut write = self.0.write(context.gc_context);
+        let mut write = self.0.write(context.gc());
         write.show_menu = show_menu;
     }
 
@@ -477,7 +477,7 @@ impl<'gc> Stage<'gc> {
 
     /// Update the stage's transform matrix in response to a root movie change.
     pub fn build_matrices(self, context: &mut UpdateContext<'gc>) {
-        let mut stage = self.0.write(context.gc_context);
+        let mut stage = self.0.write(context.gc());
         let scale_mode = stage.scale_mode;
         let align = stage.align;
         let prev_stage_size = stage.stage_size;
@@ -564,7 +564,7 @@ impl<'gc> Stage<'gc> {
 
         drop(stage);
 
-        self.0.write(context.gc_context).view_bounds = if self.should_letterbox() {
+        self.0.write(context.gc()).view_bounds = if self.should_letterbox() {
             // Letterbox: movie area
             Rectangle {
                 x_min: Twips::ZERO,
@@ -701,7 +701,7 @@ impl<'gc> Stage<'gc> {
         let dobject_constr = context.avm2.classes().display_object;
         Avm2::broadcast_event(context, render_evt, dobject_constr);
 
-        self.set_invalidated(context.gc_context, false);
+        self.set_invalidated(context.gc(), false);
     }
 
     /// Fires `Stage.onFullScreen` in AVM1 or `Event.FULLSCREEN` in AVM2.
@@ -793,7 +793,7 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
 
         match avm2_stage {
             Ok(avm2_stage) => {
-                let mut write = self.0.write(activation.context.gc_context);
+                let mut write = self.0.write(activation.context.gc());
                 write.avm2_object = Some(avm2_stage.into());
                 write.stage3ds = vec![stage3d];
             }

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -44,11 +44,11 @@ impl<'gc> Text<'gc> {
         tag: &swf::Text,
     ) -> Self {
         Text(GcCell::new(
-            context.gc_context,
+            context.gc(),
             TextData {
                 base: Default::default(),
                 static_data: gc_arena::Gc::new(
-                    context.gc_context,
+                    context.gc(),
                     TextStatic {
                         swf,
                         id: tag.id,
@@ -127,11 +127,11 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
             .library_for_movie_mut(self.movie())
             .get_text(id)
         {
-            self.0.write(context.gc_context).static_data = new_text.0.read().static_data;
+            self.0.write(context.gc()).static_data = new_text.0.read().static_data;
         } else {
             tracing::warn!("PlaceObject: expected text at character ID {}", id);
         }
-        self.invalidate_cached_bitmap(context.gc_context);
+        self.invalidate_cached_bitmap(context.gc());
     }
 
     fn run_frame_avm1(&self, _context: &mut UpdateContext) {
@@ -285,7 +285,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
                 statictext,
             ) {
                 Ok(object) => {
-                    self.0.write(activation.context.gc_context).avm2_object = Some(object.into())
+                    self.0.write(activation.context.gc()).avm2_object = Some(object.into())
                 }
                 Err(e) => tracing::error!("Got error when creating AVM2 side of Text: {}", e),
             }
@@ -303,7 +303,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
     }
 
     fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
-        self.0.write(context.gc_context).avm2_object = Some(to);
+        self.0.write(context.gc()).avm2_object = Some(to);
     }
 }
 

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -284,9 +284,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
                 (*self).into(),
                 statictext,
             ) {
-                Ok(object) => {
-                    self.0.write(activation.context.gc()).avm2_object = Some(object.into())
-                }
+                Ok(object) => self.0.write(activation.gc()).avm2_object = Some(object.into()),
                 Err(e) => tracing::error!("Got error when creating AVM2 side of Text: {}", e),
             }
 

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -170,21 +170,21 @@ impl Value {
                 } else {
                     &value
                 };
-                Avm1Value::String(AvmString::new_utf8(activation.context.gc(), value))
+                Avm1Value::String(AvmString::new_utf8(activation.gc(), value))
             }
             Value::Object(values) => {
                 let object = Avm1ScriptObject::new(
-                    activation.context.gc(),
+                    activation.gc(),
                     Some(activation.context.avm1.prototypes().object),
                 );
                 for (key, value) in values {
-                    let key = AvmString::new_utf8(activation.context.gc(), key);
+                    let key = AvmString::new_utf8(activation.gc(), key);
                     let _ = object.set(key, value.into_avm1(activation), activation);
                 }
                 object.into()
             }
             Value::List(values) => Avm1ArrayObject::new(
-                activation.context.gc(),
+                activation.gc(),
                 activation.context.avm1.prototypes().array,
                 values
                     .iter()
@@ -246,14 +246,12 @@ impl Value {
             Value::Null => Avm2Value::Null,
             Value::Bool(value) => Avm2Value::Bool(value),
             Value::Number(value) => Avm2Value::Number(value),
-            Value::String(value) => {
-                Avm2Value::String(AvmString::new_utf8(activation.context.gc(), value))
-            }
+            Value::String(value) => Avm2Value::String(AvmString::new_utf8(activation.gc(), value)),
             Value::Object(values) => {
                 let obj = Avm2ScriptObject::new_object(activation);
 
                 for (key, value) in values.into_iter() {
-                    let key = AvmString::new_utf8(activation.context.gc(), key);
+                    let key = AvmString::new_utf8(activation.gc(), key);
                     let value = value.into_avm2(activation);
                     obj.set_string_property_local(key, value, activation)
                         .unwrap();
@@ -304,7 +302,7 @@ impl<'gc> Callback<'gc> {
                         .into_iter()
                         .map(|v| v.into_avm1(&mut activation))
                         .collect();
-                    let name = AvmString::new_utf8(activation.context.gc(), name);
+                    let name = AvmString::new_utf8(activation.gc(), name);
                     if let Ok(result) = method
                         .call(name, &mut activation, this.into(), &args)
                         .and_then(|value| Value::from_avm1(&mut activation, value))

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -170,21 +170,21 @@ impl Value {
                 } else {
                     &value
                 };
-                Avm1Value::String(AvmString::new_utf8(activation.context.gc_context, value))
+                Avm1Value::String(AvmString::new_utf8(activation.context.gc(), value))
             }
             Value::Object(values) => {
                 let object = Avm1ScriptObject::new(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     Some(activation.context.avm1.prototypes().object),
                 );
                 for (key, value) in values {
-                    let key = AvmString::new_utf8(activation.context.gc_context, key);
+                    let key = AvmString::new_utf8(activation.context.gc(), key);
                     let _ = object.set(key, value.into_avm1(activation), activation);
                 }
                 object.into()
             }
             Value::List(values) => Avm1ArrayObject::new(
-                activation.context.gc_context,
+                activation.context.gc(),
                 activation.context.avm1.prototypes().array,
                 values
                     .iter()
@@ -247,13 +247,13 @@ impl Value {
             Value::Bool(value) => Avm2Value::Bool(value),
             Value::Number(value) => Avm2Value::Number(value),
             Value::String(value) => {
-                Avm2Value::String(AvmString::new_utf8(activation.context.gc_context, value))
+                Avm2Value::String(AvmString::new_utf8(activation.context.gc(), value))
             }
             Value::Object(values) => {
                 let obj = Avm2ScriptObject::new_object(activation);
 
                 for (key, value) in values.into_iter() {
-                    let key = AvmString::new_utf8(activation.context.gc_context, key);
+                    let key = AvmString::new_utf8(activation.context.gc(), key);
                     let value = value.into_avm2(activation);
                     obj.set_string_property_local(key, value, activation)
                         .unwrap();
@@ -304,7 +304,7 @@ impl<'gc> Callback<'gc> {
                         .into_iter()
                         .map(|v| v.into_avm1(&mut activation))
                         .collect();
-                    let name = AvmString::new_utf8(activation.context.gc_context, name);
+                    let name = AvmString::new_utf8(activation.context.gc(), name);
                     if let Ok(result) = method
                         .call(name, &mut activation, this.into(), &args)
                         .and_then(|value| Value::from_avm1(&mut activation, value))

--- a/core/src/frame_lifecycle.rs
+++ b/core/src/frame_lifecycle.rs
@@ -137,7 +137,7 @@ pub fn run_inner_goto_frame<'gc>(
         // We skip the next `enter_frame` call, so that we will still run the framescripts
         // queued for our target frame.
         initial_clip
-            .base_mut(context.gc_context)
+            .base_mut(context.gc())
             .set_skip_next_enter_frame(true);
 
         return;

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1336,8 +1336,8 @@ impl<'gc> Loader<'gc> {
                 };
 
                 for (k, v) in form_urlencoded::parse(utf8_body) {
-                    let k = AvmString::new_utf8(activation.context.gc(), k);
-                    let v = AvmString::new_utf8(activation.context.gc(), v);
+                    let k = AvmString::new_utf8(activation.gc(), k);
+                    let v = AvmString::new_utf8(activation.gc(), v);
                     that.set(k, v.into(), &mut activation)?;
                 }
 
@@ -1417,8 +1417,7 @@ impl<'gc> Loader<'gc> {
                         let value_data = if length == 0 {
                             Value::Undefined
                         } else {
-                            AvmString::new_utf8(activation.context.gc(), UTF_8.decode(&body).0)
-                                .into()
+                            AvmString::new_utf8(activation.gc(), UTF_8.decode(&body).0).into()
                         };
                         let _ = that.call_method(
                             "onData".into(),
@@ -1495,8 +1494,7 @@ impl<'gc> Loader<'gc> {
                 match response {
                     Ok((body, _, _, _)) => {
                         // Fire the parse & onLoad methods with the loaded string.
-                        let css =
-                            AvmString::new_utf8(activation.context.gc(), UTF_8.decode(&body).0);
+                        let css = AvmString::new_utf8(activation.gc(), UTF_8.decode(&body).0);
                         let success = that
                             .call_method(
                                 "parse".into(),
@@ -2109,7 +2107,7 @@ impl<'gc> Loader<'gc> {
             // to their real values)
             loader_info.set_loader_stream(
                 LoaderStream::NotYetLoaded(fake_movie, Some(clip), false),
-                activation.context.gc(),
+                activation.gc(),
             );
 
             // Flash always fires an initial 'progress' event with
@@ -2122,7 +2120,7 @@ impl<'gc> Loader<'gc> {
             // (`LoaderInfo.parameters` is always empty during the first 'progress' event)
             loader_info.set_loader_stream(
                 LoaderStream::NotYetLoaded(movie.clone(), Some(clip), false),
-                activation.context.gc(),
+                activation.gc(),
             );
         }
 
@@ -2215,7 +2213,7 @@ impl<'gc> Loader<'gc> {
                     bitmap.as_colors().map(Color::from).collect(),
                 );
                 let bitmapdata_wrapper =
-                    BitmapDataWrapper::new(GcCell::new(activation.context.gc(), bitmap_data));
+                    BitmapDataWrapper::new(GcCell::new(activation.gc(), bitmap_data));
                 let bitmapdata_class = activation.context.avm2.classes().bitmapdata;
                 let bitmapdata_avm2 = BitmapDataObject::from_bitmap_data_internal(
                     &mut activation,
@@ -2240,7 +2238,7 @@ impl<'gc> Loader<'gc> {
 
                     loader_info.set_loader_stream(
                         LoaderStream::NotYetLoaded(fake_movie, Some(bitmap_dobj), false),
-                        activation.context.gc(),
+                        activation.gc(),
                     );
                 }
 
@@ -2254,7 +2252,7 @@ impl<'gc> Loader<'gc> {
 
                     loader_info.set_loader_stream(
                         LoaderStream::NotYetLoaded(fake_movie, Some(bitmap_dobj), false),
-                        activation.context.gc(),
+                        activation.gc(),
                     );
                 }
 
@@ -2317,7 +2315,7 @@ impl<'gc> Loader<'gc> {
 
                         loader_info.set_loader_stream(
                             LoaderStream::NotYetLoaded(fake_movie, None, false),
-                            activation.context.gc(),
+                            activation.gc(),
                         );
 
                         Loader::movie_loader_progress(handle, activation.context, length, length)?;
@@ -2469,9 +2467,9 @@ impl<'gc> Loader<'gc> {
                     let object = dobj.object().coerce_to_object(&mut activation);
                     for (key, value) in flashvars.iter() {
                         object.define_value(
-                            activation.context.gc(),
-                            AvmString::new_utf8(activation.context.gc(), key),
-                            AvmString::new_utf8(activation.context.gc(), value).into(),
+                            activation.gc(),
+                            AvmString::new_utf8(activation.gc(), key),
+                            AvmString::new_utf8(activation.gc(), value).into(),
                             Attribute::empty(),
                         );
                     }

--- a/core/src/net_connection.rs
+++ b/core/src/net_connection.rs
@@ -543,8 +543,7 @@ impl FlashRemoting {
                             match connection.object {
                                 NetConnectionObject::Avm2(object) => {
                                     let mut activation = Avm2Activation::from_nothing(uc);
-                                    let url =
-                                        AvmString::new_utf8(activation.context.gc(), response.url);
+                                    let url = AvmString::new_utf8(activation.gc(), response.url);
                                     let event = Avm2EventObject::net_status_event(
                                         &mut activation,
                                         "netStatus",

--- a/core/src/net_connection.rs
+++ b/core/src/net_connection.rs
@@ -543,10 +543,8 @@ impl FlashRemoting {
                             match connection.object {
                                 NetConnectionObject::Avm2(object) => {
                                     let mut activation = Avm2Activation::from_nothing(uc);
-                                    let url = AvmString::new_utf8(
-                                        activation.context.gc_context,
-                                        response.url,
-                                    );
+                                    let url =
+                                        AvmString::new_utf8(activation.context.gc(), response.url);
                                     let event = Avm2EventObject::net_status_event(
                                         &mut activation,
                                         "netStatus",

--- a/core/src/pixel_bender.rs
+++ b/core/src/pixel_bender.rs
@@ -134,7 +134,7 @@ impl PixelBenderTypeExt for PixelBenderType {
         };
         let vals: Vec<Value<'gc>> = match self {
             PixelBenderType::TString(string) => {
-                return Ok(AvmString::new_utf8(activation.context.gc(), string).into());
+                return Ok(AvmString::new_utf8(activation.gc(), string).into());
             }
             PixelBenderType::TInt(i) => {
                 if tint_as_int {

--- a/core/src/pixel_bender.rs
+++ b/core/src/pixel_bender.rs
@@ -134,7 +134,7 @@ impl PixelBenderTypeExt for PixelBenderType {
         };
         let vals: Vec<Value<'gc>> = match self {
             PixelBenderType::TString(string) => {
-                return Ok(AvmString::new_utf8(activation.context.gc_context, string).into());
+                return Ok(AvmString::new_utf8(activation.context.gc(), string).into());
             }
             PixelBenderType::TInt(i) => {
                 if tint_as_int {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -905,9 +905,7 @@ impl Player {
 
     pub fn set_background_color(&mut self, color: Option<Color>) {
         self.mutate_with_update_context(|context| {
-            context
-                .stage
-                .set_background_color(context.gc_context, color)
+            context.stage.set_background_color(context.gc(), color)
         })
     }
 
@@ -917,7 +915,7 @@ impl Player {
 
     pub fn set_letterbox(&mut self, letterbox: Letterbox) {
         self.mutate_with_update_context(|context| {
-            context.stage.set_letterbox(context.gc_context, letterbox)
+            context.stage.set_letterbox(context.gc(), letterbox)
         })
     }
 
@@ -1154,7 +1152,7 @@ impl Player {
 
                 let keyboardevent_class = activation.avm2().classes().keyboardevent;
                 let event_name_val: Avm2Value<'_> =
-                    AvmString::new_utf8(activation.context.gc_context, event_name).into();
+                    AvmString::new_utf8(activation.context.gc(), event_name).into();
 
                 // TODO: keyLocation should not be a dummy value.
                 // ctrlKey and controlKey can be different from each other on Mac.
@@ -1460,8 +1458,8 @@ impl Player {
             };
 
             // TODO: Introduce `DisplayObject::set_position()`?
-            display_object.set_x(context.gc_context, new_position.x);
-            display_object.set_y(context.gc_context, new_position.y);
+            display_object.set_x(context.gc(), new_position.x);
+            display_object.set_y(context.gc(), new_position.y);
 
             // Update `_droptarget` property of dragged object.
             if let Some(movie_clip) = display_object.as_movie_clip() {
@@ -1472,7 +1470,7 @@ impl Player {
                 // Set `_droptarget` to the object the mouse is hovering over.
                 let drop_target_object = run_mouse_pick(context, false);
                 movie_clip.set_drop_target(
-                    context.gc_context,
+                    context.gc(),
                     drop_target_object.map(|d| d.as_displayobject()),
                 );
                 display_object.set_visible(context, was_visible);
@@ -2092,7 +2090,7 @@ impl Player {
                     if let Ok(prototype) = constructor.get("prototype", &mut activation) {
                         if let Value::Object(object) = action.clip.object() {
                             object.define_value(
-                                activation.context.gc_context,
+                                activation.context.gc(),
                                 "__proto__",
                                 prototype,
                                 Attribute::DONT_ENUM | Attribute::DONT_DELETE,
@@ -2425,7 +2423,7 @@ impl Player {
         self.mutate_with_update_context(|context| {
             context
                 .library
-                .register_device_font(context.gc_context, context.renderer, definition);
+                .register_device_font(context.gc(), context.renderer, definition);
         });
     }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1152,7 +1152,7 @@ impl Player {
 
                 let keyboardevent_class = activation.avm2().classes().keyboardevent;
                 let event_name_val: Avm2Value<'_> =
-                    AvmString::new_utf8(activation.context.gc(), event_name).into();
+                    AvmString::new_utf8(activation.gc(), event_name).into();
 
                 // TODO: keyLocation should not be a dummy value.
                 // ctrlKey and controlKey can be different from each other on Mac.
@@ -2090,7 +2090,7 @@ impl Player {
                     if let Ok(prototype) = constructor.get("prototype", &mut activation) {
                         if let Value::Object(object) = action.clip.object() {
                             object.define_value(
-                                activation.context.gc(),
+                                activation.gc(),
                                 "__proto__",
                                 prototype,
                                 Attribute::DONT_ENUM | Attribute::DONT_DELETE,

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -1293,8 +1293,7 @@ impl<'gc> NetStream<'gc> {
                     Avm1ActivationIdentifier::root("[NetStream Status Event]"),
                     root,
                 );
-                let info_object =
-                    Avm1ScriptObject::new(activation.context.gc(), Some(object_proto));
+                let info_object = Avm1ScriptObject::new(activation.gc(), Some(object_proto));
 
                 for (key, value) in values {
                     info_object
@@ -1367,7 +1366,7 @@ impl<'gc> NetStream<'gc> {
                 let data_object = variable_data.to_avm2_value(&mut activation);
 
                 client_object.call_public_property(
-                    AvmString::new_utf8_bytes(activation.context.gc(), variable_name),
+                    AvmString::new_utf8_bytes(activation.gc(), variable_name),
                     &[data_object],
                     &mut activation,
                 )?;

--- a/core/src/xml/tree.rs
+++ b/core/src/xml/tree.rs
@@ -82,24 +82,21 @@ impl<'gc> XmlNode<'gc> {
         id_map: ScriptObject<'gc>,
         decoder: quick_xml::Decoder,
     ) -> Result<Self, quick_xml::Error> {
-        let name = AvmString::new_utf8_bytes(activation.context.gc_context, bs.name().into_inner());
-        let mut node = Self::new(activation.context.gc_context, ELEMENT_NODE, Some(name));
+        let name = AvmString::new_utf8_bytes(activation.context.gc(), bs.name().into_inner());
+        let mut node = Self::new(activation.context.gc(), ELEMENT_NODE, Some(name));
 
         // Reverse attributes so they appear in the `PropertyMap` in their definition order.
         let attributes: Result<Vec<_>, _> = bs.attributes().collect();
         let attributes = attributes?;
         for attribute in attributes.iter().rev() {
-            let key = AvmString::new_utf8_bytes(
-                activation.context.gc_context,
-                attribute.key.into_inner(),
-            );
+            let key =
+                AvmString::new_utf8_bytes(activation.context.gc(), attribute.key.into_inner());
             let value_str = custom_unescape(&attribute.value, decoder)?;
-            let value =
-                AvmString::new_utf8_bytes(activation.context.gc_context, value_str.as_bytes());
+            let value = AvmString::new_utf8_bytes(activation.context.gc(), value_str.as_bytes());
 
             // Insert an attribute.
             node.attributes().define_value(
-                activation.context.gc_context,
+                activation.context.gc(),
                 key,
                 value.into(),
                 Attribute::empty(),
@@ -108,7 +105,7 @@ impl<'gc> XmlNode<'gc> {
             // Update the ID map.
             if attribute.key.into_inner() == b"id" {
                 id_map.define_value(
-                    activation.context.gc_context,
+                    activation.context.gc(),
                     value,
                     node.script_object(activation).into(),
                     Attribute::empty(),
@@ -365,9 +362,9 @@ impl<'gc> XmlNode<'gc> {
                     .get("prototype", activation)
                     .map(|p| p.coerce_to_object(activation))
                     .ok();
-                let object = ScriptObject::new(activation.context.gc_context, prototype);
-                self.introduce_script_object(activation.context.gc_context, object.into());
-                object.set_native(activation.context.gc_context, NativeObject::XmlNode(*self));
+                let object = ScriptObject::new(activation.context.gc(), prototype);
+                self.introduce_script_object(activation.context.gc(), object.into());
+                object.set_native(activation.context.gc(), NativeObject::XmlNode(*self));
                 object.into()
             }
         }
@@ -388,9 +385,7 @@ impl<'gc> XmlNode<'gc> {
             Ok(array)
         } else {
             let array = ArrayObject::empty(activation);
-            self.0
-                .write(activation.context.gc_context)
-                .cached_child_nodes = Some(array);
+            self.0.write(activation.context.gc()).cached_child_nodes = Some(array);
             self.refresh_cached_child_nodes(activation)?;
             Ok(array)
         }

--- a/core/src/xml/tree.rs
+++ b/core/src/xml/tree.rs
@@ -82,30 +82,25 @@ impl<'gc> XmlNode<'gc> {
         id_map: ScriptObject<'gc>,
         decoder: quick_xml::Decoder,
     ) -> Result<Self, quick_xml::Error> {
-        let name = AvmString::new_utf8_bytes(activation.context.gc(), bs.name().into_inner());
-        let mut node = Self::new(activation.context.gc(), ELEMENT_NODE, Some(name));
+        let name = AvmString::new_utf8_bytes(activation.gc(), bs.name().into_inner());
+        let mut node = Self::new(activation.gc(), ELEMENT_NODE, Some(name));
 
         // Reverse attributes so they appear in the `PropertyMap` in their definition order.
         let attributes: Result<Vec<_>, _> = bs.attributes().collect();
         let attributes = attributes?;
         for attribute in attributes.iter().rev() {
-            let key =
-                AvmString::new_utf8_bytes(activation.context.gc(), attribute.key.into_inner());
+            let key = AvmString::new_utf8_bytes(activation.gc(), attribute.key.into_inner());
             let value_str = custom_unescape(&attribute.value, decoder)?;
-            let value = AvmString::new_utf8_bytes(activation.context.gc(), value_str.as_bytes());
+            let value = AvmString::new_utf8_bytes(activation.gc(), value_str.as_bytes());
 
             // Insert an attribute.
-            node.attributes().define_value(
-                activation.context.gc(),
-                key,
-                value.into(),
-                Attribute::empty(),
-            );
+            node.attributes()
+                .define_value(activation.gc(), key, value.into(), Attribute::empty());
 
             // Update the ID map.
             if attribute.key.into_inner() == b"id" {
                 id_map.define_value(
-                    activation.context.gc(),
+                    activation.gc(),
                     value,
                     node.script_object(activation).into(),
                     Attribute::empty(),
@@ -362,9 +357,9 @@ impl<'gc> XmlNode<'gc> {
                     .get("prototype", activation)
                     .map(|p| p.coerce_to_object(activation))
                     .ok();
-                let object = ScriptObject::new(activation.context.gc(), prototype);
-                self.introduce_script_object(activation.context.gc(), object.into());
-                object.set_native(activation.context.gc(), NativeObject::XmlNode(*self));
+                let object = ScriptObject::new(activation.gc(), prototype);
+                self.introduce_script_object(activation.gc(), object.into());
+                object.set_native(activation.gc(), NativeObject::XmlNode(*self));
                 object.into()
             }
         }
@@ -385,7 +380,7 @@ impl<'gc> XmlNode<'gc> {
             Ok(array)
         } else {
             let array = ArrayObject::empty(activation);
-            self.0.write(activation.context.gc()).cached_child_nodes = Some(array);
+            self.0.write(activation.gc()).cached_child_nodes = Some(array);
             self.refresh_cached_child_nodes(activation)?;
             Ok(array)
         }


### PR DESCRIPTION
This refactor makes code more concise and prevents mistakes when copy-pasting code (such as https://github.com/ruffle-rs/ruffle/pull/19024#discussion_r1894986715).