### PR TITLE
web: Improve navigator.plugins and navigator.mimeTypes so they can be used with JSON.stringify

### DIFF
--- a/web/packages/selfhosted/test/polyfill/spoofing/test.ts
+++ b/web/packages/selfhosted/test/polyfill/spoofing/test.ts
@@ -62,4 +62,20 @@ describe("Spoofing is not easily detectable", () => {
         });
         expect(instance).be.true;
     });
+
+    it("Spoof of navigator.plugins works with JSON.stringify", async () => {
+        const json = await browser.execute(() => {
+            return JSON.stringify(navigator.plugins);
+        });
+        expect(json).to.equal(
+            '{"0":{"0":{},"1":{}},"1":{"0":{},"1":{}},"2":{"0":{},"1":{}},"3":{"0":{},"1":{}},"4":{"0":{},"1":{}},"5":{"0":{},"1":{},"2":{},"3":{}}}',
+        );
+    });
+
+    it("Spoof of navigator.mimeTypes works with JSON.stringify", async () => {
+        const json = await browser.execute(() => {
+            return JSON.stringify(navigator.mimeTypes);
+        });
+        expect(json).to.equal('{"0":{},"1":{},"2":{},"3":{},"4":{},"5":{}}');
+    });
 });


### PR DESCRIPTION
To make JSON.stringify work with `navigator.plugins` and `navigator.mimeTypes` we have to make sure all _enumerable_ properties are non-cyclic.

It seems like in a normal browser e.g. `navigator.mimeTypes["application/pdf"]` (all names) and `navigator.plugins["PDF Viewer"]` are not enumerable. So I switched to using `Object.defineProperty` for those.

To hide our internal private variables I switched those to [ECMAScript Private Fields](https://www.typescriptlang.org/docs/handbook/classes.html#ecmascript-private-fields). This also prevents them from being enumerated of course.

`RufflePlugin` didn't use getters so I fixed this as well for consistency with the browser `Plugin` type.

Fixes #19957