### PR TITLE
Version pinning just the wix base

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -121,9 +121,9 @@ jobs:
 
       - name: Install WiX
         run: |
-          dotnet tool install --global wix
-          dotnet add package WixToolset.UI.wixext
-          dotnet add package WixToolset.Util.wixext
+          dotnet tool install --global wix --version 5.0.2
+          wix extension add -g WixToolset.UI.wixext
+          wix extension add -g WixToolset.Util.wixext
         if: runner.os == 'Windows'
 
       - name: Cargo build


### PR DESCRIPTION
Realized after looking into the approach to this more closely that just the base package should be pinned. The toolset extensions need to continue to be added globally to the cache as they were since we're not actually coding in a .NET project.