### PR TITLE
github: Remove default title for error reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/error_report.md
+++ b/.github/ISSUE_TEMPLATE/error_report.md
@@ -1,7 +1,7 @@
 ---
 name: Error report
 about: "[DON'T CHOOSE THIS]: For auto-generated error reports"
-title: Error
+title: ''
 labels: error-report
 assignees: ''
 


### PR DESCRIPTION
GitHub seems to be prepending the default title to the title generated by Ruffle, resulting in issues titled "Error error on..."