### PR TITLE
render: Remove `Rc` around `wgpu` objects

### DIFF
--- a/render/wgpu/src/context3d/current_pipeline.rs
+++ b/render/wgpu/src/context3d/current_pipeline.rs
@@ -88,7 +88,7 @@ pub struct BoundTextureData {
     /// it's used with `setRenderToTexture`. The actual shader binding
     /// uses `view`
     pub id: Rc<dyn Texture>,
-    pub view: Rc<TextureView>,
+    pub view: TextureView,
     pub cube: bool,
 }
 


### PR DESCRIPTION
I missed them in #19574