### PR TITLE
frontend_utils: Be more verbose on IO bundle errors

### DIFF
--- a/frontend-utils/src/bundle/source.rs
+++ b/frontend-utils/src/bundle/source.rs
@@ -31,7 +31,7 @@ pub enum BundleSourceError {
     #[error("Invalid or corrupt zip")]
     InvalidZip,
 
-    #[error("IO error opening file")]
+    #[error("IO error opening file: {0}")]
     Io(#[from] Error),
 }
 


### PR DESCRIPTION
When an IO error occurs, be more verbose and include the inner error in the message, that makes it easier to debug issues.