### PR TITLE
avm2: Avoid allocating when calling a method

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -813,6 +813,10 @@ impl<'gc> Avm2<'gc> {
         args
     }
 
+    fn stack_slice(&mut self, start: usize, len: usize) -> &[Value<'gc>] {
+        &self.stack[start..start + len]
+    }
+
     fn truncate_stack(&mut self, size: usize) {
         self.stack.truncate(size);
     }

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -311,12 +311,7 @@ impl<'gc> Avm2<'gc> {
 
                     // This exists purely to check if the builtin is OK with being called with
                     // no parameters.
-                    init_activation.resolve_parameters(
-                        Method::Native(method),
-                        &[],
-                        resolved_signature,
-                        None,
-                    )?;
+                    init_activation.resolve_parameters(method, &[], resolved_signature, None)?;
                     init_activation
                         .context
                         .avm2

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -451,9 +451,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         // Statically verify all non-variadic, provided parameters.
         let static_arg_count = min(user_arguments.len(), signature.len());
-        for i in 0..static_arg_count {
+        for (i, param_config) in signature.iter().enumerate().take(static_arg_count) {
             let arg = user_arguments.get_at(self, i);
-            let param_config = &signature[i];
 
             let coerced_arg = if let Some(param_class) = param_config.param_type {
                 arg.coerce_to_type(self, param_class)?

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1149,9 +1149,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         // However, the optimizer can still generate it.
 
+        let stack_base = self.avm2().stack.len() - arg_count as usize;
+
         let args = FunctionArgs::OnAvmStack {
             arg_count: arg_count as usize,
-            stack_base: self.avm2().stack.len() - arg_count as usize,
+            stack_base,
         };
         let receiver = self
             .avm2()
@@ -1160,8 +1162,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let value = receiver.call_method_with_args(index, args, self)?;
 
-        // Pop receiver now: `call_method_with_args` is responsible for popping the args
-        let _ = self.pop_stack();
+        // Ensure all arguments are popped
+        self.avm2().truncate_stack(stack_base - 1);
 
         if push_return_value {
             self.push_stack(value);

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -811,7 +811,7 @@ pub fn error<'gc>(
 pub fn make_mismatch_error<'gc>(
     activation: &mut Activation<'_, 'gc>,
     method: Method<'gc>,
-    user_arguments: &[Value<'gc>],
+    passed_arg_count: usize,
     bound_class: Option<Class<'gc>>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let expected_num_params = method
@@ -828,8 +828,7 @@ pub fn make_mismatch_error<'gc>(
         activation,
         &format!(
             "Error #1063: Argument count mismatch on {function_name}. Expected {}, got {}.",
-            expected_num_params,
-            user_arguments.len(),
+            expected_num_params, passed_arg_count,
         ),
         1063,
     )?));

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -8,6 +8,7 @@ use crate::avm2::value::Value;
 use crate::avm2::{Error, Multiname};
 use crate::string::WString;
 use gc_arena::{Collect, Gc};
+use std::borrow::Cow;
 use std::fmt;
 
 /// Represents a bound method.
@@ -79,7 +80,7 @@ impl<'gc> BoundMethod<'gc> {
             receiver,
             self.bound_superclass,
             self.bound_class,
-            arguments,
+            FunctionArgs::AsArgSlice { arguments },
             activation,
             callee,
         )
@@ -128,6 +129,41 @@ impl<'gc> BoundMethod<'gc> {
     }
 }
 
+pub enum FunctionArgs<'a, 'gc> {
+    OnAvmStack { arg_count: u32 },
+    AsArgSlice { arguments: &'a [Value<'gc>] },
+}
+
+impl<'a, 'gc> FunctionArgs<'a, 'gc> {
+    pub fn to_slice(self, activation: &mut Activation<'_, 'gc>) -> Cow<'a, [Value<'gc>]> {
+        match self {
+            FunctionArgs::OnAvmStack { arg_count } => {
+                let args = activation.pop_stack_args(arg_count);
+                Cow::Owned(args)
+            }
+            FunctionArgs::AsArgSlice { arguments } => Cow::Borrowed(arguments),
+        }
+    }
+
+    pub fn get_at(&self, activation: &mut Activation<'_, 'gc>, index: usize) -> Value<'gc> {
+        match self {
+            FunctionArgs::OnAvmStack { arg_count } => {
+                assert!(index < *arg_count as usize);
+
+                activation.avm2().peek(*arg_count as usize - index - 1)
+            }
+            FunctionArgs::AsArgSlice { arguments } => arguments[index],
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            FunctionArgs::OnAvmStack { arg_count } => *arg_count as usize,
+            FunctionArgs::AsArgSlice { arguments } => arguments.len(),
+        }
+    }
+}
+
 /// Execute a method.
 ///
 /// The function will either be called directly if it is a Rust builtin, or
@@ -149,12 +185,14 @@ pub fn exec<'gc>(
     receiver: Value<'gc>,
     bound_superclass: Option<ClassObject<'gc>>,
     bound_class: Option<Class<'gc>>,
-    mut arguments: &[Value<'gc>],
+    arguments: FunctionArgs<'_, 'gc>,
     activation: &mut Activation<'_, 'gc>,
     callee: Value<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let ret = match method {
         Method::Native(bm) => {
+            let arguments = &arguments.to_slice(activation);
+
             let caller_domain = activation.caller_domain();
             let caller_movie = activation.caller_movie();
             let mut activation = Activation::from_builtin(
@@ -208,13 +246,6 @@ pub fn exec<'gc>(
             (bm.method)(&mut activation, receiver, &arguments)
         }
         Method::Bytecode(bm) => {
-            if bm.is_unchecked() {
-                let max_args = bm.signature().len();
-                if arguments.len() > max_args && !bm.is_variadic() {
-                    arguments = &arguments[..max_args];
-                }
-            }
-
             // This used to be a one step called Activation::from_method,
             // but avoiding moving an Activation around helps perf
             let mut activation = Activation::from_nothing(activation.context);

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -225,12 +225,8 @@ pub fn exec<'gc>(
             let resolved_signature = bm.resolved_signature.read();
             let resolved_signature = resolved_signature.as_ref().unwrap();
 
-            let arguments = activation.resolve_parameters(
-                method,
-                arguments,
-                resolved_signature,
-                bound_class,
-            )?;
+            let arguments =
+                activation.resolve_parameters(bm, arguments, resolved_signature, bound_class)?;
 
             #[cfg(feature = "tracy_avm")]
             let _span = {

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -167,12 +167,6 @@ impl<'gc> BytecodeMethod<'gc> {
             }
         }
 
-        let is_unchecked = if let Some(method) = abc.methods.get(abc_method.0 as usize) {
-            is_function && all_params_unchecked && !method.flags.contains(AbcMethodFlags::NEED_REST)
-        } else {
-            false
-        };
-
         Ok(Self {
             txunit,
             abc: txunit.abc(),
@@ -182,7 +176,7 @@ impl<'gc> BytecodeMethod<'gc> {
             signature,
             return_type,
             is_function,
-            is_unchecked,
+            is_unchecked: is_function && all_params_unchecked,
             activation_class: Lock::new(None),
         })
     }

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -128,9 +128,8 @@ pub struct BytecodeMethod<'gc> {
 
     /// Whether or not this method substitutes Undefined for missing arguments.
     ///
-    /// This is true when the method is a free-standing function, none of the
-    /// declared arguments have a type or a default value, and the method does
-    /// not have the NEED_REST flag.
+    /// This is true when the method is a free-standing function and none of the
+    /// declared arguments have a type or a default value.
     pub is_unchecked: bool,
 }
 
@@ -266,10 +265,9 @@ impl<'gc> BytecodeMethod<'gc> {
 
     /// Determine if a given method is unchecked.
     ///
-    /// A method is unchecked if all of the following are true:
+    /// A method is unchecked if both of the following are true:
     ///
     ///  * The method was declared as a free-standing function
-    ///  * The function does not use rest-parameters
     ///  * The function's parameters have no declared types or default values
     pub fn is_unchecked(&self) -> bool {
         self.is_unchecked

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{AllocatorFn, Class, CustomConstructorFn};
 use crate::avm2::error::{argument_error, make_error_1127, reference_error, type_error};
-use crate::avm2::function::exec;
+use crate::avm2::function::{exec, FunctionArgs};
 use crate::avm2::method::Method;
 use crate::avm2::object::function_object::FunctionObject;
 use crate::avm2::object::script_object::ScriptObjectData;
@@ -334,7 +334,7 @@ impl<'gc> ClassObject<'gc> {
             receiver,
             self.superclass_object(),
             Some(self.inner_class_definition()),
-            arguments,
+            FunctionArgs::AsArgSlice { arguments },
             activation,
             self.into(),
         )
@@ -619,7 +619,7 @@ impl<'gc> ClassObject<'gc> {
                 self.into(),
                 self.superclass_object(),
                 Some(self.inner_class_definition()),
-                arguments,
+                FunctionArgs::AsArgSlice { arguments },
                 activation,
                 self.into(),
             )

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -471,7 +471,7 @@ impl<'gc> Script<'gc> {
         let init = unit.load_method(script.init_method, false, activation)?;
 
         // Script initializers cannot have parameters declared
-        if init.signature().len() != 0 {
+        if !init.signature().is_empty() {
             return Err(make_error_1107(activation));
         }
 

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -4,6 +4,7 @@ use super::api_version::ApiVersion;
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
 use crate::avm2::domain::Domain;
+use crate::avm2::error::{make_error_1107, Error};
 use crate::avm2::globals::global_scope;
 use crate::avm2::method::{BytecodeMethod, Method};
 use crate::avm2::object::{Object, ScriptObject, TObject};
@@ -11,9 +12,7 @@ use crate::avm2::scope::ScopeChain;
 use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::value::Value;
 use crate::avm2::vtable::VTable;
-use crate::avm2::Multiname;
-use crate::avm2::Namespace;
-use crate::avm2::{Avm2, Error};
+use crate::avm2::{Avm2, Multiname, Namespace};
 use crate::context::UpdateContext;
 use crate::string::{AvmAtom, AvmString, StringContext};
 use crate::tag_utils::SwfMovie;
@@ -470,6 +469,11 @@ impl<'gc> Script<'gc> {
             .expect("Script index should be valid");
 
         let init = unit.load_method(script.init_method, false, activation)?;
+
+        // Script initializers cannot have parameters declared
+        if init.signature().len() != 0 {
+            return Err(make_error_1107(activation));
+        }
 
         let globals = Script::create_globals_object(unit, script, domain, activation)?;
 

--- a/tests/tests/swfs/from_avmplus/as3/Statements/Exceptions/MultipleCatchBlocks2/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Statements/Exceptions/MultipleCatchBlocks2/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true # https://github.com/ruffle-rs/ruffle/issues/12346

--- a/tests/tests/swfs/from_avmplus/as3/Statements/Exceptions/MultipleCatchBlocksArgument/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Statements/Exceptions/MultipleCatchBlocksArgument/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true # https://github.com/ruffle-rs/ruffle/issues/12346

--- a/tests/tests/swfs/from_avmplus/e4x/XML/e13_4_4_17/test.toml
+++ b/tests/tests/swfs/from_avmplus/e4x/XML/e13_4_4_17/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/e4x/XML/e13_4_4_2/test.toml
+++ b/tests/tests/swfs/from_avmplus/e4x/XML/e13_4_4_2/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
This makes bytecode method calls with `call_method` about 30-40% faster and any other method calls 10-20% faster.

The unchecked function fix closes #12346.