### PR TITLE
ci: Use dotnet to install wix extensions

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -121,9 +121,9 @@ jobs:
 
       - name: Install WiX
         run: |
-          dotnet tool install --global wix
-          wix extension add -g WixToolset.UI.wixext
-          wix extension add -g WixToolset.Util.wixext
+          dotnet tool install --global wix --version 5.0.2 
+          dotnet add package WixToolset.UI.wixext --version 5.0.2
+          dotnet add package WixToolset.Util.wixext --version 5.0.2
         if: runner.os == 'Windows'
 
       - name: Cargo build

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -121,9 +121,9 @@ jobs:
 
       - name: Install WiX
         run: |
-          dotnet tool install --global wix --version 5.0.2 
-          dotnet add package WixToolset.UI.wixext --version 5.0.2
-          dotnet add package WixToolset.Util.wixext --version 5.0.2
+          dotnet tool install --global wix
+          dotnet add package WixToolset.UI.wixext
+          dotnet add package WixToolset.Util.wixext
         if: runner.os == 'Windows'
 
       - name: Cargo build


### PR DESCRIPTION
@danielhjacobs Proposes we hardcode to either the last general release or the RC so as to resolve the conflicting installs which are likely blocking the desktop builds. I would opt to stay with the general release for now.