### PR TITLE
web: Check if custom Map is defined as fluent loop is iterating

### DIFF
--- a/web/packages/core/src/internal/i18n.ts
+++ b/web/packages/core/src/internal/i18n.ts
@@ -21,9 +21,10 @@ const bundles: Record<string, FluentBundle> = {};
 for (const [locale, files] of Object.entries(BUNDLED_TEXTS)) {
     const bundle = new FluentBundle(locale);
     if (files) {
-        const customMap = resetCustomMap();
+        let customMap: typeof Map | undefined = undefined;
         for (const [filename, text] of Object.entries(files)) {
             if (text) {
+                customMap ??= resetCustomMap();
                 for (const error of bundle.addResource(
                     new FluentResource(text),
                 )) {


### PR DESCRIPTION
While the custom Map is only defined once, it seems to fairly frequently be defined while this loop is running. See also https://github.com/ruffle-rs/ruffle/pull/19939#discussion_r2021244480.