### PR TITLE
chore: Bump Binaryen (wasm-opt) to version 123

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -356,7 +356,7 @@ jobs:
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
-          tag: version_122
+          tag: version_123
           name: wasm-opt
 
       - name: Install node packages

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -38,7 +38,7 @@ jobs:
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
-          tag: version_122
+          tag: version_123
           name: wasm-opt
 
       - name: Install fclones

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -74,7 +74,7 @@ jobs:
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
-          tag: version_122
+          tag: version_123
           name: wasm-opt
 
       - name: Build

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -6,7 +6,7 @@ FROM node:22
 
 # Installing wasm-opt from GitHub:
 # Keep the version number in sync with the ones in the Actions workflows!
-RUN wget --progress=:giga https://github.com/WebAssembly/binaryen/releases/download/version_122/binaryen-version_122-x86_64-linux.tar.gz -O- | \
+RUN wget --progress=:giga https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz -O- | \
     tar xzf - --wildcards "*wasm-opt" --strip-components=2 && \
     mv wasm-opt /usr/local/bin
 


### PR DESCRIPTION
https://github.com/WebAssembly/binaryen/pull/7394:
> Given the big speedup in our official release binaries for Linux, this seems useful to get to users quickly.

https://github.com/WebAssembly/binaryen/pull/7378:
> fixes performance problems, especially on heavily multi-threaded workloads (many functions, high core count machines)