### PR TITLE
web: Replace deprecated `String.substr` with `String.substring`

### DIFF
--- a/web/packages/core/tools/set_version.ts
+++ b/web/packages/core/tools/set_version.ts
@@ -19,7 +19,7 @@ try {
 
 let versionName =
     versionChannel === "nightly"
-        ? `nightly ${buildDate.substr(0, 10)}`
+        ? `nightly ${buildDate.substring(0, 10)}`
         : versionNumber;
 
 interface VersionInformation {


### PR DESCRIPTION
The editor showed a little squiggly underneath it. I don't like squigglies in my code.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr