### PR TITLE
Revert "chore: Fix a nightly `clippy::unnecessary_map_or` lint"

### DIFF
--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1230,7 +1230,7 @@ impl<'gc> E4XNode<'gc> {
         };
 
         // 2.a. If N.prefix == "" and x.[[Name]].uri == "", return
-        if prefix.is_empty() && self.namespace().is_none_or(|ns| ns.uri.is_empty()) {
+        if prefix.is_empty() && self.namespace().map_or(true, |ns| ns.uri.is_empty()) {
             return;
         }
 


### PR DESCRIPTION
Reverts ruffle-rs/ruffle#19073

Can only be re-merged after https://github.com/ruffle-rs/ruffle/pull/18399, which itself needs other PR(s): https://github.com/ruffle-rs/ruffle/pull/18399#issuecomment-2514682267

The suggested code has only been available in stable since Rust 1.82: https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none_or