### PR TITLE
avm2: Make the size constraint on Value be an upper bound

### DIFF
--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -38,7 +38,7 @@ impl Debug for Error<'_> {
 }
 
 // This type is used very frequently, so make sure it doesn't unexpectedly grow.
-const _: () = assert!(size_of::<Result<Value<'_>, Error<'_>>>() == 24);
+const _: () = assert!(size_of::<Result<Value<'_>, Error<'_>>>() <= 24);
 
 #[inline(never)]
 #[cold]


### PR DESCRIPTION
Because on `i686-unknown-linux-gnu` for example, its 16 bytes, and the Android app is built for that target as well.

Fixes a regression introduced in https://github.com/ruffle-rs/ruffle/pull/19716.
Unblocks https://github.com/ruffle-rs/ruffle-android/pull/410.
See: https://github.com/ruffle-rs/ruffle-android/actions/runs/13898078735/job/38883161245?pr=410#step:6:57.
Resembles https://github.com/ruffle-rs/ruffle/pull/11263.

All the other similar asserts (except in the `wstr` crate) use `<=` instead of `==` as well.