### PR TITLE
refactor: Add InputEvent

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,4 +1,4 @@
-use crate::display_object::InteractiveObject;
+use crate::{display_object::InteractiveObject, input::InputEvent};
 use std::str::FromStr;
 use swf::ClipEventFlag;
 
@@ -766,17 +766,17 @@ impl ButtonKeyCode {
         })
     }
 
-    pub fn from_player_event(event: PlayerEvent) -> Option<Self> {
+    pub fn from_input_event(event: InputEvent) -> Option<Self> {
         match event {
             // ASCII characters convert directly to keyPress button events.
-            PlayerEvent::TextInput { codepoint }
+            InputEvent::TextInput { codepoint }
                 if codepoint as u32 >= 32 && codepoint as u32 <= 126 =>
             {
                 Some(ButtonKeyCode::from_u8(codepoint as u8).unwrap())
             }
 
             // Special keys have custom values for keyPress.
-            PlayerEvent::KeyDown { key_code, .. } => Self::from_key_code(key_code),
+            InputEvent::KeyDown { key_code, .. } => Self::from_key_code(key_code),
             _ => None,
         }
     }

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -67,9 +67,9 @@ impl InputManager {
         }
     }
 
-    pub fn map_input_event(&mut self, event: PlayerEvent) -> Option<PlayerEvent> {
+    pub fn process_input_event(&mut self, event: PlayerEvent) -> Option<PlayerEvent> {
         // Optionally transform gamepad button events into key events.
-        match event {
+        let event = match event {
             PlayerEvent::GamepadButtonDown { button } => {
                 if let Some(key_code) = self.gamepad_button_mapping.get(&button) {
                     Some(PlayerEvent::KeyDown {
@@ -93,10 +93,16 @@ impl InputManager {
                 }
             }
             _ => Some(event),
+        };
+
+        if let Some(event) = event {
+            self.handle_event(&event);
         }
+
+        event
     }
 
-    pub fn handle_event(&mut self, event: &PlayerEvent) {
+    fn handle_event(&mut self, event: &PlayerEvent) {
         match *event {
             PlayerEvent::KeyDown { key_code, key_char } => {
                 self.last_char = key_char;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1048,12 +1048,11 @@ impl Player {
     ///    second wave of event processing.
     fn handle_input_event(&mut self, event: PlayerEvent) -> bool {
         let mut player_event_handled = false;
-        let Some(event) = self.input.map_input_event(event) else {
+        let prev_mouse_buttons = self.input.get_mouse_down_buttons();
+        let Some(event) = self.input.process_input_event(event) else {
             return false;
         };
 
-        let prev_mouse_buttons = self.input.get_mouse_down_buttons();
-        self.input.handle_event(&event);
         let changed_mouse_buttons = self
             .input
             .get_mouse_down_buttons()


### PR DESCRIPTION
This refactor simplifies code and is a first step towards tidying up and unifying input handling across platforms.

The most important improvement is the addition of `InputEvent`, which represents a mapped `PlayerEvent` related to input. It proves to be useful even now by discarding gamepad events and having click index present at all times. In the future this will make it possible to pass information about keys in `PlayerEvent` without any knowledge about Flash Player (so no `KeyCode`).