### PR TITLE
avm1: Replace `GcCell` with `Gc` in AVM1 structs

### DIFF
--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -5,40 +5,43 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
 use crate::string::StringContext;
-use gc_arena::{Collect, GcCell, Mutation};
-use std::ops::Deref;
+use gc_arena::{Collect, Gc, Mutation};
+use std::cell::Cell;
 use swf::{Color, DropShadowFilterFlags, Fixed16, Fixed8};
 
 #[derive(Clone, Debug, Collect)]
 #[collect(require_static)]
 struct DropShadowFilterData {
-    distance: f64,
+    distance: Cell<f64>,
     // TODO: Introduce `Angle<Radians>` struct.
-    angle: f64,
-    color: Color,
-    quality: i32,
-    inner: bool,
-    knockout: bool,
-    blur_x: f64,
-    blur_y: f64,
+    angle: Cell<f64>,
+    color: Cell<Color>,
+    quality: Cell<i32>,
+    inner: Cell<bool>,
+    knockout: Cell<bool>,
+    blur_x: Cell<f64>,
+    blur_y: Cell<f64>,
     // TODO: Introduce unsigned `Fixed8`?
-    strength: u16,
-    hide_object: bool,
+    strength: Cell<u16>,
+    hide_object: Cell<bool>,
 }
 
 impl From<&DropShadowFilterData> for swf::DropShadowFilter {
     fn from(filter: &DropShadowFilterData) -> swf::DropShadowFilter {
         let mut flags = DropShadowFilterFlags::empty();
-        flags |= DropShadowFilterFlags::from_passes(filter.quality as u8);
-        flags.set(DropShadowFilterFlags::KNOCKOUT, filter.knockout);
-        flags.set(DropShadowFilterFlags::INNER_SHADOW, filter.inner);
-        flags.set(DropShadowFilterFlags::COMPOSITE_SOURCE, !filter.hide_object);
+        flags |= DropShadowFilterFlags::from_passes(filter.quality.get() as u8);
+        flags.set(DropShadowFilterFlags::KNOCKOUT, filter.knockout.get());
+        flags.set(DropShadowFilterFlags::INNER_SHADOW, filter.inner.get());
+        flags.set(
+            DropShadowFilterFlags::COMPOSITE_SOURCE,
+            !filter.hide_object.get(),
+        );
         swf::DropShadowFilter {
-            color: filter.color,
-            blur_x: Fixed16::from_f64(filter.blur_x),
-            blur_y: Fixed16::from_f64(filter.blur_y),
-            angle: Fixed16::from_f64(filter.angle),
-            distance: Fixed16::from_f64(filter.distance),
+            color: filter.color.get(),
+            blur_x: Fixed16::from_f64(filter.blur_x.get()),
+            blur_y: Fixed16::from_f64(filter.blur_y.get()),
+            angle: Fixed16::from_f64(filter.angle.get()),
+            distance: Fixed16::from_f64(filter.distance.get()),
             strength: Fixed8::from_f64(filter.strength()),
             flags,
         }
@@ -48,16 +51,16 @@ impl From<&DropShadowFilterData> for swf::DropShadowFilter {
 impl From<swf::DropShadowFilter> for DropShadowFilterData {
     fn from(filter: swf::DropShadowFilter) -> DropShadowFilterData {
         Self {
-            distance: filter.distance.into(),
-            angle: filter.angle.into(),
-            color: filter.color,
-            quality: filter.num_passes().into(),
-            strength: (filter.strength.to_f64() * 256.0) as u16,
-            knockout: filter.is_knockout(),
-            blur_x: filter.blur_x.into(),
-            blur_y: filter.blur_y.into(),
-            inner: filter.is_inner(),
-            hide_object: filter.hide_object(),
+            distance: Cell::new(filter.distance.into()),
+            angle: Cell::new(filter.angle.into()),
+            color: Cell::new(filter.color),
+            quality: Cell::new(filter.num_passes().into()),
+            strength: Cell::new((filter.strength.to_f64() * 256.0) as u16),
+            knockout: Cell::new(filter.is_knockout()),
+            blur_x: Cell::new(filter.blur_x.into()),
+            blur_y: Cell::new(filter.blur_y.into()),
+            inner: Cell::new(filter.is_inner()),
+            hide_object: Cell::new(filter.hide_object()),
         }
     }
 }
@@ -66,38 +69,39 @@ impl Default for DropShadowFilterData {
     #[allow(clippy::approx_constant)]
     fn default() -> Self {
         Self {
-            distance: 4.0,
-            angle: 0.785398163, // ~45 degrees
-            color: Color::BLACK,
-            quality: 1,
-            inner: false,
-            knockout: false,
-            blur_x: 4.0,
-            blur_y: 4.0,
-            strength: 1 << 8,
-            hide_object: false,
+            distance: Cell::new(4.0),
+            angle: Cell::new(0.785398163), // ~45 degrees
+            color: Cell::new(Color::BLACK),
+            quality: Cell::new(1),
+            inner: Cell::new(false),
+            knockout: Cell::new(false),
+            blur_x: Cell::new(4.0),
+            blur_y: Cell::new(4.0),
+            strength: Cell::new(1 << 8),
+            hide_object: Cell::new(false),
         }
     }
 }
 
 impl DropShadowFilterData {
     pub fn strength(&self) -> f64 {
-        f64::from(self.strength) / 256.0
+        f64::from(self.strength.get()) / 256.0
     }
 
-    pub fn set_strength(&mut self, strength: f64) {
-        self.strength = ((strength * 256.0) as u16).clamp(0, 0xFF00)
+    pub fn set_strength(&self, strength: f64) {
+        let strength = ((strength * 256.0) as u16).clamp(0, 0xFF00);
+        self.strength.set(strength);
     }
 }
 
 #[derive(Copy, Clone, Debug, Collect)]
 #[collect(no_drop)]
 #[repr(transparent)]
-pub struct DropShadowFilter<'gc>(GcCell<'gc, DropShadowFilterData>);
+pub struct DropShadowFilter<'gc>(Gc<'gc, DropShadowFilterData>);
 
 impl<'gc> DropShadowFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let drop_shadow_filter = Self(GcCell::new(activation.gc(), Default::default()));
+        let drop_shadow_filter = Self(Gc::new(activation.gc(), Default::default()));
         drop_shadow_filter.set_distance(activation, args.get(0))?;
         drop_shadow_filter.set_angle(activation, args.get(1))?;
         drop_shadow_filter.set_color(activation, args.get(2))?;
@@ -113,193 +117,193 @@ impl<'gc> DropShadowFilter<'gc> {
     }
 
     pub fn from_filter(gc_context: &Mutation<'gc>, filter: swf::DropShadowFilter) -> Self {
-        Self(GcCell::new(gc_context, filter.into()))
+        Self(Gc::new(gc_context, filter.into()))
     }
 
-    pub(crate) fn duplicate(&self, gc_context: &Mutation<'gc>) -> Self {
-        Self(GcCell::new(gc_context, self.0.read().clone()))
+    pub(crate) fn duplicate(self, gc_context: &Mutation<'gc>) -> Self {
+        Self(Gc::new(gc_context, self.0.as_ref().clone()))
     }
 
-    fn distance(&self) -> f64 {
-        self.0.read().distance
+    fn distance(self) -> f64 {
+        self.0.distance.get()
     }
 
     fn set_distance(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let distance = value.coerce_to_f64(activation)?;
-            self.0.write(activation.gc()).distance = distance;
+            self.0.distance.set(distance);
         }
         Ok(())
     }
 
-    fn angle(&self) -> f64 {
-        self.0.read().angle.to_degrees()
+    fn angle(self) -> f64 {
+        self.0.angle.get().to_degrees()
     }
 
     fn set_angle(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let angle = (value.coerce_to_f64(activation)? % 360.0).to_radians();
-            self.0.write(activation.gc()).angle = angle;
+            self.0.angle.set(angle);
         }
         Ok(())
     }
 
-    fn color(&self) -> i32 {
-        self.0.read().color.to_rgb() as i32
+    fn color(self) -> i32 {
+        self.0.color.get().to_rgb() as i32
     }
 
     fn set_color(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let value = value.coerce_to_u32(activation)?;
-            let mut write = self.0.write(activation.gc());
-            write.color = Color::from_rgb(value, write.color.a);
+            let color = self.0.color.get();
+            self.0.color.set(Color::from_rgb(value, color.a));
         }
         Ok(())
     }
 
-    fn alpha(&self) -> f64 {
-        f64::from(self.0.read().color.a) / 255.0
+    fn alpha(self) -> f64 {
+        f64::from(self.0.color.get().a) / 255.0
     }
 
     fn set_alpha(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.0.write(activation.gc()).color.a = alpha;
+            let mut color = self.0.color.get();
+            color.a = alpha;
+            self.0.color.set(color);
         }
         Ok(())
     }
 
-    fn quality(&self) -> i32 {
-        self.0.read().quality
+    fn quality(self) -> i32 {
+        self.0.quality.get()
     }
 
     fn set_quality(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.gc()).quality = quality;
+            self.0.quality.set(quality);
         }
         Ok(())
     }
 
-    fn inner(&self) -> bool {
-        self.0.read().inner
+    fn inner(self) -> bool {
+        self.0.inner.get()
     }
 
     fn set_inner(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let inner = value.as_bool(activation.swf_version());
-            self.0.write(activation.gc()).inner = inner;
+            self.0.inner.set(inner);
         }
         Ok(())
     }
 
-    fn knockout(&self) -> bool {
-        self.0.read().knockout
+    fn knockout(self) -> bool {
+        self.0.knockout.get()
     }
 
     fn set_knockout(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.0.write(activation.gc()).knockout = knockout;
+            self.0.knockout.set(knockout);
         }
         Ok(())
     }
 
-    fn blur_x(&self) -> f64 {
-        self.0.read().blur_x
+    fn blur_x(self) -> f64 {
+        self.0.blur_x.get()
     }
 
     fn set_blur_x(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.gc()).blur_x = blur_x;
+            self.0.blur_x.set(blur_x);
         }
         Ok(())
     }
 
-    fn blur_y(&self) -> f64 {
-        self.0.read().blur_y
+    fn blur_y(self) -> f64 {
+        self.0.blur_y.get()
     }
 
     fn set_blur_y(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.0.write(activation.gc()).blur_y = blur_y;
+            self.0.blur_y.set(blur_y);
         }
         Ok(())
     }
 
-    fn strength(&self) -> f64 {
-        self.0.read().strength()
+    fn strength(self) -> f64 {
+        self.0.strength()
     }
 
     fn set_strength(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
-            self.0
-                .write(activation.gc())
-                .set_strength(value.coerce_to_f64(activation)?);
+            self.0.set_strength(value.coerce_to_f64(activation)?);
         }
         Ok(())
     }
 
-    fn hide_object(&self) -> bool {
-        self.0.read().hide_object
+    fn hide_object(self) -> bool {
+        self.0.hide_object.get()
     }
 
     fn set_hide_object(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let hide_object = value.as_bool(activation.swf_version());
-            self.0.write(activation.gc()).hide_object = hide_object;
+            self.0.hide_object.set(hide_object);
         }
         Ok(())
     }
 
-    pub fn filter(&self) -> swf::DropShadowFilter {
-        self.0.read().deref().into()
+    pub fn filter(self) -> swf::DropShadowFilter {
+        self.0.as_ref().into()
     }
 }
 

--- a/core/src/avm1/globals/gradient_filter.rs
+++ b/core/src/avm1/globals/gradient_filter.rs
@@ -7,9 +7,9 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
 use crate::string::StringContext;
-use gc_arena::{Collect, GcCell, Mutation};
+use gc_arena::{Collect, Gc, Mutation};
 use ruffle_macros::istr;
-use std::ops::Deref;
+use std::cell::{Cell, RefCell};
 use swf::{Color, Fixed16, Fixed8, GradientFilterFlags, GradientRecord};
 
 const MAX_COLORS: usize = 16;
@@ -17,32 +17,37 @@ const MAX_COLORS: usize = 16;
 #[derive(Clone, Debug, Collect)]
 #[collect(require_static)]
 struct GradientFilterData {
-    distance: f64,
+    distance: Cell<f64>,
     // TODO: Introduce `Angle<Radians>` struct.
-    angle: f64,
-    colors: [GradientRecord; MAX_COLORS],
-    num_colors: usize,
-    blur_x: f64,
-    blur_y: f64,
+    angle: Cell<f64>,
+    colors: RefCell<[GradientRecord; MAX_COLORS]>,
+    num_colors: Cell<usize>,
+    blur_x: Cell<f64>,
+    blur_y: Cell<f64>,
     // TODO: Introduce unsigned `Fixed8`?
-    strength: u16,
-    quality: i32,
-    type_: BevelFilterType,
-    knockout: bool,
+    strength: Cell<u16>,
+    quality: Cell<i32>,
+    type_: Cell<BevelFilterType>,
+    knockout: Cell<bool>,
 }
 
 impl From<&GradientFilterData> for swf::GradientFilter {
     fn from(filter: &GradientFilterData) -> swf::GradientFilter {
         let mut flags = GradientFilterFlags::COMPOSITE_SOURCE;
-        flags |= GradientFilterFlags::from_passes(filter.quality as u8);
-        flags |= filter.type_.as_gradient_flags();
-        flags.set(GradientFilterFlags::KNOCKOUT, filter.knockout);
+        flags |= GradientFilterFlags::from_passes(filter.quality.get() as u8);
+        flags |= filter.type_.get().as_gradient_flags();
+        flags.set(GradientFilterFlags::KNOCKOUT, filter.knockout.get());
         swf::GradientFilter {
-            colors: filter.colors.into_iter().take(filter.num_colors).collect(),
-            blur_x: Fixed16::from_f64(filter.blur_x),
-            blur_y: Fixed16::from_f64(filter.blur_y),
-            angle: Fixed16::from_f64(filter.angle),
-            distance: Fixed16::from_f64(filter.distance),
+            colors: filter
+                .colors
+                .borrow()
+                .into_iter()
+                .take(filter.num_colors.get())
+                .collect(),
+            blur_x: Fixed16::from_f64(filter.blur_x.get()),
+            blur_y: Fixed16::from_f64(filter.blur_y.get()),
+            angle: Fixed16::from_f64(filter.angle.get()),
+            distance: Fixed16::from_f64(filter.distance.get()),
             strength: Fixed8::from_f64(filter.strength()),
             flags,
         }
@@ -60,16 +65,16 @@ impl From<swf::GradientFilter> for GradientFilterData {
         let quality = filter.num_passes().into();
         let knockout = filter.is_knockout();
         Self {
-            distance: filter.distance.into(),
-            angle: filter.angle.into(),
-            colors,
-            num_colors,
-            quality,
-            strength: (filter.strength.to_f64() * 256.0) as u16,
-            knockout,
-            blur_x: filter.blur_x.into(),
-            blur_y: filter.blur_y.into(),
-            type_: filter.flags.into(),
+            distance: Cell::new(filter.distance.into()),
+            angle: Cell::new(filter.angle.into()),
+            colors: RefCell::new(colors),
+            num_colors: Cell::new(num_colors),
+            quality: Cell::new(quality),
+            strength: Cell::new((filter.strength.to_f64() * 256.0) as u16),
+            knockout: Cell::new(knockout),
+            blur_x: Cell::new(filter.blur_x.into()),
+            blur_y: Cell::new(filter.blur_y.into()),
+            type_: Cell::new(filter.flags.into()),
         }
     }
 }
@@ -78,38 +83,39 @@ impl Default for GradientFilterData {
     #[allow(clippy::approx_constant)]
     fn default() -> Self {
         Self {
-            distance: 4.0,
-            angle: 0.785398163, // ~45 degrees
+            distance: Cell::new(4.0),
+            angle: Cell::new(0.785398163), // ~45 degrees
             colors: Default::default(),
-            num_colors: 0,
-            blur_x: 4.0,
-            blur_y: 4.0,
-            strength: 1 << 8,
-            quality: 1,
-            type_: BevelFilterType::Inner,
-            knockout: false,
+            num_colors: Cell::new(0),
+            blur_x: Cell::new(4.0),
+            blur_y: Cell::new(4.0),
+            strength: Cell::new(1 << 8),
+            quality: Cell::new(1),
+            type_: Cell::new(BevelFilterType::Inner),
+            knockout: Cell::new(false),
         }
     }
 }
 
 impl GradientFilterData {
     pub fn strength(&self) -> f64 {
-        f64::from(self.strength) / 256.0
+        f64::from(self.strength.get()) / 256.0
     }
 
-    pub fn set_strength(&mut self, strength: f64) {
-        self.strength = ((strength * 256.0) as u16).clamp(0, 0xFF00)
+    pub fn set_strength(&self, strength: f64) {
+        let strength = ((strength * 256.0) as u16).clamp(0, 0xFF00);
+        self.strength.set(strength);
     }
 }
 
 #[derive(Copy, Clone, Debug, Collect)]
 #[collect(no_drop)]
 #[repr(transparent)]
-pub struct GradientFilter<'gc>(GcCell<'gc, GradientFilterData>);
+pub struct GradientFilter<'gc>(Gc<'gc, GradientFilterData>);
 
 impl<'gc> GradientFilter<'gc> {
     fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
-        let gradient_bevel_filter = Self(GcCell::new(activation.gc(), Default::default()));
+        let gradient_bevel_filter = Self(Gc::new(activation.gc(), Default::default()));
         gradient_bevel_filter.set_distance(activation, args.get(0))?;
         gradient_bevel_filter.set_angle(activation, args.get(1))?;
         gradient_bevel_filter.set_colors(activation, args.get(2))?;
@@ -125,56 +131,56 @@ impl<'gc> GradientFilter<'gc> {
     }
 
     pub fn from_filter(gc_context: &Mutation<'gc>, filter: swf::GradientFilter) -> Self {
-        Self(GcCell::new(gc_context, filter.into()))
+        Self(Gc::new(gc_context, filter.into()))
     }
 
-    pub(crate) fn duplicate(&self, gc_context: &Mutation<'gc>) -> Self {
-        Self(GcCell::new(gc_context, self.0.read().clone()))
+    pub(crate) fn duplicate(self, gc_context: &Mutation<'gc>) -> Self {
+        Self(Gc::new(gc_context, self.0.as_ref().clone()))
     }
 
-    fn distance(&self) -> f64 {
-        self.0.read().distance
+    fn distance(self) -> f64 {
+        self.0.distance.get()
     }
 
     fn set_distance(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let distance = value.coerce_to_f64(activation)?;
-            self.0.write(activation.gc()).distance = distance;
+            self.0.distance.set(distance);
         }
         Ok(())
     }
 
-    fn angle(&self) -> f64 {
-        self.0.read().angle.to_degrees()
+    fn angle(self) -> f64 {
+        self.0.angle.get().to_degrees()
     }
 
     fn set_angle(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let angle = (value.coerce_to_f64(activation)? % 360.0).to_radians();
-            self.0.write(activation.gc()).angle = angle;
+            self.0.angle.set(angle);
         }
         Ok(())
     }
 
-    fn colors(&self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
-        let read = self.0.read();
+    fn colors(self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
+        let num_colors = self.0.num_colors.get();
         ArrayObject::builder(activation).with(
-            read.colors[..read.num_colors]
+            self.0.colors.borrow()[..num_colors]
                 .iter()
                 .map(|r| r.color.to_rgb().into()),
         )
     }
 
     fn set_colors(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
@@ -187,38 +193,39 @@ impl<'gc> GradientFilter<'gc> {
         let length = usize::try_from(object.length(activation)?).unwrap_or_default();
         let num_colors = length.min(MAX_COLORS);
 
-        self.0.write(activation.gc()).num_colors = num_colors;
+        self.0.num_colors.set(num_colors);
 
+        let mut colors = self.0.colors.borrow_mut();
         for i in 0..num_colors {
             let rgb = object
                 .get_element(activation, i as i32)
                 .coerce_to_i32(activation)? as u32;
-            let mut write = self.0.write(activation.gc());
-            let alpha = write.colors[i].color.a;
-            write.colors[i].color = Color::from_rgb(rgb, alpha);
+            let alpha = colors[i].color.a;
+            colors[i].color = Color::from_rgb(rgb, alpha);
         }
         Ok(())
     }
 
-    fn alphas(&self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
-        let read = self.0.read();
+    fn alphas(self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
+        let num_colors = self.0.num_colors.get();
         ArrayObject::builder(activation).with(
-            read.colors[..read.num_colors]
+            self.0.colors.borrow()[..num_colors]
                 .iter()
                 .map(|r| (f64::from(r.color.a) / 255.0).into()),
         )
     }
 
     fn set_alphas(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(Value::Object(object)) = value {
             // Note that unlike `colors` and `ratios`, setting `alphas` doesn't change
             // the number of colors in the gradient.
-            let num_colors = self.0.read().num_colors;
+            let num_colors = self.0.num_colors.get();
             let length = usize::try_from(object.length(activation)?).unwrap_or_default();
+            let mut colors = self.0.colors.borrow_mut();
             for i in 0..num_colors {
                 let alpha = if i < length {
                     let alpha = object
@@ -232,116 +239,114 @@ impl<'gc> GradientFilter<'gc> {
                 } else {
                     u8::MAX
                 };
-                self.0.write(activation.gc()).colors[i].color.a = alpha;
+                colors[i].color.a = alpha;
             }
         }
         Ok(())
     }
 
-    fn ratios(&self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
-        let read = self.0.read();
+    fn ratios(self, activation: &Activation<'_, 'gc>) -> ArrayObject<'gc> {
+        let num_colors = self.0.num_colors.get();
         ArrayObject::builder(activation).with(
-            read.colors[..read.num_colors]
+            self.0.colors.borrow()[..num_colors]
                 .iter()
                 .map(|r| r.ratio.into()),
         )
     }
 
     fn set_ratios(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(Value::Object(object)) = value {
             let num_colors = usize::try_from(object.length(activation)?).unwrap_or_default();
-            let mut write = self.0.write(activation.gc());
-            // Modifying `ratios` can only reduce the number of colors, never increase it.
-            let num_colors = num_colors.min(write.num_colors);
-            write.num_colors = num_colors;
-            drop(write);
 
+            // Modifying `ratios` can only reduce the number of colors, never increase it.
+            let num_colors = num_colors.min(self.0.num_colors.get());
+            self.0.num_colors.set(num_colors);
+
+            let mut colors = self.0.colors.borrow_mut();
             for i in 0..num_colors {
                 let ratio = object
                     .get_element(activation, i as i32)
                     .coerce_to_i32(activation)?
                     .clamp(0, u8::MAX.into()) as u8;
-                self.0.write(activation.gc()).colors[i].ratio = ratio;
+                colors[i].ratio = ratio;
             }
         }
         Ok(())
     }
 
-    fn blur_x(&self) -> f64 {
-        self.0.read().blur_x
+    fn blur_x(self) -> f64 {
+        self.0.blur_x.get()
     }
 
     fn set_blur_x(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp_also_nan(0.0, 255.0);
-            self.0.write(activation.gc()).blur_x = blur_x;
+            self.0.blur_x.set(blur_x);
         }
         Ok(())
     }
 
-    fn blur_y(&self) -> f64 {
-        self.0.read().blur_y
+    fn blur_y(self) -> f64 {
+        self.0.blur_y.get()
     }
 
     fn set_blur_y(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp_also_nan(0.0, 255.0);
-            self.0.write(activation.gc()).blur_y = blur_y;
+            self.0.blur_y.set(blur_y);
         }
         Ok(())
     }
 
-    fn strength(&self) -> f64 {
-        self.0.read().strength()
+    fn strength(self) -> f64 {
+        self.0.strength()
     }
 
     fn set_strength(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
-            self.0
-                .write(activation.gc())
-                .set_strength(value.coerce_to_f64(activation)?);
+            self.0.set_strength(value.coerce_to_f64(activation)?);
         }
         Ok(())
     }
 
-    fn quality(&self) -> i32 {
-        self.0.read().quality
+    fn quality(self) -> i32 {
+        self.0.quality.get()
     }
 
     fn set_quality(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.0.write(activation.gc()).quality = quality;
+            self.0.quality.set(quality);
         }
         Ok(())
     }
 
-    fn type_(&self) -> BevelFilterType {
-        self.0.read().type_
+    fn type_(self) -> BevelFilterType {
+        self.0.type_.get()
     }
 
     fn set_type(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
@@ -356,29 +361,29 @@ impl<'gc> GradientFilter<'gc> {
                 BevelFilterType::Full
             };
 
-            self.0.write(activation.gc()).type_ = type_;
+            self.0.type_.set(type_);
         }
         Ok(())
     }
 
-    fn knockout(&self) -> bool {
-        self.0.read().knockout
+    fn knockout(self) -> bool {
+        self.0.knockout.get()
     }
 
     fn set_knockout(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.0.write(activation.gc()).knockout = knockout;
+            self.0.knockout.set(knockout);
         }
         Ok(())
     }
 
-    pub fn filter(&self) -> swf::GradientFilter {
-        self.0.read().deref().into()
+    pub fn filter(self) -> swf::GradientFilter {
+        self.0.as_ref().into()
     }
 }
 


### PR DESCRIPTION
This refactor replaces `GcCell` with `Gc` and uses interior mutability instead.

By getting rid of `GcCell`, we don't have to lock every time we do anything with the object.