### PR TITLE
web: Allow scrolling the panic screen

### DIFF
--- a/web/packages/core/src/internal/ui/static-styles.css
+++ b/web/packages/core/src/internal/ui/static-styles.css
@@ -95,6 +95,7 @@
     display: flex;
     flex-flow: column;
     justify-content: space-around;
+    overflow: auto;
 
     a {
         color: var(--ruffle-blue);


### PR DESCRIPTION
Useful when the Ruffle instance is smaller than the text of the Panic screen, such as on a Flash-based website with small elements.