### PR TITLE
refactor: Make events not Copy

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -766,17 +766,17 @@ impl ButtonKeyCode {
         })
     }
 
-    pub fn from_input_event(event: InputEvent) -> Option<Self> {
+    pub fn from_input_event(event: &InputEvent) -> Option<Self> {
         match event {
             // ASCII characters convert directly to keyPress button events.
             InputEvent::TextInput { codepoint }
-                if codepoint as u32 >= 32 && codepoint as u32 <= 126 =>
+                if *codepoint as u32 >= 32 && *codepoint as u32 <= 126 =>
             {
-                Some(ButtonKeyCode::from_u8(codepoint as u8).unwrap())
+                Some(ButtonKeyCode::from_u8(*codepoint as u8).unwrap())
             }
 
             // Special keys have custom values for keyPress.
-            InputEvent::KeyDown { key_code, .. } => Self::from_key_code(key_code),
+            InputEvent::KeyDown { key_code, .. } => Self::from_key_code(*key_code),
             _ => None,
         }
     }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -2,7 +2,7 @@ use crate::{display_object::InteractiveObject, input::InputEvent};
 use std::str::FromStr;
 use swf::ClipEventFlag;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum PlayerEvent {
     KeyDown {
         key_code: KeyCode,

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 /// An event describing input in general.
 ///
 /// It's usually a processed [`PlayerEvent`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum InputEvent {
     KeyDown {
         key_code: KeyCode,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1134,11 +1134,11 @@ impl Player {
         }
 
         self.mutate_with_update_context(|context| {
-            let button_event = ButtonKeyCode::from_input_event(event)
+            let button_event = ButtonKeyCode::from_input_event(&event)
                 .map(|key_code| ClipEvent::KeyPress { key_code });
 
             if let InputEvent::KeyDown { key_code, key_char }
-            | InputEvent::KeyUp { key_code, key_char } = event
+            | InputEvent::KeyUp { key_code, key_char } = &event
             {
                 let ctrl_key = context.input.is_key_down(KeyCode::CONTROL);
                 let alt_key = context.input.is_key_down(KeyCode::ALT);
@@ -1192,7 +1192,7 @@ impl Player {
             }
 
             // Propagate clip events.
-            let (clip_event, listener) = match event {
+            let (clip_event, listener) = match &event {
                 InputEvent::KeyDown { .. } => {
                     (Some(ClipEvent::KeyDown), Some(("Key", "onKeyDown", vec![])))
                 }
@@ -1279,11 +1279,11 @@ impl Player {
             // KeyPress events take precedence over text input.
             if !key_press_handled {
                 if let Some(text) = context.focus_tracker.get_as_edit_text() {
-                    if let InputEvent::TextInput { codepoint } = event {
-                        text.text_input(codepoint, context);
+                    if let InputEvent::TextInput { codepoint } = &event {
+                        text.text_input(*codepoint, context);
                     }
-                    if let InputEvent::TextControl { code } = event {
-                        text.text_control_input(code, context);
+                    if let InputEvent::TextControl { code } = &event {
+                        text.text_control_input(*code, context);
                     }
                 }
             }
@@ -1293,7 +1293,7 @@ impl Player {
                 if let InputEvent::KeyDown {
                     key_code: KeyCode::TAB,
                     ..
-                } = event
+                } = &event
                 {
                     let reversed = context.input.is_key_down(KeyCode::SHIFT);
                     let tracker = context.focus_tracker;
@@ -1306,7 +1306,7 @@ impl Player {
             if !key_press_handled && context.focus_tracker.highlight().is_visible() {
                 if let Some(focus) = context.focus_tracker.get() {
                     if matches!(
-                        event,
+                        &event,
                         InputEvent::KeyDown {
                             key_code: KeyCode::ENTER,
                             ..
@@ -1318,8 +1318,8 @@ impl Player {
                         focus.handle_clip_event(context, ClipEvent::Release { index: 0 });
                     }
 
-                    if let InputEvent::KeyDown { key_code, .. } = event {
-                        if let Some(direction) = NavigationDirection::from_key_code(key_code) {
+                    if let InputEvent::KeyDown { key_code, .. } = &event {
+                        if let Some(direction) = NavigationDirection::from_key_code(*key_code) {
                             let tracker = context.focus_tracker;
                             tracker.navigate(context, direction);
                         }
@@ -1357,7 +1357,7 @@ impl Player {
             }
         }
 
-        if let InputEvent::MouseWheel { delta } = event {
+        if let InputEvent::MouseWheel { delta } = &event {
             self.mutate_with_update_context(|context| {
                 let target = if let Some(over_object) = context.mouse_data.hovered {
                     if over_object.as_displayobject().movie().is_action_script_3()
@@ -1371,7 +1371,7 @@ impl Player {
                     context.stage.as_interactive()
                 };
                 if let Some(target) = target {
-                    let event = ClipEvent::MouseWheel { delta };
+                    let event = ClipEvent::MouseWheel { delta: *delta };
                     target.event_dispatch_to_avm2(context, event);
                     target.handle_clip_event(context, event);
                 }

--- a/desktop/src/gui/context_menu.rs
+++ b/desktop/src/gui/context_menu.rs
@@ -24,7 +24,7 @@ impl ContextMenu {
         }
     }
 
-    pub fn close_event(&self) -> PlayerEvent {
+    pub fn close_event(self) -> PlayerEvent {
         self.close_event
     }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -599,15 +599,16 @@ impl RuffleHandle {
                                 .set_pointer_capture(js_event.pointer_id());
                         }
                         let device_pixel_ratio = instance.device_pixel_ratio;
+                        let button = match js_event.button() {
+                            0 => MouseButton::Left,
+                            1 => MouseButton::Middle,
+                            2 => MouseButton::Right,
+                            _ => MouseButton::Unknown,
+                        };
                         let event = PlayerEvent::MouseDown {
                             x: f64::from(js_event.offset_x()) * device_pixel_ratio,
                             y: f64::from(js_event.offset_y()) * device_pixel_ratio,
-                            button: match js_event.button() {
-                                0 => MouseButton::Left,
-                                1 => MouseButton::Middle,
-                                2 => MouseButton::Right,
-                                _ => MouseButton::Unknown,
-                            },
+                            button,
                             // TODO The index should be provided by the browser, not calculated.
                             index: None,
                         };
@@ -615,15 +616,7 @@ impl RuffleHandle {
                             .with_core_mut(|core| core.handle_event(event))
                             .unwrap_or_default();
 
-                        if handled
-                            && matches!(
-                                event,
-                                PlayerEvent::MouseDown {
-                                    button: MouseButton::Right,
-                                    ..
-                                }
-                            )
-                        {
+                        if handled && matches!(button, MouseButton::Right) {
                             js_player_callback.suppress_context_menu();
                         }
 


### PR DESCRIPTION
Implementing IME requires passing events which are not Copy, so this refactor makes it easier to implement IME.