### PR TITLE
avm1: migrate `StageObject` to `NativeObject`

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -32,7 +32,6 @@ pub use globals::array::ArrayBuilder;
 pub use globals::context_menu::make_context_menu_state;
 pub use globals::sound::start as start_sound;
 pub use object::script_object::ScriptObject;
-pub use object::stage_object::StageObject;
 pub use object::{NativeObject, Object, ObjectPtr, TObject};
 pub use property::Attribute;
 pub use property_map::PropertyMap;

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1157,7 +1157,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 .avm1
                 .display_properties()
                 .get_by_index(prop_index as usize)
-                .copied()
         };
 
         let result = if let Some(clip) = clip {
@@ -1917,7 +1916,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .avm1
             .display_properties()
             .get_by_index(prop_index as usize)
-            .copied()
         {
             if clip.is_none() || property.is_read_only() {
                 // `prop_value` must be coerced even if the target is invalid or the property is read-only.

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -582,7 +582,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     }
 
     fn stack_push(&mut self, mut value: Value<'gc>) {
-        if let Value::Object(Object::StageObject(s)) = value {
+        if let Value::Object(obj) = value {
             // Note that there currently exists a subtle issue with this logic:
             // If the cached `Object` in a `MovieClipReference` becomes invalidated, causing it to switch back to path-based object resolution,
             // it should *never* switch back to cache-based resolution
@@ -591,7 +591,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             // Fixing this will require a thorough refactor of AVM1 to store `Either<MovieClipReference, Object>
             // can refer to a MovieClip
             // There is a ignored test for this issue of "reference laundering" at "avm1/string_paths_reference_launder"
-            if let Some(mcr) = MovieClipReference::try_from_stage_object(self, s) {
+            if let Some(mcr) = MovieClipReference::try_from_stage_object(self, obj) {
                 value = Value::MovieClip(mcr);
             }
         }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -540,14 +540,10 @@ pub fn set_selectable<'gc>(
 
 fn variable<'gc>(
     this: EditText<'gc>,
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(variable) = this.variable() {
-        return Ok(AvmString::new_utf8(activation.gc(), &variable[..]).into());
-    }
-
     // Unset `variable` returns null, not undefined
-    Ok(Value::Null)
+    Ok(this.variable().map(Value::from).unwrap_or(Value::Null))
 }
 
 fn set_variable<'gc>(
@@ -559,7 +555,7 @@ fn set_variable<'gc>(
         Value::Undefined | Value::Null => None,
         v => Some(v.coerce_to_string(activation)?),
     };
-    this.set_variable(variable.map(|v| v.to_string()), activation);
+    this.set_variable(variable, activation);
     Ok(())
 }
 

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -24,10 +24,7 @@ impl<'gc> TransformObject<'gc> {
         let clip = match args {
             // `Transform` constructor accepts exactly 1 argument.
             [Value::MovieClip(clip)] => Some(*clip),
-            [Value::Object(clip)] => {
-                let stage_object = clip.as_stage_object()?;
-                MovieClipReference::try_from_stage_object(activation, stage_object)
-            }
+            [Value::Object(clip)] => MovieClipReference::try_from_stage_object(activation, *clip),
             _ => return None,
         };
         Some(Self { clip })

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -1,8 +1,7 @@
 use crate::avm1::function::ExecutionReason;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::globals::{as_broadcaster, create_globals};
-use crate::avm1::object::stage_object;
-use crate::avm1::object::TObject;
+use crate::avm1::object::{stage_object, TObject};
 use crate::avm1::property_map::PropertyMap;
 use crate::avm1::scope::Scope;
 use crate::avm1::{scope, Activation, ActivationIdentifier, Error, Object, Value};

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -1,4 +1,6 @@
-use crate::avm1::{Activation, ActivationIdentifier, Object, StageObject, TObject, Value};
+use crate::avm1::{
+    Activation, ActivationIdentifier, NativeObject, Object, ScriptObject, TObject, Value,
+};
 use crate::backend::audio::AudioManager;
 use crate::backend::ui::MouseCursor;
 use crate::context::{ActionType, RenderContext, UpdateContext};
@@ -283,10 +285,10 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         }
 
         if self.0.object.get().is_none() {
-            let object = StageObject::for_display_object(
+            let object = ScriptObject::new_with_native(
                 &context.strings,
-                (*self).into(),
-                context.avm1.prototypes().button,
+                Some(context.avm1.prototypes().button),
+                NativeObject::Button(*self),
             );
             let obj = unlock!(Gc::write(context.gc(), self.0), Avm1ButtonData, object);
             obj.set(Some(object.into()));

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1,12 +1,9 @@
 //! `EditText` display object and support code.
 
-use crate::avm1::Avm1;
-use crate::avm1::ExecutionReason;
-use crate::avm1::NativeObject as Avm1NativeObject;
-use crate::avm1::{Activation as Avm1Activation, ActivationIdentifier};
 use crate::avm1::{
-    Object as Avm1Object, StageObject as Avm1StageObject, TObject as Avm1TObject,
-    Value as Avm1Value,
+    Activation as Avm1Activation, ActivationIdentifier, Avm1, ExecutionReason,
+    NativeObject as Avm1NativeObject, Object as Avm1Object, ScriptObject as Avm1ScriptObject,
+    TObject as Avm1TObject, Value as Avm1Value,
 };
 use crate::avm2::object::{
     ClassObject as Avm2ClassObject, EventObject as Avm2EventObject, Object as Avm2Object,
@@ -2164,14 +2161,13 @@ impl<'gc> EditText<'gc> {
     fn construct_as_avm1_object(self, context: &mut UpdateContext<'gc>, run_frame: bool) {
         let mut text = self.0.write(context.gc());
         if text.object.is_none() {
-            let object: Avm1Object<'gc> = Avm1StageObject::for_display_object(
+            let object = Avm1ScriptObject::new_with_native(
                 &context.strings,
-                self.into(),
-                context.avm1.prototypes().text_field,
-            )
-            .into();
+                Some(context.avm1.prototypes().text_field),
+                Avm1NativeObject::EditText(self),
+            );
 
-            text.object = Some(object.into());
+            text.object = Some(Avm1Object::from(object).into());
         }
         drop(text);
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1,5 +1,8 @@
 //! `MovieClip` display object and support code.
-use crate::avm1::{Object as Avm1Object, StageObject, TObject as Avm1TObject, Value as Avm1Value};
+use crate::avm1::{
+    NativeObject as Avm1NativeObject, Object as Avm1Object, ScriptObject as Avm1ScriptObject,
+    TObject as Avm1TObject, Value as Avm1Value,
+};
 use crate::avm2::object::LoaderInfoObject;
 use crate::avm2::object::LoaderStream;
 use crate::avm2::script::Script;
@@ -2008,12 +2011,11 @@ impl<'gc> MovieClip<'gc> {
                     .get(istr!("prototype"), &mut activation)
                     .map(|v| v.coerce_to_object(&mut activation))
                 {
-                    let object: Avm1Object<'gc> = StageObject::for_display_object(
-                        activation.strings(),
-                        self.into(),
-                        prototype,
-                    )
-                    .into();
+                    let object = Avm1Object::from(Avm1ScriptObject::new_with_native(
+                        &activation.context.strings,
+                        Some(prototype),
+                        Avm1NativeObject::MovieClip(self),
+                    ));
                     self.0.write(activation.gc()).object = Some(object.into());
 
                     if run_frame {
@@ -2039,12 +2041,11 @@ impl<'gc> MovieClip<'gc> {
                 return;
             }
 
-            let object: Avm1Object<'gc> = StageObject::for_display_object(
+            let object = Avm1Object::from(Avm1ScriptObject::new_with_native(
                 &context.strings,
-                self.into(),
-                context.avm1.prototypes().movie_clip,
-            )
-            .into();
+                Some(context.avm1.prototypes().movie_clip),
+                Avm1NativeObject::MovieClip(self),
+            ));
             self.0.write(context.gc()).object = Some(object.into());
 
             if run_frame {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2858,11 +2858,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
 
         // Unregister any text field variable bindings.
-        if let Avm1Value::Object(object) = self.object() {
-            if let Some(stage_object) = object.as_stage_object() {
-                stage_object.unregister_text_field_bindings(context);
-            }
-        }
+        Avm1TextFieldBinding::unregister_bindings((*self).into(), context);
 
         self.drop_focus(context);
 

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -1,6 +1,9 @@
 //! Video player display object
 
-use crate::avm1::{Object as Avm1Object, StageObject as Avm1StageObject, Value as Avm1Value};
+use crate::avm1::{
+    NativeObject as Avm1NativeObject, Object as Avm1Object, ScriptObject as Avm1ScriptObject,
+    Value as Avm1Value,
+};
 use crate::avm2::{
     Activation as Avm2Activation, Object as Avm2Object, StageObject as Avm2StageObject,
     Value as Avm2Value,
@@ -448,12 +451,11 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         write.keyframes = keyframes;
 
         if write.object.is_none() && !movie.is_action_script_3() {
-            let object: Avm1Object<'_> = Avm1StageObject::for_display_object(
+            let object = Avm1Object::from(Avm1ScriptObject::new_with_native(
                 &context.strings,
-                (*self).into(),
-                context.avm1.prototypes().video,
-            )
-            .into();
+                Some(context.avm1.prototypes().video),
+                Avm1NativeObject::Video(*self),
+            ));
             write.object = Some(object.into());
         }
 

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -104,13 +104,10 @@ impl<'gc> Timers<'gc> {
                     let mut removed = false;
 
                     // We can't use as_display_object + as_movie_clip here as we explicitly don't want to convert `SuperObjects`
-                    if let Avm1Object::StageObject(s) = this {
-                        let d_o = s.as_display_object().unwrap();
-                        if let DisplayObject::MovieClip(mc) = d_o {
-                            // Note that we don't want to fire the timer here
-                            if mc.avm1_removed() {
-                                removed = true;
-                            }
+                    if let Some(DisplayObject::MovieClip(mc)) = this.as_display_object_no_super() {
+                        // Note that we don't want to fire the timer here
+                        if mc.avm1_removed() {
+                            removed = true;
                         }
                     }
 


### PR DESCRIPTION
The display objects (`Avm1Button`, `EditText`, `MovieClip`, `Video`) are directly stored as `NativeObject` variants of their `ScriptObject`s, and the `StageObject`-specific data (namely, the AVM1 text field binding list) is moved directly inside the DO structs.

After this, only `SuperObject` will be left as a `Object` variant.