### PR TITLE
chore: Ignore advisory about `paste` being unmaintained

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -89,3 +89,6 @@ github = [
 
 [advisories]
 version = 2
+
+# `paste` crate is no longer maintained https://rustsec.org/advisories/RUSTSEC-2024-0436
+ignore = ["RUSTSEC-2024-0436"]


### PR DESCRIPTION
Basically https://github.com/gfx-rs/wgpu/pull/7301.

There's nothing explicitly wrong with this crate, and since it's an indirect dependency, with depending crates not eager/willing to replace it, there's not much else we can do.