### PR TITLE
extension: Update declarativeNetRequest rules using the chrome namespace

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -141,7 +141,7 @@ async function enableSWFTakeover() {
                     },
                 },
             ];
-            await utils.declarativeNetRequest.updateDynamicRules({
+            await chrome.declarativeNetRequest.updateDynamicRules({
                 removeRuleIds: [1, 2, 3],
                 addRules: rules,
             });


### PR DESCRIPTION
I prefer using `utils` whenever possible, but sometimes DefinitelyTyped makes that harder than it should be. This should let #19206 be merged I think.