### PR TITLE
video/external: Reorder frames decoded by OpenH264 manually

### DIFF
--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -312,6 +312,7 @@ impl<'gc> Video<'gc> {
                         codec: streamdef.codec,
                         data: &read.movie.data()[*slice_start..*slice_end],
                         frame_id,
+                        composition_time: None,
                     };
                     context
                         .video
@@ -409,6 +410,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
                                 codec: streamdef.codec,
                                 data: &movie.data()[*frame_start..*frame_end],
                                 frame_id: *frame_id,
+                                composition_time: None,
                             },
                         );
 

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -947,6 +947,7 @@ impl<'gc> NetStream<'gc> {
                         codec,
                         data, //TODO: ScreenVideo's decoder wants the FLV header bytes
                         frame_id,
+                        composition_time: Some(write.stream_time as i32),
                     };
 
                     if let Err(e) = context
@@ -961,6 +962,7 @@ impl<'gc> NetStream<'gc> {
                     codec,
                     data, //TODO: ScreenVideo's decoder wants the FLV header bytes
                     frame_id,
+                    composition_time: Some(write.stream_time as i32),
                 };
 
                 match context.video.decode_video_stream_frame(
@@ -998,7 +1000,7 @@ impl<'gc> NetStream<'gc> {
                 Some(video_handle),
                 Some(codec),
                 FlvVideoPacket::AvcNalu {
-                    composition_time_offset: _,
+                    composition_time_offset,
                     data,
                 },
             ) => {
@@ -1006,6 +1008,7 @@ impl<'gc> NetStream<'gc> {
                     codec,
                     data,
                     frame_id,
+                    composition_time: Some(write.stream_time as i32 + composition_time_offset),
                 };
 
                 match context.video.decode_video_stream_frame(

--- a/video/external/src/decoder/openh264.rs
+++ b/video/external/src/decoder/openh264.rs
@@ -293,15 +293,22 @@ impl VideoDecoder for H264Decoder {
             //in-out: for Decoding only: declare and initialize the output buffer info
             let mut dest_buf_info: openh264_sys::SBufferInfo = std::mem::zeroed();
 
-            let _ret = decoder_vtbl.DecodeFrameNoDelay.unwrap()(
+            let ret = decoder_vtbl.DecodeFrameNoDelay.unwrap()(
                 self.decoder,
                 buffer.as_mut_ptr(),
                 buffer.len() as c_int,
                 output.as_mut_ptr(),
                 &mut dest_buf_info as *mut openh264_sys::SBufferInfo,
             );
+
+            if ret == 0 {
+                Ok(())
+            } else {
+                Err(Error::DecoderError(
+                    format!("Configuration failed with status code: {}", ret).into(),
+                ))
+            }
         }
-        Ok(())
     }
 
     fn preload_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<FrameDependency, Error> {

--- a/video/src/frame.rs
+++ b/video/src/frame.rs
@@ -12,6 +12,8 @@ pub struct EncodedFrame<'a> {
     /// A caller-specified frame ID. Frame IDs must be consistent between
     /// subsequent uses of the same data stream.
     pub frame_id: u32,
+
+    pub composition_time: Option<i32>,
 }
 
 impl<'a> EncodedFrame<'a> {


### PR DESCRIPTION
This should unblock https://github.com/ruffle-rs/ruffle/pull/18581, despite https://github.com/cisco/openh264/issues/3837.