### PR TITLE
core: Handle font fallback for more known monospace fonts

### DIFF
--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -719,7 +719,10 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
         let default_font = match font_name.deref() {
             "Times New Roman" => DefaultFont::Serif,
             "Arial" => DefaultFont::Sans,
+            "Consolas" => DefaultFont::Typewriter,
+            "Courier" => DefaultFont::Typewriter,
             "Courier New" => DefaultFont::Typewriter,
+            "NSimSun" => DefaultFont::Typewriter,
             _ => {
                 if font_name.contains("Ming") || font_name.contains('明') {
                     DefaultFont::JapaneseMincho


### PR DESCRIPTION
* Progresses https://github.com/ruffle-rs/ruffle/issues/12257

This is based on the behavior of Flash: when no device font is available, Flash falls back to a monospace font for the following fonts:

* Consolas
* Courier
* Courier New
* NSimSun

Checked all default fonts of Windows and MacOS.