### PR TITLE
web: Bump webpack to 5.99.5

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -41,7 +41,7 @@
                 "typescript": "^5.8.3",
                 "typescript-eslint": "^8.29.1",
                 "webdriverio": "^9.2.2",
-                "webpack": "^5.99.0",
+                "webpack": "^5.99.5",
                 "webpack-cli": "^6.0.1"
             }
         },
@@ -14939,9 +14939,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.99.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.0.tgz",
-            "integrity": "sha512-//MpHjkKV7dhKheJ1lJuHkR6tv8ycfYy7YVzVhhIpwKuKCu5/Zty/vGpFi0fV2RRAWTYDuj6oKn4vYyLzRh55g==",
+            "version": "5.99.5",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.5.tgz",
+            "integrity": "sha512-q+vHBa6H9qwBLUlHL4Y7L0L1/LlyBKZtS9FHNCQmtayxjI5RKC9yD8gpvLeqGv5lCQp1Re04yi0MF40pf30Pvg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15862,7 +15862,7 @@
                 "@types/chai-html": "^3.0.0",
                 "json5": "^2.2.3",
                 "ts-node": "^10.9.2",
-                "webpack": "^5.99.0",
+                "webpack": "^5.99.5",
                 "webpack-cli": "^6.0.1",
                 "webpack-dev-server": "^5.2.1"
             }

--- a/web/package.json
+++ b/web/package.json
@@ -38,7 +38,7 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.29.1",
         "webdriverio": "^9.2.2",
-        "webpack": "^5.99.0",
+        "webpack": "^5.99.5",
         "webpack-cli": "^6.0.1"
     },
     "scripts": {

--- a/web/packages/selfhosted/package.json
+++ b/web/packages/selfhosted/package.json
@@ -22,12 +22,12 @@
         "ruffle-core": "^0.1.0"
     },
     "devDependencies": {
-        "json5": "^2.2.3",
-        "webpack": "^5.99.0",
-        "webpack-cli": "^6.0.1",
-        "webpack-dev-server": "^5.2.1",
-        "ts-node": "^10.9.2",
         "@types/chai": "^5.2.1",
-        "@types/chai-html": "^3.0.0"
+        "@types/chai-html": "^3.0.0",
+        "json5": "^2.2.3",
+        "ts-node": "^10.9.2",
+        "webpack": "^5.99.5",
+        "webpack-cli": "^6.0.1",
+        "webpack-dev-server": "^5.2.1"
     }
 }


### PR DESCRIPTION
5.99.0 has regressions: https://github.com/webpack/webpack/issues/19394

Unsure if it's causing issues for us, but figured an upgrade cannot hurt. Perhaps relates to #20045, but no actual idea nor any idea how to test that.