### PR TITLE
swf: Add and use `[read|write]_ubits_ct` for compile-time known width fields

### DIFF
--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -147,6 +147,18 @@ impl<W: Write> BitWriter<W> {
         self.bits.write_bit(bit)
     }
 
+    /// A variant of `write_ubits` for when the number of bits to write is
+    /// a *c*ompile-*t*ime constant. This should be more efficient.
+    #[inline]
+    fn write_ubits_ct<const NUM_BITS: u32>(&mut self, n: u32) -> io::Result<()> {
+        if NUM_BITS > 0 {
+            self.bits.write::<NUM_BITS, u32>(n)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// If `num_bits` is a compile-time constant, consider `write_ubits_ct` instead.
     #[inline]
     fn write_ubits(&mut self, num_bits: u32, n: u32) -> io::Result<()> {
         if num_bits > 0 {
@@ -307,7 +319,7 @@ impl<W: Write> Writer<W> {
         .max()
         .unwrap();
         let mut bits = self.bits();
-        bits.write_ubits(5, num_bits)?;
+        bits.write_ubits_ct::<5>(num_bits)?;
         bits.write_sbits_twips(num_bits, rectangle.x_min)?;
         bits.write_sbits_twips(num_bits, rectangle.x_max)?;
         bits.write_sbits_twips(num_bits, rectangle.y_min)?;
@@ -371,7 +383,7 @@ impl<W: Write> Writer<W> {
                 add.iter().map(|n| count_sbits((*n).into())).max().unwrap(),
             );
         }
-        bits.write_ubits(4, num_bits)?;
+        bits.write_ubits_ct::<4>(num_bits)?;
         if has_mult {
             bits.write_sbits_fixed8(num_bits, color_transform.r_multiply)?;
             bits.write_sbits_fixed8(num_bits, color_transform.g_multiply)?;
@@ -424,7 +436,7 @@ impl<W: Write> Writer<W> {
                 add.iter().map(|n| count_sbits((*n).into())).max().unwrap(),
             );
         }
-        bits.write_ubits(4, num_bits)?;
+        bits.write_ubits_ct::<4>(num_bits)?;
         if has_mult {
             bits.write_sbits_fixed8(num_bits, color_transform.r_multiply)?;
             bits.write_sbits_fixed8(num_bits, color_transform.g_multiply)?;
@@ -447,7 +459,7 @@ impl<W: Write> Writer<W> {
         bits.write_bit(has_scale)?;
         if has_scale {
             let num_bits = max(count_fbits(m.a), count_fbits(m.d));
-            bits.write_ubits(5, num_bits)?;
+            bits.write_ubits_ct::<5>(num_bits)?;
             bits.write_fbits(num_bits, m.a)?;
             bits.write_fbits(num_bits, m.d)?;
         }
@@ -456,13 +468,13 @@ impl<W: Write> Writer<W> {
         bits.write_bit(has_rotate_skew)?;
         if has_rotate_skew {
             let num_bits = max(count_fbits(m.b), count_fbits(m.c));
-            bits.write_ubits(5, num_bits)?;
+            bits.write_ubits_ct::<5>(num_bits)?;
             bits.write_fbits(num_bits, m.b)?;
             bits.write_fbits(num_bits, m.c)?;
         }
         // Translate (always written)
         let num_bits = max(count_sbits_twips(m.tx), count_sbits_twips(m.ty));
-        bits.write_ubits(5, num_bits)?;
+        bits.write_ubits_ct::<5>(num_bits)?;
         bits.write_sbits_twips(num_bits, m.tx)?;
         bits.write_sbits_twips(num_bits, m.ty)?;
         Ok(())
@@ -639,7 +651,7 @@ impl<W: Write> Writer<W> {
                             Self::write_shape_record(shape_record, &mut bits, &mut shape_context)?;
                         }
                         // End shape record.
-                        bits.write_ubits(6, 0)?;
+                        bits.write_ubits_ct::<6>(0)?;
                     }
                 }
 
@@ -1063,7 +1075,7 @@ impl<W: Write> Writer<W> {
                 Self::write_shape_record(shape_record, &mut bits, &mut shape_context)?;
             }
             // End shape record.
-            bits.write_ubits(6, 0)?;
+            bits.write_ubits_ct::<6>(0)?;
         }
 
         let mut buf = Vec::new();
@@ -1096,7 +1108,7 @@ impl<W: Write> Writer<W> {
                 Self::write_shape_record(shape_record, &mut bits, &mut shape_context)?;
             }
             // End shape record.
-            bits.write_ubits(6, 0)?;
+            bits.write_ubits_ct::<6>(0)?;
         }
 
         let tag_code = if data.version == 1 {
@@ -1305,7 +1317,7 @@ impl<W: Write> Writer<W> {
                 Self::write_shape_record(shape_record, &mut bits, &mut shape_context)?;
             }
             // End shape record.
-            bits.write_ubits(6, 0)?;
+            bits.write_ubits_ct::<6>(0)?;
         }
 
         let tag_code = match shape.version {
@@ -1426,13 +1438,13 @@ impl<W: Write> Writer<W> {
     ) -> Result<()> {
         match record {
             ShapeRecord::StraightEdge { delta } => {
-                bits.write_ubits(2, 0b11)?; // Straight edge
-                                            // TODO: Check underflow?
+                bits.write_ubits_ct::<2>(0b11)?; // Straight edge
+                                                 // TODO: Check underflow?
                 let num_bits = count_sbits_twips(delta.dx)
                     .max(count_sbits_twips(delta.dy))
                     .max(2);
                 let is_axis_aligned = delta.dx == Twips::ZERO || delta.dy == Twips::ZERO;
-                bits.write_ubits(4, num_bits - 2)?;
+                bits.write_ubits_ct::<4>(num_bits - 2)?;
                 bits.write_bit(!is_axis_aligned)?;
                 let is_vertical = is_axis_aligned && delta.dx == Twips::ZERO;
                 if is_axis_aligned {
@@ -1449,13 +1461,13 @@ impl<W: Write> Writer<W> {
                 control_delta,
                 anchor_delta,
             } => {
-                bits.write_ubits(2, 0b10)?; // Curved edge
+                bits.write_ubits_ct::<2>(0b10)?; // Curved edge
                 let num_bits = count_sbits_twips(control_delta.dx)
                     .max(count_sbits_twips(control_delta.dy))
                     .max(count_sbits_twips(anchor_delta.dx))
                     .max(count_sbits_twips(anchor_delta.dy))
                     .max(2);
-                bits.write_ubits(4, num_bits - 2)?;
+                bits.write_ubits_ct::<4>(num_bits - 2)?;
                 bits.write_sbits_twips(num_bits, control_delta.dx)?;
                 bits.write_sbits_twips(num_bits, control_delta.dy)?;
                 bits.write_sbits_twips(num_bits, anchor_delta.dx)?;
@@ -1483,10 +1495,10 @@ impl<W: Write> Writer<W> {
                     ShapeRecordFlag::NEW_STYLES,
                     style_change.new_styles.is_some(),
                 );
-                bits.write_ubits(5, flags.bits().into())?;
+                bits.write_ubits_ct::<5>(flags.bits().into())?;
                 if let Some(move_to) = &style_change.move_to {
                     let num_bits = count_sbits_twips(move_to.x).max(count_sbits_twips(move_to.y));
-                    bits.write_ubits(5, num_bits)?;
+                    bits.write_ubits_ct::<5>(num_bits)?;
                     bits.write_sbits_twips(num_bits, move_to.x)?;
                     bits.write_sbits_twips(num_bits, move_to.y)?;
                 }
@@ -1965,17 +1977,14 @@ impl<W: Write> Writer<W> {
 
     fn write_sound_format(&mut self, sound_format: &SoundFormat) -> Result<()> {
         let mut bits = self.bits();
-        bits.write_ubits(4, sound_format.compression as u32)?;
-        bits.write_ubits(
-            2,
-            match sound_format.sample_rate {
-                5512 => 0,
-                11025 => 1,
-                22050 => 2,
-                44100 => 3,
-                _ => return Err(Error::invalid_data("Invalid sample rate.")),
-            },
-        )?;
+        bits.write_ubits_ct::<4>(sound_format.compression as u32)?;
+        bits.write_ubits_ct::<2>(match sound_format.sample_rate {
+            5512 => 0,
+            11025 => 1,
+            22050 => 2,
+            44100 => 3,
+            _ => return Err(Error::invalid_data("Invalid sample rate.")),
+        })?;
         bits.write_bit(sound_format.is_16_bit)?;
         bits.write_bit(sound_format.is_stereo)?;
         Ok(())
@@ -2058,7 +2067,7 @@ impl<W: Write> Writer<W> {
                         Self::write_shape_record(shape_record, &mut bits, &mut shape_context)?;
                     }
                     // End shape record.
-                    bits.write_ubits(6, 0)?;
+                    bits.write_ubits_ct::<6>(0)?;
                 }
             }
 
@@ -2529,6 +2538,21 @@ mod tests {
             let mut bits = writer.bits();
             for b in &out_bits {
                 bits.write_bit(*b).unwrap();
+            }
+        }
+        assert_eq!(buf, [0b01010101, 0b00100101]);
+    }
+
+    #[test]
+    fn write_ubits_ct() {
+        const NUM_BITS: u32 = 2;
+        let nums = [1, 1, 1, 1, 0, 2, 1, 1];
+        let mut buf = Vec::new();
+        {
+            let mut writer = Writer::new(&mut buf, 1);
+            let mut bits = writer.bits();
+            for n in &nums {
+                bits.write_ubits_ct::<NUM_BITS>(*n).unwrap();
             }
         }
         assert_eq!(buf, [0b01010101, 0b00100101]);


### PR DESCRIPTION
This builds on https://github.com/ruffle-rs/ruffle/pull/20044.

Instead of renaming the methods with runtime width parameters to have the `_var` prefix, like `bitstream-io` did, I opted to add a compile-time parameter variant to read simple integers, because we also have `Fixed8` and `Twips` reader/writer methods, and it would have been too much churn to rename those too, for the sake of consistency.

Other suffix ideas to bikeshed:  `_fixed` (but it colludes with `fixed8`), `_cw` for "constant width", etc...

The `sbits` variants didn't seem to ever be used with literal constant bit widths.