### PR TITLE
web: Reload with canvas when webglcontextlost and 8+ instances exist

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -74,7 +74,7 @@ features = [
     "EventTarget", "GainNode", "Headers", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement",
     "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent",
     "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "ReadableStream", "RequestCredentials",
-    "Url", "Clipboard", "FocusEvent", "ShadowRoot", "Gamepad", "GamepadButton"
+    "Url", "WebGlContextEvent", "Clipboard", "FocusEvent", "ShadowRoot", "Gamepad", "GamepadButton"
 ]
 
 [package.metadata.cargo-machete]

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -5,6 +5,7 @@ import {
     DataLoadOptions,
     DEFAULT_CONFIG,
     NetworkingAccessMode,
+    RenderBackend,
     UnmuteOverlay,
     URLLoadOptions,
     WindowMode,
@@ -792,6 +793,21 @@ export class InnerPlayer {
             throw new Error("Cannot reload if load wasn't first called");
         }
     }
+
+    /**
+     * Reloads the player, as if you called {@link RufflePlayer.load} with the same config as the last time it was called, but setting the preferredRenderer to "canvas".
+     *
+     * If this player has never been loaded, this method will return an error.
+     */
+    async reloadWithCanvasRenderer(): Promise<void> {
+        if (this.loadedConfig) {
+            const combinedOptions = { ...this.loadedConfig, preferredRenderer: RenderBackend.Canvas};
+            await this.load(combinedOptions);
+        } else {
+            throw new Error("Cannot reload if load wasn't first called");
+        }
+    }
+
 
     /**
      * Loads a specified movie into this player.

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -798,11 +798,14 @@ export class InnerPlayer {
      * Reloads the player, as if you called {@link RufflePlayer.load} with the same config as the last time it was called, but setting the preferredRenderer to "canvas".
      *
      * If this player has never been loaded, this method will return an error.
+     * If this player was already trying to use the canvas render, this method will panic.
      */
-    async reloadWithCanvasRenderer(): Promise<void> {
-        if (this.loadedConfig) {
+    protected async reloadWithCanvasRenderer(): Promise<void> {
+        if (this.loadedConfig && this.loadedConfig.preferredRenderer !== RenderBackend.Canvas) {
             const combinedOptions = { ...this.loadedConfig, preferredRenderer: RenderBackend.Canvas};
             await this.load(combinedOptions);
+        } else if (this.loadedConfig) {
+            this.panic(new Error(text("error-canvas-reload")));
         } else {
             throw new Error("Cannot reload if load wasn't first called");
         }

--- a/web/packages/core/texts/en-US/messages.ftl
+++ b/web/packages/core/texts/en-US/messages.ftl
@@ -24,6 +24,7 @@ clipboard-message-description =
 clipboard-message-copy = { " " } for copy
 clipboard-message-cut = { " " } for cut
 clipboard-message-paste = { " " } for paste
+error-canvas-reload = Cannot reload with the canvas renderer when the canvas renderer is already in use.
 error-file-protocol =
     It appears you are running Ruffle on the "file:" protocol.
     This doesn't work as browsers block many features from working for security reasons.


### PR DESCRIPTION
Intended to fix this comment in https://github.com/ruffle-rs/ruffle/issues/1905#issuecomment-1030111132