### PR TITLE
Small improvements to render crates

### DIFF
--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -923,18 +923,13 @@ impl<'a> NagaBuilder<'a> {
             (source.swizzle >> 4) & 0b11,
             (source.swizzle >> 6) & 0b11,
         ];
-        let swizzle_components: [SwizzleComponent; 4] = swizzle_flags
-            .into_iter()
-            .map(|flag| match flag {
-                0b00 => SwizzleComponent::X,
-                0b01 => SwizzleComponent::Y,
-                0b10 => SwizzleComponent::Z,
-                0b11 => SwizzleComponent::W,
-                _ => unreachable!(),
-            })
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
+        let swizzle_components = swizzle_flags.map(|flag| match flag {
+            0b00 => SwizzleComponent::X,
+            0b01 => SwizzleComponent::Y,
+            0b10 => SwizzleComponent::Z,
+            0b11 => SwizzleComponent::W,
+            _ => unreachable!(),
+        });
 
         Ok(self.evaluate_expr(Expression::Swizzle {
             size: output,

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -656,7 +656,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         );
 
         let handle = BitmapHandle(Arc::new(Texture {
-            texture: Arc::new(texture),
+            texture,
             bind_linear: Default::default(),
             bind_nearest: Default::default(),
             copy_count: Cell::new(0),
@@ -912,7 +912,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                             | wgpu::TextureUsages::COPY_SRC,
                     });
                 BitmapHandle(Arc::new(Texture {
-                    texture: Arc::new(texture),
+                    texture,
                     bind_linear: Default::default(),
                     bind_nearest: Default::default(),
                     copy_count: Cell::new(0),
@@ -1072,7 +1072,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                     | wgpu::TextureUsages::COPY_SRC,
             });
         Ok(BitmapHandle(Arc::new(Texture {
-            texture: Arc::new(texture),
+            texture,
             bind_linear: Default::default(),
             bind_nearest: Default::default(),
             copy_count: Cell::new(0),
@@ -1170,9 +1170,9 @@ pub enum RenderTargetMode {
     // we will blend with the previous contents of the texture.
     // This is used in `render_offscreen`, as we need to blend with the previous
     // contents of our `BitmapData` texture
-    FreshWithTexture(Arc<wgpu::Texture>),
+    FreshWithTexture(wgpu::Texture),
     // Use the provided texture as our frame buffer, and clear it with the given color.
-    ExistingWithColor(Arc<wgpu::Texture>, wgpu::Color),
+    ExistingWithColor(wgpu::Texture, wgpu::Color),
 }
 
 impl RenderTargetMode {

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -122,7 +122,7 @@ impl WgpuContext3D {
             BitmapHandle(Arc::new(Texture {
                 bind_linear: Default::default(),
                 bind_nearest: Default::default(),
-                texture: Arc::new(dummy_texture),
+                texture: dummy_texture,
                 copy_count: Cell::new(0),
             }))
         };
@@ -669,13 +669,13 @@ impl Context3D for WgpuContext3D {
                     // which is what the Stage rendering code expects. In multisample mode,
                     // this is our resolve texture.
                     self.back_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
-                        texture: Arc::new(back_buffer_resolve_texture.unwrap()),
+                        texture: back_buffer_resolve_texture.unwrap(),
                         bind_linear: Default::default(),
                         bind_nearest: Default::default(),
                         copy_count: Cell::new(0),
                     }));
                     self.front_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
-                        texture: Arc::new(front_buffer_resolve_texture.unwrap()),
+                        texture: front_buffer_resolve_texture.unwrap(),
                         bind_linear: Default::default(),
                         bind_nearest: Default::default(),
                         copy_count: Cell::new(0),
@@ -685,13 +685,13 @@ impl Context3D for WgpuContext3D {
                     // so our main texture gets used as the raw texture handle.
 
                     self.back_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
-                        texture: Arc::new(back_buffer_texture),
+                        texture: back_buffer_texture,
                         bind_linear: Default::default(),
                         bind_nearest: Default::default(),
                         copy_count: Cell::new(0),
                     }));
                     self.front_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
-                        texture: Arc::new(front_buffer_texture),
+                        texture: front_buffer_texture,
                         bind_linear: Default::default(),
                         bind_nearest: Default::default(),
                         copy_count: Cell::new(0),

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -248,7 +248,7 @@ impl QueueSyncHandle {
 
 #[derive(Debug)]
 pub struct Texture {
-    pub(crate) texture: Arc<wgpu::Texture>,
+    pub(crate) texture: wgpu::Texture,
     bind_linear: OnceCell<BitmapBinds>,
     bind_nearest: OnceCell<BitmapBinds>,
     copy_count: Cell<u8>,

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -65,14 +65,11 @@ impl ShapePipeline {
         stencilless: wgpu::RenderPipeline,
         mut f: impl FnMut(MaskState) -> wgpu::RenderPipeline,
     ) -> Self {
-        let mask_array: [wgpu::RenderPipeline; MaskState::LENGTH] = (0..MaskState::LENGTH)
-            .map(|mask_enum| {
+        let mask_array: [wgpu::RenderPipeline; MaskState::LENGTH] =
+            std::array::from_fn(|mask_enum| {
                 let mask_state = MaskState::from_usize(mask_enum);
                 f(mask_state)
-            })
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
+            });
         ShapePipeline {
             pipelines: EnumMap::from_array(mask_array),
             stencilless,
@@ -162,8 +159,8 @@ impl Pipelines {
             &bind_layouts.bitmap,
         ];
 
-        let bitmap_pipelines: [ShapePipeline; TrivialBlend::LENGTH] = (0..TrivialBlend::LENGTH)
-            .map(|blend| {
+        let bitmap_pipelines: [ShapePipeline; TrivialBlend::LENGTH] =
+            std::array::from_fn(|blend| {
                 let blend = TrivialBlend::from_usize(blend);
                 let name = format!("Bitmap ({blend:?})");
                 create_shape_pipeline(
@@ -178,10 +175,7 @@ impl Pipelines {
                     &[],
                     PrimitiveTopology::TriangleList,
                 )
-            })
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
+            });
 
         let bitmap_opaque_pipeline_layout_label =
             create_debug_label!("Opaque bitmap pipeline layout");

--- a/render/wgpu/src/surface/target.rs
+++ b/render/wgpu/src/surface/target.rs
@@ -28,7 +28,7 @@ impl ResolveBuffer {
     }
 
     #[allow(dead_code)]
-    pub fn new_manual(texture: Arc<wgpu::Texture>) -> Self {
+    pub fn new_manual(texture: wgpu::Texture) -> Self {
         Self {
             texture: PoolOrArcTexture::Manual((
                 texture.clone(),
@@ -69,7 +69,7 @@ pub struct FrameBuffer {
 /// (when doing an offscreen render to a BitmapData texture)
 pub enum PoolOrArcTexture {
     Pool(PoolEntry<(wgpu::Texture, wgpu::TextureView), AlwaysCompatible>),
-    Manual((Arc<wgpu::Texture>, wgpu::TextureView)),
+    Manual((wgpu::Texture, wgpu::TextureView)),
 }
 
 impl PoolOrArcTexture {
@@ -105,7 +105,7 @@ impl FrameBuffer {
     }
 
     #[allow(dead_code)]
-    pub fn new_manual(texture: Arc<wgpu::Texture>, size: wgpu::Extent3d) -> Self {
+    pub fn new_manual(texture: wgpu::Texture, size: wgpu::Extent3d) -> Self {
         Self {
             texture: PoolOrArcTexture::Manual((
                 texture.clone(),

--- a/render/wgpu/src/target.rs
+++ b/render/wgpu/src/target.rs
@@ -4,7 +4,6 @@ use crate::Error;
 use ruffle_render::bitmap::PixelRegion;
 use std::fmt::Debug;
 use std::ops::Deref;
-use std::sync::Arc;
 use tracing::instrument;
 
 pub trait RenderTargetFrame: Debug {
@@ -166,7 +165,7 @@ pub struct TextureBufferInfo {
 #[derive(Debug)]
 pub struct TextureTarget {
     pub size: wgpu::Extent3d,
-    pub texture: Arc<wgpu::Texture>,
+    pub texture: wgpu::Texture,
     pub format: wgpu::TextureFormat,
     pub buffer: Option<TextureBufferInfo>,
 }
@@ -228,7 +227,7 @@ impl TextureTarget {
         });
         Ok(Self {
             size,
-            texture: Arc::new(texture),
+            texture,
             format,
             buffer: Some(TextureBufferInfo {
                 buffer: MaybeOwnedBuffer::Owned(buffer, buffer_dimensions),
@@ -237,7 +236,7 @@ impl TextureTarget {
         })
     }
 
-    pub fn get_texture(&self) -> Arc<wgpu::Texture> {
+    pub fn get_texture(&self) -> wgpu::Texture {
         self.texture.clone()
     }
 


### PR DESCRIPTION
- Use array methods instead of collecting to a vector first
- Remove `Arc`s around `wgpu` objects thanks to wgpu 24 improvements