### PR TITLE
AVM2: Partially support parentAllowsChild when domains match

### DIFF
--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -302,6 +302,7 @@ impl<'gc> LoaderInfoObject<'gc> {
 
     /// Unwrap this object's loader stream
     pub fn as_loader_stream(&self) -> Option<Ref<LoaderStream<'gc>>> {
+        // TODO: this can be non-Option.
         Some(self.0.loaded_stream.borrow())
     }
 


### PR DESCRIPTION
Partially addresses https://github.com/ruffle-rs/ruffle/issues/14455 .

The window now kinda works, though it's slow, leaks memory (known unload() issues) and sometimes hangs after throwing:
```
2025-02-14T22:19:50.642618Z ERROR ruffle_core::avm2::events: Error dispatching event EventObject { type: "getUserEnvironment", class: src.com.gaiaonline.FishTank.events::DataConnectorEvent, ptr: 0x2a5c77646f0 } to handler FunctionObject(FunctionObject { ptr: 0x2a5c5b73e00, name: "src.com.gaiaonline.FishTank.services::SpecialEventManager/onGetSettings()" }) : TypeError: Error #1010: A term is undefined and has no properties. (accessing field: events)
        at src.com.gaiaonline.FishTank.services::SpecialEventManager/onGetSettings()
        at flash.events::EventDispatcher/dispatchEventInternal()
        at flash.events::EventDispatcher/dispatchEvent()
        at src.com.gaiaonline.FishTank.services::DataConnector/onGSILoaded()
        at flash.events::EventDispatcher/dispatchEventInternal()
        at flash.events::EventDispatcher/dispatchEvent()
        at com.gaiaonline.gsi::GSIGateway/onComplete()
2025-02-14T22:19:50.642730Z ERROR ruffle_core::avm2::events: Error dispatching event EventObject { type: "getUserEnvironment", class: src.com.gaiaonline.FishTank.events::DataConnectorEvent, ptr: 0x2a5c77646f0 } to handler FunctionObject(FunctionObject { ptr: 0x2a5c5b76800, name: "FishTank/onUserEnvironment()" }) : TypeError: Error #1010: A term is undefined and has no properties. (accessing field: user_id)
        at FishTank/onUserEnvironment()
        at flash.events::EventDispatcher/dispatchEventInternal()
        at flash.events::EventDispatcher/dispatchEvent()
        at src.com.gaiaonline.FishTank.services::DataConnector/onGSILoaded()
        at flash.events::EventDispatcher/dispatchEventInternal()
        at flash.events::EventDispatcher/dispatchEvent()
        at com.gaiaonline.gsi::GSIGateway/onComplete()
2025-02-14T22:19:50.642782Z ERROR ruffle_core::avm2::events: Error dispatching event EventObject { type: "getUserEnvironment", class: src.com.gaiaonline.FishTank.events::DataConnectorEvent, ptr: 0x2a5c77646f0 } to handler FunctionObject(FunctionObject { ptr: 0x2a5c5b77900, name: "src.com.gaiaonline.FishTank.miniGames::GameManager/onUserEnvironment()" }) : TypeError: Error #1010: A term is undefined and has no properties. (accessing field: game_info)
        at src.com.gaiaonline.FishTank.miniGames::GameManager/onUserEnvironment()
        at flash.events::EventDispatcher/dispatchEventInternal()
        at flash.events::EventDispatcher/dispatchEvent()
        at src.com.gaiaonline.FishTank.services::DataConnector/onGSILoaded()
        at flash.events::EventDispatcher/dispatchEventInternal()
        at flash.events::EventDispatcher/dispatchEvent()
        at com.gaiaonline.gsi::GSIGateway/onComplete()
```