### PR TITLE
avm2: Add proper API versioning for FTE classes

### DIFF
--- a/core/src/avm2/globals/flash/text/engine/BreakOpportunity.as
+++ b/core/src/avm2/globals/flash/text/engine/BreakOpportunity.as
@@ -5,22 +5,19 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class BreakOpportunity
     {
         // Treats all characters in the ContentElement object as line break opportunities, meaning that a line break will occur after each character.
         public static const ALL:String = "all";
-        
+
         // Treats any character in the ContentElement object as a line break opportunity.
         public static const ANY:String = "any";
-        
+
         // Bases line break opportunities on Unicode character properties.
         public static const AUTO:String = "auto";
-        
+
         // Treats no characters in the ContentElement object as line break opportunities.
         public static const NONE:String = "none";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/CFFHinting.as
+++ b/core/src/avm2/globals/flash/text/engine/CFFHinting.as
@@ -5,16 +5,13 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class CFFHinting
     {
         // Fits strong horizontal stems to the pixel grid for improved readability.
         public static const HORIZONTAL_STEM:String = "horizontalStem";
-        
+
         // No hinting is applied.
         public static const NONE:String = "none";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/ContentElement.as
+++ b/core/src/avm2/globals/flash/text/engine/ContentElement.as
@@ -1,5 +1,7 @@
 package flash.text.engine {
     import flash.events.EventDispatcher;
+
+    [API("662")]
     public class ContentElement {
         public static const GRAPHIC_ELEMENT:uint = 65007;
         public var userData;

--- a/core/src/avm2/globals/flash/text/engine/DigitCase.as
+++ b/core/src/avm2/globals/flash/text/engine/DigitCase.as
@@ -5,19 +5,16 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class DigitCase
     {
         // Used to specify default digit case.
         public static const DEFAULT:String = "default";
-        
+
         // Used to specify lining digit case.
         public static const LINING:String = "lining";
-        
+
         // Used to specify old style digit case.
         public static const OLD_STYLE:String = "oldStyle";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/DigitWidth.as
+++ b/core/src/avm2/globals/flash/text/engine/DigitWidth.as
@@ -5,19 +5,16 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class DigitWidth
     {
         // Used to specify default digit width.
         public static const DEFAULT:String = "default";
-        
+
         // Used to specify proportional digit width.
         public static const PROPORTIONAL:String = "proportional";
-        
+
         // Used to specify tabular digit width.
         public static const TABULAR:String = "tabular";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/EastAsianJustifier.as
+++ b/core/src/avm2/globals/flash/text/engine/EastAsianJustifier.as
@@ -1,4 +1,5 @@
 package flash.text.engine {
+    [API("662")]
     public final class EastAsianJustifier extends TextJustifier {
         public function EastAsianJustifier(locale:String = "ja", lineJustification:String = "allButLast", justificationStyle:String = "pushInKinsoku") {
             super(locale, lineJustification);

--- a/core/src/avm2/globals/flash/text/engine/ElementFormat.as
+++ b/core/src/avm2/globals/flash/text/engine/ElementFormat.as
@@ -1,4 +1,5 @@
 package flash.text.engine {
+    [API("662")]
     public final class ElementFormat {
         private var _alignmentBaseline:String;
 

--- a/core/src/avm2/globals/flash/text/engine/FontDescription.as
+++ b/core/src/avm2/globals/flash/text/engine/FontDescription.as
@@ -1,6 +1,7 @@
 package flash.text.engine {
     import __ruffle__.stub_method;
 
+    [API("662")]
     public final class FontDescription {
         [Ruffle(InternalSlot)]
         private var _fontName:String;

--- a/core/src/avm2/globals/flash/text/engine/FontLookup.as
+++ b/core/src/avm2/globals/flash/text/engine/FontLookup.as
@@ -5,16 +5,13 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class FontLookup
     {
         // Used to indicate device font lookup.
         public static const DEVICE:String = "device";
-        
+
         // Used to indicate embedded CFF (Compact Font Format) font lookup.
         public static const EMBEDDED_CFF:String = "embeddedCFF";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/FontMetrics.as
+++ b/core/src/avm2/globals/flash/text/engine/FontMetrics.as
@@ -1,6 +1,7 @@
 package flash.text.engine {
     import flash.geom.Rectangle;
 
+    [API("662")]
     public final class FontMetrics {
         public var emBox:Rectangle;
 
@@ -22,7 +23,7 @@ package flash.text.engine {
 
         [API("674")]
         public var lineGap:Number;
-      
+
         public function FontMetrics(emBox:Rectangle, strikethroughOffset:Number, strikethroughThickness:Number, underlineOffset:Number, underlineThickness:Number, subscriptOffset:Number, subscriptScale:Number, superscriptOffset:Number, superscriptScale:Number, lineGap:Number = 0) {
             this.emBox = emBox;
             this.strikethroughOffset = strikethroughOffset;
@@ -37,4 +38,3 @@ package flash.text.engine {
         }
     }
 }
-

--- a/core/src/avm2/globals/flash/text/engine/FontPosture.as
+++ b/core/src/avm2/globals/flash/text/engine/FontPosture.as
@@ -5,16 +5,13 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class FontPosture
     {
         // Used to indicate italic font posture.
         public static const ITALIC:String = "italic";
-        
+
         // Used to indicate normal font posture.
         public static const NORMAL:String = "normal";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/FontWeight.as
+++ b/core/src/avm2/globals/flash/text/engine/FontWeight.as
@@ -5,16 +5,13 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class FontWeight
     {
         // Used to indicate bold font weight.
         public static const BOLD:String = "bold";
-        
+
         // Used to indicate normal font weight.
         public static const NORMAL:String = "normal";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/GraphicElement.as
+++ b/core/src/avm2/globals/flash/text/engine/GraphicElement.as
@@ -6,6 +6,7 @@ package flash.text.engine {
     import __ruffle__.stub_getter;
     import __ruffle__.stub_setter;
 
+    [API("662")]
     public final class GraphicElement extends ContentElement {
         public function GraphicElement(graphic:DisplayObject = null, elementWidth:Number = 15.0, elementHeight:Number = 15.0, elementFormat:ElementFormat = null, eventMirror:EventDispatcher = null, textRotation:String = "rotate0") {
             stub_constructor("flash.text.engine.GraphicElement");

--- a/core/src/avm2/globals/flash/text/engine/GroupElement.as
+++ b/core/src/avm2/globals/flash/text/engine/GroupElement.as
@@ -3,6 +3,7 @@ package flash.text.engine {
 
     import flash.events.EventDispatcher;
 
+    [API("662")]
     public final class GroupElement extends ContentElement {
         internal var _elements = null;
 
@@ -82,4 +83,3 @@ package flash.text.engine {
         }
     }
 }
-

--- a/core/src/avm2/globals/flash/text/engine/JustificationStyle.as
+++ b/core/src/avm2/globals/flash/text/engine/JustificationStyle.as
@@ -5,19 +5,16 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class JustificationStyle
     {
         // Bases justification on either expanding or compressing the line, whichever gives a result closest to the desired width.
         public static const PRIORITIZE_LEAST_ADJUSTMENT:String = "prioritizeLeastAdjustment";
-        
+
         // Bases justification on compressing kinsoku at the end of the line, or expanding it if no kinsoku occurs or if that space is insufficient.
         public static const PUSH_IN_KINSOKU:String = "pushInKinsoku";
-        
+
         // Bases justification on expanding the line.
         public static const PUSH_OUT_ONLY:String = "pushOutOnly";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/Kerning.as
+++ b/core/src/avm2/globals/flash/text/engine/Kerning.as
@@ -5,19 +5,16 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class Kerning
     {
         // Used to indicate that kerning is enabled except where inappropriate in Asian typography.
         public static const AUTO:String = "auto";
-        
+
         // Used to indicate kerning is disabled.
         public static const OFF:String = "off";
-        
+
         // Used to indicate kerning is enabled.
         public static const ON:String = "on";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/LigatureLevel.as
+++ b/core/src/avm2/globals/flash/text/engine/LigatureLevel.as
@@ -5,25 +5,22 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class LigatureLevel
     {
         // Used to specify common ligatures.
         public static const COMMON:String = "common";
-        
+
         // Used to specify exotic ligatures.
         public static const EXOTIC:String = "exotic";
-        
+
         // Used to specify minimum ligatures.
         public static const MINIMUM:String = "minimum";
-        
+
         // Used to specify no ligatures.
         public static const NONE:String = "none";
-        
+
         // Used to specify uncommon ligatures.
         public static const UNCOMMON:String = "uncommon";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/LineJustification.as
+++ b/core/src/avm2/globals/flash/text/engine/LineJustification.as
@@ -5,23 +5,20 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class LineJustification
     {
         // Justify all but the last line.
         public static const ALL_BUT_LAST:String = "allButLast";
-        
+
         // Justify all but the last line and lines ending in mandatory breaks.
         [API("674")]
         public static const ALL_BUT_MANDATORY_BREAK:String = "allButMandatoryBreak";
-        
+
         // Justify all lines.
         public static const ALL_INCLUDING_LAST:String = "allIncludingLast";
-        
+
         // Do not justify lines.
         public static const UNJUSTIFIED:String = "unjustified";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/RenderingMode.as
+++ b/core/src/avm2/globals/flash/text/engine/RenderingMode.as
@@ -5,16 +5,13 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class RenderingMode
     {
         // Sets rendering mode to CFF (Compact Font Format).
         public static const CFF:String = "cff";
-        
+
         // Sets rendering mode to the rendering mode that is used in Flash Player 7 and earlier.
         public static const NORMAL:String = "normal";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/SpaceJustifier.as
+++ b/core/src/avm2/globals/flash/text/engine/SpaceJustifier.as
@@ -1,4 +1,5 @@
 package flash.text.engine {
+    [API("662")]
     public final class SpaceJustifier extends TextJustifier {
         private var _letterSpacing:Boolean;
         private var _minimumSpacing:Number = 0.5;

--- a/core/src/avm2/globals/flash/text/engine/TabAlignment.as
+++ b/core/src/avm2/globals/flash/text/engine/TabAlignment.as
@@ -5,22 +5,19 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class TabAlignment
     {
         // Positions the center of the tabbed text at the tab stop.
         public static const CENTER:String = "center";
-        
+
         // Positions the alignment token of the tabbed text at the tab stop.
         public static const DECIMAL:String = "decimal";
-        
+
         // Positions the end of the tabbed text at the tab stop.
         public static const END:String = "end";
-        
+
         // Positions the start of the tabbed text at the tab stop.
         public static const START:String = "start";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/TabStop.as
+++ b/core/src/avm2/globals/flash/text/engine/TabStop.as
@@ -1,10 +1,11 @@
 package flash.text.engine {
+    [API("662")]
     public final class TabStop {
         // FIXME: These should be getters/setters to match Flash
         public var alignment:String;
         public var position:Number;
         public var decimalAlignmentToken:String;
-        
+
         public function TabStop(alignment:String = "start", position:Number = 0, decimalAlignmentToken:String = "") {
             this.alignment = alignment;
             this.position = position;

--- a/core/src/avm2/globals/flash/text/engine/TextBaseline.as
+++ b/core/src/avm2/globals/flash/text/engine/TextBaseline.as
@@ -5,31 +5,30 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class TextBaseline
     {
         // Specifies an ascent baseline.
         public static const ASCENT:String = "ascent";
-        
+
         // Specifies a descent baseline.
         public static const DESCENT:String = "descent";
-        
+
         // Specifies an ideographic bottom baseline.
         public static const IDEOGRAPHIC_BOTTOM:String = "ideographicBottom";
-        
+
         // Specifies an ideographic center baseline.
         public static const IDEOGRAPHIC_CENTER:String = "ideographicCenter";
-        
+
         // Specifies an ideographic top baseline.
         public static const IDEOGRAPHIC_TOP:String = "ideographicTop";
-        
+
         // Specifies a roman baseline.
         public static const ROMAN:String = "roman";
-        
+
         // Specifies that the alignmentBaseline is the same as the dominantBaseline.
         public static const USE_DOMINANT_BASELINE:String = "useDominantBaseline";
-        
-        
+
+
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/TextBlock.as
+++ b/core/src/avm2/globals/flash/text/engine/TextBlock.as
@@ -1,6 +1,7 @@
 package flash.text.engine {
     import __ruffle__.stub_method;
 
+    [API("662")]
     public final class TextBlock {
         public var userData;
 
@@ -167,7 +168,7 @@ package flash.text.engine {
         public function get lastLine():TextLine {
             return this._firstLine;
         }
-        
+
         public function releaseLines(start:TextLine, end:TextLine):void {
             if (start != end || end != this._firstLine) {
                 stub_method("flash.text.engine.TextBlock", "releaseLines", "with start != end or multiple lines");

--- a/core/src/avm2/globals/flash/text/engine/TextElement.as
+++ b/core/src/avm2/globals/flash/text/engine/TextElement.as
@@ -2,13 +2,14 @@ package flash.text.engine {
     import flash.events.EventDispatcher;
     import __ruffle__.stub_setter;
     import __ruffle__.stub_method;
-   
+
+    [API("662")]
     public final class TextElement extends ContentElement {
         public function TextElement(text:String = null, elementFormat:ElementFormat = null, eventMirror:EventDispatcher = null, textRotation:String = "rotate0") {
             super(elementFormat, eventMirror, textRotation);
             this.text = text;
         }
-        
+
         // Contrary to the documentation, TextElement does not implement a getter here. It inherits the getter from ContentElement.
         public function set text(value:String):void {
             this._text = value;

--- a/core/src/avm2/globals/flash/text/engine/TextJustifier.as
+++ b/core/src/avm2/globals/flash/text/engine/TextJustifier.as
@@ -1,6 +1,7 @@
 package flash.text.engine {
     import flash.utils.getQualifiedClassName;
 
+    [API("662")]
     public class TextJustifier {
         private var _lineJustification:String = null;
         public function TextJustifier(locale:String, lineJustification:String) {

--- a/core/src/avm2/globals/flash/text/engine/TextLine.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLine.as
@@ -13,6 +13,7 @@ package flash.text.engine {
     // however, it's unlikely that SWFs will actually attempt to add children
     // to a TextLine.
     [Ruffle(Abstract)]
+    [API("662")]
     public final class TextLine extends DisplayObjectContainer {
         [Ruffle(InternalSlot)]
         private var _specifiedWidth:Number = 0.0;

--- a/core/src/avm2/globals/flash/text/engine/TextLineCreationResult.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLineCreationResult.as
@@ -5,22 +5,19 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class TextLineCreationResult
     {
         // Indicates no line was created because all text in the block had already been broken.
         public static const COMPLETE:String = "complete";
-        
+
         // Indicates the line was created with an emergency break because no break opportunity was available in the specified width.
         public static const EMERGENCY:String = "emergency";
-        
+
         // Indicates no line was created because no text could fit in the specified width and fitSomething was not specified in the call to createTextLine().
         public static const INSUFFICIENT_WIDTH:String = "insufficientWidth";
-        
+
         // Indicates the line was successfully broken.
         public static const SUCCESS:String = "success";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/TextLineValidity.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLineValidity.as
@@ -5,22 +5,21 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class TextLineValidity
     {
         // Specifies that the line is invalid.
         public static const INVALID:String = "invalid";
-        
+
         // Specifies that the text line is possibly invalid.
         public static const POSSIBLY_INVALID:String = "possiblyInvalid";
-        
+
         // Specifies that the line is static, and that the connection between the line and the text block has been severed.
         public static const STATIC:String = "static";
-        
+
         // Specifies that the text line is valid.
         public static const VALID:String = "valid";
-        
-        
+
+
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/TextRotation.as
+++ b/core/src/avm2/globals/flash/text/engine/TextRotation.as
@@ -5,25 +5,22 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class TextRotation
     {
         // Specifies a 90 degree counter clockwise rotation for full width and wide glyphs only, as determined by the Unicode properties of the glyph.
         public static const AUTO:String = "auto";
-        
+
         // Specifies no rotation.
         public static const ROTATE_0:String = "rotate0";
-        
+
         // Specifies a 180 degree rotation.
         public static const ROTATE_180:String = "rotate180";
-        
+
         // Specifies a 270 degree clockwise rotation.
         public static const ROTATE_270:String = "rotate270";
-        
+
         // Specifies a 90 degree clockwise rotation.
         public static const ROTATE_90:String = "rotate90";
-        
-        
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/TypographicCase.as
+++ b/core/src/avm2/globals/flash/text/engine/TypographicCase.as
@@ -5,31 +5,28 @@
 
 package flash.text.engine
 {
-    
-    
+    [API("662")]
     public final class TypographicCase
     {
         // Specifies that spacing is adjusted for uppercase characters on output.
         public static const CAPS:String = "caps";
-        
+
         // Specifies that all lowercase characters use small-caps glyphs on output.
         public static const CAPS_AND_SMALL_CAPS:String = "capsAndSmallCaps";
-        
+
         // Specifies default typographic case.
         public static const DEFAULT:String = "default";
-        
+
         // Specifies that all characters use lowercase glyphs on output.
         public static const LOWERCASE:String = "lowercase";
-        
+
         // Specifies that uppercase characters use small-caps glyphs on output.
         public static const SMALL_CAPS:String = "smallCaps";
-        
+
         // Specifies that uppercase characters use title glyphs on output.
         public static const TITLE:String = "title";
-        
+
         // Specifies that all characters use uppercase glyphs on output.
         public static const UPPERCASE:String = "uppercase";
-        
-        
     }
 }


### PR DESCRIPTION
Docs claim every class is _Flash Player 10, AIR 1.5, Flash Lite 4_.