### PR TITLE
chore: Bump `egui` to `0.31.1`, switch back to mainline `wgpu` `24.0.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,7 +2993,8 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "24.0.0"
-source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -6122,7 +6123,8 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 [[package]]
 name = "wgpu"
 version = "24.0.1"
-source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f55718f85c2fa756edffa0e7f0e0a60aba463d1362b57e23123c58f035e4b6"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.0",
@@ -6146,8 +6148,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "24.0.0"
-source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
+version = "24.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c25545d479b47d3f0a8e373aceb2060b67c6eb841b24ac8c32348151c7a0c"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -6170,8 +6173,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "24.0.0"
-source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
+version = "24.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4317a17171dc20e6577bf606796794580accae0716a69edbc7388c86a3ec9f23"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6216,7 +6220,8 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "24.0.0"
-source = "git+https://github.com/ruffle-rs/wgpu?tag=v24.0.1-ruffle1#f75a042f1c3e6f460d3b49d40717eef84b7da3f1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
 dependencies = [
  "bitflags 2.9.0",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,9 +1294,9 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "ecolor"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878e9005799dd739e5d5d89ff7480491c12d0af571d44399bcaefa1ee172dd76"
+checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2768eaa6d5c80a6e2a008da1f0e062dff3c83eb2b28605ea2d0732d46e74d6"
+checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
 dependencies = [
  "ahash",
  "bitflags 2.9.0",
@@ -1319,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8151704bcef6271bec1806c51544d70e79ef20e8616e5eac01facfd9c8c54a"
+checksum = "d319dfef570f699b6e9114e235e862a2ddcf75f0d1a061de9e1328d92146d820"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1339,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace791b367c1f63e6044aef2f3834904509d1d1a6912fd23ebf3f6a9af92cd84"
+checksum = "7d9dfbb78fe4eb9c3a39ad528b90ee5915c252e77bbab9d4ebc576541ab67e13"
 dependencies = [
  "ahash",
  "arboard",
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b5cf69510eb3d19211fc0c062fb90524f43fe8e2c012967dcf0e2d81cb040f"
+checksum = "624659a2e972a46f4d5f646557906c55f1cd5a0836eddbe610fdf1afba1b4226"
 dependencies = [
  "ahash",
  "egui",
@@ -1378,9 +1378,9 @@ checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "emath"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b7b6be5ad1d247f11738b0e4699d9c20005ed366f2c29f5ec1f8e1de180bc2"
+checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
 ]
@@ -1508,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275b665a7b9611d8317485187e5458750850f9e64604d3c58434bb3fc1d22915"
+checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1526,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9343d356d7cac894dacafc161b4654e0881301097bdf32a122ed503d97cb94b6"
+checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 naga = { version = "24.0.0", features = ["wgsl-out"] }
 wgpu = "24.0.1"
-egui = "0.31.0"
+egui = "0.31.1"
 clap = { version = "4.5.31", features = ["derive"] }
 cpal = "0.15.3"
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/ruffle-rs/ruffle"
 version = "0.1.0"
 
-# TODO: remove this when v25 releases with https://github.com/gfx-rs/wgpu/pull/6994
-# (or a v24.x with the backport: https://github.com/gfx-rs/wgpu/pull/7169)
-[patch.crates-io]
-wgpu = { git = "https://github.com/ruffle-rs/wgpu", tag = "v24.0.1-ruffle1" }
-naga = { git = "https://github.com/ruffle-rs/wgpu", tag = "v24.0.1-ruffle1" }
-
 [workspace.dependencies]
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.13.0"
 egui = { workspace = true, optional = true }
-egui_extras = { version = "0.31.0", default-features = false, optional = true }
+egui_extras = { version = "0.31.1", default-features = false, optional = true }
 png = { version = "0.17.16", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 clap = { workspace = true }
 cpal = { workspace = true }
 egui = { workspace = true }
-egui_extras = { version = "0.31.0", default-features = false, features = ["image"] }
-egui-wgpu = { version = "0.31.0", features = ["winit"] }
+egui_extras = { version = "0.31.1", default-features = false, features = ["image"] }
+egui-wgpu = { version = "0.31.1", features = ["winit"] }
 image = { workspace = true, features = ["png"] }
-egui-winit = "0.31.0"
+egui-winit = "0.31.1"
 fontdb = "0.23"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "aac", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }


### PR DESCRIPTION
Reverts/replaces https://github.com/ruffle-rs/ruffle/pull/19512.

Changelogs:
 - https://github.com/emilk/egui/releases/tag/0.31.1
 - https://github.com/gfx-rs/wgpu/releases/tag/v24.0.2