### PR TITLE
build(deps): bump the cargo-minor group across 1 directory with 4 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2796,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
 ]
@@ -3794,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.0"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbfb3ddf5364c9cfcd65549a1e7b801d0e8d1b14c1a1590a6408aa93cfbfa84"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
 dependencies = [
  "memchr",
 ]
@@ -4869,9 +4869,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "smithay-client-toolkit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 naga = { version = "24.0.0", features = ["wgsl-out"] }
 wgpu = "24.0.1"
 egui = "0.31.0"
-clap = { version = "4.5.27", features = ["derive"] }
+clap = { version = "4.5.30", features = ["derive"] }
 cpal = "0.15.3"
 anyhow = "1.0"
 slotmap = "1.0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,10 +26,10 @@ ruffle_macros = { path = "macros" }
 ruffle_wstr = { path = "../wstr" }
 swf = { path = "../swf" }
 bitflags = { workspace = true }
-smallvec = { version = "1.13.2", features = ["union"] }
+smallvec = { version = "1.14.0", features = ["union"] }
 num-traits = { workspace = true }
 num-derive = { workspace = true }
-quick-xml = "0.37.0"
+quick-xml = "0.37.2"
 downcast-rs = "2.0.1"
 url = { workspace = true }
 weak-table = "0.3.2"

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 gif = "0.13.1"
 png = "0.17.16"
 flate2 = { workspace = true }
-smallvec = { version = "1.13.2", features = ["union"] }
+smallvec = { version = "1.14.0", features = ["union"] }
 downcast-rs = "2.0.1"
 lyon = { version = "1.0.1", optional = true }
 lyon_geom = "1.0.6"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -23,7 +23,7 @@ image = { workspace = true }
 naga-agal = { path = "../naga-agal" }
 naga-pixelbender = { path = "../naga-pixelbender" }
 profiling = { version = "1.0", default-features = false, optional = true }
-lru = "0.12.5"
+lru = "0.13.0"
 naga = { workspace = true }
 indexmap = "2.7.1"
 


### PR DESCRIPTION
This is 2/3 of https://github.com/ruffle-rs/ruffle/pull/19549, removing `ashpd` and `tempfile` bumps from it, to avoid the nasty `rand`/`getrandom`/`zerocopy`/etc. duplications.

Bumps the cargo-minor group with 4 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [clap](https://github.com/clap-rs/clap) | `4.5.29` | `4.5.30` |
| [smallvec](https://github.com/servo/rust-smallvec) | `1.13.2` | `1.14.0` |
| [quick-xml](https://github.com/tafia/quick-xml) | `0.37.0` | `0.37.2` |
| [lru](https://github.com/jeromefroe/lru-rs) | `0.12.5` | `0.13.0` |


Updates `clap` from 4.5.29 to 4.5.30
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/clap-rs/clap/releases">clap's releases</a>.</em></p>
<blockquote>
<h2>v4.5.30</h2>
<h2>[4.5.30] - 2025-02-17</h2>
<h3>Fixes</h3>
<ul>
<li><em>(assert)</em> Allow <code>num_args(0..=1)</code> to be used with <code>SetTrue</code></li>
<li><em>(assert)</em> Clean up rendering of <code>takes_values</code> assertions</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/clap-rs/clap/blob/master/CHANGELOG.md">clap's changelog</a>.</em></p>
<blockquote>
<h2>[4.5.30] - 2025-02-17</h2>
<h3>Fixes</h3>
<ul>
<li><em>(assert)</em> Allow <code>num_args(0..=1)</code> to be used with <code>SetTrue</code></li>
<li><em>(assert)</em> Clean up rendering of <code>takes_values</code> assertions</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/clap-rs/clap/commit/f40b37f1d849dc0446e4ebfb8430f142c370903b"><code>f40b37f</code></a> chore: Release</li>
<li><a href="https://github.com/clap-rs/clap/commit/63bfe1a532ad817b35d2804198d31e2b8f272adf"><code>63bfe1a</code></a> docs: Update changelog</li>
<li><a href="https://github.com/clap-rs/clap/commit/d6bd7e2ea658c0b3fa82624ca496872627228bda"><code>d6bd7e2</code></a> Merge pull request <a href="https://redirect.github.com/clap-rs/clap/issues/5763">#5763</a> from epage/complete</li>
<li><a href="https://github.com/clap-rs/clap/commit/08875932f7164fad33576e242dcd7a3863844201"><code>0887593</code></a> fix(complete): Change ValueHint::Unknown to Other, from AnyPath</li>
<li><a href="https://github.com/clap-rs/clap/commit/61ebe72203f118de5b04692d45714e817a0172bd"><code>61ebe72</code></a> chore: Release</li>
<li><a href="https://github.com/clap-rs/clap/commit/2e3fcc6aeed8411d7995bf1bdc770e079bc52346"><code>2e3fcc6</code></a> docs: Update changelog</li>
<li><a href="https://github.com/clap-rs/clap/commit/13dad4c275f9d8f52c28a455160b236a331d1c60"><code>13dad4c</code></a> Merge pull request <a href="https://redirect.github.com/clap-rs/clap/issues/5759">#5759</a> from clap-rs/renovate/unicode-width-0.x</li>
<li><a href="https://github.com/clap-rs/clap/commit/3ca44c7fdbc669222dd52c68a90fd5b7d5ee8323"><code>3ca44c7</code></a> Merge pull request <a href="https://redirect.github.com/clap-rs/clap/issues/5758">#5758</a> from clap-rs/renovate/terminal_size-0.x</li>
<li><a href="https://github.com/clap-rs/clap/commit/d71ae66c49c38bfe32ce2a30724dd5f64cfe1fde"><code>d71ae66</code></a> Merge pull request <a href="https://redirect.github.com/clap-rs/clap/issues/5760">#5760</a> from clap-rs/renovate/stable-1.x</li>
<li><a href="https://github.com/clap-rs/clap/commit/a25c73411d96c655a4ea73a050eba1a39564f737"><code>a25c734</code></a> chore(deps): Update dependency STABLE to v1.81.0</li>
<li>Additional commits viewable in <a href="https://github.com/clap-rs/clap/compare/clap_complete-v4.5.29...clap_complete-v4.5.30">compare view</a></li>
</ul>
</details>
<br />

Updates `smallvec` from 1.13.2 to 1.14.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/servo/rust-smallvec/releases">smallvec's releases</a>.</em></p>
<blockquote>
<h2>v1.14.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Implement <code>MallocSizeOf</code> for SmallVec (v1) by <a href="https://github.com/nicoburns"><code>@​nicoburns</code></a> in <a href="https://redirect.github.com/servo/rust-smallvec/pull/370">servo/rust-smallvec#370</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/nicoburns"><code>@​nicoburns</code></a> made their first contribution in <a href="https://redirect.github.com/servo/rust-smallvec/pull/370">servo/rust-smallvec#370</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/servo/rust-smallvec/compare/v1.13.2...v1.14.0">https://github.com/servo/rust-smallvec/compare/v1.13.2...v1.14.0</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/servo/rust-smallvec/commit/174f4f02566d7377aa0e8f9566e73f21f14ce4eb"><code>174f4f0</code></a> Version 1.14.0</li>
<li><a href="https://github.com/servo/rust-smallvec/commit/eaeb87182da3d35574e26dbccc12d58a127063d3"><code>eaeb871</code></a> Bump locked hongfuzz version</li>
<li><a href="https://github.com/servo/rust-smallvec/commit/cd9f7d3c9a6ea74e4aef713f720c8c0e37330479"><code>cd9f7d3</code></a> Implement MallocSizeOf for SmallVec (v1)</li>
<li><a href="https://github.com/servo/rust-smallvec/commit/03d90694561cb4843727b1beef025283667efebb"><code>03d9069</code></a> Make test_size test aware of target pointer width and &quot;union&quot; feature.</li>
<li>See full diff in <a href="https://github.com/servo/rust-smallvec/compare/v1.13.2...v1.14.0">compare view</a></li>
</ul>
</details>
<br />

Updates `quick-xml` from 0.37.0 to 0.37.2
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/tafia/quick-xml/releases">quick-xml's releases</a>.</em></p>
<blockquote>
<h2>v0.37.2 - se::to_utf8_io_writer()</h2>
<h2>What's Changed</h2>
<h3>New Features</h3>
<ul>
<li><a href="https://redirect.github.com/tafia/quick-xml/issues/836">#836</a>: Add <code>se::to_utf8_io_writer()</code> helper compatible with <code>std::io::Write</code> and restricted to UTF-8 encoding.</li>
</ul>
<p><a href="https://redirect.github.com/tafia/quick-xml/issues/836">#836</a>: <a href="https://redirect.github.com/tafia/quick-xml/pull/836">tafia/quick-xml#836</a></p>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/pronebird"><code>@​pronebird</code></a> made their first contribution in <a href="https://redirect.github.com/tafia/quick-xml/pull/836">tafia/quick-xml#836</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/tafia/quick-xml/compare/v0.37.1...v0.37.2">https://github.com/tafia/quick-xml/compare/v0.37.1...v0.37.2</a></p>
<h2>v0.37.1 - Write CDATA safely</h2>
<h2>What's Changed</h2>
<h3>New Features</h3>
<ul>
<li><a href="https://redirect.github.com/tafia/quick-xml/issues/831">#831</a>: Add <code>BytesCData::escaped()</code> fn to construct CDATA events from arbitrary user input.</li>
</ul>
<p><a href="https://redirect.github.com/tafia/quick-xml/issues/831">#831</a>: <a href="https://redirect.github.com/tafia/quick-xml/issues/831">tafia/quick-xml#831</a></p>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/allan2"><code>@​allan2</code></a> made their first contribution in <a href="https://redirect.github.com/tafia/quick-xml/pull/830">tafia/quick-xml#830</a></li>
<li><a href="https://github.com/Turbo87"><code>@​Turbo87</code></a> made their first contribution in <a href="https://redirect.github.com/tafia/quick-xml/pull/832">tafia/quick-xml#832</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/tafia/quick-xml/compare/v0.37.0...v0.37.1">https://github.com/tafia/quick-xml/compare/v0.37.0...v0.37.1</a></p>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/tafia/quick-xml/blob/master/Changelog.md">quick-xml's changelog</a>.</em></p>
<blockquote>
<h2>0.37.2 -- 2024-12-29</h2>
<h3>New Features</h3>
<ul>
<li><a href="https://redirect.github.com/tafia/quick-xml/issues/836">#836</a>: Add <code>se::to_utf8_io_writer()</code> helper compatible with <code>std::io::Write</code> and restricted to UTF-8 encoding.</li>
</ul>
<p><a href="https://redirect.github.com/tafia/quick-xml/issues/836">#836</a>: <a href="https://redirect.github.com/tafia/quick-xml/pull/836">tafia/quick-xml#836</a></p>
<h2>0.37.1 -- 2024-11-17</h2>
<h3>New Features</h3>
<ul>
<li><a href="https://redirect.github.com/tafia/quick-xml/issues/831">#831</a>: Add <code>BytesCData::escaped()</code> fn to construct CDATA events from arbitrary user input.</li>
</ul>
<p><a href="https://redirect.github.com/tafia/quick-xml/issues/831">#831</a>: <a href="https://redirect.github.com/tafia/quick-xml/issues/831">tafia/quick-xml#831</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/tafia/quick-xml/commit/52169caefdfda36dfd16b935b20c07427a23b9cf"><code>52169ca</code></a> Release 0.37.2</li>
<li><a href="https://github.com/tafia/quick-xml/commit/9ad201093adb4f58ff0aae98cd934dc0ba70f14f"><code>9ad2010</code></a> Merge pull request <a href="https://redirect.github.com/tafia/quick-xml/issues/836">#836</a> from pronebird/utf8writer</li>
<li><a href="https://github.com/tafia/quick-xml/commit/3b5c74df5b838ead3f8cf34ed2b815865e8fd7ee"><code>3b5c74d</code></a> Add to_utf8_io_writer accepting std::io::Write</li>
<li><a href="https://github.com/tafia/quick-xml/commit/0793d6a8d006cb5dabf66bf2a25ddbf198305b46"><code>0793d6a</code></a> Merge pull request <a href="https://redirect.github.com/tafia/quick-xml/issues/833">#833</a> from Mingun/fix-serde-warnings</li>
<li><a href="https://github.com/tafia/quick-xml/commit/65f57b2067920f25bf6c13c64123166c9dfccb20"><code>65f57b2</code></a> Remove ignored tests which produces warnings since serde 1.0.215</li>
<li><a href="https://github.com/tafia/quick-xml/commit/10177b11f4e5f623f62237f8443359c3ec35fab4"><code>10177b1</code></a> Release 0.37.1</li>
<li><a href="https://github.com/tafia/quick-xml/commit/6c4c766a5d927b4a9394f76fa9bbc48b7afe0993"><code>6c4c766</code></a> Merge pull request <a href="https://redirect.github.com/tafia/quick-xml/issues/832">#832</a> from Turbo87/cdata-escape</li>
<li><a href="https://github.com/tafia/quick-xml/commit/be098763a07acc35734798b291b98044f993097c"><code>be09876</code></a> Add <code>BytesCData::escaped()</code> fn</li>
<li><a href="https://github.com/tafia/quick-xml/commit/a5ad85e0020b62182a377338b887e8796ffb0acf"><code>a5ad85e</code></a> Merge pull request <a href="https://redirect.github.com/tafia/quick-xml/issues/830">#830</a> from allan2/fix-typo</li>
<li><a href="https://github.com/tafia/quick-xml/commit/7b5c972563382b3073f61b39f10ddbb07372c88c"><code>7b5c972</code></a> Fix typo</li>
<li>See full diff in <a href="https://github.com/tafia/quick-xml/compare/v0.37.0...v0.37.2">compare view</a></li>
</ul>
</details>
<br />

Updates `lru` from 0.12.5 to 0.13.0
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/jeromefroe/lru-rs/blob/master/CHANGELOG.md">lru's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/jeromefroe/lru-rs/tree/0.13.0">v0.13.0</a> - 2025-01-27</h2>
<ul>
<li>Add <code>peek_mru</code> and <code>pop_mru</code> methods, upgrade dependency on <code>hashbrown</code> to 0.15.2, and update MSRV to 1.65.0.</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/jeromefroe/lru-rs/commit/6ad112706c32cb588b6d4ba099f1b4f4c6d8a9ff"><code>6ad1127</code></a> Merge pull request <a href="https://redirect.github.com/jeromefroe/lru-rs/issues/208">#208</a> from jeromefroe/jerome/prepare-0-13-0-release</li>
<li><a href="https://github.com/jeromefroe/lru-rs/commit/e0d89c7eaea0ccb6a65a2b1c2e32b9878af45a38"><code>e0d89c7</code></a> Prepare 0.13.0 release</li>
<li><a href="https://github.com/jeromefroe/lru-rs/commit/32e2c06fa7cd01f750e1a3c2730a679c652b7921"><code>32e2c06</code></a> Merge pull request <a href="https://redirect.github.com/jeromefroe/lru-rs/issues/204">#204</a> from magick93/upgrade_hashbrown</li>
<li><a href="https://github.com/jeromefroe/lru-rs/commit/5c1b2d988b04a1526de7a0bc10d5693007530a24"><code>5c1b2d9</code></a> Merge pull request <a href="https://redirect.github.com/jeromefroe/lru-rs/issues/207">#207</a> from jeromefroe/jerome/bump-msrv-to-1-65</li>
<li><a href="https://github.com/jeromefroe/lru-rs/commit/2f10be2e077f14486e17a7fb4d956a83a9d9adf7"><code>2f10be2</code></a> Bump MSRV to 1.65.0</li>
<li><a href="https://github.com/jeromefroe/lru-rs/commit/16048d8fddd81ef009e97442b9c7540f103df096"><code>16048d8</code></a> Merge pull request <a href="https://redirect.github.com/jeromefroe/lru-rs/issues/206">#206</a> from traceflight/mru</li>
<li><a href="https://github.com/jeromefroe/lru-rs/commit/066d9bffefba45945ee488481357ae9fdf5eb6a6"><code>066d9bf</code></a> Add peek_mru pop_mru</li>
<li><a href="https://github.com/jeromefroe/lru-rs/commit/b7fec4ac6a4854ac970481fb18aff7fe0f7b1393"><code>b7fec4a</code></a> Update hashbrown dependency to version 0.15.2</li>
<li>See full diff in <a href="https://github.com/jeromefroe/lru-rs/compare/0.12.5...0.13.0">compare view</a></li>
</ul>
</details>
<br />