### PR TITLE
avm2: Fix URShift in optimizer and hasnext in interpreter when passed a negative index

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2531,7 +2531,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let cur_index = self.pop_stack().coerce_to_i32(self)?;
 
         if cur_index < 0 {
-            self.push_stack(false);
+            self.push_stack(0);
 
             return Ok(FrameControl::Continue);
         }
@@ -2619,17 +2619,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let value = self.pop_stack();
         let object = match value.null_check(self, None)? {
-            Value::Object(obj) => Some(obj),
-            value => value.proto(self),
+            Value::Object(obj) => obj,
+            value => value
+                .proto(self)
+                .expect("Primitives always have a prototype"),
         };
 
-        if let Some(object) = object {
-            let name = object.get_enumerant_name(cur_index as u32, self)?;
-
-            self.push_stack(name);
-        } else {
-            self.push_stack(Value::Undefined);
-        }
+        let name = object.get_enumerant_name(cur_index as u32, self)?;
+        self.push_stack(name);
 
         Ok(FrameControl::Continue)
     }
@@ -2645,17 +2642,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let value = self.pop_stack();
         let object = match value.null_check(self, None)? {
-            Value::Object(obj) => Some(obj),
-            value => value.proto(self),
+            Value::Object(obj) => obj,
+            value => value
+                .proto(self)
+                .expect("Primitives always have a prototype"),
         };
 
-        if let Some(object) = object {
-            let value = object.get_enumerant_value(cur_index as u32, self)?;
-
-            self.push_stack(value);
-        } else {
-            self.push_stack(Value::Undefined);
-        }
+        let value = object.get_enumerant_value(cur_index as u32, self)?;
+        self.push_stack(value);
 
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -153,6 +153,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
             .coerce_to_boolean())
     }
 
+    // FIXME: The AS-side Proxy.nextNameIndex returns an int, so this should return an i32
     fn get_next_enumerant(
         self,
         last_index: u32,

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -951,7 +951,7 @@ pub fn optimize<'gc>(
                 Op::URShift => {
                     stack.pop(activation)?;
                     stack.pop(activation)?;
-                    stack.push_class(activation, types.int)?;
+                    stack.push_class(activation, types.uint)?;
                 }
                 Op::PushDouble { .. } => {
                     stack.push_class(activation, types.number)?;
@@ -1252,14 +1252,20 @@ pub fn optimize<'gc>(
                 Op::HasNext => {
                     stack.pop(activation)?;
                     stack.pop(activation)?;
-                    stack.push_any(activation)?;
+
+                    // FIXME this should push `int` instead of `number`, but we have
+                    // to fix TObject::get_next_enumerant to return i32 for that
+                    stack.push_class(activation, types.number)?;
                 }
                 Op::HasNext2 {
                     index_register,
                     object_register,
                 } => {
                     stack.push_class(activation, types.boolean)?;
-                    local_types.set_any(*index_register as usize);
+
+                    // FIXME this should set the local to `int` instead of `number`, but
+                    // we have to fix TObject::get_next_enumerant to return i32 for that
+                    local_types.set(*index_register as usize, OptValue::of_type(types.number));
                     local_types.set_any(*object_register as usize);
                 }
                 Op::GetSlot { index: slot_id } => {


### PR DESCRIPTION
`op_has_next` should push `false`, not `0` when `cur_index` is negative, and Op::URShift should push the uint type in the optimizer, not the int type.