### PR TITLE
Removed "rust" as a keyword in the .desktop

### DIFF
--- a/desktop/packages/linux/rs.ruffle.Ruffle.desktop.in
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.desktop.in
@@ -7,4 +7,4 @@ Icon=rs.ruffle.Ruffle
 Exec=ruffle %u
 MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie
 Categories=AudioVideo;Player;Graphics;Viewer;VectorGraphics;Game
-Keywords=flash;swf;player;emulator;rust
+Keywords=flash;swf;player;emulator

--- a/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml.in
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml.in
@@ -43,7 +43,6 @@
         <keyword>swf</keyword>
         <keyword>player</keyword>
         <keyword>emulator</keyword>
-        <keyword>rust</keyword>
     </keywords>
     <url type="homepage">https://ruffle.rs</url>
     <url type="bugtracker">https://github.com/ruffle-rs/ruffle/issues</url>


### PR DESCRIPTION
First of all, I know how this might looks, and I don't wish to sound "insulting" or petty. :)
I know you're all proud rustaceans, and you should be, because Rust is a great programming language. Be proud of your project, Ruffle is amazing! :D

But... was it necessary to put "rust" as a keyword in the .desktop file? To me the end user shouldn't care about what programming language was used to develop Ruffle... besides, it is already mentionned in the package description and it messes up my start menu when I type "rust"...

However don't worry, I wouldn't mind much if you choose to reject my PR. Have a great day.