### PR TITLE
chore: Apply fixes for beta `clippy::precedence` lint

### DIFF
--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -441,13 +441,13 @@ pub fn copy_channel<'gc>(
 
             let result_color: u32 = match dest_channel {
                 // red
-                1 => (original_color & 0xFF00FFFF) | source_part << 16,
+                1 => (original_color & 0xFF00FFFF) | (source_part << 16),
                 // green
-                2 => (original_color & 0xFFFF00FF) | source_part << 8,
+                2 => (original_color & 0xFFFF00FF) | (source_part << 8),
                 // blue
                 4 => (original_color & 0xFFFFFF00) | source_part,
                 // alpha
-                8 => (original_color & 0x00FFFFFF) | source_part << 24,
+                8 => (original_color & 0x00FFFFFF) | (source_part << 24),
                 _ => original_color,
             };
 

--- a/flv/src/tag.rs
+++ b/flv/src/tag.rs
@@ -59,7 +59,7 @@ impl<'a> Tag<'a> {
             let timestamp_extended = reader.read_u8()?;
             let stream_id = reader.read_u24()?;
 
-            let timestamp = ((timestamp_extended as u32) << 24 | timestamp) as i32;
+            let timestamp = (((timestamp_extended as u32) << 24) | timestamp) as i32;
             let data_position = reader.stream_position()?;
             let new_position = data_position + data_size as u64;
 

--- a/render/src/pixel_bender.rs
+++ b/render/src/pixel_bender.rs
@@ -377,7 +377,7 @@ fn read_src_reg(val: u32, size: u8) -> Result<PixelBenderReg, Box<dyn std::error
     let swizzle = val >> 16;
     let mut channels = Vec::new();
     for i in 0..size {
-        channels.push(CHANNELS[(swizzle >> (6 - i * 2) & 3) as usize])
+        channels.push(CHANNELS[((swizzle >> (6 - i * 2)) & 3) as usize])
     }
 
     let kind = if val & 0x8000 != 0 {

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -1982,7 +1982,7 @@ impl<W: Write> Writer<W> {
     }
 
     fn write_sound_info(&mut self, sound_info: &SoundInfo) -> Result<()> {
-        let flags = (sound_info.event as u8) << 4
+        let flags = ((sound_info.event as u8) << 4)
             | if sound_info.in_sample.is_some() {
                 0b1
             } else {

--- a/video/software/src/decoder/screen.rs
+++ b/video/software/src/decoder/screen.rs
@@ -66,7 +66,7 @@ impl<'a> ByteReader<'a> {
     fn read_u16be(&mut self) -> Result<u16, ScreenError> {
         let byte1 = self.read_byte()?;
         let byte2 = self.read_byte()?;
-        Ok((byte1 as u16) << 8 | (byte2 as u16))
+        Ok(((byte1 as u16) << 8) | (byte2 as u16))
     }
 
     fn read_buf_ref(&mut self, length: usize) -> Result<&[u8], ScreenError> {


### PR DESCRIPTION
Not including https://github.com/ruffle-rs/ruffle/pull/19073 of course, see https://github.com/ruffle-rs/ruffle/pull/19075.