### PR TITLE
Move the empty and one-char strings to `CommonStrings`, and allow `istr!` to access them.

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -20,6 +20,7 @@ use crate::{avm_error, avm_warn};
 use gc_arena::{Gc, GcCell, Mutation};
 use indexmap::IndexMap;
 use rand::Rng;
+use ruffle_macros::istr;
 use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::cmp::min;
@@ -831,7 +832,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let object = object_val.coerce_to_object(self);
 
         let method_name = if method_name == Value::Undefined {
-            self.strings().empty()
+            istr!(self, "")
         } else {
             method_name.coerce_to_string(self)?
         };
@@ -1717,7 +1718,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let object = object_val.coerce_to_object(self);
 
         let method_name = if method_name == Value::Undefined {
-            self.strings().empty()
+            istr!(self, "")
         } else {
             method_name.coerce_to_string(self)?
         };

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -9,6 +9,7 @@ use crate::avm1::{ArrayObject, Object, TObject, Value};
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::string::{AvmString, StringContext};
 use bitflags::bitflags;
+use ruffle_macros::istr;
 use std::cmp::Ordering;
 
 bitflags! {
@@ -256,7 +257,7 @@ pub fn join<'gc>(
     };
 
     if length <= 0 {
-        return Ok(activation.strings().empty().into());
+        return Ok(istr!("").into());
     }
 
     let parts = (0..length)

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -253,7 +253,7 @@ pub fn join<'gc>(
     let separator = if let Some(v) = args.get(0) {
         v.coerce_to_string(activation)?
     } else {
-        ",".into()
+        istr!(",")
     };
 
     if length <= 0 {

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -159,7 +159,7 @@ fn send<'gc>(
 
     let window = match args.get(1) {
         Some(window) => window.coerce_to_string(activation)?,
-        None => activation.strings().empty(),
+        None => istr!(""),
     };
 
     let method_name = args

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1550,7 +1550,7 @@ pub fn get_url<'gc>(
 
         let window = match args.get(1) {
             Some(window) => window.coerce_to_string(activation)?,
-            None => activation.strings().empty(),
+            None => istr!(""),
         };
 
         let method = match args.get(2) {

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -1,6 +1,7 @@
 //! `Number` class impl
 
 use gc_arena::Gc;
+use ruffle_macros::istr;
 
 use crate::avm1::activation::Activation;
 use crate::avm1::clamp::Clamp;
@@ -134,7 +135,7 @@ fn to_string<'gc>(
             Ordering::Greater => (number, false),
             Ordering::Equal => {
                 // Bail out immediately if we're 0.
-                return Ok("0".into());
+                return Ok(istr!("0").into());
             }
         };
 

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -1,3 +1,5 @@
+use ruffle_macros::istr;
+
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
@@ -105,7 +107,7 @@ pub fn get_focus<'gc>(
             .as_displayobject()
             .object()
             .coerce_to_string(activation)
-            .unwrap_or_else(|_| activation.strings().empty())
+            .unwrap_or_else(|_| istr!(""))
             .into(),
         None => Value::Null,
     })

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -1,6 +1,7 @@
 //! `String` class impl
 
 use gc_arena::Gc;
+use ruffle_macros::istr;
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
@@ -39,7 +40,7 @@ pub fn string<'gc>(
     let value = match args.get(0).cloned() {
         Some(Value::String(s)) => s,
         Some(v) => v.coerce_to_string(activation)?,
-        None => activation.strings().empty(),
+        None => istr!(""),
     };
 
     // Called from a constructor, populate `this`.
@@ -65,7 +66,7 @@ pub fn string_function<'gc>(
     let value = match args.get(0).cloned() {
         Some(Value::String(s)) => s,
         Some(v) => v.coerce_to_string(activation)?,
-        None => activation.strings().empty(),
+        None => istr!(""),
     };
 
     Ok(value.into())
@@ -116,7 +117,7 @@ fn char_at<'gc>(
         .and_then(|i| string.get(i))
         .map(WString::from_unit)
         .map(|ret| AvmString::new(activation.gc(), ret))
-        .unwrap_or_else(|| activation.strings().empty());
+        .unwrap_or_else(|| istr!(""));
 
     Ok(ret.into())
 }
@@ -250,7 +251,7 @@ fn slice<'gc>(
         let ret = WString::from(&this[start_index..end_index]);
         Ok(AvmString::new(activation.gc(), ret).into())
     } else {
-        Ok(activation.strings().empty().into())
+        Ok(istr!("").into())
     }
 }
 
@@ -332,7 +333,7 @@ fn substr<'gc>(
         let ret = WString::from(&this[start_index..end_index]);
         Ok(AvmString::new(activation.gc(), ret).into())
     } else {
-        Ok(activation.strings().empty().into())
+        Ok(istr!("").into())
     }
 }
 

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -269,7 +269,7 @@ fn split<'gc>(
     // and the empty string behaves the same as undefined does in later SWF versions.
     let is_swf5 = activation.swf_version() == 5;
     if let Some(delimiter) = match args.get(0).unwrap_or(&Value::Undefined) {
-        &Value::Undefined => is_swf5.then_some(",".into()),
+        &Value::Undefined => is_swf5.then_some(istr!(",")),
         v => Some(v.coerce_to_string(activation)?).filter(|s| !(is_swf5 && s.is_empty())),
     } {
         if delimiter.is_empty() {

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -1,5 +1,7 @@
 //! XMLNode class
 
+use ruffle_macros::istr;
+
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
@@ -43,7 +45,7 @@ pub fn constructor<'gc>(
         let node_value = value.coerce_to_string(activation)?;
         XmlNode::new(mc, node_type, Some(node_value))
     } else {
-        XmlNode::new(mc, TEXT_NODE, Some(activation.strings().empty()))
+        XmlNode::new(mc, TEXT_NODE, Some(istr!("")))
     };
     node.introduce_script_object(mc, this);
     this.set_native(mc, NativeObject::XmlNode(node));
@@ -146,7 +148,7 @@ fn get_prefix_for_namespace<'gc>(
                         if let Some(prefix) = prefix.strip_prefix(b':') {
                             return Ok(AvmString::new(activation.gc(), prefix).into());
                         } else {
-                            return Ok(activation.strings().empty().into());
+                            return Ok(istr!("").into());
                         }
                     }
                 }
@@ -195,7 +197,7 @@ fn to_string<'gc>(
         return Ok(AvmString::new(activation.gc(), string).into());
     }
 
-    Ok(activation.strings().empty().into())
+    Ok(istr!("").into())
 }
 
 fn local_name<'gc>(
@@ -382,7 +384,7 @@ fn namespace_uri<'gc>(
         if let Some(prefix) = node.prefix(activation.strings()) {
             return Ok(node
                 .lookup_namespace_uri(&prefix)
-                .unwrap_or_else(|| activation.strings().empty().into()));
+                .unwrap_or_else(|| istr!("").into()));
         }
 
         return Ok(Value::Null);

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -13,6 +13,7 @@ use crate::display_object::{
 use crate::string::{AvmString, WStr};
 use crate::types::Percent;
 use gc_arena::{Collect, GcCell, GcWeakCell, Mutation};
+use ruffle_macros::istr;
 use std::fmt;
 use swf::Twips;
 
@@ -658,9 +659,7 @@ fn frames_loaded<'gc>(
 }
 
 fn name<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.name()
-        .unwrap_or_else(|| activation.strings().empty())
-        .into()
+    this.name().unwrap_or_else(|| istr!("")).into()
 }
 
 fn set_name<'gc>(
@@ -677,14 +676,14 @@ fn drop_target<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'g
     match this.as_movie_clip().and_then(|mc| mc.drop_target()) {
         Some(target) => AvmString::new(activation.gc(), target.slash_path()).into(),
         None if activation.swf_version() < 6 => Value::Undefined,
-        None => activation.strings().empty().into(),
+        None => istr!("").into(),
     }
 }
 
 fn url<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
     match this.as_movie_clip() {
         Some(mc) => AvmString::new_utf8(activation.gc(), mc.movie().url()).into(),
-        None => activation.strings().empty().into(),
+        None => istr!("").into(),
     }
 }
 

--- a/core/src/avm1/object_reference.rs
+++ b/core/src/avm1/object_reference.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use gc_arena::lock::Lock;
 use gc_arena::{Collect, Gc, GcWeakCell, Mutation};
+use ruffle_macros::istr;
 
 #[derive(Clone, Debug, Collect)]
 #[collect(no_drop)]
@@ -188,7 +189,7 @@ impl<'gc> MovieClipReference<'gc> {
     pub fn coerce_to_string(&self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
         match self.resolve_reference(activation) {
             // Couldn't find the reference
-            None => activation.strings().empty(),
+            None => istr!(""),
             // Found the reference, cached, we can't re-use `self.path` sadly, it would be quicker if we could
             // But if the clip has been re-named, since being created then `mc.path() != path`
             Some((true, _, dobj)) => AvmString::new(activation.gc(), dobj.path()),

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -410,7 +410,7 @@ impl<'gc> Value<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         Ok(match self {
-            Value::Undefined if activation.swf_version() < 7 => activation.strings().empty(),
+            Value::Undefined if activation.swf_version() < 7 => istr!(""),
             Value::Bool(true) if activation.swf_version() < 5 => {
                 activation.strings().ascii_char(b'1')
             }

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -412,10 +412,10 @@ impl<'gc> Value<'gc> {
         Ok(match self {
             Value::Undefined if activation.swf_version() < 7 => istr!(""),
             Value::Bool(true) if activation.swf_version() < 5 => {
-                activation.strings().ascii_char(b'1')
+                istr!("1")
             }
             Value::Bool(false) if activation.swf_version() < 5 => {
-                activation.strings().ascii_char(b'0')
+                istr!("0")
             }
             Value::Object(object) => {
                 if let Some(object) = object
@@ -571,7 +571,7 @@ fn f64_to_string<'gc>(activation: &mut Activation<'_, 'gc>, mut n: f64) -> AvmSt
         // FIXME is there an easy way to use istr! here?
         AvmString::new_utf8_bytes(activation.gc(), b"-Infinity")
     } else if n == 0.0 {
-        activation.strings().ascii_char(b'0')
+        istr!("0")
     } else if n >= -2147483648.0 && n <= 2147483647.0 && n.fract() == 0.0 {
         // Fast path for integers.
         let n = n as i32;

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -12,6 +12,7 @@ use quick_xml::{
     name::ResolveResult,
     Error as XmlError, NsReader,
 };
+use ruffle_macros::istr;
 
 use std::cell::{Ref, RefMut};
 use std::fmt::{self, Debug};
@@ -755,7 +756,7 @@ impl<'gc> E4XNode<'gc> {
     ) -> Result<Vec<Self>, Error<'gc>> {
         let string = match &value {
             // The docs claim that this throws a TypeError, but it actually doesn't
-            Value::Null | Value::Undefined => activation.strings().empty(),
+            Value::Null | Value::Undefined => istr!(""),
             // The docs claim that only String, Number or Boolean are accepted, but that's also a lie
             val => {
                 if let Some(obj) = val.as_object() {
@@ -962,7 +963,7 @@ impl<'gc> E4XNode<'gc> {
                     } else {
                         (
                             AvmString::new_utf8_bytes(activation.gc(), text.as_bytes()),
-                            activation.strings().empty(),
+                            istr!(""),
                         )
                     };
                     let node = E4XNode(GcCell::new(
@@ -1073,7 +1074,7 @@ impl<'gc> E4XNode<'gc> {
                     if &*name == b"xmlns" {
                         namespaces.push(E4XNamespace {
                             uri: value,
-                            prefix: Some(activation.strings().empty()),
+                            prefix: Some(istr!("")),
                         });
                         continue;
                     }
@@ -1418,7 +1419,7 @@ pub fn simple_content_to_string<'gc>(
     children: impl Iterator<Item = E4XOrXml<'gc>>,
     activation: &mut Activation<'_, 'gc>,
 ) -> AvmString<'gc> {
-    let mut out = activation.strings().empty();
+    let mut out = istr!("");
     for child in children {
         if matches!(
             &*child.node().kind(),

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -9,6 +9,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
 use bitflags::bitflags;
+use ruffle_macros::istr;
 use std::cmp::{min, Ordering};
 use std::mem::swap;
 
@@ -175,7 +176,7 @@ pub fn join<'gc>(
             let item = resolve_array_hole(activation, this, i, item)?;
 
             if matches!(item, Value::Undefined) || matches!(item, Value::Null) {
-                accum.push(activation.strings().empty());
+                accum.push(istr!(""));
             } else {
                 accum.push(item.coerce_to_string(activation)?);
             }

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -165,7 +165,7 @@ pub fn join<'gc>(
 
     if let Some(array) = this.as_array_storage() {
         let string_separator = if matches!(separator, Value::Undefined) {
-            activation.strings().ascii_char(b',')
+            istr!(",")
         } else {
             separator.coerce_to_string(activation)?
         };

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -458,7 +458,7 @@ fn display_name<'gc>(
     if let Some(name) = name {
         name.to_qualified_name_or_star(context)
     } else {
-        context.ascii_char(b'*')
+        istr!(context, "*")
     }
 }
 

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -21,6 +21,7 @@ use crate::string::AvmString;
 use crate::types::{Degrees, Percent};
 use crate::vminterface::Instantiator;
 use crate::{avm2_stub_getter, avm2_stub_setter};
+use ruffle_macros::istr;
 use ruffle_render::blend::ExtendedBlendMode;
 use ruffle_render::filters::Filter;
 use std::str::FromStr;
@@ -549,10 +550,7 @@ pub fn get_name<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        return Ok(dobj
-            .name()
-            .unwrap_or_else(|| activation.strings().empty())
-            .into());
+        return Ok(dobj.name().unwrap_or_else(|| istr!("")).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -1,5 +1,7 @@
 //! `flash.system.ApplicationDomain` class
 
+use ruffle_macros::istr;
+
 use crate::avm2::activation::Activation;
 use crate::avm2::object::{DomainObject, Object, TObject, VectorObject};
 use crate::avm2::parameters::ParametersExt;
@@ -75,7 +77,7 @@ pub fn get_definition<'gc>(
     if let Some(appdomain) = this.as_application_domain() {
         let name = match args.get(0) {
             Some(arg) => arg.coerce_to_string(activation)?,
-            None => activation.strings().empty(),
+            None => istr!(""),
         };
         return appdomain.get_defined_value_handling_vector(activation, name);
     }
@@ -94,7 +96,7 @@ pub fn has_definition<'gc>(
     if let Some(appdomain) = this.as_application_domain() {
         let name = match args.get(0) {
             Some(arg) => arg.coerce_to_string(activation)?,
-            None => activation.strings().empty(),
+            None => istr!(""),
         };
 
         return Ok(appdomain

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -1,3 +1,5 @@
+use ruffle_macros::istr;
+
 use crate::avm2::activation::Activation;
 use crate::avm2::error::Error;
 use crate::avm2::globals::flash::display::display_object::initialize_for_allocator;
@@ -51,7 +53,7 @@ pub fn create_text_line<'gc>(
         None => {
             let txt = content
                 .call_method(element_methods::GET_TEXT, &[], activation)
-                .unwrap_or_else(|_| activation.strings().empty().into());
+                .unwrap_or_else(|_| istr!("").into());
 
             if matches!(txt, Value::Null) {
                 // FP returns a null TextLine when `o` is null- note that

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -1592,7 +1592,7 @@ pub fn get_selected_text<'gc>(
 
         return Ok(AvmString::new(activation.gc(), &text[start_index..end_index]).into());
     }
-    Ok(activation.strings().empty().into())
+    Ok(istr!("").into())
 }
 
 pub fn get_text_runs<'gc>(

--- a/core/src/avm2/globals/json.rs
+++ b/core/src/avm2/globals/json.rs
@@ -76,7 +76,7 @@ fn deserialize_json<'gc>(
     match reviver {
         None => Ok(val),
         Some(reviver) => {
-            let args = [activation.strings().empty().into(), val];
+            let args = [istr!("").into(), val];
             reviver.call(activation, Value::Null, &args)
         }
     }
@@ -252,7 +252,7 @@ impl<'gc> AvmSerializer<'gc> {
         activation: &mut Activation<'_, 'gc>,
         value: Value<'gc>,
     ) -> Result<JsonValue, Error<'gc>> {
-        let empty = activation.strings().empty();
+        let empty = istr!("");
         let mapped = self.map_value(activation, || empty, value)?;
         self.serialize_value(activation, mapped)
     }

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -1,5 +1,7 @@
 //! `Namespace` impl
 
+use ruffle_macros::istr;
+
 use crate::avm2::activation::Activation;
 use crate::avm2::e4x::is_xml_name;
 use crate::avm2::error::make_error_1098;
@@ -17,7 +19,7 @@ pub fn namespace_constructor<'gc>(
     let namespaces = activation.avm2().namespaces;
 
     let (prefix, namespace) = match args.len() {
-        0 => (Some(activation.strings().empty()), namespaces.public_all()),
+        0 => (Some(istr!("")), namespaces.public_all()),
         1 => {
             // These cases only activate with exactly one argument passed
             match args[0] {
@@ -28,7 +30,7 @@ pub fn namespace_constructor<'gc>(
                     });
                     let prefix = match uri {
                         Some(name) if !name.is_empty() => None,
-                        _ => Some(activation.strings().empty()),
+                        _ => Some(istr!("")),
                     };
                     (prefix, ns)
                 }
@@ -36,7 +38,7 @@ pub fn namespace_constructor<'gc>(
                 val => {
                     let name = val.coerce_to_string(activation)?;
                     let ns = Namespace::package(name, api_version, activation.strings());
-                    let prefix = name.is_empty().then(|| activation.strings().empty());
+                    let prefix = name.is_empty().then(|| istr!(""));
                     (prefix, ns)
                 }
             }
@@ -46,9 +48,7 @@ pub fn namespace_constructor<'gc>(
             let uri = args[1];
 
             let namespace_uri = if let Value::Object(Object::QNameObject(qname)) = uri {
-                qname
-                    .uri(activation.strings())
-                    .unwrap_or_else(|| activation.strings().empty())
+                qname.uri(activation.strings()).unwrap_or_else(|| istr!(""))
             } else {
                 uri.coerce_to_string(activation)?
             };

--- a/core/src/avm2/globals/q_name.rs
+++ b/core/src/avm2/globals/q_name.rs
@@ -1,5 +1,7 @@
 //! `QName` impl
 
+use ruffle_macros::istr;
+
 use crate::avm2::activation::Activation;
 use crate::avm2::api_version::ApiVersion;
 use crate::avm2::object::{Object, QNameObject, TObject};
@@ -45,7 +47,7 @@ pub fn q_name_constructor<'gc>(
         let mut local_arg = args[1];
 
         if matches!(local_arg, Value::Undefined) {
-            local_arg = activation.strings().empty().into();
+            local_arg = istr!("").into();
         }
 
         let api_version = activation.avm2().root_api_version;
@@ -79,7 +81,7 @@ pub fn q_name_constructor<'gc>(
         }
 
         let local = if qname_arg == Value::Undefined {
-            activation.strings().empty()
+            istr!("")
         } else {
             qname_arg.coerce_to_string(activation)?
         };

--- a/core/src/avm2/globals/reg_exp.rs
+++ b/core/src/avm2/globals/reg_exp.rs
@@ -1,5 +1,7 @@
 //! `RegExp` impl
 
+use ruffle_macros::istr;
+
 use crate::avm2::error::type_error;
 use crate::avm2::object::{ArrayObject, Object, TObject};
 use crate::avm2::regexp::RegExpFlags;
@@ -20,7 +22,7 @@ pub fn init<'gc>(
 
     if let Some(mut regexp) = this.as_regexp_mut(activation.gc()) {
         let source: AvmString<'gc> = match args.get(0) {
-            Some(Value::Undefined) => activation.strings().empty(),
+            Some(Value::Undefined) => istr!(""),
             Some(Value::Object(Object::RegExpObject(o))) => {
                 if !matches!(args.get(1), Some(Value::Undefined)) {
                     return Err(Error::AvmError(type_error(
@@ -35,13 +37,13 @@ pub fn init<'gc>(
                 return Ok(Value::Undefined);
             }
             Some(arg) => arg.coerce_to_string(activation)?,
-            None => activation.strings().empty(),
+            None => istr!(""),
         };
 
         regexp.set_source(source);
 
         let flag_chars = match args.get(1) {
-            None | Some(Value::Undefined) => activation.strings().empty(),
+            None | Some(Value::Undefined) => istr!(""),
             Some(arg) => arg.coerce_to_string(activation)?,
         };
 

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -1,5 +1,7 @@
 //! `String` impl
 
+use ruffle_macros::istr;
+
 use crate::avm2::activation::Activation;
 use crate::avm2::object::TObject;
 use crate::avm2::parameters::ParametersExt;
@@ -15,7 +17,7 @@ pub fn string_constructor<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let string_value = match args.get(0) {
         Some(arg) => arg.coerce_to_string(activation)?,
-        None => activation.strings().empty(),
+        None => istr!(""),
     };
 
     Ok(string_value.into())
@@ -28,7 +30,7 @@ pub fn call_handler<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     match args.get(0) {
         Some(arg) => arg.coerce_to_string(activation).map(Into::into),
-        None => Ok(activation.strings().empty().into()),
+        None => Ok(istr!("").into()),
     }
 }
 
@@ -56,14 +58,14 @@ pub fn char_at<'gc>(
         let n = args.get_f64(activation, 0)?;
 
         if n < 0.0 {
-            return Ok(activation.strings().empty().into());
+            return Ok(istr!("").into());
         }
 
         let index = if !n.is_nan() { n as usize } else { 0 };
         let ret = if let Some(c) = s.get(index) {
             activation.strings().make_char(c)
         } else {
-            activation.strings().empty()
+            istr!("")
         };
         return Ok(ret.into());
     }
@@ -360,7 +362,7 @@ pub fn slice<'gc>(
             .substring(this, start_index..end_index)
             .into())
     } else {
-        Ok(activation.strings().empty().into())
+        Ok(istr!("").into())
     }
 }
 
@@ -432,7 +434,7 @@ pub fn substr<'gc>(
         } else if len <= -1.0 {
             let wrapped_around = this.len() as f64 + len;
             if wrapped_around as usize + start_index >= this.len() {
-                return Ok(activation.strings().empty().into());
+                return Ok(istr!("").into());
             };
             wrapped_around
         } else {

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -1,5 +1,7 @@
 //! XML builtin and prototype
 
+use ruffle_macros::istr;
+
 use crate::avm2::e4x::{name_to_multiname, E4XNamespace, E4XNode, E4XNodeKind};
 use crate::avm2::error::{make_error_1117, type_error};
 pub use crate::avm2::object::xml_allocator;
@@ -54,7 +56,7 @@ pub fn init<'gc>(
 
     let node = match nodes.as_slice() {
         // XML defaults to an empty text node when nothing was parsed
-        [] => E4XNode::text(activation.gc(), activation.strings().empty(), None),
+        [] => E4XNode::text(activation.gc(), istr!(""), None),
         [node] => *node,
         nodes => {
             let mut single_element_node = None;

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -9,6 +9,7 @@ use crate::string::{AvmString, StringContext, WStr, WString};
 use bitflags::bitflags;
 use gc_arena::Gc;
 use gc_arena::{Collect, Mutation};
+use ruffle_macros::istr;
 use std::fmt::Debug;
 use std::ops::Deref;
 use swf::avm2::types::{Index, Multiname as AbcMultiname, NamespaceSet as AbcNamespaceSet};
@@ -480,7 +481,7 @@ impl<'gc> Multiname<'gc> {
     /// This is used by `describeType`
     pub fn to_qualified_name_or_star(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         if self.is_any_name() {
-            context.ascii_char(b'*')
+            istr!(context, "*")
         } else {
             self.to_qualified_name(context.gc())
         }
@@ -497,7 +498,7 @@ impl<'gc> Multiname<'gc> {
 
         if ns.is_empty() {
             // Special-case this to avoid allocating.
-            self.name.unwrap_or_else(|| context.ascii_char(b'*'))
+            self.name.unwrap_or_else(|| istr!(context, "*"))
         } else {
             let mut uri = WString::new();
             uri.push_str(ns);

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -28,7 +28,7 @@ pub fn event_allocator<'gc>(
         activation.gc(),
         EventObjectData {
             base,
-            event: RefLock::new(Event::new(activation.strings().empty())),
+            event: RefLock::new(Event::new(istr!(""))),
         },
     ))
     .into())

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -77,7 +77,7 @@ impl<'gc> NamespaceObject<'gc> {
                 base,
                 namespace,
                 prefix: if namespace.as_uri(activation.strings()).is_empty() {
-                    Some(activation.strings().empty())
+                    Some(istr!(""))
                 } else {
                     None
                 },

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -10,6 +10,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak};
+use ruffle_macros::istr;
 
 /// A class instance allocator that allocates Proxy objects.
 pub fn proxy_allocator<'gc>(
@@ -130,10 +131,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         Ok(self_val
             .call_method(
                 proxy_methods::HAS_PROPERTY,
-                &[name
-                    .local_name()
-                    .unwrap_or_else(|| activation.strings().ascii_char(b'*'))
-                    .into()],
+                &[name.local_name().unwrap_or_else(|| istr!("*")).into()],
                 activation,
             )?
             .coerce_to_boolean())

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -93,7 +93,7 @@ impl<'gc> QNameObject<'gc> {
     pub fn local_name(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         let name = self.name();
 
-        name.local_name().unwrap_or(context.ascii_char(b'*'))
+        name.local_name().unwrap_or_else(|| istr!(context, "*"))
     }
 
     pub fn set_is_qname(&self, mc: &Mutation<'gc>, is_qname: bool) {

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -163,7 +163,7 @@ impl<'gc> TObject<'gc> for QNameObject<'gc> {
             1 => self.local_name(activation.strings()).into(),
             2 => self
                 .uri(activation.strings())
-                .unwrap_or_else(|| activation.strings().empty())
+                .unwrap_or_else(|| istr!(""))
                 .into(),
             _ => Value::Undefined,
         })

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -8,6 +8,7 @@ use crate::avm2::Error;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
+use ruffle_macros::istr;
 use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates RegExp objects.
@@ -21,7 +22,7 @@ pub fn reg_exp_allocator<'gc>(
         activation.gc(),
         RegExpObjectData {
             base,
-            regexp: RefLock::new(RegExp::new(activation.strings().empty())),
+            regexp: RefLock::new(RegExp::new(istr!(""))),
         },
     ))
     .into())

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -12,6 +12,7 @@ use gc_arena::{
     lock::{Lock, RefLock},
     Collect, Gc, GcWeak, Mutation,
 };
+use ruffle_macros::istr;
 use ruffle_wstr::WString;
 use std::cell::{Cell, Ref, RefMut};
 use std::fmt::{self, Debug};
@@ -292,7 +293,7 @@ impl<'gc> XmlListObject<'gc> {
                 // 2.e.ii. Call [[Put]] on base with arguments x.[[TargetProperty]] and the empty string
                 base.as_object().set_property_local(
                     &target_property,
-                    activation.strings().empty().into(),
+                    istr!("").into(),
                     activation,
                 )?;
 
@@ -718,7 +719,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                                     activation.gc(),
                                     x.explicit_namespace().map(E4XNamespace::new_uri),
                                     x.local_name().unwrap(),
-                                    activation.strings().empty(),
+                                    istr!(""),
                                     r,
                                 )
                             }
@@ -726,9 +727,9 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                             // 2.c.v.1. Let y.[[Name]] = null
                             // 2.c.v.2. Let y.[[Class]] = "text"
                             Some(x) if x.is_any_name() => {
-                                E4XNode::text(activation.gc(), activation.strings().empty(), r)
+                                E4XNode::text(activation.gc(), istr!(""), r)
                             }
-                            None => E4XNode::text(activation.gc(), activation.strings().empty(), r),
+                            None => E4XNode::text(activation.gc(), istr!(""), r),
                             // NOTE: avmplus edge case.
                             //       See https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/XMLListObject.cpp#L297-L300
                             _ if value
@@ -736,7 +737,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                                 .and_then(|x| x.as_xml_object())
                                 .is_some_and(|x| x.node().is_text() || x.node().is_attribute()) =>
                             {
-                                E4XNode::text(activation.gc(), activation.strings().empty(), r)
+                                E4XNode::text(activation.gc(), istr!(""), r)
                             }
 
                             // 2.c.vi. Else let y.[[Class]] = "element"

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -7,6 +7,7 @@ use crate::avm2::TranslationUnit;
 use crate::avm2::Value;
 use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, Gc};
+use ruffle_macros::istr;
 
 use super::class::Class;
 
@@ -116,7 +117,7 @@ impl<'gc> PropertyClass<'gc> {
         match self {
             PropertyClass::Class(class) => class.name().to_qualified_name(context.gc()),
             PropertyClass::Name(name, _) => name.to_qualified_name_or_star(context),
-            PropertyClass::Any => context.ascii_char(b'*'),
+            PropertyClass::Any => istr!(context, "*"),
         }
     }
 }

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -11,6 +11,7 @@ use crate::string::WString;
 use crate::string::{AvmString, Units, WStrToUtf8};
 use bitflags::bitflags;
 use gc_arena::Collect;
+use ruffle_macros::istr;
 use ruffle_wstr::WStr;
 
 use super::object::RegExpObject;
@@ -232,7 +233,7 @@ impl<'gc> RegExp<'gc> {
                 .chain((m.captures.iter()).map(|x| x.as_ref()))
                 .map(|o| match o {
                     Some(r) => AvmString::new(activation.gc(), &txt[r.start..r.end]).into(),
-                    None => activation.strings().empty().into(),
+                    None => istr!("").into(),
                 })
                 .chain(std::iter::once(m.range.start.into()))
                 .chain(std::iter::once((*txt).into()))

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -777,7 +777,7 @@ impl<'gc> Value<'gc> {
             Value::Bool(true) => istr!("true"),
             Value::Bool(false) => istr!("false"),
             Value::Number(n) if n.is_nan() => istr!("NaN"),
-            Value::Number(n) if *n == 0.0 => activation.strings().ascii_char(b'0'),
+            Value::Number(n) if *n == 0.0 => istr!("0"),
             Value::Number(n) if *n < 0.0 => AvmString::new_utf8(
                 activation.gc(),
                 format!("-{}", Value::Number(-n).coerce_to_string(activation)?),

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -16,7 +16,7 @@ use crate::types::{Degrees, Percent};
 use crate::vminterface::Instantiator;
 use bitflags::bitflags;
 use gc_arena::{Collect, Mutation};
-use ruffle_macros::enum_trait_object;
+use ruffle_macros::{enum_trait_object, istr};
 use ruffle_render::pixel_bender::PixelBenderShaderHandle;
 use ruffle_render::transform::{Transform, TransformStack};
 use std::cell::{Ref, RefMut};
@@ -2475,7 +2475,7 @@ pub trait TDisplayObject<'gc>:
             let name = AvmString::new_utf8(context.gc(), format!("root{}", self.depth() + 1));
             self.set_name(context.gc(), name);
         } else {
-            self.set_name(context.gc(), context.strings.empty());
+            self.set_name(context.gc(), istr!(context, ""));
         }
     }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -34,6 +34,7 @@ use chrono::DateTime;
 use chrono::Utc;
 use core::fmt;
 use gc_arena::{Collect, Gc, GcCell, Mutation};
+use ruffle_macros::istr;
 use ruffle_render::commands::CommandHandler;
 use ruffle_render::quality::StageQuality;
 use ruffle_render::transform::Transform;
@@ -1403,7 +1404,7 @@ impl<'gc> EditText<'gc> {
                                 self.set_html_text(
                                     &value
                                         .coerce_to_string(activation)
-                                        .unwrap_or_else(|_| activation.strings().empty()),
+                                        .unwrap_or_else(|_| istr!("")),
                                     activation.context,
                                 );
                             } else {

--- a/core/src/string/common.rs
+++ b/core/src/string/common.rs
@@ -2,17 +2,28 @@ use super::AvmAtom;
 use gc_arena::Collect;
 
 macro_rules! define_common_strings {
-    ($($field:ident: $str:literal,)*) => {
+    (
+        $ascii:ident: <ASCII>,
+        $($field:ident: $str:literal,)*
+    ) => {
         #[allow(non_snake_case)]
         #[derive(Collect)]
         #[collect(no_drop)]
         pub struct CommonStrings<'gc> {
-            $(pub $field: AvmAtom<'gc>,)*
+            pub $ascii: [AvmAtom<'gc>; ASCII_CHARS_LEN],
+
+            $(
+                pub $field: AvmAtom<'gc>,
+            )*
         }
 
         impl<'gc> CommonStrings<'gc> {
-            pub fn new(mut intern_from_static: impl FnMut(&'static [u8]) -> AvmAtom<'gc>) -> Self {
+            pub(super) fn new(mut intern_from_static: impl FnMut(&'static [u8]) -> AvmAtom<'gc>) -> Self {
                 Self {
+                    $ascii: std::array::from_fn(|i| {
+                        let c = &ASCII_CHARS[i];
+                        intern_from_static(std::slice::from_ref(c))
+                    }),
                     $($field: intern_from_static($str)),*
                 }
             }
@@ -20,13 +31,28 @@ macro_rules! define_common_strings {
     };
 }
 
+const ASCII_CHARS_LEN: usize = 0x80;
+static ASCII_CHARS: [u8; ASCII_CHARS_LEN] = {
+    let mut chs = [0; ASCII_CHARS_LEN];
+    let mut i = 0;
+    while i < chs.len() {
+        chs[i] = i as u8;
+        i += 1;
+    }
+    chs
+};
+
 define_common_strings! {
+    ascii_chars: <ASCII>,
+
+    // Alphanumeric strings, in alphabetical order.
+    // The field name should always be the string prefixed with `str_`.
+    str_: b"",
     str___constructor__: b"__constructor__",
     str___proto__: b"__proto__",
     str___resolve: b"__resolve",
     str__bytesLoaded: b"_bytesLoaded",
     str__bytesTotal: b"_bytesTotal",
-    str_a: b"a",
     str_access: b"access",
     str_accessors: b"accessors",
     str_advanced: b"advanced",
@@ -36,7 +62,6 @@ define_common_strings! {
     str_ascent: b"ascent",
     str_asyncError: b"asyncError",
     str_auto: b"auto",
-    str_b: b"b",
     str_bases: b"bases",
     str_block: b"block",
     str_blueMultiplier: b"blueMultiplier",
@@ -45,7 +70,6 @@ define_common_strings! {
     str_boldItalic: b"boldItalic",
     str_boolean: b"boolean",
     str_builtInItems: b"builtInItems",
-    str_c: b"c",
     str_callee: b"callee",
     str_caption: b"caption",
     str_center: b"center",
@@ -54,7 +78,6 @@ define_common_strings! {
     str_color: b"color",
     str_constructor: b"constructor",
     str_customItems: b"customItems",
-    str_d: b"d",
     str_declaredBy: b"declaredBy",
     str_decode: b"decode",
     str_descent: b"descent",
@@ -70,7 +93,6 @@ define_common_strings! {
     str_function: b"function",
     str_greenMultiplier: b"greenMultiplier",
     str_greenOffset: b"greenOffset",
-    str_h: b"h",
     str_height: b"height",
     str_httpStatus: b"httpStatus",
     str_ignore: b"ignore",
@@ -140,7 +162,6 @@ define_common_strings! {
     str_print: b"print",
     str_prototype: b"prototype",
     str_quality: b"quality",
-    str_r: b"r",
     str_readonly: b"readonly",
     str_readwrite: b"readwrite",
     str_redMultiplier: b"redMultiplier",
@@ -175,15 +196,12 @@ define_common_strings! {
     str_valueOf: b"valueOf",
     str_variables: b"variables",
     str_visible: b"visible",
-    str_w: b"w",
     str_width: b"width",
     str_wrap: b"wrap",
     str_writeonly: b"writeonly",
-    str_x: b"x",
     str_xMax: b"xMax",
     str_xMin: b"xMin",
     str_xml: b"xml",
-    str_y: b"y",
     str_yMax: b"yMax",
     str_yMin: b"yMin",
     str_zoom: b"zoom",

--- a/core/src/string/context.rs
+++ b/core/src/string/context.rs
@@ -77,12 +77,12 @@ impl<'gc> StringContext<'gc> {
 
     #[must_use]
     pub fn empty(&self) -> AvmString<'gc> {
-        self.interner.empty.into()
+        self.common().str_.into()
     }
 
     #[must_use]
     pub fn make_char(&self, c: u16) -> AvmString<'gc> {
-        if let Some(s) = self.interner.chars.get(c as usize) {
+        if let Some(s) = self.common().ascii_chars.get(c as usize) {
             (*s).into()
         } else {
             AvmString::new(self.gc(), WString::from_unit(c))
@@ -92,7 +92,7 @@ impl<'gc> StringContext<'gc> {
     /// Like `make_char`, but panics if the passed char is not ASCII.
     #[must_use]
     pub fn ascii_char(&self, c: u8) -> AvmString<'gc> {
-        self.interner.chars[c as usize].into()
+        self.common().ascii_chars[c as usize].into()
     }
 
     #[must_use]


### PR DESCRIPTION
Not entirely sure this is worth the extra complexity in macro code, but this does have a few nice consequences:
- it removes some "duplicates" strings like `"x"` or `"y"`, that were both in the one-char cache and in `CommonStrings`;
- being able to use `istr!` in more places makes code more readable, even if not that much shorter.