### PR TITLE
web: Add support for RTL context menu

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -282,11 +282,7 @@ export class InnerPlayer {
         this.contextMenuElement.addEventListener("contextmenu", preserveMenu);
         this.contextMenuElement.addEventListener("click", preserveMenu);
 
-        // TODO Add support for RTL context menu.
-        //   It should use the direction of the browser, not the document.
-        //   See <https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language>
-        //   See <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo>
-        this.contextMenuElement.dir = 'ltr';
+        this.contextMenuElement.dir = detectBrowserDirection();
 
         document.documentElement.addEventListener(
             "pointerdown",
@@ -2327,4 +2323,32 @@ function parseAllowScriptAccess(
         default:
             return null;
     }
+}
+
+/**
+ * Detect direction (LTR/RTL) of the preferred language of the browser.
+ *
+ * @returns 'ltr' or 'rtl' depending on the detected direction
+ */
+function detectBrowserDirection(): string {
+    const browserLocale = new Intl.Locale(navigator.language);
+
+    let textInfo = null;
+    if ('getTextInfo' in browserLocale &&
+        typeof browserLocale.getTextInfo === 'function') {
+        textInfo = browserLocale.getTextInfo();
+    } else if ('textInfo' in browserLocale &&
+        typeof browserLocale.textInfo === 'object') {
+        textInfo = browserLocale.textInfo;
+    } else {
+        return 'ltr';
+    }
+
+    if (typeof textInfo === 'object' &&
+        'direction' in textInfo &&
+        typeof textInfo.direction === 'string') {
+        return textInfo.direction || 'ltr';
+    }
+
+    return 'ltr';
 }

--- a/web/packages/selfhosted/test/integration_tests/context_menu_position/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/context_menu_position/test.ts
@@ -10,6 +10,20 @@ async function getViewportWidth(): Promise<number> {
     });
 }
 
+async function setDirection(
+    element: ChainablePromiseElement,
+    direction: string,
+) {
+    await browser.execute(
+        (element, direction) => {
+            const el = element as unknown as HTMLElement;
+            el.dir = direction;
+        },
+        element,
+        direction,
+    );
+}
+
 describe("Context Menu", () => {
     it("load the test", async () => {
         await openTest(browser, "integration_tests/context_menu_position");
@@ -67,7 +81,6 @@ describe("Context Menu", () => {
 
         const menu = await player.$("#context-menu");
         const menuLocation = await menu.getLocation();
-
         expect(menuLocation.x).to.equal(viewportWidth - 500);
         expect(menuLocation.y).to.equal(500);
 
@@ -84,6 +97,54 @@ describe("Context Menu", () => {
         const menu = await player.$("#context-menu");
         const menuLocation = await menu.getLocation();
         expect(menuLocation.x).to.equal(viewportWidth - 650);
+        expect(menuLocation.y).to.equal(650);
+
+        // Dismiss the menu
+        await player.click({ x: -10, y: -10 });
+    });
+
+    it("switch context menu LTR -> RTL", async () => {
+        // Note: normally we should change the preferred user language
+        //   (navigator.language), but that's not easy without creating
+        //   a new browser instance.
+
+        const player = await browser.$("#objectElement");
+        const menu = await player.$("#context-menu");
+        await setDirection(menu, "rtl");
+    });
+
+    it("open RTL context menu in the middle RTL", async () => {
+        const player = await browser.$("#objectElement");
+        const viewportWidth = await getViewportWidth();
+
+        await player.click({ x: 0, y: 0, button: "right" });
+
+        const menu = await player.$("#context-menu");
+        const menuLocation = await menu.getLocation();
+        const menuSize = await menu.getSize();
+        expect(menuLocation.x).to.approximately(
+            viewportWidth - 500 - menuSize.width,
+            0.6,
+        );
+        expect(menuLocation.y).to.equal(500);
+
+        // Dismiss the menu
+        await player.click({ x: -10, y: -10 });
+    });
+
+    it("open RTL context menu in the corner RTL", async () => {
+        const player = await browser.$("#objectElement");
+        const viewportWidth = await getViewportWidth();
+
+        await player.click({ x: -150, y: 150, button: "right" });
+
+        const menu = await player.$("#context-menu");
+        const menuLocation = await menu.getLocation();
+        const menuSize = await menu.getSize();
+        expect(menuLocation.x).to.approximately(
+            viewportWidth - 650 - menuSize.width,
+            0.6,
+        );
         expect(menuLocation.y).to.equal(650);
 
         // Dismiss the menu


### PR DESCRIPTION
This patch adds support for RTL context menu. The context menu will use RTL when the preferred language of the user is RTL.

This patch will work only for browsers supporting `Intl.Locale.getTextInfo`, which sadly does not include Firefox.