### PR TITLE
ci: Build dual-wasm for selfhosted/demo/docs

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -520,7 +520,7 @@ jobs:
           WASM_SOURCE: cargo_and_store
         working-directory: web
         shell: bash -l {0}
-        run: npm run build:repro
+        run: npm run build:dual-wasm-repro
 
       - name: Build web docs
         working-directory: web


### PR DESCRIPTION
#19767 was not meant to affect this.

May be unrelated to https://github.com/ruffle-rs/ruffle/actions/runs/14392606559/job/40362550974#step:11:49 so we should look into that too.