### PR TITLE
avm2: Set correct version to Socket::timeout

### DIFF
--- a/core/src/avm2/globals/flash/net/Socket.as
+++ b/core/src/avm2/globals/flash/net/Socket.as
@@ -19,7 +19,9 @@ package flash.net {
 
         public native function connect(host: String, port: int):void;
 
+        [API("662")]
         public native function get timeout():uint;
+        [API("662")]
         public native function set timeout(value:uint):void;
 
         public native function close():void;


### PR DESCRIPTION
Fixes a noticed regression from https://github.com/ruffle-rs/ruffle/pull/17119 .