### PR TITLE
chore: Address nightly clippy lints `double_ended_iterator_last` and `len_zero`

### DIFF
--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -333,7 +333,7 @@ pub fn download<'gc>(
             Some(file_name) => file_name.coerce_to_string(activation)?.to_string(),
             None => {
                 // Try to get the end of the path as a file name, if we can't bail and return false
-                match url.path().split('/').last() {
+                match url.path().split('/').next_back() {
                     Some(path_end) => path_end.to_string(),
                     None => return Ok(false.into()),
                 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -272,7 +272,7 @@ fn new_lso<'gc>(activation: &mut Activation<'_, 'gc>, name: &str, data: Object<'
     w.commit_lso(
         &name
             .split('/')
-            .last()
+            .next_back()
             .map(|e| e.to_string())
             .unwrap_or_else(|| "<unknown>".to_string()),
     )

--- a/core/src/avm2/globals/flash/net/shared_object.rs
+++ b/core/src/avm2/globals/flash/net/shared_object.rs
@@ -25,7 +25,7 @@ fn new_lso<'gc>(
     Ok(Lso::new(
         elements,
         name.split('/')
-            .last()
+            .next_back()
             .map(|e| e.to_string())
             .unwrap_or_else(|| "<unknown>".to_string()),
         AMFVersion::AMF3,

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -548,7 +548,7 @@ pub fn normalize<'gc>(
                     )?;
                 }
 
-                text.len() == 0
+                text.is_empty()
             };
 
             // ii. If list[i].[[Value]].length == 0

--- a/core/src/debug_ui/movie.rs
+++ b/core/src/debug_ui/movie.rs
@@ -277,7 +277,7 @@ pub fn open_character_button(ui: &mut Ui, character: &Character) {
 fn save_swf(movie: &Arc<SwfMovie>, messages: &mut Vec<Message>) {
     let suggested_name = if let Ok(url) = Url::parse(movie.url()) {
         url.path_segments()
-            .and_then(|segments| segments.last())
+            .and_then(|mut segments| segments.next_back())
             .map(|str| str.to_string())
     } else {
         None

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -1393,11 +1393,11 @@ impl<'gc> LayoutBox<'gc> {
             LayoutContent::Text {
                 text_format: TextFormat { url: Some(url), .. },
                 ..
-            } => url.len() > 0,
+            } => !url.is_empty(),
             LayoutContent::Bullet {
                 text_format: TextFormat { url: Some(url), .. },
                 ..
-            } => url.len() > 0,
+            } => !url.is_empty(),
             _ => false,
         }
     }

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -867,8 +867,8 @@ impl FormatSpans {
                         tag @ b"li" => {
                             format = apply_style(style_sheet, format, WStr::from_units(tag));
 
-                            let is_last_nl = text.iter().last() == Some(HTML_NEWLINE);
-                            if is_multiline && !is_last_nl && text.len() > 0 {
+                            let is_last_nl = text.iter().next_back() == Some(HTML_NEWLINE);
+                            if is_multiline && !is_last_nl && !text.is_empty() {
                                 // If the last paragraph was not closed and
                                 // there was some text since then,
                                 // we need to close it here.

--- a/frontend-utils/src/lib.rs
+++ b/frontend-utils/src/lib.rs
@@ -16,7 +16,7 @@ pub static INVALID_URL: &str = "invalid:///";
 pub fn url_to_readable_name(url: &Url) -> Cow<'_, str> {
     let name = url
         .path_segments()
-        .and_then(|segments| segments.last())
+        .and_then(|mut segments| segments.next_back())
         .unwrap_or_else(|| url.as_str());
 
     urlencoding::decode(name).unwrap_or(Cow::Borrowed(name))


### PR DESCRIPTION
See: https://github.com/ruffle-rs/ruffle/actions/runs/12819112889/job/35746103823?pr=19251#step:6:1045

https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last
https://rust-lang.github.io/rust-clippy/master/index.html#len_zero