### PR TITLE
Add "StartupNotify=false" to Linux .desktop file

### DIFF
--- a/desktop/packages/linux/rs.ruffle.Ruffle.desktop
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.desktop
@@ -73,3 +73,4 @@ Keywords[uk]=flash;swf;програвач;емулятор
 Keywords[zh_CN]=flash;swf;播放器;模拟器
 Keywords[zh_TW]=flash;swf;播放器;模擬器
 Keywords=flash;swf;player;emulator
+StartupNotify=false


### PR DESCRIPTION
This fixes two windows appearing in the KDE Plasma taskbar when starting Ruffle under Wayland (the first one takes some time to disappear, and serves no purpose).

This probably should not be done this way, but for now this fixes it.

See https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html#id-1.7.6 and https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/ for more details.