### PR TITLE
6075 duration issue fix

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -354,7 +354,7 @@ pub struct Player {
     instance_counter: i32,
 
     /// Time remaining until the next timer will fire.
-    time_til_next_timer: Option<f64>,
+    time_til_next_timer: Option<std::time::Duration>,
 
     /// The instant at which the SWF was launched.
     start_time: Instant,
@@ -571,14 +571,14 @@ impl Player {
 
         self.update_sockets();
         self.update_net_connections();
-        self.update_timers(dt);
+        self.update_timers(Duration::new(dt as u64, 0));
         self.update(|context| {
             StreamManager::tick(context, dt);
         });
         self.audio.tick();
     }
 
-    pub fn time_til_next_timer(&self) -> Option<f64> {
+    pub fn time_til_next_timer(&self) -> Option<std::time::Duration> {
         self.time_til_next_timer
     }
 
@@ -595,7 +595,9 @@ impl Player {
         };
 
         if let Some(time_til_next_timer) = self.time_til_next_timer {
-            dt = dt.min(time_til_next_timer)
+            dt = dt.min(time_til_next_timer.as_secs_f64());
+            // let a = Duration::from_millis(12.0);
+            // a.min();
         }
 
         dt = dt.max(0.0);
@@ -2354,7 +2356,7 @@ impl Player {
 
     /// Update all AVM-based timers (such as created via setInterval).
     /// Returns the approximate amount of time until the next timer tick.
-    pub fn update_timers(&mut self, dt: f64) {
+    pub fn update_timers(&mut self, dt: std::time::Duration) {
         self.time_til_next_timer =
             self.mutate_with_update_context(|context| Timers::update_timers(context, dt));
     }

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -14,6 +14,7 @@ use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::string::AvmString;
 use gc_arena::Collect;
 use std::collections::{binary_heap::PeekMut, BinaryHeap};
+use std::time::Duration;
 
 /// Manages the collection of timers.
 #[derive(Collect)]
@@ -31,11 +32,11 @@ pub struct Timers<'gc> {
 
 impl<'gc> Timers<'gc> {
     /// Ticks all timers and runs necessary callbacks.
-    pub fn update_timers(context: &mut UpdateContext<'gc>, dt: f64) -> Option<f64> {
+    pub fn update_timers(context: &mut UpdateContext<'gc>, dt: std::time::Duration) -> Option<std::time::Duration> {
         context.timers.cur_time = context
             .timers
             .cur_time
-            .wrapping_add((dt * Self::TIMER_SCALE) as u64);
+            .wrapping_add((dt.as_secs_f64() * Self::TIMER_SCALE) as u64);
 
         if context.timers.is_empty() {
             return None;
@@ -190,7 +191,9 @@ impl<'gc> Timers<'gc> {
 
         // Return estimated time until next timer tick.
         context.timers.peek().map(|timer| {
-            (timer.tick_time.wrapping_sub(context.timers.cur_time)) as f64 / Self::TIMER_SCALE
+            Duration::new(
+                Duration::new(timer.tick_time.wrapping_sub(context.timers.cur_time), 0) 
+            .div_duration_f64(Duration::new(Self::TIMER_SCALE as u64, 0)) as u64, 0)
         })
     }
 

--- a/scanner/src/execute.rs
+++ b/scanner/src/execute.rs
@@ -29,7 +29,7 @@ fn execute_swf(file: &Path) {
     player.lock().unwrap().preload(&mut ExecutionLimit::none());
 
     player.lock().unwrap().run_frame();
-    player.lock().unwrap().update_timers(frame_time);
+    player.lock().unwrap().update_timers(Duration::new(frame_time as u64, 0));
     //executor.poll_all().unwrap();
 }
 


### PR DESCRIPTION
Replaced f64 time durations in Ruffle with std::time::Duration.