### PR TITLE
core: update `gc-arena` to latest `master`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,19 +1924,16 @@ dependencies = [
 [[package]]
 name = "gc-arena"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd70cf88a32937834aae9614ff2569b5d9467fa0c42c5d7762fd94a8de88266"
+source = "git+https://github.com/kyren/gc-arena.git?rev=d394233a367ec7352a361cf93572c428ec092d66#d394233a367ec7352a361cf93572c428ec092d66"
 dependencies = [
  "gc-arena-derive",
- "hashbrown 0.14.5",
  "sptr",
 ]
 
 [[package]]
 name = "gc-arena-derive"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c612a69f5557a11046b77a7408d2836fe77077f842171cd211c5ef504bd3cddd"
+source = "git+https://github.com/kyren/gc-arena.git?rev=d394233a367ec7352a361cf93572c428ec092d66#d394233a367ec7352a361cf93572c428ec092d66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -46,11 +46,11 @@ macro_rules! avm_debug {
 #[derive(Clone)]
 pub struct RegisterSet<'gc>(SmallVec<[Value<'gc>; 8]>);
 
-unsafe impl gc_arena::Collect for RegisterSet<'_> {
+unsafe impl<'gc> gc_arena::Collect<'gc> for RegisterSet<'gc> {
     #[inline]
-    fn trace(&self, cc: &gc_arena::Collection) {
+    fn trace<C: gc_arena::collect::Trace<'gc>>(&self, cc: &mut C) {
         for register in &self.0 {
-            register.trace(cc);
+            cc.trace(register);
         }
     }
 }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -88,7 +88,7 @@ pub enum NativeObject<'gc> {
         FunctionObject(FunctionObject<'gc>),
     }
 )]
-pub trait TObject<'gc>: 'gc + Collect + Into<Object<'gc>> + Clone + Copy {
+pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
     /// Get the underlying raw script object.
     fn raw_script_object(&self) -> ScriptObject<'gc>;
 

--- a/core/src/avm2/dynamic_map.rs
+++ b/core/src/avm2/dynamic_map.rs
@@ -25,14 +25,25 @@ pub enum DynamicKey<'gc> {
 }
 
 /// A HashMap designed for dynamic properties on an object.
-#[derive(Debug, Collect, Clone)]
-#[collect(no_drop)]
-pub struct DynamicMap<K: Eq + PartialEq + Hash, V> {
+#[derive(Debug, Clone)]
+pub struct DynamicMap<K, V> {
     values: hashbrown::HashMap<K, DynamicProperty<V>, FnvBuildHasher>,
     // The last index that was given back to flash
     public_index: Cell<usize>,
     // The actual index that represents where an item is in the HashMap
     real_index: Cell<usize>,
+}
+
+// `gc-arena` doesn't provide a `Collect` impl for the version of `hashbrown` we use.
+unsafe impl<'gc, K: Collect<'gc>, V: Collect<'gc>> Collect<'gc> for DynamicMap<K, V> {
+    const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
+
+    fn trace<T: gc_arena::collect::Trace<'gc>>(&self, cc: &mut T) {
+        for (k, v) in &self.values {
+            cc.trace(k);
+            cc.trace(v);
+        }
+    }
 }
 
 impl<K: Eq + PartialEq + Hash, V> Default for DynamicMap<K, V> {

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -14,7 +14,7 @@ use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{ArrayObject, ClassObject, Object, TObject};
 use crate::avm2::{Activation, Error, Value};
 
-use gc_arena::{Collect, DynamicRoot, Rootable};
+use gc_arena::{Collect, DynamicRoot, Gc, Rootable};
 use ruffle_macros::istr;
 use ruffle_render::filters::{
     DisplacementMapFilter, DisplacementMapFilterMode, Filter, ShaderFilter, ShaderObject,
@@ -838,7 +838,7 @@ fn avm2_to_shader_filter<'gc>(
     let dyn_root = activation
         .context
         .dynamic_root
-        .stash(activation.gc(), shader_obj);
+        .stash(activation.gc(), Gc::new(activation.gc(), shader_obj));
 
     let (shader_handle, shader_args) = get_shader_args(shader_obj, activation)?;
 

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -206,7 +206,7 @@ use crate::font::Font;
         StyleSheetObject(StyleSheetObject<'gc>),
     }
 )]
-pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy {
+pub trait TObject<'gc>: 'gc + Collect<'gc> + Debug + Into<Object<'gc>> + Clone + Copy {
     /// Get the base of this object.
     /// Any trait method implementations that were not overridden will forward the call to this instead.
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>>;

--- a/core/src/debug_ui/handle.rs
+++ b/core/src/debug_ui/handle.rs
@@ -2,7 +2,7 @@ use crate::avm1::TObject as _;
 use crate::avm2::object::TObject as _;
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, DisplayObjectPtr, TDisplayObject};
-use gc_arena::{DynamicRoot, DynamicRootSet, Rootable};
+use gc_arena::{DynamicRoot, DynamicRootSet, Gc, Rootable};
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 
@@ -20,7 +20,10 @@ impl DisplayObjectHandle {
     ) -> Self {
         let object = object.into();
         Self {
-            root: context.dynamic_root.stash(context.gc(), object),
+            // TODO(moulins): it'd be nice to avoid the double indirection here...
+            root: context
+                .dynamic_root
+                .stash(context.gc(), Gc::new(context.gc(), object)),
             ptr: object.as_ptr(),
         }
     }
@@ -66,7 +69,10 @@ pub struct AVM1ObjectHandle {
 impl AVM1ObjectHandle {
     pub fn new<'gc>(context: &mut UpdateContext<'gc>, object: crate::avm1::Object<'gc>) -> Self {
         Self {
-            root: context.dynamic_root.stash(context.gc(), object),
+            // TODO(moulins): it'd be nice to avoid the double indirection here...
+            root: context
+                .dynamic_root
+                .stash(context.gc(), Gc::new(context.gc(), object)),
             ptr: object.as_ptr(),
         }
     }
@@ -106,7 +112,10 @@ pub struct AVM2ObjectHandle {
 impl AVM2ObjectHandle {
     pub fn new<'gc>(context: &mut UpdateContext<'gc>, object: crate::avm2::Object<'gc>) -> Self {
         Self {
-            root: context.dynamic_root.stash(context.gc(), object),
+            // TODO(moulins): it'd be nice to avoid the double indirection here...
+            root: context
+                .dynamic_root
+                .stash(context.gc(), Gc::new(context.gc(), object)),
             ptr: object.as_ptr(),
         }
     }
@@ -148,7 +157,10 @@ pub struct DomainHandle {
 impl DomainHandle {
     pub fn new<'gc>(context: &mut UpdateContext<'gc>, domain: crate::avm2::Domain<'gc>) -> Self {
         Self {
-            root: context.dynamic_root.stash(context.gc(), domain),
+            // TODO(moulins): it'd be nice to avoid the double indirection here...
+            root: context
+                .dynamic_root
+                .stash(context.gc(), Gc::new(context.gc(), domain)),
             ptr: domain.as_ptr(),
         }
     }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1120,7 +1120,7 @@ pub fn apply_standard_mask_and_scroll<'gc, F>(
     }
 )]
 pub trait TDisplayObject<'gc>:
-    'gc + Clone + Copy + Collect + Debug + Into<DisplayObject<'gc>>
+    'gc + Clone + Copy + Collect<'gc> + Debug + Into<DisplayObject<'gc>>
 {
     fn base<'a>(&'a self) -> Ref<'a, DisplayObjectBase<'gc>>;
     fn base_mut<'a>(&'a self, mc: &Mutation<'gc>) -> RefMut<'a, DisplayObjectBase<'gc>>;

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -126,7 +126,13 @@ pub fn dispatch_added_event<'gc>(
     }
 )]
 pub trait TDisplayObjectContainer<'gc>:
-    'gc + Clone + Copy + Collect + Debug + Into<DisplayObjectContainer<'gc>> + Into<DisplayObject<'gc>>
+    'gc
+    + Clone
+    + Copy
+    + Collect<'gc>
+    + Debug
+    + Into<DisplayObjectContainer<'gc>>
+    + Into<DisplayObject<'gc>>
 {
     /// Get read-only access to the raw container.
     fn raw_container(&self) -> Ref<'_, ChildContainer<'gc>>;

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -123,7 +123,7 @@ impl Default for InteractiveObjectBase<'_> {
     }
 )]
 pub trait TInteractiveObject<'gc>:
-    'gc + Clone + Copy + Collect + Debug + Into<InteractiveObject<'gc>>
+    'gc + Clone + Copy + Collect<'gc> + Debug + Into<InteractiveObject<'gc>>
 {
     fn raw_interactive(&self) -> Ref<InteractiveObjectBase<'gc>>;
 

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -1163,7 +1163,7 @@ mod tests {
     use crate::font::{EvalParameters, Font, FontDescriptor, FontType};
     use crate::string::WStr;
     use flate2::read::DeflateDecoder;
-    use gc_arena::{rootless_arena, Mutation};
+    use gc_arena::{arena::rootless_mutate, Mutation};
     use std::borrow::Cow;
     use std::io::Read;
     use swf::Twips;
@@ -1174,7 +1174,7 @@ mod tests {
     where
         F: for<'gc> FnOnce(&Mutation<'gc>, Font<'gc>),
     {
-        rootless_arena(|mc| {
+        rootless_mutate(|mc| {
             let mut data = Vec::new();
             let mut decoder = DeflateDecoder::new(DEVICE_FONT);
             decoder

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -33,6 +33,7 @@ use crate::tag_utils::SwfMovie;
 use crate::vminterface::Instantiator;
 use chardetng::EncodingDetector;
 use encoding_rs::{UTF_8, WINDOWS_1252};
+use gc_arena::collect::Trace;
 use gc_arena::{Collect, GcCell};
 use indexmap::IndexMap;
 use ruffle_macros::istr;
@@ -241,10 +242,10 @@ impl From<crate::avm1::Error<'_>> for Error {
 /// Holds all in-progress loads for the player.
 pub struct LoadManager<'gc>(SlotMap<LoaderHandle, Loader<'gc>>);
 
-unsafe impl Collect for LoadManager<'_> {
-    fn trace(&self, cc: &gc_arena::Collection) {
+unsafe impl<'gc> Collect<'gc> for LoadManager<'gc> {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for (_, loader) in self.0.iter() {
-            loader.trace(cc)
+            cc.trace(loader);
         }
     }
 }

--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -9,6 +9,7 @@ use crate::context::UpdateContext;
 use crate::string::AvmString;
 
 use async_channel::{unbounded, Receiver, Sender as AsyncSender, Sender};
+use gc_arena::collect::Trace;
 use gc_arena::Collect;
 use ruffle_macros::istr;
 use slotmap::{new_key_type, SlotMap};
@@ -68,10 +69,10 @@ pub struct Sockets<'gc> {
     sender: Sender<SocketAction>,
 }
 
-unsafe impl Collect for Sockets<'_> {
-    fn trace(&self, cc: &gc_arena::Collection) {
+unsafe impl<'gc> Collect<'gc> for Sockets<'gc> {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for (_, socket) in self.sockets.iter() {
-            socket.trace(cc)
+            cc.trace(socket);
         }
     }
 }

--- a/core/src/string/context.rs
+++ b/core/src/string/context.rs
@@ -71,7 +71,7 @@ impl<'gc> StringContext<'gc> {
     }
 
     #[must_use]
-    pub fn get_interned(&self, s: &WStr) -> Option<AvmAtom<'gc>> {
+    pub fn get_interned(&mut self, s: &WStr) -> Option<AvmAtom<'gc>> {
         self.interner.get(self.gc(), s)
     }
 

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -16,6 +16,8 @@ use gc_arena::Collect;
 use std::collections::{binary_heap::PeekMut, BinaryHeap};
 
 /// Manages the collection of timers.
+#[derive(Collect)]
+#[collect(no_drop)]
 pub struct Timers<'gc> {
     /// The collection of active timers.
     timers: BinaryHeap<Timer<'gc>>,
@@ -307,13 +309,6 @@ impl Default for Timers<'_> {
     }
 }
 
-unsafe impl Collect for Timers<'_> {
-    fn trace(&self, cc: &gc_arena::Collection) {
-        for timer in &self.timers {
-            timer.trace(cc);
-        }
-    }
-}
 /// A timer created via `setInterval`/`setTimeout`.
 /// Runs a callback when it ticks.
 #[derive(Clone, Collect)]

--- a/deny.toml
+++ b/deny.toml
@@ -85,6 +85,7 @@ unknown-git = "deny"
 # github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
+    "kyren", # for `gc-arena`
 ]
 
 [advisories]

--- a/ruffle_gc_arena/Cargo.toml
+++ b/ruffle_gc_arena/Cargo.toml
@@ -12,4 +12,4 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-gc-arena = { version = "0.5.0", features = ["hashbrown"] }
+gc-arena = { git = "https://github.com/kyren/gc-arena.git", rev = "d394233a367ec7352a361cf93572c428ec092d66" }

--- a/ruffle_gc_arena/src/gc_weak_cell.rs
+++ b/ruffle_gc_arena/src/gc_weak_cell.rs
@@ -1,5 +1,6 @@
+use crate::collect::{Collect, Trace};
 use crate::lock::RefLock;
-use crate::{Collect, Collection, GcCell, GcWeak, Mutation};
+use crate::{GcCell, GcWeak, Mutation};
 
 use core::fmt::{self, Debug};
 
@@ -21,9 +22,9 @@ impl<'gc, T: ?Sized + 'gc> Debug for GcWeakCell<'gc, T> {
     }
 }
 
-unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeakCell<'gc, T> {
+unsafe impl<'gc, T: ?Sized + 'gc> Collect<'gc> for GcWeakCell<'gc, T> {
     #[inline]
-    fn trace(&self, cc: &Collection) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         self.0.trace(cc);
     }
 }


### PR DESCRIPTION
Notable changes:
- `Collect::trace` is now generic over the tracing context: this makes the `CollectCell` abstraction used in the string interner unsound (as `Collect::trace` can now be, in principle, called at any time). As such, this is replaced by a simpler `RefCell`.
- `gc-arena` upgraded its `hashbrown` dependency to `0.15`, but we need to stay on `0.14` because we use `RawTable` (in the AVM2 `DynamicMap` and in the string interner). The work-around is to manually implement `Collect` on these types.
- `gc-arena` improved its pacing algorithm; there are no API changes, but we should investigate the performance impact before merging.
