### PR TITLE
desktop: Make the main window at minimum wider than the menu bar

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -436,7 +436,12 @@ impl ApplicationHandler<RuffleEvent> for App {
                 Icon::from_rgba(icon_bytes.to_vec(), 32, 32).expect("App icon should be correct");
 
             let no_gui = self.preferences.cli.no_gui;
-            let min_window_size = (16, if no_gui { 16 } else { MENU_HEIGHT + 16 }).into();
+            let min_window_size = if no_gui {
+                (16, 16)
+            } else {
+                (350, MENU_HEIGHT + 16)
+            }
+            .into();
             let preferred_width = self.preferences.cli.width;
             let preferred_height = self.preferences.cli.height;
             let start_fullscreen = self.preferences.cli.fullscreen;


### PR DESCRIPTION
Fixes #16700

This is how the main window looks at its smallest size:
![image](https://github.com/user-attachments/assets/9197d97a-5d40-46c7-9561-93f040224240)
