### PR TITLE
core: Use player notifications for virtual keyboard

### DIFF
--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -89,10 +89,6 @@ pub trait UiBackend: Downcast {
     // Unused, but kept in case we need it later.
     fn message(&self, message: &str);
 
-    fn open_virtual_keyboard(&self);
-
-    fn close_virtual_keyboard(&self);
-
     fn language(&self) -> LanguageIdentifier;
 
     fn display_unsupported_video(&self, url: Url);
@@ -194,10 +190,6 @@ impl UiBackend for NullUiBackend {
         _register: &mut dyn FnMut(FontDefinition),
     ) {
     }
-
-    fn open_virtual_keyboard(&self) {}
-
-    fn close_virtual_keyboard(&self) {}
 
     fn language(&self) -> LanguageIdentifier {
         US_ENGLISH.clone()

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1154,6 +1154,9 @@ pub enum KeyLocation {
 #[derive(Debug, Clone)]
 pub enum PlayerNotification {
     ImeNotification(ImeNotification),
+
+    OpenVirtualKeyboard,
+    CloseVirtualKeybard,
 }
 
 #[derive(Debug, Clone)]

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -6,6 +6,7 @@ pub use crate::display_object::{
     DisplayObject, TDisplayObject, TDisplayObjectContainer, TextSelection,
 };
 use crate::display_object::{EditText, InteractiveObject, TInteractiveObject};
+use crate::events::PlayerNotification;
 use crate::events::{ClipEvent, KeyCode};
 use crate::prelude::Avm2Value;
 use crate::Player;
@@ -208,15 +209,17 @@ impl<'gc> FocusTracker<'gc> {
     }
 
     fn update_virtual_keyboard(&self, context: &mut UpdateContext<'gc>) {
-        if let Some(text_field) = self.get_as_edit_text() {
+        let notification = if let Some(text_field) = self.get_as_edit_text() {
             if text_field.is_editable() {
-                context.ui.open_virtual_keyboard();
+                PlayerNotification::OpenVirtualKeyboard
             } else {
-                context.ui.close_virtual_keyboard();
+                PlayerNotification::CloseVirtualKeybard
             }
         } else {
-            context.ui.close_virtual_keyboard();
-        }
+            PlayerNotification::CloseVirtualKeybard
+        };
+
+        context.send_notification(notification);
     }
 
     /// Update selection on the newly focused text field.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -617,6 +617,10 @@ impl ApplicationHandler<RuffleEvent> for App {
                     PlayerNotification::ImeNotification(ImeNotification::ImeNotReady) => {
                         main_window.gui.set_ime_allowed(false);
                     }
+                    PlayerNotification::OpenVirtualKeyboard
+                    | PlayerNotification::CloseVirtualKeybard => {
+                        // TODO Winit does not support soft input (yet?)
+                    }
                 }
             }
 

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -344,11 +344,6 @@ impl UiBackend for DesktopUiBackend {
         }
     }
 
-    // Unused on desktop
-    fn open_virtual_keyboard(&self) {}
-
-    fn close_virtual_keyboard(&self) {}
-
     fn language(&self) -> LanguageIdentifier {
         self.preferences.language().clone()
     }

--- a/tests/framework/src/backends/ui.rs
+++ b/tests/framework/src/backends/ui.rs
@@ -115,10 +115,6 @@ impl UiBackend for TestUiBackend {
 
     fn message(&self, _message: &str) {}
 
-    fn open_virtual_keyboard(&self) {}
-
-    fn close_virtual_keyboard(&self) {}
-
     fn language(&self) -> LanguageIdentifier {
         US_ENGLISH.clone()
     }

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -298,14 +298,6 @@ impl UiBackend for WebUiBackend {
         self.js_player.display_message(message);
     }
 
-    fn open_virtual_keyboard(&self) {
-        self.js_player.open_virtual_keyboard()
-    }
-
-    fn close_virtual_keyboard(&self) {
-        self.js_player.close_virtual_keyboard()
-    }
-
     fn language(&self) -> LanguageIdentifier {
         self.language.clone()
     }


### PR DESCRIPTION
This refactor replaces `open_virtual_keyboard`/`close_virtual_keyboard methods` from `UiBackend` with `OpenVirtualKeyboard`/`CloseVirtualKeybard` player notifications.

It's a follow up to https://github.com/ruffle-rs/ruffle/pull/19666 and a PoC of how notifications can be used for other purposes too.
