### PR TITLE
avm2: Replace complex ops with simpler ops

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -862,7 +862,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::PopScope => self.op_pop_scope(),
                 Op::GetOuterScope { index } => self.op_get_outer_scope(*index),
                 Op::GetScopeObject { index } => self.op_get_scope_object(*index),
-                Op::GetGlobalScope => self.op_get_global_scope(),
                 Op::FindDef { multiname } => self.op_find_def(*multiname),
                 Op::FindProperty { multiname } => self.op_find_property(*multiname),
                 Op::FindPropStrict { multiname } => self.op_find_prop_strict(*multiname),
@@ -871,7 +870,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::GetSlot { index } => self.op_get_slot(*index),
                 Op::SetSlot { index } => self.op_set_slot(*index),
                 Op::SetSlotNoCoerce { index } => self.op_set_slot_no_coerce(*index),
-                Op::GetGlobalSlot { index } => self.op_get_global_slot(*index),
                 Op::SetGlobalSlot { index } => self.op_set_global_slot(*index),
                 Op::Construct { num_args } => self.op_construct(*num_args),
                 Op::ConstructProp {
@@ -1610,12 +1608,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn op_get_global_scope(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
-        self.push_stack(self.global_scope().unwrap_or(Value::Null));
-
-        Ok(FrameControl::Continue)
-    }
-
     fn op_find_def(
         &mut self,
         multiname: Gc<'gc, Multiname<'gc>>,
@@ -1739,17 +1731,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .expect("Cannot set_slot on primitive");
 
         object.set_slot_no_coerce(index, value, self.gc());
-
-        Ok(FrameControl::Continue)
-    }
-
-    fn op_get_global_slot(&mut self, index: u32) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let value = self
-            .global_scope()
-            .map(|global| global.as_object().unwrap().get_slot(index))
-            .unwrap_or(Value::Undefined);
-
-        self.push_stack(value);
 
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -800,12 +800,10 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         {
             let result = match op {
-                Op::PushByte { value } => self.op_push_byte(*value),
                 Op::PushDouble { value } => self.op_push_double(*value),
                 Op::PushFalse => self.op_push_false(),
                 Op::PushInt { value } => self.op_push_int(*value),
                 Op::PushNamespace { value } => self.op_push_namespace(method, *value),
-                Op::PushNaN => self.op_push_nan(),
                 Op::PushNull => self.op_push_null(),
                 Op::PushShort { value } => self.op_push_short(*value),
                 Op::PushString { string } => self.op_push_string(*string),
@@ -996,11 +994,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
     }
 
-    fn op_push_byte(&mut self, value: i8) -> Result<FrameControl<'gc>, Error<'gc>> {
-        self.push_stack(value as i32);
-        Ok(FrameControl::Continue)
-    }
-
     fn op_push_double(&mut self, value: f64) -> Result<FrameControl<'gc>, Error<'gc>> {
         self.push_stack(value);
         Ok(FrameControl::Continue)
@@ -1025,11 +1018,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let ns_object = NamespaceObject::from_namespace(self, ns);
 
         self.push_stack(ns_object);
-        Ok(FrameControl::Continue)
-    }
-
-    fn op_push_nan(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
-        self.push_stack(f64::NAN);
         Ok(FrameControl::Continue)
     }
 

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -842,10 +842,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                     multiname,
                     num_args,
                 } => self.op_call_super(*multiname, *num_args),
-                Op::CallSuperVoid {
-                    multiname,
-                    num_args,
-                } => self.op_call_super_void(*multiname, *num_args),
                 Op::ReturnValue => self.op_return_value(method),
                 Op::ReturnValueNoCoerce => self.op_return_value_no_coerce(),
                 Op::ReturnVoid => self.op_return_void(),
@@ -1221,26 +1217,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value = bound_superclass_object.call_super(&multiname, receiver, &args, self)?;
 
         self.push_stack(value);
-
-        Ok(FrameControl::Continue)
-    }
-
-    fn op_call_super_void(
-        &mut self,
-        multiname: Gc<'gc, Multiname<'gc>>,
-        arg_count: u32,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let args = self.pop_stack_args(arg_count);
-        let multiname = multiname.fill_with_runtime_params(self)?;
-        let receiver = self
-            .pop_stack()
-            .null_check(self, Some(&multiname))?
-            .as_object()
-            .expect("Super ops should not appear in primitive functions");
-
-        let bound_superclass_object = self.bound_superclass_object(&multiname);
-
-        bound_superclass_object.call_super(&multiname, receiver, &args, self)?;
 
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -137,11 +137,6 @@ pub enum Op<'gc> {
     GetDescendants {
         multiname: Gc<'gc, Multiname<'gc>>,
     },
-    GetGlobalScope,
-    GetGlobalSlot {
-        // note: 0-indexed, as opposed to FP.
-        index: u32,
-    },
     GetLocal {
         index: u32,
     },
@@ -381,10 +376,8 @@ impl Op<'_> {
                 | Op::Swap
                 | Op::Pop
                 | Op::TypeOf
-                | Op::GetGlobalScope
                 | Op::GetScopeObject { .. }
                 | Op::GetOuterScope { .. }
-                | Op::GetGlobalSlot { .. }
                 | Op::GetLocal { .. }
                 | Op::SetLocal { .. }
                 | Op::Kill { .. }

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -264,9 +264,6 @@ pub enum Op<'gc> {
     Not,
     Pop,
     PopScope,
-    PushByte {
-        value: i8,
-    },
     PushDouble {
         value: f64,
     },
@@ -278,7 +275,6 @@ pub enum Op<'gc> {
         #[collect(require_static)]
         value: Index<Namespace>,
     },
-    PushNaN,
     PushNull,
     PushScope,
     PushShort {
@@ -355,12 +351,10 @@ impl Op<'_> {
             Op::Bkpt
                 | Op::BkptLine { .. }
                 | Op::Timestamp
-                | Op::PushByte { .. }
                 | Op::PushDouble { .. }
                 | Op::PushFalse
                 | Op::PushInt { .. }
                 | Op::PushNamespace { .. }
-                | Op::PushNaN
                 | Op::PushNull
                 | Op::PushShort { .. }
                 | Op::PushString { .. }

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -60,11 +60,6 @@ pub enum Op<'gc> {
 
         num_args: u32,
     },
-    CallSuperVoid {
-        multiname: Gc<'gc, Multiname<'gc>>,
-
-        num_args: u32,
-    },
     CheckFilter,
     Coerce {
         class: Class<'gc>,

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -778,17 +778,6 @@ pub fn optimize<'gc>(
                 Op::PushUndefined => {
                     stack.push_class(activation, types.void)?;
                 }
-                Op::PushNaN => {
-                    stack.push_class(activation, types.number)?;
-                }
-                Op::PushByte { value } => {
-                    let mut new_value = OptValue::of_type(types.int);
-                    new_value.contains_valid_integer = true;
-                    if *value >= 0 {
-                        new_value.contains_valid_unsigned = true;
-                    }
-                    stack.push(activation, new_value)?;
-                }
                 Op::PushShort { value } => {
                     let mut new_value = OptValue::of_type(types.int);
                     new_value.contains_valid_integer = true;

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -1661,18 +1661,6 @@ pub fn optimize<'gc>(
                     // Avoid checking return value for now
                     stack.push_any(activation)?;
                 }
-                Op::CallSuperVoid {
-                    multiname,
-                    num_args,
-                } => {
-                    // Arguments
-                    stack.popn(activation, *num_args)?;
-
-                    stack.pop_for_multiname(activation, *multiname)?;
-
-                    // Then receiver.
-                    stack.pop(activation)?;
-                }
                 Op::SetGlobalSlot { .. } => {
                     let outer_scope = activation.outer();
                     if outer_scope.is_empty() && scope_stack.is_empty() {

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -910,7 +910,9 @@ fn resolve_op<'gc>(
     op: AbcOp,
 ) -> Result<Op<'gc>, Error<'gc>> {
     Ok(match op {
-        AbcOp::PushByte { value } => Op::PushByte { value: value as i8 },
+        AbcOp::PushByte { value } => Op::PushShort {
+            value: value as i8 as i16,
+        },
         AbcOp::PushDouble { value } => {
             let value = pool_double(activation, translation_unit, value)?;
 
@@ -923,7 +925,7 @@ fn resolve_op<'gc>(
             Op::PushInt { value }
         }
         AbcOp::PushNamespace { value } => Op::PushNamespace { value },
-        AbcOp::PushNaN => Op::PushNaN,
+        AbcOp::PushNaN => Op::PushDouble { value: f64::NAN },
         AbcOp::PushNull => Op::PushNull,
         AbcOp::PushShort { value } => Op::PushShort { value },
         AbcOp::PushString { value } => {


### PR DESCRIPTION
This should shrink `Activation::run_actions`

This removes the ops `getglobalscope`, `getglobalslot`, `callsupervoid`, `pushnan`, and `pushbyte`- instead, we now use `getouterscope`/`getscopeobject`, `getouterscope`/`getscopeobject`+`getslot`, `callsuper`+`pop`, `pushdouble`, and `pushshort`.