### PR TITLE
desktop: Fix translations for IME preferences

### DIFF
--- a/desktop/assets/texts/en-US/preferences_dialog.ftl
+++ b/desktop/assets/texts/en-US/preferences_dialog.ftl
@@ -45,7 +45,5 @@ gamemode-default-tooltip = GameMode will be enabled only when power preference i
 # See for context https://wiki.archlinux.org/title/Input_method
 ime-enabled = Input Method
 ime-enabled-experimental = (experimental)
-ime-enabled-tooltip = An input method allows inputting characters that are not available on the kaybord, for instance Chinese, Japanese, or Korean characters.
+ime-enabled-tooltip = An input method allows inputting characters that are not available on the keyboard, for instance Chinese, Japanese, or Korean characters.
 ime-enabled-default = Default
-ime-enabled-on = On
-ime-enabled-off = Off

--- a/desktop/src/gui/dialogs/preferences_dialog.rs
+++ b/desktop/src/gui/dialogs/preferences_dialog.rs
@@ -693,8 +693,8 @@ fn storage_backend_name(locale: &LanguageIdentifier, backend: StorageBackend) ->
 fn ime_enabled_name(locale: &LanguageIdentifier, ime_enabled: Option<bool>) -> Cow<str> {
     match ime_enabled {
         None => text(locale, "ime-enabled-default"),
-        Some(true) => text(locale, "ime-enabled-on"),
-        Some(false) => text(locale, "ime-enabled-off"),
+        Some(true) => text(locale, "enable"),
+        Some(false) => text(locale, "disable"),
     }
 }
 


### PR DESCRIPTION
This patch fixes a typo and removes unnecessary strings.

I'll fix up the translations in Crowdin when this lands.