### PR TITLE
swf: Bump version to 0.2.2 for crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4971,7 +4971,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bitflags 2.7.0",
  "bitstream-io",

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf"
-version = "0.2.1"
+version = "0.2.2"
 description = "Read and write the Adobe Flash SWF file format."
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
I don't think we do anything more here - no changelog, no anything.
I'm just gonna run `cargo publish` after merging.

I also looked through commit list, I think this is the only possibly incompatible change: https://github.com/ruffle-rs/ruffle/pull/17030