### PR TITLE
debug_ui: Add Style Sheet tab for AVM1 objects

### DIFF
--- a/core/src/debug_ui.rs
+++ b/core/src/debug_ui.rs
@@ -1,5 +1,6 @@
 mod avm1;
 mod avm2;
+mod common;
 mod display_object;
 mod domain;
 mod handle;

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -5,11 +5,11 @@ use crate::debug_ui::display_object::open_display_object_button;
 use crate::debug_ui::handle::{AVM1ObjectHandle, DisplayObjectHandle};
 use crate::debug_ui::Message;
 use crate::string::AvmString;
-use egui::{CollapsingHeader, Grid, Id, TextBuffer, TextEdit, Ui, Window};
+use egui::{Grid, Id, TextBuffer, TextEdit, Ui, Window};
 use gc_arena::Mutation;
 use ruffle_wstr::{WStr, WString};
 
-use super::display_object::show_text_format;
+use super::common::show_style_sheet;
 
 #[derive(Debug, Eq, PartialEq, Hash, Default, Copy, Clone)]
 enum Panel {
@@ -265,19 +265,7 @@ impl Avm1ObjectWindow {
 
     fn show_style_sheet_panel(&mut self, ui: &mut Ui, object: StyleSheetObject<'_>) {
         let style_sheet = object.style_sheet();
-        let mut selectors = style_sheet.selectors();
-        selectors.sort();
-        for selector in selectors {
-            CollapsingHeader::new(selector.to_utf8_lossy())
-                .id_salt(ui.id().with(selector.to_utf8_lossy()))
-                .show(ui, |ui| {
-                    if let Some(tf) = style_sheet.get_style(&selector) {
-                        show_text_format(ui, &tf, true);
-                    } else {
-                        ui.weak("No styles");
-                    }
-                });
-        }
+        show_style_sheet(ui, style_sheet);
     }
 }
 

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -7,13 +7,13 @@ use crate::context::UpdateContext;
 use crate::debug_ui::display_object::open_display_object_button;
 use crate::debug_ui::handle::{AVM2ObjectHandle, DisplayObjectHandle};
 use crate::debug_ui::{ItemToSave, Message};
-use egui::{Align, Checkbox, CollapsingHeader, Grid, Id, Layout, TextEdit, Ui, Window};
+use egui::{Align, Checkbox, Grid, Id, Layout, TextEdit, Ui, Window};
 use egui_extras::{Column, TableBody, TableBuilder, TableRow};
 use fnv::FnvHashMap;
 use gc_arena::Mutation;
 use std::borrow::Cow;
 
-use super::display_object::show_text_format;
+use super::common::show_style_sheet;
 use super::movie::open_movie_button;
 
 #[derive(Debug, Eq, PartialEq, Hash, Default, Copy, Clone)]
@@ -292,19 +292,7 @@ impl Avm2ObjectWindow {
     }
 
     fn show_style_sheet(&mut self, style_sheet: StyleSheetObject<'_>, ui: &mut Ui) {
-        let mut selectors = style_sheet.style_sheet().selectors();
-        selectors.sort();
-        for selector in selectors {
-            CollapsingHeader::new(selector.to_utf8_lossy())
-                .id_salt(ui.id().with(selector.to_utf8_lossy()))
-                .show(ui, |ui| {
-                    if let Some(tf) = style_sheet.style_sheet().get_style(&selector) {
-                        show_text_format(ui, &tf, true);
-                    } else {
-                        ui.weak("No styles");
-                    }
-                });
-        }
+        show_style_sheet(ui, style_sheet.style_sheet());
     }
 
     fn show_properties<'gc>(

--- a/core/src/debug_ui/common.rs
+++ b/core/src/debug_ui/common.rs
@@ -1,0 +1,63 @@
+use crate::html::{StyleSheet, TextFormat};
+use egui::{CollapsingHeader, Grid, Ui};
+
+pub fn show_text_format(ui: &mut Ui, tf: &TextFormat, skip_none: bool) {
+    Grid::new(ui.id().with("text_format_table"))
+        .num_columns(2)
+        .striped(true)
+        .show(ui, |ui| {
+            for (key, value) in [
+                ("Font Face", tf.font.as_ref().map(|v| v.to_string())),
+                ("Font Size", tf.size.map(|v| v.to_string())),
+                ("Color", tf.color.map(|v| format!("{v:?}"))),
+                ("Align", tf.align.map(|v| format!("{v:?}"))),
+                ("Bold?", tf.bold.map(|v| v.to_string())),
+                ("Italic?", tf.italic.map(|v| v.to_string())),
+                ("Underline?", tf.underline.map(|v| v.to_string())),
+                ("Left Margin", tf.left_margin.map(|v| v.to_string())),
+                ("Right Margin", tf.right_margin.map(|v| v.to_string())),
+                ("Indent", tf.indent.map(|v| v.to_string())),
+                ("Block Indent", tf.block_indent.map(|v| v.to_string())),
+                ("Kerning?", tf.kerning.map(|v| v.to_string())),
+                ("Leading", tf.leading.map(|v| v.to_string())),
+                ("Letter Spacing", tf.letter_spacing.map(|v| v.to_string())),
+                ("Tab Stops", tf.tab_stops.as_ref().map(|v| format!("{v:?}"))),
+                ("Bullet?", tf.bullet.map(|v| v.to_string())),
+                ("URL", tf.url.as_ref().map(|v| v.to_string())),
+                ("Target", tf.target.as_ref().map(|v| v.to_string())),
+                ("Display", tf.display.map(|v| format!("{v:?}"))),
+            ] {
+                if skip_none && value.is_none() {
+                    continue;
+                }
+
+                ui.label(key);
+                if let Some(value) = value {
+                    if !value.is_empty() {
+                        ui.label(value);
+                    } else {
+                        ui.weak("Empty");
+                    }
+                } else {
+                    ui.weak("None");
+                }
+                ui.end_row();
+            }
+        });
+}
+
+pub fn show_style_sheet(ui: &mut Ui, style_sheet: StyleSheet<'_>) {
+    let mut selectors = style_sheet.selectors();
+    selectors.sort();
+    for selector in selectors {
+        CollapsingHeader::new(selector.to_utf8_lossy())
+            .id_salt(ui.id().with(selector.to_utf8_lossy()))
+            .show(ui, |ui| {
+                if let Some(tf) = style_sheet.get_style(&selector) {
+                    show_text_format(ui, &tf, true);
+                } else {
+                    ui.weak("No styles");
+                }
+            });
+    }
+}

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -26,6 +26,8 @@ use std::borrow::Cow;
 use std::ops::RangeInclusive;
 use swf::{Color, ColorTransform, Fixed8, Rectangle, Twips};
 
+use super::common::show_text_format;
+
 const DEFAULT_DEBUG_COLORS: [[f32; 3]; 10] = [
     [0.00, 0.39, 0.00], // "darkgreen" / #006400
     [0.00, 0.00, 0.55], // "darkblue" / #00008b
@@ -1489,51 +1491,6 @@ fn show_text_format_hover(ui: &mut Ui, tf: &TextFormat) {
         ui.style_mut().interaction.selectable_labels = true;
         show_text_format(ui, tf, false);
     });
-}
-
-pub fn show_text_format(ui: &mut Ui, tf: &TextFormat, skip_none: bool) {
-    Grid::new(ui.id().with("text_format_table"))
-        .num_columns(2)
-        .striped(true)
-        .show(ui, |ui| {
-            for (key, value) in [
-                ("Font Face", tf.font.as_ref().map(|v| v.to_string())),
-                ("Font Size", tf.size.map(|v| v.to_string())),
-                ("Color", tf.color.map(|v| format!("{v:?}"))),
-                ("Align", tf.align.map(|v| format!("{v:?}"))),
-                ("Bold?", tf.bold.map(|v| v.to_string())),
-                ("Italic?", tf.italic.map(|v| v.to_string())),
-                ("Underline?", tf.underline.map(|v| v.to_string())),
-                ("Left Margin", tf.left_margin.map(|v| v.to_string())),
-                ("Right Margin", tf.right_margin.map(|v| v.to_string())),
-                ("Indent", tf.indent.map(|v| v.to_string())),
-                ("Block Indent", tf.block_indent.map(|v| v.to_string())),
-                ("Kerning?", tf.kerning.map(|v| v.to_string())),
-                ("Leading", tf.leading.map(|v| v.to_string())),
-                ("Letter Spacing", tf.letter_spacing.map(|v| v.to_string())),
-                ("Tab Stops", tf.tab_stops.as_ref().map(|v| format!("{v:?}"))),
-                ("Bullet?", tf.bullet.map(|v| v.to_string())),
-                ("URL", tf.url.as_ref().map(|v| v.to_string())),
-                ("Target", tf.target.as_ref().map(|v| v.to_string())),
-                ("Display", tf.display.map(|v| format!("{v:?}"))),
-            ] {
-                if skip_none && value.is_none() {
-                    continue;
-                }
-
-                ui.label(key);
-                if let Some(value) = value {
-                    if !value.is_empty() {
-                        ui.label(value);
-                    } else {
-                        ui.weak("Empty");
-                    }
-                } else {
-                    ui.weak("None");
-                }
-                ui.end_row();
-            }
-        });
 }
 
 pub fn open_display_object_button<'gc>(


### PR DESCRIPTION
This patch adds a way of displaying tabs for native objects. In this case it makes it easier to debug AVM1 style sheets.

Also some code is refactored so that functions used in multiple files are moved into `common.rs`.