### PR TITLE
desktop: Implement basic IME support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4229,6 +4229,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ashpd",
+ "async-channel",
  "bytemuck",
  "chrono",
  "clap",

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -44,6 +44,7 @@ pub enum PlayerEvent {
     TextControl {
         code: TextControlCode,
     },
+    Ime(ImeEvent),
     FocusGained,
     FocusLost,
 }
@@ -465,6 +466,25 @@ impl TextControlCode {
                 | Self::DeleteWord
         )
     }
+}
+
+/// Input method allows inputting non-Latin characters on a Latin keyboard.
+///
+/// When IME is enabled, Ruffle will accept [`ImeEvent`]s instead of key events.
+/// It allows dynamically changing the inputted text and then committing it at
+/// the end.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImeEvent {
+    /// A new composing text should be set.
+    ///
+    /// The second parameter is the position of the cursor. When it's `None`,
+    /// the cursor should be hidden.
+    ///
+    /// An empty text indicates that preedit was cleared.
+    Preedit(String, Option<(usize, usize)>),
+
+    /// Composition is finished, and the text should be inserted.
+    Commit(String),
 }
 
 /// Flash virtual keycode.
@@ -1132,4 +1152,31 @@ pub enum KeyLocation {
 }
 
 #[derive(Debug, Clone)]
-pub enum PlayerNotification {}
+pub enum PlayerNotification {
+    ImeNotification(ImeNotification),
+}
+
+#[derive(Debug, Clone)]
+pub enum ImeNotification {
+    ImeReady {
+        purpose: ImePurpose,
+        cursor_area: ImeCursorArea,
+    },
+    ImePurposeUpdated(ImePurpose),
+    ImeCursorAreaUpdated(ImeCursorArea),
+    ImeNotReady,
+}
+
+#[derive(Debug, Clone)]
+pub enum ImePurpose {
+    Standard,
+    Password,
+}
+
+#[derive(Debug, Clone)]
+pub struct ImeCursorArea {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1130,3 +1130,6 @@ pub enum KeyLocation {
     Right = 2,
     Numpad = 3,
 }
+
+#[derive(Debug, Clone)]
+pub enum PlayerNotification {}

--- a/core/src/input.rs
+++ b/core/src/input.rs
@@ -1,6 +1,6 @@
 use crate::events::{
-    GamepadButton, KeyCode, KeyDescriptor, KeyLocation, LogicalKey, MouseButton, MouseWheelDelta,
-    NamedKey, PhysicalKey, PlayerEvent, TextControlCode,
+    GamepadButton, ImeEvent, KeyCode, KeyDescriptor, KeyLocation, LogicalKey, MouseButton,
+    MouseWheelDelta, NamedKey, PhysicalKey, PlayerEvent, TextControlCode,
 };
 use chrono::{DateTime, TimeDelta, Utc};
 use std::collections::{HashMap, HashSet};
@@ -53,6 +53,7 @@ pub enum InputEvent {
     TextControl {
         code: TextControlCode,
     },
+    Ime(ImeEvent),
 }
 
 struct ClickEventData {
@@ -190,6 +191,7 @@ impl InputManager {
 
             PlayerEvent::TextInput { codepoint } => InputEvent::TextInput { codepoint },
             PlayerEvent::TextControl { code } => InputEvent::TextControl { code },
+            PlayerEvent::Ime(ime) => InputEvent::Ime(ime),
 
             // The following are not input events.
             PlayerEvent::FocusGained | PlayerEvent::FocusLost => return None,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1016,6 +1016,7 @@ impl Player {
             | PlayerEvent::MouseWheel { .. }
             | PlayerEvent::GamepadButtonDown { .. }
             | PlayerEvent::GamepadButtonUp { .. }
+            | PlayerEvent::Ime { .. }
             | PlayerEvent::TextInput { .. }
             | PlayerEvent::TextControl { .. } => self.handle_input_event(event),
         }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1317,6 +1317,9 @@ impl Player {
                     if let InputEvent::TextControl { code } = &event {
                         text.text_control_input(*code, context);
                     }
+                    if let InputEvent::Ime(ime) = &event {
+                        text.ime(ime.clone(), context);
+                    }
                 }
             }
 

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 tracing-tracy = { version = "0.11.3", optional = true, features = ["demangle"] }
 rand = "0.8.5"
 thiserror.workspace = true
+async-channel.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = "0.10.2"

--- a/desktop/assets/texts/en-US/preferences_dialog.ftl
+++ b/desktop/assets/texts/en-US/preferences_dialog.ftl
@@ -41,3 +41,11 @@ gamemode-tooltip =
     Ruffle requests GameMode only when a movie is being played.
 gamemode-default = Default
 gamemode-default-tooltip = GameMode will be enabled only when power preference is set to high.
+
+# See for context https://wiki.archlinux.org/title/Input_method
+ime-enabled = Input Method
+ime-enabled-experimental = (experimental)
+ime-enabled-tooltip = An input method allows inputting characters that are not available on the kaybord, for instance Chinese, Japanese, or Korean characters.
+ime-enabled-default = Default
+ime-enabled-on = On
+ime-enabled-off = Off

--- a/desktop/src/custom_event.rs
+++ b/desktop/src/custom_event.rs
@@ -1,5 +1,7 @@
 //! Custom event type for desktop ruffle
 
+use ruffle_core::events::PlayerNotification;
+
 use crate::{gui::DialogDescriptor, player::LaunchOptions};
 
 /// User-defined events.
@@ -33,4 +35,7 @@ pub enum RuffleEvent {
 
     /// The movie wants to open a dialog.
     OpenDialog(DialogDescriptor),
+
+    /// Ruffle core has a notification to handle.
+    PlayerNotification(PlayerNotification),
 }

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -8,6 +8,7 @@ use crate::preferences::GlobalPreferences;
 use anyhow::anyhow;
 use egui::{Context, ViewportId};
 use fontdb::{Database, Family, Query, Source};
+use ruffle_core::events::{ImeCursorArea, ImePurpose};
 use ruffle_core::{Player, PlayerEvent};
 use ruffle_render_wgpu::backend::{request_adapter_and_device, WgpuRenderBackend};
 use ruffle_render_wgpu::descriptors::Descriptors;
@@ -21,7 +22,7 @@ use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event::WindowEvent;
 use winit::event_loop::EventLoopProxy;
 use winit::keyboard::{Key, NamedKey};
-use winit::window::{Theme, Window};
+use winit::window::{ImePurpose as WinitImePurpose, Theme, Window};
 
 use super::{DialogDescriptor, FilePicker};
 
@@ -269,6 +270,11 @@ impl GuiController {
         (x, y)
     }
 
+    pub fn movie_to_window_position(&self, x: f64, y: f64) -> PhysicalPosition<f64> {
+        let y = y + self.height_offset();
+        PhysicalPosition::new(x, y)
+    }
+
     pub fn render(&mut self, mut player: Option<MutexGuard<Player>>) {
         let surface_texture = match self.surface.get_current_texture() {
             Ok(surface_texture) => surface_texture,
@@ -438,6 +444,24 @@ impl GuiController {
 
     pub fn open_dialog(&mut self, dialog_event: DialogDescriptor) {
         self.gui.dialogs.open_dialog(dialog_event);
+    }
+
+    pub fn set_ime_allowed(&self, allowed: bool) {
+        self.window.set_ime_allowed(allowed);
+    }
+
+    pub fn set_ime_purpose(&self, purpose: ImePurpose) {
+        self.window.set_ime_purpose(match purpose {
+            ImePurpose::Standard => WinitImePurpose::Normal,
+            ImePurpose::Password => WinitImePurpose::Password,
+        });
+    }
+
+    pub fn set_ime_cursor_area(&self, cursor_area: ImeCursorArea) {
+        self.window.set_ime_cursor_area(
+            self.movie_to_window_position(cursor_area.x, cursor_area.y),
+            PhysicalSize::new(cursor_area.width, cursor_area.height),
+        );
     }
 }
 

--- a/desktop/src/preferences.rs
+++ b/desktop/src/preferences.rs
@@ -222,6 +222,13 @@ impl GlobalPreferences {
         })
     }
 
+    pub fn ime_enabled(&self) -> Option<bool> {
+        self.preferences
+            .lock()
+            .expect("Non-poisoned preferences")
+            .ime_enabled
+    }
+
     pub fn recents<R>(&self, fun: impl FnOnce(&Recents) -> R) -> R {
         fun(&self.recents.lock().expect("Recents is not reentrant"))
     }
@@ -279,6 +286,7 @@ pub struct SavedGlobalPreferences {
     pub storage: StoragePreferences,
     pub theme_preference: ThemePreference,
     pub open_url_mode: OpenUrlMode,
+    pub ime_enabled: Option<bool>,
 }
 
 impl Default for SavedGlobalPreferences {
@@ -302,6 +310,7 @@ impl Default for SavedGlobalPreferences {
             storage: Default::default(),
             theme_preference: Default::default(),
             open_url_mode: Default::default(),
+            ime_enabled: None,
         }
     }
 }

--- a/desktop/src/preferences/write.rs
+++ b/desktop/src/preferences/write.rs
@@ -131,6 +131,17 @@ impl<'a> PreferencesWriter<'a> {
             values.open_url_mode = open_url_mode;
         });
     }
+
+    pub fn set_ime_enabled(&mut self, ime_enabled: Option<bool>) {
+        self.0.edit(|values, toml_document| {
+            if let Some(ime_enabled) = ime_enabled {
+                toml_document["ime"]["enabled"] = value(ime_enabled);
+            } else {
+                toml_document["ime"]["enabled"] = toml_edit::Item::None;
+            }
+            values.ime_enabled = ime_enabled;
+        });
+    }
 }
 
 #[cfg(test)]
@@ -324,6 +335,25 @@ mod tests {
         test(
             "open_url_mode = \"deny\"",
             |writer| writer.set_open_url_mode(OpenUrlMode::Confirm),
+            "",
+        );
+    }
+
+    #[test]
+    fn set_ime_enabled() {
+        test(
+            "ime.enabled = true\n",
+            |writer| writer.set_ime_enabled(Some(false)),
+            "ime.enabled = false\n",
+        );
+        test(
+            "ime = {}",
+            |writer| writer.set_ime_enabled(Some(true)),
+            "ime = { enabled = true }\n",
+        );
+        test(
+            "ime.enabled = false",
+            |writer| writer.set_ime_enabled(None),
             "",
         );
     }


### PR DESCRIPTION
* Progresses https://github.com/ruffle-rs/ruffle/issues/1778

The basic IME support includes displaying popups in roughly the right position, and handling IME commit events without preediting yet.

Tested manually with Anthy (no automated tests yet due to lack of preediting).

IME preference is also added to the GUI (disabled by default):
![image](https://github.com/user-attachments/assets/4052b4c3-f1a0-4351-9555-26776028a344)

