### PR TITLE
web: Migrate WASM initialization to use module_or_path parameter

### DIFF
--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -111,7 +111,7 @@ async function fetchRuffle(
         response = wasmResponse;
     }
 
-    await init(response);
+    await init({ module_or_path: response });
 
     return [RuffleInstanceBuilder, ZipWriter];
 }


### PR DESCRIPTION
The legacy WASM initialization API now triggers a console warning:
```text
"using deprecated parameters for the initialization function; pass a single object instead"
```
So migrate to the new one
```js
// Before (deprecated):
wasm_bindgen(your_array_buffer); 

// After (recommended):
wasm_bindgen({ module_or_path: your_array_buffer });
```