### PR TITLE
avm2: Store locals on AVM stack instead of per-Activation RegisterSets

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -784,7 +784,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         opcodes: &[Op<'gc>],
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         self.actions_since_timeout_check += 1;
-        if self.actions_since_timeout_check >= 64000 {
+        if self.actions_since_timeout_check >= 200000 {
             self.actions_since_timeout_check = 0;
             if self.context.update_start.elapsed() >= self.context.max_execution_duration {
                 return Err(

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -248,7 +248,12 @@ pub fn exec<'gc>(
                 .context
                 .avm2
                 .push_call(activation.gc(), method, bound_class);
-            activation.run_actions(bm)
+
+            let result = activation.run_actions(bm);
+
+            activation.cleanup();
+
+            result
         }
     };
     activation.context.avm2.pop_call(activation.gc());

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -502,19 +502,7 @@ pub fn optimize<'gc>(
         .body()
         .expect("Cannot verify non-native method without body!");
 
-    // This can probably be done better by recording the receiver in `Activation`,
-    // but this works since it's guaranteed to be set in `Activation::from_method`.
-    let this_value = activation.local_register(0);
-
-    let this_class = if let Some(this_class) = activation.bound_class() {
-        if this_value.is_of_type(activation, this_class) {
-            Some(this_class)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    let this_class = activation.bound_class();
 
     let this_value = OptValue {
         class: this_class,


### PR DESCRIPTION
This speeds up `getlocal`/`setlocal` by about 10%