### PR TITLE
render: Switch to wgpu fork with backported GLES limits fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,8 +2994,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -6124,8 +6123,7 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 [[package]]
 name = "wgpu"
 version = "24.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f55718f85c2fa756edffa0e7f0e0a60aba463d1362b57e23123c58f035e4b6"
+source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
 dependencies = [
  "arrayvec",
  "bitflags 2.8.0",
@@ -6150,8 +6148,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a39b8842dc9ffcbe34346e3ab6d496b32a47f6497e119d762c97fcaae3cb37"
+source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -6175,8 +6172,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a782e5056b060b0b4010881d1decddd059e44f2ecd01e2db2971b48ad3627e5"
+source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6221,8 +6217,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
 dependencies = [
  "bitflags 2.8.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,12 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/ruffle-rs/ruffle"
 version = "0.1.0"
 
+# TODO: remove this when v25 releases with https://github.com/gfx-rs/wgpu/pull/6994
+# (or a v24.x with the backport: https://github.com/gfx-rs/wgpu/pull/7169)
+[patch.crates-io]
+wgpu = { git = "https://github.com/ruffle-rs/wgpu", tag = "v24.0.1-ruffle1" }
+naga = { git = "https://github.com/ruffle-rs/wgpu", tag = "v24.0.1-ruffle1" }
+
 [workspace.dependencies]
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }


### PR DESCRIPTION
Should fix hopefully all instances of https://github.com/ruffle-rs/ruffle/issues/19278 that appeared after we bumped to v23.

Same with all Android errors with this style: https://github.com/ruffle-rs/ruffle-android/issues/338