### PR TITLE
web: Allow defining custom names for TTF fontSources

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -615,17 +615,19 @@ export class InnerPlayer {
                     }
                 } else if (typeof fontSource === "object") {
                     // Handle new format (object with additional properties)
-                    try {
-                        const response = await fetch(key);
-                        builder.addFont(
-                            key,
-                            typeof fontSource['name'] === "string" ? fontSource['name'] : null,
-                            typeof fontSource['bold'] === "boolean" ? fontSource['bold'] : null,
-                            typeof fontSource['italics'] === "boolean" ? fontSource['italics'] : null,
-                            new Uint8Array(await response.arrayBuffer()),
-                        );
-                    } catch (error) {
-                        console.warn(`Couldn't download font source from ${key}`, error);
+                    for (const [url, fontInfo] of Object.entries(fontSource)) {
+                        try {
+                            const response = await fetch(url);
+                            builder.addFont(
+                                url,
+                                fontInfo?.['name'] || null,
+                                fontInfo?.['bold'] ?? null,
+                                fontInfo?.['italics'] ?? null,
+                                new Uint8Array(await response.arrayBuffer()),
+                            );
+                        } catch (error) {
+                            console.warn(`Couldn't download font source from ${key}`, error);
+                        }
                     }
                 }
             }

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -597,37 +597,55 @@ export class InnerPlayer {
         builder.setVolume(this.volumeSettings.get_volume());
 
         if (this.loadedConfig?.fontSources) {
-            for (const key in this.loadedConfig.fontSources) {
-                const fontSource = this.loadedConfig.fontSources[key];
-                if (typeof fontSource === "string") {
-                    // Handle old format (array of strings)
-                    try {
-                        const response = await fetch(fontSource);
-                        builder.addFont(
-                            fontSource,
-                            null, // No custom name
-                            null, // No bold override
-                            null, // No italic override
-                            new Uint8Array(await response.arrayBuffer()),
-                        );
-                    } catch (error) {
-                        console.warn(`Couldn't download font source from ${fontSource}`, error);
-                    }
-                } else if (typeof fontSource === "object") {
-                    // Handle new format (object with additional properties)
-                    for (const [url, fontInfo] of Object.entries(fontSource)) {
+            const fontSources  = this.loadedConfig.fontSources;
+            if (Array.isArray(fontSources)) {
+                for (const fontSource of fontSources) {
+                    if (typeof fontSource === "string") {
+                        // Handle old format (array of strings)
                         try {
-                            const response = await fetch(url);
+                            const response = await fetch(fontSource);
                             builder.addFont(
-                                url,
-                                fontInfo?.['name'] || null,
-                                fontInfo?.['bold'] ?? null,
-                                fontInfo?.['italics'] ?? null,
+                                fontSource,
+                                null, // No custom name
+                                null, // No bold override
+                                null, // No italic override
                                 new Uint8Array(await response.arrayBuffer()),
                             );
                         } catch (error) {
-                            console.warn(`Couldn't download font source from ${key}`, error);
+                            console.warn(`Couldn't download font source from ${fontSource}`, error);
                         }
+                    } else if (typeof fontSource === "object") {
+                        // Handle new format (object with additional properties)
+                        for (const [url, fontInfo] of Object.entries(fontSource)) {
+                            try {
+                                const response = await fetch(url);
+                                builder.addFont(
+                                    url,
+                                    fontInfo?.['name'] || null,
+                                    fontInfo?.['bold'] ?? null,
+                                    fontInfo?.['italics'] ?? null,
+                                    new Uint8Array(await response.arrayBuffer()),
+                                );
+                            } catch (error) {
+                                console.warn(`Couldn't download font source from ${url}`, error);
+                            }
+                        }
+                    }
+                }
+            } else if (typeof fontSources === "object") {
+                // Handle the case where fontSources is a plain object
+                for (const [url, fontInfo] of Object.entries(fontSources)) {
+                    try {
+                        const response = await fetch(url);
+                        builder.addFont(
+                            url,
+                            fontInfo?.['name'] || null,
+                            fontInfo?.['bold'] ?? null,
+                            fontInfo?.['italics'] ?? null,
+                            new Uint8Array(await response.arrayBuffer()),
+                        );
+                    } catch (error) {
+                        console.warn(`Couldn't download font source from ${url}`, error);
                     }
                 }
             }

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -597,18 +597,36 @@ export class InnerPlayer {
         builder.setVolume(this.volumeSettings.get_volume());
 
         if (this.loadedConfig?.fontSources) {
-            for (const url of this.loadedConfig.fontSources) {
-                try {
-                    const response = await fetch(url);
-                    builder.addFont(
-                        url,
-                        new Uint8Array(await response.arrayBuffer()),
-                    );
-                } catch (error) {
-                    console.warn(
-                        `Couldn't download font source from ${url}`,
-                        error,
-                    );
+            for (const key in this.loadedConfig.fontSources) {
+                const fontSource = this.loadedConfig.fontSources[key];
+                if (typeof fontSource === "string") {
+                    // Handle old format (array of strings)
+                    try {
+                        const response = await fetch(fontSource);
+                        builder.addFont(
+                            fontSource,
+                            null, // No custom name
+                            null, // No bold override
+                            null, // No italic override
+                            new Uint8Array(await response.arrayBuffer()),
+                        );
+                    } catch (error) {
+                        console.warn(`Couldn't download font source from ${fontSource}`, error);
+                    }
+                } else if (typeof fontSource === "object") {
+                    // Handle new format (object with additional properties)
+                    try {
+                        const response = await fetch(key);
+                        builder.addFont(
+                            key,
+                            fontSource["name"] || null,
+                            fontSource["bold"] ?? null,
+                            fontSource["italics"] ?? null,
+                            new Uint8Array(await response.arrayBuffer()),
+                        );
+                    } catch (error) {
+                        console.warn(`Couldn't download font source from ${key}`, error);
+                    }
                 }
             }
         }

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -619,9 +619,9 @@ export class InnerPlayer {
                         const response = await fetch(key);
                         builder.addFont(
                             key,
-                            fontSource["name"] || null,
-                            fontSource["bold"] ?? null,
-                            fontSource["italics"] ?? null,
+                            typeof fontSource['name'] === "string" ? fontSource['name'] : null,
+                            typeof fontSource['bold'] === "boolean" ? fontSource['bold'] : null,
+                            typeof fontSource['italics'] === "boolean" ? fontSource['italics'] : null,
                             new Uint8Array(await response.arrayBuffer()),
                         );
                     } catch (error) {

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -656,7 +656,13 @@ export interface BaseLoadOptions {
      */
     fontSources?: Array<
         | string
-        | { [key: string]: { name?: string; bold?: boolean; italics?: boolean } }
+        | {
+              [key: string]: {
+                  name?: string;
+                  bold?: boolean;
+                  italics?: boolean;
+              };
+          }
     >;
 
     /**

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -648,14 +648,13 @@ export interface BaseLoadOptions {
      *
      * These will be fetched by the browser as part of the loading of Flash content, which may slow down load times.
      *
-     * When using an SWF source, and each font embedded within that SWF will be used as device font by Flash content.
+     * When using an SWF source, each font embedded within that SWF will be used as device font by Flash content.
      *
      * If any URL fails to load (either it's an invalid file, or a network error occurs), Ruffle will log an error but continue without it.
      *
      * @default []
      */
-    fontSources?: Array<
-        | string
+    fontSources?:
         | {
               [key: string]: {
                   name?: string;
@@ -663,7 +662,16 @@ export interface BaseLoadOptions {
                   italics?: boolean;
               };
           }
-    >;
+        | Array<
+              | string
+              | {
+                    [key: string]: {
+                        name?: string;
+                        bold?: boolean;
+                        italics?: boolean;
+                    };
+                }
+          >;
 
     /**
      * The font names to use for each "default" Flash device font.

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -644,17 +644,20 @@ export interface BaseLoadOptions {
     socketProxy?: Array<SocketProxy>;
 
     /**
-     * An array of font URLs to eagerly load and provide to Ruffle.
+     * An array of font URLs, or objects with font URL keys and name, bold, and italic values to eagerly load and provide to Ruffle.
      *
      * These will be fetched by the browser as part of the loading of Flash content, which may slow down load times.
      *
-     * Currently only SWFs are supported, and each font embedded within that SWF will be used as device font by Flash content.
+     * When using an SWF source, and each font embedded within that SWF will be used as device font by Flash content.
      *
      * If any URL fails to load (either it's an invalid file, or a network error occurs), Ruffle will log an error but continue without it.
      *
      * @default []
      */
-    fontSources?: Array<string>;
+    fontSources?: Array<
+        | string
+        | { [key: string]: { name?: string; bold?: boolean; italics?: boolean } }
+    >;
 
     /**
      * The font names to use for each "default" Flash device font.

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -310,9 +310,17 @@ impl RuffleInstanceBuilder {
         font_name: Option<String>,
         bold: Option<bool>,
         italic: Option<bool>,
-        data: Vec<u8>
+        data: Vec<u8>,
     ) {
-        self.custom_fonts.push((font_url, FontSource { name: font_name, bold, italic, data }));
+        self.custom_fonts.push((
+            font_url,
+            FontSource {
+                name: font_name,
+                bold,
+                italic,
+                data,
+            },
+        ));
     }
 
     #[wasm_bindgen(js_name = "setDefaultFont")]
@@ -377,7 +385,13 @@ impl RuffleInstanceBuilder {
                 // Register all remaining fonts in the collection if it is a collection
                 for i in 1u32..number_of_fonts {
                     if let Ok(face) = ttf_parser::Face::parse(bytes_slice, i) {
-                        Self::register_ttf_face_by_name(font_name, font_source.clone(), face, i, player);
+                        Self::register_ttf_face_by_name(
+                            font_name,
+                            font_source.clone(),
+                            face,
+                            i,
+                            player,
+                        );
                     } else {
                         tracing::warn!(
                             "Failed to parse font {font_name} at index {i} in font collection"

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -32,7 +32,6 @@ use tracing_wasm::{WASMLayer, WASMLayerConfigBuilder};
 use wasm_bindgen::prelude::*;
 use web_sys::{HtmlCanvasElement, HtmlElement};
 
-#[wasm_bindgen(inspectable)]
 #[derive(Debug, Clone)]
 pub struct FontSource {
     pub name: Option<String>,
@@ -387,7 +386,7 @@ impl RuffleInstanceBuilder {
                 }
             } else {
                 tracing::debug!("Loading font {font_name} as SWF font");
-                if let Ok(swf_stream) = swf::decompress_swf(&bytes[..]) {
+                if let Ok(swf_stream) = swf::decompress_swf(&font_source.data[..]) {
                     if let Ok(swf) = swf::parse_swf(&swf_stream) {
                         let encoding = swf::SwfStr::encoding_for_version(swf.header.version());
                         for tag in swf.tags {


### PR DESCRIPTION
Per https://github.com/ruffle-rs/ruffle/issues/19269#issuecomment-2613619265, draft PR to try to fix that issue. Note, it is mostly human-reviewed AI generated content. For full transparency, the prompt was this:

> I have this current code in web/src/builder.rs:
> https://github.com/ruffle-rs/ruffle/blob/41e373c5aaee802658c0a5f40a9b9fd307902fbb/web/src/builder.rs#L34-L36
> ...
> https://github.com/ruffle-rs/ruffle/blob/41e373c5aaee802658c0a5f40a9b9fd307902fbb/web/src/builder.rs#L63-L67
> ...
> https://github.com/ruffle-rs/ruffle/blob/41e373c5aaee802658c0a5f40a9b9fd307902fbb/web/src/builder.rs#L72
> ...
> https://github.com/ruffle-rs/ruffle/blob/41e373c5aaee802658c0a5f40a9b9fd307902fbb/web/src/builder.rs#L99-L102
> ...
> https://github.com/ruffle-rs/ruffle/blob/41e373c5aaee802658c0a5f40a9b9fd307902fbb/web/src/builder.rs#L339-L360
> ...
> https://github.com/ruffle-rs/ruffle/blob/41e373c5aaee802658c0a5f40a9b9fd307902fbb/web/src/builder.rs#L406-L407
> ...
> https://github.com/ruffle-rs/ruffle/blob/41e373c5aaee802658c0a5f40a9b9fd307902fbb/web/src/builder.rs#L412-L442
> ...
> https://github.com/ruffle-rs/ruffle/blob/41e373c5aaee802658c0a5f40a9b9fd307902fbb/web/src/builder.rs#L687
> ...
> https://github.com/ruffle-rs/ruffle/blob/41e373c5aaee802658c0a5f40a9b9fd307902fbb/web/src/builder.rs#L295-L298
> In a TS file, I have this code that uses that addFont wasm_bindgen function:
> https://github.com/ruffle-rs/ruffle/blob/32f6322efba15ba1d37fbc64ba6cda3b3d0ff7c5/web/packages/core/src/internal/player/inner.tsx#L599-L614
> fontSources is defined in a different file as this:
> https://github.com/ruffle-rs/ruffle/blob/c15c273b75b2e4782e5c480a58cf6a8a6900af96/web/packages/core/src/public/config/load-options.ts#L637
> An example of fontSources is this:
> ```js
> fontSources: ["NotoSans-Bold.ttf", "NotoSans-Italic.ttf"]
> ```
> Adjust the code's logic to allow either this structure with this current logic or this structure:
> ```js
> fontSources: [
>    "fonts/Noto-Sans-Bold.ttf": {
>        "name": "Noto Sans",
>        "bold": true,
>        "italics": false
>     }
> ]
> ```
> With that structure the logic should use the name as the name in register_device_font, the bold boolean in the is_bold of register_device_font, and the italics boolean as the is_italic in register_device_font
> It should also allow not providing any of the three of those (name, bold, or italics), and should fall back to the current values from the the ttf file if they are not provided.

