### PR TITLE
debug_ui: More frame list related improvements

### DIFF
--- a/core/src/debug_ui.rs
+++ b/core/src/debug_ui.rs
@@ -16,6 +16,7 @@ use crate::debug_ui::handle::{
 };
 use crate::debug_ui::movie::{MovieListWindow, MovieWindow};
 use crate::display_object::TDisplayObject;
+use crate::prelude::DisplayObject;
 use crate::tag_utils::SwfMovie;
 use gc_arena::DynamicRootSet;
 use hashbrown::HashMap;
@@ -51,6 +52,7 @@ pub enum Message {
     ShowDomains,
     SaveFile(ItemToSave),
     SearchForDisplayObject,
+    TrackRootMovieClip,
 }
 
 impl DebugUi {
@@ -132,6 +134,15 @@ impl DebugUi {
                 }
                 Message::SearchForDisplayObject => {
                     self.display_object_search = Some(Default::default());
+                }
+                Message::TrackRootMovieClip => {
+                    // Convenience action to quickly access the root movie clip
+                    if let Some(obj @ DisplayObject::MovieClip(_)) = context.stage.root_clip() {
+                        let win =
+                            DisplayObjectWindow::with_panel(display_object::Panel::TypeSpecific);
+                        self.display_objects
+                            .insert(DisplayObjectHandle::new(context, obj), win);
+                    }
                 }
             }
         }

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -59,7 +59,7 @@ const ALL_BLEND_MODES: [ExtendedBlendMode; 15] = [
 ];
 
 #[derive(Debug, Eq, PartialEq, Hash, Default, Copy, Clone)]
-enum Panel {
+pub enum Panel {
     #[default]
     Position,
     Display,
@@ -106,6 +106,12 @@ impl Default for DisplayObjectWindow {
 }
 
 impl DisplayObjectWindow {
+    pub fn with_panel(panel: Panel) -> Self {
+        Self {
+            open_panel: panel,
+            ..Default::default()
+        }
+    }
     pub fn debug_rect_color(&self) -> Option<Color> {
         if self.debug_rect_visible {
             Some(Color {

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -833,10 +833,14 @@ impl DisplayObjectWindow {
                     row.col(|ui| {
                         ui.menu_button("Scene", |ui| {
                             egui::ScrollArea::vertical().show(ui, |ui| {
-                                for scene in &scenes {
-                                    if ui.button(scene.name.to_string()).clicked() {
-                                        ui.close_menu();
-                                        self.scroll_to_frame = Some(usize::from(scene.start));
+                                if scenes.is_empty() {
+                                    ui.label("<no scenes>");
+                                } else {
+                                    for scene in &scenes {
+                                        if ui.button(scene.name.to_string()).clicked() {
+                                            ui.close_menu();
+                                            self.scroll_to_frame = Some(usize::from(scene.start));
+                                        }
                                     }
                                 }
                             });
@@ -845,10 +849,15 @@ impl DisplayObjectWindow {
                     row.col(|ui| {
                         ui.menu_button("Label", |ui| {
                             egui::ScrollArea::vertical().show(ui, |ui| {
-                                for (name, frame) in object.labels_in_range(0, u16::MAX) {
-                                    if ui.button(name.to_string()).clicked() {
-                                        ui.close_menu();
-                                        self.scroll_to_frame = Some(usize::from(frame));
+                                let labels = object.labels_in_range(0, u16::MAX);
+                                if labels.is_empty() {
+                                    ui.label("<no labels>");
+                                } else {
+                                    for (name, frame) in labels {
+                                        if ui.button(name.to_string()).clicked() {
+                                            ui.close_menu();
+                                            self.scroll_to_frame = Some(usize::from(frame));
+                                        }
                                     }
                                 }
                             });

--- a/desktop/assets/texts/en-US/main_menu.ftl
+++ b/desktop/assets/texts/en-US/main_menu.ftl
@@ -36,6 +36,7 @@ bookmarks-menu-manage = Manage Bookmarks...
 
 debug-menu = Debug Tools
 debug-menu-open-stage = View Stage Info
+debug-menu-open-root-movie-clip = View Root MovieClip
 debug-menu-open-movie = View Movie
 debug-menu-open-movie-list = Show Known Movies
 debug-menu-open-domain-list = Show Domains

--- a/desktop/src/gui/menu_bar.rs
+++ b/desktop/src/gui/menu_bar.rs
@@ -5,6 +5,7 @@ use crate::player::LaunchOptions;
 use crate::preferences::GlobalPreferences;
 use egui::{menu, Button, Key, KeyboardShortcut, Modifiers, Widget};
 use ruffle_core::config::Letterbox;
+use ruffle_core::focus_tracker::DisplayObject;
 use ruffle_core::{Player, StageScaleMode};
 use ruffle_frontend_utils::recents::Recent;
 use ruffle_render::quality::StageQuality;
@@ -133,6 +134,17 @@ impl MenuBar {
                             ui.close_menu();
                             if let Some(player) = &mut player {
                                 player.debug_ui().queue_message(DebugMessage::TrackStage);
+                            }
+                        }
+                        if let Some(player) = &mut player {
+                            let mut has_root_movie_clip = false;
+                            player.mutate_with_update_context(|ctx| {
+                                has_root_movie_clip = matches!(ctx.stage.root_clip(), Some(DisplayObject::MovieClip(_)));
+                            });
+                            let button = Button::new(text(locale, "debug-menu-open-root-movie-clip"));
+                            if ui.add_enabled(has_root_movie_clip, button).clicked() {
+                                ui.close_menu();
+                                player.debug_ui().queue_message(DebugMessage::TrackRootMovieClip);
                             }
                         }
                         if Button::new(text(locale, "debug-menu-open-movie")).ui(ui).clicked() {


### PR DESCRIPTION
- Add scene and label selection menu buttons to the table header
- Add a top menu action to quickly open the root `MovieClip`, if it exists
  This provides quick access the "main" frame list, to quickly seek to interesting parts of a movie.

On demand, I can split this into two pull requests, but hopefully they both make sense to merge.

## Showcase video

https://github.com/user-attachments/assets/87120124-42e5-4814-9ceb-36f091a7e992

