### PR TITLE
avm1: Don't use a static `AvmString` for AVM1 array's length property

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1470,12 +1470,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             // InitArray pops no args and pushes undefined if num_elements is out of range.
             Value::Undefined
         } else {
-            ArrayObject::new(
-                self.gc(),
-                self.context.avm1.prototypes().array,
-                (0..num_elements as i32).map(|_| self.context.avm1.pop()),
-            )
-            .into()
+            ArrayObject::builder(self)
+                .with((0..num_elements as i32).map(|_| self.context.avm1.pop()))
+                .into()
         };
 
         self.context.avm1.push(result);

--- a/core/src/avm1/flv.rs
+++ b/core/src/avm1/flv.rs
@@ -39,12 +39,9 @@ fn avm1_array_from_flv_values<'gc>(
     activation: &mut Activation<'_, 'gc>,
     values: Vec<FlvValue>,
 ) -> Avm1Value<'gc> {
-    ArrayObject::new(
-        activation.gc(),
-        activation.context.avm1.prototypes().array,
-        values.iter().map(|v| v.clone().to_avm1_value(activation)),
-    )
-    .into()
+    ArrayObject::builder(activation)
+        .with(values.iter().map(|v| v.clone().to_avm1_value(activation)))
+        .into()
 }
 
 pub trait FlvValueAvm1Ext<'gc> {

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -194,11 +194,7 @@ impl<'gc> Avm1Function<'gc> {
             return;
         }
 
-        let arguments = ArrayObject::new(
-            frame.gc(),
-            frame.context.avm1.prototypes().array,
-            args.iter().cloned(),
-        );
+        let arguments = ArrayObject::builder(frame).with(args.iter().cloned());
 
         arguments.define_value(
             frame.gc(),

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -95,14 +95,13 @@ fn filters<'gc>(
     this: Avm1Button<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(ArrayObject::new(
-        activation.gc(),
-        activation.context.avm1.prototypes().array,
-        this.filters()
-            .into_iter()
-            .map(|filter| bitmap_filter::filter_to_avm1(activation, filter)),
-    )
-    .into())
+    Ok(ArrayObject::builder(activation)
+        .with(
+            this.filters()
+                .into_iter()
+                .map(|filter| bitmap_filter::filter_to_avm1(activation, filter)),
+        )
+        .into())
 }
 
 fn set_filters<'gc>(

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -65,12 +65,9 @@ impl<'gc> ColorMatrixFilter<'gc> {
     }
 
     fn matrix(&self, activation: &mut Activation<'_, 'gc>) -> Value<'gc> {
-        ArrayObject::new(
-            activation.gc(),
-            activation.context.avm1.prototypes().array,
-            self.0.read().matrix.iter().map(|&v| v.into()),
-        )
-        .into()
+        ArrayObject::builder(activation)
+            .with(self.0.read().matrix.iter().map(|&v| v.into()))
+            .into()
     }
 
     fn set_matrix(

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -5,7 +5,6 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::context::UpdateContext;
 use crate::string::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use std::ops::Deref;
@@ -167,12 +166,8 @@ impl<'gc> ConvolutionFilter<'gc> {
         Ok(())
     }
 
-    fn matrix(&self, context: &mut UpdateContext<'gc>) -> ArrayObject<'gc> {
-        ArrayObject::new(
-            context.gc(),
-            context.avm1.prototypes().array,
-            self.0.read().matrix.iter().map(|&x| x.into()),
-        )
+    fn matrix(&self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
+        ArrayObject::builder(activation).with(self.0.read().matrix.iter().map(|&x| x.into()))
     }
 
     fn set_matrix(
@@ -366,7 +361,7 @@ fn method<'gc>(
             this.set_matrix_y(activation, args.get(0))?;
             Value::Undefined
         }
-        GET_MATRIX => this.matrix(activation.context).into(),
+        GET_MATRIX => this.matrix(activation).into(),
         SET_MATRIX => {
             this.set_matrix(activation, args.get(0))?;
             Value::Undefined

--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -442,7 +442,7 @@ pub fn create_constructor<'gc>(
 ) -> Object<'gc> {
     let file_reference_proto = ScriptObject::new(context.gc(), Some(proto));
     define_properties_on(PROTO_DECLS, context, file_reference_proto, fn_proto);
-    broadcaster_functions.initialize(context.gc(), file_reference_proto.into(), array_proto);
+    broadcaster_functions.initialize(context, file_reference_proto.into(), array_proto);
     let constructor = FunctionObject::constructor(
         context.gc(),
         Executable::Native(constructor),

--- a/core/src/avm1/globals/gradient_filter.rs
+++ b/core/src/avm1/globals/gradient_filter.rs
@@ -6,7 +6,6 @@ use crate::avm1::globals::bevel_filter::BevelFilterType;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::context::UpdateContext;
 use crate::string::StringContext;
 use gc_arena::{Collect, GcCell, Mutation};
 use ruffle_macros::istr;
@@ -165,11 +164,9 @@ impl<'gc> GradientFilter<'gc> {
         Ok(())
     }
 
-    fn colors(&self, context: &mut UpdateContext<'gc>) -> ArrayObject<'gc> {
+    fn colors(&self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
         let read = self.0.read();
-        ArrayObject::new(
-            context.gc(),
-            context.avm1.prototypes().array,
+        ArrayObject::builder(activation).with(
             read.colors[..read.num_colors]
                 .iter()
                 .map(|r| r.color.to_rgb().into()),
@@ -203,11 +200,9 @@ impl<'gc> GradientFilter<'gc> {
         Ok(())
     }
 
-    fn alphas(&self, context: &mut UpdateContext<'gc>) -> ArrayObject<'gc> {
+    fn alphas(&self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
         let read = self.0.read();
-        ArrayObject::new(
-            context.gc(),
-            context.avm1.prototypes().array,
+        ArrayObject::builder(activation).with(
             read.colors[..read.num_colors]
                 .iter()
                 .map(|r| (f64::from(r.color.a) / 255.0).into()),
@@ -243,11 +238,9 @@ impl<'gc> GradientFilter<'gc> {
         Ok(())
     }
 
-    fn ratios(&self, context: &mut UpdateContext<'gc>) -> ArrayObject<'gc> {
+    fn ratios(&self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
         let read = self.0.read();
-        ArrayObject::new(
-            context.gc(),
-            context.avm1.prototypes().array,
+        ArrayObject::builder(activation).with(
             read.colors[..read.num_colors]
                 .iter()
                 .map(|r| r.ratio.into()),
@@ -474,17 +467,17 @@ fn method<'gc>(
             this.set_angle(activation, args.get(0))?;
             Value::Undefined
         }
-        GET_COLORS => this.colors(activation.context).into(),
+        GET_COLORS => this.colors(activation).into(),
         SET_COLORS => {
             this.set_colors(activation, args.get(0))?;
             Value::Undefined
         }
-        GET_ALPHAS => this.alphas(activation.context).into(),
+        GET_ALPHAS => this.alphas(activation).into(),
         SET_ALPHAS => {
             this.set_alphas(activation, args.get(0))?;
             Value::Undefined
         }
-        GET_RATIOS => this.ratios(activation.context).into(),
+        GET_RATIOS => this.ratios(activation).into(),
         SET_RATIOS => {
             this.set_ratios(activation, args.get(0))?;
             Value::Undefined

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -89,7 +89,7 @@ pub fn create_key_object<'gc>(
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
     let key = ScriptObject::new(context.gc(), Some(proto));
-    broadcaster_functions.initialize(context.gc(), key.into(), array_proto);
+    broadcaster_functions.initialize(context, key.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, key, fn_proto);
     key.into()
 }

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -38,7 +38,7 @@ pub fn create_mouse_object<'gc>(
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
     let mouse = ScriptObject::new(context.gc(), Some(proto));
-    broadcaster_functions.initialize(context.gc(), mouse.into(), array_proto);
+    broadcaster_functions.initialize(context, mouse.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, mouse, fn_proto);
     mouse.into()
 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1784,14 +1784,13 @@ fn filters<'gc>(
     this: MovieClip<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(ArrayObject::new(
-        activation.gc(),
-        activation.context.avm1.prototypes().array,
-        this.filters()
-            .into_iter()
-            .map(|filter| bitmap_filter::filter_to_avm1(activation, filter)),
-    )
-    .into())
+    Ok(ArrayObject::builder(activation)
+        .with(
+            this.filters()
+                .into_iter()
+                .map(|filter| bitmap_filter::filter_to_avm1(activation, filter)),
+        )
+        .into())
 }
 
 fn set_filters<'gc>(

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -24,11 +24,7 @@ pub fn constructor<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let listeners = ArrayObject::new(
-        activation.gc(),
-        activation.context.avm1.prototypes().array,
-        [this.into()],
-    );
+    let listeners = ArrayObject::builder(activation).with([this.into()]);
     this.define_value(
         activation.gc(),
         "_listeners",
@@ -170,7 +166,7 @@ pub fn create_proto<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
     let mcl_proto = ScriptObject::new(context.gc(), Some(proto));
-    broadcaster_functions.initialize(context.gc(), mcl_proto.into(), array_proto);
+    broadcaster_functions.initialize(context, mcl_proto.into(), array_proto);
     define_properties_on(PROTO_DECLS, context, mcl_proto, fn_proto);
     mcl_proto.into()
 }

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -147,7 +147,7 @@ pub fn create_selection_object<'gc>(
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
     let object = ScriptObject::new(context.gc(), Some(proto));
-    broadcaster_functions.initialize(context.gc(), object.into(), array_proto);
+    broadcaster_functions.initialize(context, object.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -27,7 +27,7 @@ pub fn create_stage_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
     let stage = ScriptObject::new(context.gc(), Some(proto));
-    broadcaster_functions.initialize(context.gc(), stage.into(), array_proto);
+    broadcaster_functions.initialize(context, stage.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, stage, fn_proto);
     stage.into()
 }

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -277,31 +277,25 @@ fn split<'gc>(
             // but Flash does not.
             // e.g., split("foo", "") returns ["", "f", "o", "o", ""] in Rust but ["f, "o", "o"] in Flash.
             // Special case this to match Flash's behavior.
-            Ok(ArrayObject::new(
-                activation.gc(),
-                activation.context.avm1.prototypes().array,
-                this.iter()
-                    .take(limit)
-                    .map(|c| AvmString::new(activation.gc(), WString::from_unit(c)).into()),
-            )
-            .into())
+            Ok(ArrayObject::builder(activation)
+                .with(
+                    this.iter()
+                        .take(limit)
+                        .map(|c| activation.strings().make_char(c).into()),
+                )
+                .into())
         } else {
-            Ok(ArrayObject::new(
-                activation.gc(),
-                activation.context.avm1.prototypes().array,
-                this.split(&delimiter)
-                    .take(limit)
-                    .map(|c| AvmString::new(activation.gc(), c).into()),
-            )
-            .into())
+            // TODO(moulins): make dependent AvmStrings instead of reallocating.
+            Ok(ArrayObject::builder(activation)
+                .with(
+                    this.split(&delimiter)
+                        .take(limit)
+                        .map(|c| AvmString::new(activation.gc(), c).into()),
+                )
+                .into())
         }
     } else {
-        Ok(ArrayObject::new(
-            activation.gc(),
-            activation.context.avm1.prototypes().array,
-            [this.into()],
-        )
-        .into())
+        Ok(ArrayObject::builder(activation).with([this.into()]).into())
     }
 }
 

--- a/core/src/avm1/globals/style_sheet.rs
+++ b/core/src/avm1/globals/style_sheet.rs
@@ -138,14 +138,13 @@ fn get_style_names<'gc>(
     let css = this
         .get_stored("_css".into(), activation)?
         .coerce_to_object(activation);
-    Ok(ArrayObject::new(
-        activation.gc(),
-        activation.context.avm1.prototypes().array,
-        css.get_keys(activation, false)
-            .into_iter()
-            .map(Value::String),
-    )
-    .into())
+    Ok(ArrayObject::builder(activation)
+        .with(
+            css.get_keys(activation, false)
+                .into_iter()
+                .map(Value::String),
+        )
+        .into())
 }
 
 fn load<'gc>(

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -87,7 +87,7 @@ pub fn create<'gc>(
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
     let ime = ScriptObject::new(context.gc(), Some(proto));
-    broadcaster_functions.initialize(context.gc(), ime.into(), array_proto);
+    broadcaster_functions.initialize(context, ime.into(), array_proto);
     define_properties_on(OBJECT_DECLS, context, ime, fn_proto);
     ime.into()
 }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -847,14 +847,13 @@ fn filters<'gc>(
     this: EditText<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(ArrayObject::new(
-        activation.gc(),
-        activation.context.avm1.prototypes().array,
-        this.filters()
-            .into_iter()
-            .map(|filter| bitmap_filter::filter_to_avm1(activation, filter)),
-    )
-    .into())
+    Ok(ArrayObject::builder(activation)
+        .with(
+            this.filters()
+                .into_iter()
+                .map(|filter| bitmap_filter::filter_to_avm1(activation, filter)),
+        )
+        .into())
 }
 
 fn set_filters<'gc>(

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -375,12 +375,9 @@ fn tab_stops<'gc>(activation: &mut Activation<'_, 'gc>, text_format: &TextFormat
         .tab_stops
         .as_ref()
         .map_or(Value::Null, |tab_stops| {
-            ArrayObject::new(
-                activation.gc(),
-                activation.context.avm1.prototypes().array,
-                tab_stops.iter().map(|&x| x.into()),
-            )
-            .into()
+            ArrayObject::builder(activation)
+                .with(tab_stops.iter().map(|&x| x.into()))
+                .into()
         })
 }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2038,7 +2038,7 @@ impl<'gc> EditText<'gc> {
     fn initialize_as_broadcaster(&self, activation: &mut Avm1Activation<'_, 'gc>) {
         if let Avm1Value::Object(object) = self.object() {
             activation.context.avm1.broadcaster_functions().initialize(
-                activation.gc(),
+                &activation.context.strings,
                 object,
                 activation.context.avm1.prototypes().array,
             );

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -183,14 +183,13 @@ impl Value {
                 }
                 object.into()
             }
-            Value::List(values) => Avm1ArrayObject::new(
-                activation.gc(),
-                activation.context.avm1.prototypes().array,
-                values
-                    .iter()
-                    .map(|value| value.to_owned().into_avm1(activation)),
-            )
-            .into(),
+            Value::List(values) => Avm1ArrayObject::builder(activation)
+                .with(
+                    values
+                        .iter()
+                        .map(|value| value.to_owned().into_avm1(activation)),
+                )
+                .into(),
         }
     }
 


### PR DESCRIPTION
`ArrayObject` construction now requires an activation, so add `ArrayObjectBuilder` to simplify the process: it allows grabbing what we need from the activation (the interned `length` property name, and the array prototype) without running afoul of the borrow checker.