### PR TITLE
debug_ui: Show all objects when not searching

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -1326,6 +1326,10 @@ impl DisplayObjectWindow {
 }
 
 fn matches_search(object: DisplayObject, search: &WStr) -> bool {
+    if search.is_empty() {
+        return true;
+    }
+
     if object
         .name()
         .is_some_and(|n| n.to_ascii_lowercase().contains(search))


### PR DESCRIPTION
When not searching, show all objects irrespectively of their name or whether they have a name at all.