### PR TITLE
chore: Fix a nightly `clippy::unnecessary_map_or` lint

### DIFF
--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1230,7 +1230,7 @@ impl<'gc> E4XNode<'gc> {
         };
 
         // 2.a. If N.prefix == "" and x.[[Name]].uri == "", return
-        if prefix.is_empty() && self.namespace().map_or(true, |ns| ns.uri.is_empty()) {
+        if prefix.is_empty() && self.namespace().is_none_or(|ns| ns.uri.is_empty()) {
             return;
         }
 


### PR DESCRIPTION
This is https://github.com/ruffle-rs/ruffle/pull/19073 again, after having been reverted by https://github.com/ruffle-rs/ruffle/pull/19075.
To be merged only after https://github.com/ruffle-rs/ruffle/pull/18399.