### PR TITLE
core: Allow `istr!` to be used in more places

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4278,6 +4278,7 @@ dependencies = [
 name = "ruffle_macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -14,5 +14,6 @@ workspace = true
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0.91"
 quote = "1.0.38"
 syn = { version = "2.0.96", features = ["extra-traits", "full"] }

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -13,7 +13,7 @@ use crate::display_object::{
 };
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use crate::loader::MovieLoaderVMData;
-use crate::string::{AvmString, StringContext, SwfStrExt as _, WStr, WString};
+use crate::string::{AvmString, HasStringContext, StringContext, SwfStrExt as _, WStr, WString};
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
 use crate::{avm_error, avm_warn};
@@ -232,6 +232,13 @@ pub struct Activation<'a, 'gc: 'a> {
 impl Drop for Activation<'_, '_> {
     fn drop(&mut self) {
         avm_debug!(self.context.avm1, "END {}", self.id);
+    }
+}
+
+impl<'gc> HasStringContext<'gc> for Activation<'_, 'gc> {
+    #[inline(always)]
+    fn strings_ref(&self) -> &StringContext<'gc> {
+        &self.context.strings
     }
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -35,6 +35,7 @@ use crate::player::{MouseData, Player};
 use crate::prelude::*;
 use crate::socket::Sockets;
 use crate::streams::StreamManager;
+use crate::string::HasStringContext;
 use crate::string::{AvmString, StringContext};
 use crate::stub::StubCollection;
 use crate::tag_utils::{SwfMovie, SwfSlice};
@@ -225,6 +226,13 @@ pub struct UpdateContext<'gc> {
     /// Currently, this is just used for handling `Loader.loadBytes`
     #[allow(clippy::type_complexity)]
     pub post_frame_callbacks: &'gc mut Vec<PostFrameCallback<'gc>>,
+}
+
+impl<'gc> HasStringContext<'gc> for UpdateContext<'gc> {
+    #[inline(always)]
+    fn strings_ref(&self) -> &StringContext<'gc> {
+        &self.strings
+    }
 }
 
 /// Convenience methods for controlling audio.

--- a/core/src/string.rs
+++ b/core/src/string.rs
@@ -12,7 +12,7 @@ pub use ruffle_wstr::*;
 
 pub use avm_string::AvmString;
 pub use common::CommonStrings;
-pub use context::StringContext;
+pub use context::{HasStringContext, StringContext};
 pub use interner::{AvmAtom, AvmStringInterner};
 
 pub trait SwfStrExt {

--- a/core/src/string/common.rs
+++ b/core/src/string/common.rs
@@ -1,4 +1,4 @@
-use super::AvmString;
+use super::AvmAtom;
 use gc_arena::Collect;
 
 macro_rules! define_common_strings {
@@ -7,11 +7,11 @@ macro_rules! define_common_strings {
         #[derive(Collect)]
         #[collect(no_drop)]
         pub struct CommonStrings<'gc> {
-            $(pub $field: AvmString<'gc>,)*
+            $(pub $field: AvmAtom<'gc>,)*
         }
 
         impl<'gc> CommonStrings<'gc> {
-            pub fn new(mut intern_from_static: impl FnMut(&'static [u8]) -> AvmString<'gc>) -> Self {
+            pub fn new(mut intern_from_static: impl FnMut(&'static [u8]) -> AvmAtom<'gc>) -> Self {
                 Self {
                     $($field: intern_from_static($str)),*
                 }

--- a/core/src/string/context.rs
+++ b/core/src/string/context.rs
@@ -101,3 +101,14 @@ impl<'gc> StringContext<'gc> {
             .substring(self.gc(), s, range.start, range.end)
     }
 }
+
+pub trait HasStringContext<'gc> {
+    fn strings_ref(&self) -> &StringContext<'gc>;
+}
+
+impl<'gc> HasStringContext<'gc> for StringContext<'gc> {
+    #[inline(always)]
+    fn strings_ref(&self) -> &StringContext<'gc> {
+        self
+    }
+}

--- a/core/src/string/interner.rs
+++ b/core/src/string/interner.rs
@@ -53,7 +53,7 @@ pub struct AvmStringInterner<'gc> {
     interned: WeakSet<'gc, AvmStringRepr<'gc>>,
 
     /// Strings used across both AVMs and in core code.
-    pub common: CommonStrings<'gc>,
+    pub(super) common: CommonStrings<'gc>,
 
     pub(super) empty: Gc<'gc, AvmStringRepr<'gc>>,
     pub(super) chars: [Gc<'gc, AvmStringRepr<'gc>>; INTERNED_CHAR_LEN],

--- a/core/src/string/interner.rs
+++ b/core/src/string/interner.rs
@@ -92,8 +92,8 @@ impl<'gc> AvmStringInterner<'gc> {
                 // Don't insert a fresh entry for single-character strings --
                 // they were already interned! Retrieve it from the one-char
                 // string cache instead.
-                [c] => chars[*c as usize].into(),
-                _ => intern_from_static(s).into(),
+                [c] => AvmAtom(chars[*c as usize]),
+                _ => AvmAtom(intern_from_static(s)),
             },
         );
 


### PR DESCRIPTION
Add an explicit form `istr!(context, "string")` that can be used when no `activation` variable is in scope; it supports more context types through the new `HasStringContext` trait.

Modify `CommonStrings` to hold `AvmAtom`s instead of `AvmString`s, and add the `atom!` macro.
