### PR TITLE
build: Set a different channel for local builds

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -129,6 +129,7 @@ jobs:
       - name: Cargo build
         run: cargo build --locked --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
+          CFG_RELEASE_CHANNEL: nightly
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
 
@@ -178,6 +179,7 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo build --locked --package ruffle_web_safari --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
+          CFG_RELEASE_CHANNEL: nightly
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
 
@@ -368,6 +370,7 @@ jobs:
         shell: bash -l {0}
         working-directory: web
         env:
+          CFG_RELEASE_CHANNEL: nightly
           BUILD_ID: ${{ github.run_number }}
           ENABLE_VERSION_SEAL: "true"
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
@@ -375,6 +378,7 @@ jobs:
 
       - name: Build web
         env:
+          CFG_RELEASE_CHANNEL: nightly
           BUILD_ID: ${{ github.run_number }}
           CARGO_FEATURES: jpegxr
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
@@ -518,6 +522,7 @@ jobs:
         shell: bash -l {0}
         working-directory: web
         env:
+          CFG_RELEASE_CHANNEL: nightly
           BUILD_ID: ${{ github.run_number }}
           ENABLE_VERSION_SEAL: "true"
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
@@ -525,6 +530,7 @@ jobs:
 
       - name: Build web
         env:
+          CFG_RELEASE_CHANNEL: nightly
           BUILD_ID: ${{ github.run_number }}
           # NOTE: In the future, we might want to enable some features (like `webgpu`) only in
           # the demo build, for limited testing (like a Chrome origin trial) on ruffle.rs.

--- a/desktop/build.rs
+++ b/desktop/build.rs
@@ -43,6 +43,6 @@ fn channel() -> String {
     if let Ok(channel) = env::var("CFG_RELEASE_CHANNEL") {
         channel
     } else {
-        "nightly".to_owned()
+        "local".to_owned()
     }
 }

--- a/web/packages/core/tools/set_version.ts
+++ b/web/packages/core/tools/set_version.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 let buildDate = new Date().toISOString();
 let versionNumber = process.env["npm_package_version"] ?? "";
-let versionChannel = process.env["CFG_RELEASE_CHANNEL"] || "nightly";
+let versionChannel = process.env["CFG_RELEASE_CHANNEL"] || "local";
 const firefoxExtensionId =
     process.env["FIREFOX_EXTENSION_ID"] || "ruffle@ruffle.rs";
 

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -12,7 +12,7 @@ function transformManifest(content, env) {
     const manifest = json5.parse(content.toString());
 
     let packageVersion = process.env["npm_package_version"];
-    let versionChannel = process.env["CFG_RELEASE_CHANNEL"] || "nightly";
+    let versionChannel = process.env["CFG_RELEASE_CHANNEL"] || "local";
     let buildDate = new Date().toISOString().substring(0, 10);
     let buildId = process.env["BUILD_ID"];
     let firefoxExtensionId =

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -8,7 +8,7 @@ function transformPackage(content) {
 
     const packageVersion = process.env.npm_package_version;
 
-    const versionChannel = process.env.CFG_RELEASE_CHANNEL || "nightly";
+    const versionChannel = process.env.CFG_RELEASE_CHANNEL || "local";
 
     const buildDate = new Date()
         .toISOString()


### PR DESCRIPTION
That way we can differentiate easily between a local build and an official release. It's also the first step towards supporting stable releases.

The CI part is untested, I believe I provided the channel everywhere it's needed, but we'll have to make sure after publishing a nightly.