### PR TITLE
avm2: Stub more methods from FTE

### DIFF
--- a/core/src/avm2/globals/flash/text/engine/ElementFormat.as
+++ b/core/src/avm2/globals/flash/text/engine/ElementFormat.as
@@ -1,4 +1,8 @@
 package flash.text.engine {
+    import __ruffle__.stub_method;
+
+    import flash.geom.Rectangle;
+
     [API("662")]
     public final class ElementFormat {
         private var _alignmentBaseline:String;
@@ -199,6 +203,14 @@ package flash.text.engine {
 
         public function set typographicCase(value:String):void {
             this._typographicCase = value;
+        }
+
+        public function getFontMetrics():FontMetrics {
+            stub_method("flash.text.engine.ElementFormat", "getFontMetrics");
+            var emBox:Rectangle = new Rectangle(0, _fontSize * -0.8, _fontSize, _fontSize);
+            return new FontMetrics(
+                emBox, -5, 1.2, 1.8, 1.2, 0.075, 0.6, -0.35, 0.6, 0.0
+            );
         }
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/TextLine.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLine.as
@@ -3,6 +3,7 @@ package flash.text.engine {
     import __ruffle__.stub_setter;
     import __ruffle__.stub_method;
 
+    import flash.display.DisplayObject;
     import flash.display.DisplayObjectContainer;
     import flash.errors.IllegalOperationError;
     import flash.geom.Rectangle;
@@ -113,9 +114,44 @@ package flash.text.engine {
             return -1;
         }
 
+        public function getAtomBidiLevel(index:int):int {
+            stub_method("flash.text.engine.TextLine", "getAtomBidiLevel");
+            return 0;
+        }
+
         public function getAtomBounds(index:int):Rectangle {
             stub_method("flash.text.engine.TextLine", "getAtomBounds");
             return new Rectangle(0, 0, 0, 0);
+        }
+
+        public function getAtomCenter(index:int):Number {
+            stub_method("flash.text.engine.TextLine", "getAtomCenter");
+            return 1.0;
+        }
+
+        public function getAtomGraphic(index:int):DisplayObject {
+            stub_method("flash.text.engine.TextLine", "getAtomGraphic");
+            return null;
+        }
+
+        public function getAtomTextBlockBeginIndex(index:int):int {
+            stub_method("flash.text.engine.TextLine", "getAtomTextBlockBeginIndex");
+            return 0;
+        }
+
+        public function getAtomTextBlockEndIndex(index:int):int {
+            stub_method("flash.text.engine.TextLine", "getAtomTextBlockEndIndex");
+            return 0;
+        }
+
+        public function getAtomTextRotation(index:int):String {
+            stub_method("flash.text.engine.TextLine", "getAtomTextRotation");
+            return TextRotation.ROTATE_0;
+        }
+
+        public function getAtomWordBoundaryOnLeft(index:int):Boolean {
+            stub_method("flash.text.engine.TextLine", "getAtomWordBoundaryOnLeft");
+            return false;
         }
 
         // This function does nothing in Flash Player 32


### PR DESCRIPTION
Stubbed methods:
* `ElementFormat.getFontMetrics`
* `TextLine.getAtomBidiLevel`
* `TextLine.getAtomCenter`
* `TextLine.getAtomGraphic`
* `TextLine.getAtomTextBlockBeginIndex`
* `TextLine.getAtomTextBlockEndIndex`
* `TextLine.getAtomTextRotation`
* `TextLine.getAtomWordBoundaryOnLeft`