### PR TITLE
core: make `swf::Rectangle` `Copy`

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1449,7 +1449,7 @@ fn get_bounds<'gc>(
             // the final matrix, but this matches Flash's behavior.
             let to_global_matrix = movie_clip.local_to_global_matrix();
             let to_target_matrix = target.global_to_local_matrix().unwrap_or_default();
-            let target_bounds = to_target_matrix * to_global_matrix * bounds.clone();
+            let target_bounds = to_target_matrix * to_global_matrix * bounds;
 
             // If the bounds are invalid, the target space is identical to the origin space and
             // use_new_invalid_bounds_value is true, the returned bounds use a specific invalid value.

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -120,7 +120,7 @@ impl DisplayObjectWindow {
     }
 
     pub fn hovered_bounds(&self) -> Option<Rectangle<Twips>> {
-        self.hovered_bounds.clone()
+        self.hovered_bounds
     }
 
     pub fn show<'gc>(

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1721,11 +1721,11 @@ pub trait TDisplayObject<'gc>:
     }
 
     fn scroll_rect(&self) -> Option<Rectangle<Twips>> {
-        self.base().scroll_rect.clone()
+        self.base().scroll_rect
     }
 
     fn next_scroll_rect(&self) -> Rectangle<Twips> {
-        self.base().next_scroll_rect.clone()
+        self.base().next_scroll_rect
     }
 
     fn set_next_scroll_rect(&self, gc_context: &Mutation<'gc>, rectangle: Rectangle<Twips>) {
@@ -1738,7 +1738,7 @@ pub trait TDisplayObject<'gc>:
     }
 
     fn scaling_grid(&self) -> Rectangle<Twips> {
-        self.base().scaling_grid.clone()
+        self.base().scaling_grid
     }
 
     fn set_scaling_grid(&self, gc_context: &Mutation<'gc>, rect: Rectangle<Twips>) {
@@ -2107,9 +2107,7 @@ pub trait TDisplayObject<'gc>:
     fn pre_render(&self, context: &mut RenderContext<'_, 'gc>) {
         let mut this = self.base_mut(context.gc());
         this.clear_invalidate_flag();
-        this.scroll_rect = this
-            .has_scroll_rect()
-            .then(|| this.next_scroll_rect.clone());
+        this.scroll_rect = this.has_scroll_rect().then(|| this.next_scroll_rect);
     }
 
     fn render_self(&self, _context: &mut RenderContext<'_, 'gc>) {}

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -611,7 +611,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
         // usually change on hover (children are swapped out),
         // which would cause the automatic tab order to change during tabbing.
         // That could potentially create a loop in the tab ordering (soft locking the tab).
-        self.local_to_global_matrix() * self.0.cell.borrow().hit_bounds.clone()
+        self.local_to_global_matrix() * self.0.cell.borrow().hit_bounds
     }
 }
 

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -51,7 +51,7 @@ impl<'gc> Graphic<'gc> {
         let library = context.library.library_for_movie(movie.clone()).unwrap();
         let shared = GraphicShared {
             id: swf_shape.id,
-            bounds: swf_shape.shape_bounds.clone(),
+            bounds: swf_shape.shape_bounds,
             render_handle: Some(
                 context
                     .renderer
@@ -140,9 +140,9 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
 
     fn self_bounds(&self) -> Rectangle<Twips> {
         if let Some(drawing) = &self.0.read().drawing {
-            drawing.self_bounds().clone()
+            drawing.self_bounds()
         } else {
-            self.0.read().shared.bounds.clone()
+            self.0.read().shared.bounds
         }
     }
 

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -152,7 +152,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         let ratio = self.0.ratio.get();
         let shared = self.0.shared.get();
         let frame = shared.get_frame(ratio);
-        frame.bounds.clone()
+        frame.bounds
     }
 
     fn hit_test_shape(
@@ -366,8 +366,8 @@ impl MorphShapeShared {
         let shape = swf::Shape {
             version: 4,
             id: 0,
-            shape_bounds: bounds.clone(),
-            edge_bounds: bounds.clone(),
+            shape_bounds: bounds,
+            edge_bounds: bounds,
             flags: swf::ShapeFlag::HAS_SCALING_STROKES,
             styles,
             shape,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2697,9 +2697,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn self_bounds(&self) -> Rectangle<Twips> {
-        self.drawing()
-            .map(|d| d.self_bounds().clone())
-            .unwrap_or_default()
+        self.drawing().map(|d| d.self_bounds()).unwrap_or_default()
     }
 
     fn hit_test_shape(

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -451,7 +451,7 @@ impl<'gc> Stage<'gc> {
     }
 
     pub fn view_bounds(self) -> Rectangle<Twips> {
-        self.0.read().view_bounds.clone()
+        self.0.read().view_bounds
     }
 
     pub fn show_menu(self) -> bool {

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -52,7 +52,7 @@ impl<'gc> Text<'gc> {
                     TextShared {
                         swf,
                         id: tag.id,
-                        bounds: tag.bounds.clone(),
+                        bounds: tag.bounds,
                         text_transform: tag.matrix.into(),
                         text_blocks: tag.records.clone(),
                     },
@@ -194,7 +194,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
     }
 
     fn self_bounds(&self) -> Rectangle<Twips> {
-        self.0.read().shared.bounds.clone()
+        self.0.read().shared.bounds
     }
 
     fn hit_test_shape(

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -51,8 +51,8 @@ impl Drawing {
     pub fn from_swf_shape(shape: &swf::Shape) -> Self {
         let mut this = Self {
             render_handle: RefCell::new(None),
-            shape_bounds: shape.shape_bounds.clone(),
-            edge_bounds: shape.edge_bounds.clone(),
+            shape_bounds: shape.shape_bounds,
+            edge_bounds: shape.edge_bounds,
             dirty: Cell::new(true),
             paths: Vec::new(),
             bitmaps: Vec::new(),
@@ -107,8 +107,8 @@ impl Drawing {
         *self = Drawing {
             render_handle: RefCell::new(None),
             dirty: Cell::new(true),
-            shape_bounds: other.shape_bounds.clone(),
-            edge_bounds: other.edge_bounds.clone(),
+            shape_bounds: other.shape_bounds,
+            edge_bounds: other.edge_bounds,
             paths: other.paths.clone(),
             bitmaps: other.bitmaps.clone(),
             current_fill: other.current_fill.clone(),
@@ -317,8 +317,8 @@ impl Drawing {
             } else {
                 let shape = DistilledShape {
                     paths,
-                    shape_bounds: self.shape_bounds.clone(),
-                    edge_bounds: self.edge_bounds.clone(),
+                    shape_bounds: self.shape_bounds,
+                    edge_bounds: self.edge_bounds,
                     id: 0,
                 };
                 Some(renderer.register_shape(shape, self))
@@ -340,8 +340,8 @@ impl Drawing {
         }
     }
 
-    pub fn self_bounds(&self) -> &Rectangle<Twips> {
-        &self.shape_bounds
+    pub fn self_bounds(&self) -> Rectangle<Twips> {
+        self.shape_bounds
     }
 
     pub fn hit_test(
@@ -470,7 +470,6 @@ fn stretch_bounds(
     stroke_width: Twips,
     from: Point<Twips>,
 ) -> Rectangle<Twips> {
-    let bounds = bounds.clone();
     match *command {
         DrawCommand::MoveTo(point) | DrawCommand::LineTo(point) => {
             let radius = stroke_width / 2;

--- a/render/src/shape_utils.rs
+++ b/render/src/shape_utils.rs
@@ -109,8 +109,8 @@ impl<'a> From<&'a swf::Shape> for DistilledShape<'a> {
     fn from(shape: &'a Shape) -> Self {
         Self {
             paths: ShapeConverter::from_shape(shape).into_commands(),
-            shape_bounds: shape.shape_bounds.clone(),
-            edge_bounds: shape.edge_bounds.clone(),
+            shape_bounds: shape.shape_bounds,
+            edge_bounds: shape.edge_bounds,
             id: shape.id,
         }
     }
@@ -1179,13 +1179,12 @@ pub fn swf_glyph_to_shape(glyph: &swf::Glyph) -> swf::Shape {
     // SVG.
     let bounds = glyph
         .bounds
-        .clone()
         .filter(|b| b.x_min != b.x_max || b.y_min != b.y_max)
         .unwrap_or_else(|| calculate_shape_bounds(&glyph.shape_records));
     swf::Shape {
         version: 2,
         id: 0,
-        shape_bounds: bounds.clone(),
+        shape_bounds: bounds,
         edge_bounds: bounds,
         flags: swf::ShapeFlag::HAS_SCALING_STROKES | swf::ShapeFlag::NON_ZERO_WINDING_RULE,
         styles: swf::ShapeStyles {
@@ -1340,7 +1339,7 @@ mod tests {
         swf::Shape {
             version: 2,
             id: 1,
-            shape_bounds: bounds.clone(),
+            shape_bounds: bounds,
             edge_bounds: bounds,
             flags: swf::ShapeFlag::HAS_SCALING_STROKES,
             styles: swf::ShapeStyles {

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -1241,8 +1241,8 @@ impl<'a> Reader<'a> {
             end_edge_bounds = self.read_rectangle()?;
             flags = DefineMorphShapeFlag::from_bits_truncate(self.read_u8()?);
         } else {
-            start_edge_bounds = start_shape_bounds.clone();
-            end_edge_bounds = end_shape_bounds.clone();
+            start_edge_bounds = start_shape_bounds;
+            end_edge_bounds = end_shape_bounds;
             flags = DefineMorphShapeFlag::HAS_NON_SCALING_STROKES;
         }
 
@@ -1488,7 +1488,7 @@ impl<'a> Reader<'a> {
             edge_bounds = self.read_rectangle()?;
             flags = ShapeFlag::from_bits_truncate(self.read_u8()?);
         } else {
-            edge_bounds = shape_bounds.clone();
+            edge_bounds = shape_bounds;
             flags = ShapeFlag::HAS_NON_SCALING_STROKES;
         }
 

--- a/swf/src/types/rectangle.rs
+++ b/swf/src/types/rectangle.rs
@@ -10,7 +10,7 @@ impl Coordinate for Twips {
 }
 
 /// A rectangular region defined by minimum and maximum x- and y-coordinate positions.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Rectangle<T> {
     /// The minimum x-position of the rectangle.
     pub x_min: T,
@@ -49,6 +49,13 @@ impl<T: PointCoordinate + Ord> Rectangle<T> {
 
     #[inline]
     #[must_use]
+    pub fn with_width(mut self, width: T) -> Self {
+        self.set_width(width);
+        self
+    }
+
+    #[inline]
+    #[must_use]
     pub fn height(&self) -> T {
         self.y_max - self.y_min
     }
@@ -56,6 +63,12 @@ impl<T: PointCoordinate + Ord> Rectangle<T> {
     #[inline]
     pub fn set_height(&mut self, height: T) {
         self.y_max = self.y_min + height;
+    }
+    #[inline]
+    #[must_use]
+    pub fn with_height(mut self, height: T) -> Self {
+        self.set_height(height);
+        self
     }
 
     #[must_use]
@@ -120,7 +133,7 @@ impl<T: Coordinate> Rectangle<T> {
     #[must_use]
     pub fn union(mut self, other: &Self) -> Self {
         if !self.is_valid() {
-            other.clone()
+            *other
         } else {
             if other.is_valid() {
                 self.x_min = self.x_min.min(other.x_min);


### PR DESCRIPTION
`Rectangle<Twips>` is cheap to copy, being only 16 bytes, so requiring an explicit `.clone()` call is unnecessary ceremony.

Has the nice side-effect of replacing some `RefCell`s by `Cell`s.