### PR TITLE
wgpu: Lower max_color_attachments limit to 4

### DIFF
--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -1130,6 +1130,9 @@ async fn request_device(
     limits = limits.using_alignment(adapter.limits());
     limits.max_uniform_buffer_binding_size = adapter.limits().max_uniform_buffer_binding_size;
     limits.max_inter_stage_shader_components = adapter.limits().max_inter_stage_shader_components;
+    // This will be a default limit in a future wgpu version (down from 8).
+    // It's required for some WebGL devices to be supported.
+    limits.max_color_attachments = 4;
 
     let mut features = Default::default();
 


### PR DESCRIPTION
Should fix the regression once and for all, hopefully :)