### PR TITLE
web: Fix extension webpack import not working (close #10981)

### DIFF
--- a/web/packages/core/src/current-script.ts
+++ b/web/packages/core/src/current-script.ts
@@ -10,7 +10,7 @@ try {
         "src" in document.currentScript &&
         document.currentScript.src !== ""
     ) {
-        let src = document.currentScript.src;
+        let src = getScriptOriginalSrc(document.currentScript);
 
         // CDNs allow omitting the filename. If it's omitted, append a slash to
         // prevent the last component from being dropped.
@@ -23,4 +23,32 @@ try {
     }
 } catch (_e) {
     console.warn("Unable to get currentScript URL");
+}
+
+/**
+ *
+ * Obtain the origin src content according to the running environment of the \<script\> node
+ *
+ * @param script \<script\> node instance
+ *
+ * @returns \<script\> node origin src
+ */
+function getScriptOriginalSrc(script: HTMLScriptElement): string {
+    const scriptUrl = script.src;
+    const scriptUrlPolyfill = script.getAttribute("ruffle-src-polyfill");
+    // Reset webkit mask url should be safe
+    if (scriptUrlPolyfill && "webkit-masked-url://hidden/" === scriptUrl) {
+        try {
+            const currentPolyfillURL = new URL(".", scriptUrlPolyfill);
+            const isExtensionUrl =
+                currentPolyfillURL.protocol.includes("extension");
+            // Only apply to extension
+            if (isExtensionUrl) {
+                return scriptUrlPolyfill;
+            }
+        } catch {
+            // Fallback to itself src
+        }
+    }
+    return scriptUrl;
 }

--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -80,6 +80,9 @@ function injectScriptURL(url: string): Promise<void> {
     script.src = url;
     // safari 16+ script.src will be masked to "webkit-masked-url://hidden/"
     script.setAttribute("ruffle-id", String(ID));
+    if (url !== script.src) {
+        script.setAttribute("ruffle-src-polyfill", url);
+    }
     (document.head || document.documentElement).append(script);
     return promise;
 }

--- a/web/packages/extension/src/global.d.ts
+++ b/web/packages/extension/src/global.d.ts
@@ -1,0 +1,8 @@
+declare global {
+    /**
+     * https://webpack.js.org/guides/public-path/#on-the-fly
+     */
+    let __webpack_public_path__: string;
+}
+
+export {};


### PR DESCRIPTION
Close #10981 
Continue with PR #19348, this PR is used to fix the `ruffle.js` webpack import module. 