### PR TITLE
web: Support align embed/object attribute (part of #4258)

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -497,6 +497,10 @@ export class InnerPlayer {
                 const alignValue = alignAttr.value.toLowerCase();
 
                 const alignCSS = (() => {
+                    // Blink: https://source.chromium.org/chromium/chromium/src/+/42e06bc6:third_party/blink/renderer/core/html/html_element.cc;l=1062-1083
+                    // WebKit: https://github.com/WebKit/WebKit/blob/f6b6c1d/Source/WebCore/html/HTMLElement.cpp#L592-L611
+                    // Gecko: https://github.com/mozilla/gecko-dev/blob/0383ce6/dom/html/nsGenericHTMLElement.cpp#L1326-L1341
+                    // Gecko (cont): https://github.com/mozilla/gecko-dev/blob/0383ce6/dom/html/nsGenericHTMLElement.cpp#L1557-L1561
                     switch (alignValue) {
                         case "right":
                             return "vertical-align: top; float: right;";

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -492,6 +492,43 @@ export class InnerPlayer {
                 }
             }
 
+            const alignAttr = this.element.attributes.getNamedItem("align");
+            if (alignAttr !== undefined && alignAttr !== null) {
+                const alignValue = alignAttr.value.toLowerCase();
+
+                const alignCSS = (() => {
+                    switch (alignValue) {
+                        case "right":
+                            return "vertical-align: top; float: right;";
+                        case "left":
+                            return "vertical-align: top; float: left;";
+                        case "bottom":
+                            return "vertical-align: baseline;";
+                        case "top":
+                            return "vertical-align: top;";
+                        case "center":
+                            return "vertical-align: middle; vertical-align: -moz-middle-with-baseline;";
+                        case "middle":
+                            return "vertical-align: middle; vertical-align: -webkit-baseline-middle; vertical-align: -moz-middle-with-baseline;";
+                        case "absbottom":
+                            return "vertical-align: bottom;";
+                        case "absmiddle":
+                        case "abscenter":
+                            return "vertical-align: middle;";
+                        case "texttop":
+                            return "vertical-align: text-top;";
+                        default:
+                            return "";
+                    }
+                })();
+
+                if (alignCSS) {
+                    this.dynamicStyles.sheet.insertRule(
+                        `:host { ${alignCSS} }`
+                    );
+                }
+            }
+
             const widthAttr = this.element.attributes.getNamedItem("width");
             if (widthAttr !== undefined && widthAttr !== null) {
                 const width = InnerPlayer.htmlDimensionToCssDimension(

--- a/web/packages/core/src/internal/player/ruffle-embed-element.ts
+++ b/web/packages/core/src/internal/player/ruffle-embed-element.ts
@@ -76,7 +76,7 @@ export class RuffleEmbedElement extends RufflePlayerElement {
      * @internal
      */
     static override get observedAttributes(): string[] {
-        return ["src", "width", "height"];
+        return [...RufflePlayerElement.observedAttributes, "src"];
     }
 
     /**

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -76,7 +76,7 @@ export class RufflePlayerElement extends HTMLElement implements PlayerElement {
     }
 
     static get observedAttributes(): string[] {
-        return ["width", "height"];
+        return ["width", "height", "align"];
     }
 
     attributeChangedCallback(
@@ -84,7 +84,7 @@ export class RufflePlayerElement extends HTMLElement implements PlayerElement {
         _oldValue: string | undefined,
         _newValue: string | undefined,
     ): void {
-        if (name === "width" || name === "height") {
+        if (RufflePlayerElement.observedAttributes.includes(name)) {
             this.#inner.updateStyles();
         }
     }


### PR DESCRIPTION
Not added to `config`/`options` as `align` itself is deprecated for `embed`/`object` elements - the same can be accomplished with the appropriate CSS.