### PR TITLE
chore: Bump `time` and `deranged`, avoid `PartialOrd` ambiguity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]
@@ -5279,9 +5279,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -5296,15 +5296,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -766,7 +766,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         };
 
         if let Some((clip, frame)) = call_frame {
-            if frame <= u16::MAX.into() {
+            if frame <= u16::MAX as u32 {
                 for action in clip.actions_on_frame(self.context, frame as u16) {
                     let _ = self.run_child_frame_for_action("[Frame Call]", clip.into(), action)?;
                 }

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -138,7 +138,7 @@ impl Date {
         let day = self.day_within_year();
         let in_leap_year = self.in_leap_year();
         for i in 0..11 {
-            if day < Self::MONTH_OFFSETS[usize::from(in_leap_year)][i as usize + 1].into() {
+            if day < Self::MONTH_OFFSETS[usize::from(in_leap_year)][i as usize + 1] as i32 {
                 return i;
             }
         }

--- a/core/src/avm2/globals/toplevel.rs
+++ b/core/src/avm2/globals/toplevel.rs
@@ -113,7 +113,7 @@ pub fn escape<'gc>(
         if not_converted.contains(x) {
             output.push(x);
         } else {
-            let encode = if x <= u8::MAX.into() {
+            let encode = if x <= u8::MAX as u16 {
                 format!("%{x:02X}")
             } else {
                 format!("%u{x:04X}")


### PR DESCRIPTION
This would sooner or later bite us in the bottom anyway: https://github.com/ruffle-rs/ruffle-android/actions/runs/14034450723/job/39289142906?pr=419

See also:
 - https://github.com/jhpratt/deranged/issues/17
 - https://github.com/jhpratt/deranged/issues/18
 - https://github.com/time-rs/time/issues/736