### PR TITLE
core: Replace `GcCell` with `Gc` in `LoaderDisplay` & `MorphShape`

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -2237,7 +2237,7 @@ pub trait TDisplayObject<'gc>:
                 }
             }
             if let Some(ratio) = place_object.ratio {
-                if let Some(mut morph_shape) = self.as_morph_shape() {
+                if let Some(morph_shape) = self.as_morph_shape() {
                     morph_shape.set_ratio(context.gc(), ratio);
                 } else if let Some(video) = self.as_video() {
                     video.seek(context, ratio.into());


### PR DESCRIPTION
This refactor replaces `GcCell` with `Gc` and uses interior mutability instead.

By getting rid of `GcCell`, we don't have to lock every time we do anything with the object.