### PR TITLE
desktop: Use async IO for file browsing in AVM

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -44,7 +44,7 @@ chrono = { workspace = true }
 fluent-templates = "0.12.0"
 toml_edit = { version = "0.22.22", features = ["parse"] }
 gilrs = "0.11"
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 
 tracing-tracy = { version = "0.11.3", optional = true, features = ["demangle"] }
 rand = "0.8.5"


### PR DESCRIPTION
Using async IO means we're not blocking the main thread and the content doesn't freeze while reading.

In theory, Ruffle should use only async IO, as otherwise the main thread will be blocked by every bit of IO performed. According to my knowledge this is the first instance of using async IO in Ruffle.

Things to consider:
* apparently `tokio::fs` is slow: https://github.com/tokio-rs/tokio/issues/3664,
* do we want to use `tokio::fs`, or `async-fs` (or something else) so that we are compatible with other runtimes (referring specifically to `frontend_utils`).