### PR TITLE
web: Fix vulnerability for upstream dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -252,27 +252,27 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-            "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+            "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.0"
+                "@babel/template": "^7.26.9",
+                "@babel/types": "^7.26.10"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
-            "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+            "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.5"
+                "@babel/types": "^7.26.10"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -314,15 +314,15 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+            "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/code-frame": "^7.26.2",
+                "@babel/parser": "^7.26.9",
+                "@babel/types": "^7.26.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -358,9 +358,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
-            "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+            "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
Applies `npm audit fix` suggestion
This only upgrades `@babel/helpers` packages, so shouldn't be a big deal

Vulnerability:

@babel/helpers  <7.26.10
Severity: moderate
Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups - https://github.com/advisories/GHSA-968p-4wvh-cqc8