### PR TITLE
web: Qualify the vanilla (MVP) WASM module with a name suffix

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(all())']
-# NOTE that the web build overrides this setting in package.json via the RUSTFLAGS environment variable
+# NOTE that the web build overrides this setting in tools/build_wasm.ts via the RUSTFLAGS environment variable
 rustflags = [
     # We need to specify this flag for all targets because Clippy checks all of our code against all targets
     # and our web code does not compile without this flag

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,11 +117,11 @@ opt-level = 3
 [profile.dev.package.nihav_duck]
 opt-level = 3
 
-# TODO: Set rustflags here instead of in web/core/package.json, when that
+# TODO: Set rustflags here instead of in tools/build_wasm.ts, when that
 # feature becomes stable. See: https://github.com/rust-lang/cargo/issues/10271
 # Until then, these custom profiles let cargo keep the build cache alive
 # across "dual-wasm" builds, separating it for the two .wasm modules.
-[profile.web-vanilla-wasm]
+[profile.web-wasm-mvp]
 inherits = "release"
 
 [profile.web-wasm-extensions]

--- a/web/packages/core/src/internal/builder.ts
+++ b/web/packages/core/src/internal/builder.ts
@@ -1,4 +1,4 @@
-import type { RuffleInstanceBuilder } from "../../dist/ruffle_web-wasm_extensions";
+import type { RuffleInstanceBuilder } from "../../dist/ruffle_web";
 import { BaseLoadOptions, Duration, SecsDuration } from "../public/config";
 
 /**

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -1,4 +1,4 @@
-import type { RuffleHandle, ZipWriter } from "../../../dist/ruffle_web-wasm_extensions";
+import type { RuffleHandle, ZipWriter } from "../../../dist/ruffle_web";
 import {
     AutoPlay,
     ContextMenu,

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -9,10 +9,7 @@ import {
     signExtensions,
     referenceTypes,
 } from "wasm-feature-detect";
-import type {
-    RuffleInstanceBuilder,
-    ZipWriter,
-} from "../dist/ruffle_web-wasm_extensions";
+import type { RuffleInstanceBuilder, ZipWriter } from "../dist/ruffle_web";
 import { setPolyfillsOnLoad } from "./js-polyfills";
 
 import { internalSourceApi } from "./internal/internal-source-api";
@@ -49,9 +46,9 @@ async function fetchRuffle(
     ).every(Boolean);
 
     // @ts-expect-error TS2367 %FALLBACK_WASM% gets replaced in set_version.ts.
-    // %FALLBACK_WASM% is "ruffle_web" if this is a dual-wasm build.
+    // %FALLBACK_WASM% is "ruffle_web-wasm_mvp" if this is a dual-wasm build.
     // We don't say we're falling back if we have only an extension build.
-    if (!extensionsSupported && "%FALLBACK_WASM%" === "ruffle_web") {
+    if (!extensionsSupported && "%FALLBACK_WASM%" === "ruffle_web-wasm_mvp") {
         console.log(
             "Some WebAssembly extensions are NOT available, falling back to the vanilla WebAssembly module",
         );
@@ -68,12 +65,12 @@ async function fetchRuffle(
         RuffleInstanceBuilder,
         ZipWriter,
     } = await (extensionsSupported
-        ? import("../dist/ruffle_web-wasm_extensions")
+        ? import("../dist/ruffle_web")
         : // @ts-expect-error TS2307 TypeScript compiler is trying to do the import.
           import("../dist/%FALLBACK_WASM%"));
     let response;
     const wasmUrl = extensionsSupported
-        ? new URL("../dist/ruffle_web-wasm_extensions_bg.wasm", import.meta.url)
+        ? new URL("../dist/ruffle_web_bg.wasm", import.meta.url)
         : new URL("../dist/%FALLBACK_WASM%_bg.wasm", import.meta.url);
     const wasmResponse = await fetch(wasmUrl);
     // The Pale Moon browser lacks full support for ReadableStream.

--- a/web/packages/core/tools/build_wasm.ts
+++ b/web/packages/core/tools/build_wasm.ts
@@ -160,13 +160,13 @@ if (wasmSource === "cargo_and_store") {
     rmSync("../../dist", { recursive: true, force: true });
     mkdirSync("../../dist");
 }
-buildWasm(
-    "web-wasm-extensions",
-    "ruffle_web-wasm_extensions",
-    hasWasmOpt,
-    true,
-    wasmSource,
-);
+buildWasm("web-wasm-extensions", "ruffle_web", hasWasmOpt, true, wasmSource);
 if (buildWasmMvp) {
-    buildWasm("web-vanilla-wasm", "ruffle_web", hasWasmOpt, false, wasmSource);
+    buildWasm(
+        "web-wasm-mvp",
+        "ruffle_web-wasm_mvp",
+        hasWasmOpt,
+        false,
+        wasmSource,
+    );
 }

--- a/web/packages/core/tools/set_version.ts
+++ b/web/packages/core/tools/set_version.ts
@@ -66,8 +66,8 @@ if (process.env["ENABLE_VERSION_SEAL"] === "true") {
 
 const fallbackWasmName =
     process.env["BUILD_WASM_MVP"] === "true"
-        ? "ruffle_web"
-        : "ruffle_web-wasm_extensions";
+        ? "ruffle_web-wasm_mvp"
+        : "ruffle_web";
 
 const options = {
     files: "dist/**",


### PR DESCRIPTION
Instead of the one with extensions enabled.

A continuation of https://github.com/ruffle-rs/ruffle/pull/19198.