### PR TITLE
debug_ui: Fix summary of objects without a name

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -1398,13 +1398,9 @@ fn summary_name(object: DisplayObject) -> Cow<'static, str> {
     let name = object.name();
 
     if let Some(name) = name {
-        if name.is_empty() {
-            Cow::Borrowed(do_type)
-        } else {
-            Cow::Owned(format!("{do_type} \"{name}\""))
-        }
+        Cow::Owned(format!("{do_type} \"{name}\""))
     } else {
-        Cow::Borrowed("")
+        Cow::Borrowed(do_type)
     }
 }
 


### PR DESCRIPTION
Without this patch, Ruffle was displaying empty labels for objects without a name.