### PR TITLE
avm2: Shrink Method to 8 bytes by unifying BytecodeMethod and NativeMethod

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -144,16 +144,16 @@ pub struct Avm2<'gc> {
     namespaces: Gc<'gc, CommonNamespaces<'gc>>,
 
     #[collect(require_static)]
-    native_method_table: &'static [Option<(&'static str, NativeMethodImpl)>],
+    native_method_table: &'static [Option<NativeMethodImpl>],
 
     #[collect(require_static)]
-    native_instance_allocator_table: &'static [Option<(&'static str, AllocatorFn)>],
+    native_instance_allocator_table: &'static [Option<AllocatorFn>],
 
     #[collect(require_static)]
-    native_call_handler_table: &'static [Option<(&'static str, NativeMethodImpl)>],
+    native_call_handler_table: &'static [Option<NativeMethodImpl>],
 
     #[collect(require_static)]
-    native_custom_constructor_table: &'static [Option<(&'static str, CustomConstructorFn)>],
+    native_custom_constructor_table: &'static [Option<CustomConstructorFn>],
 
     /// A list of objects which are capable of receiving broadcasts.
     ///

--- a/core/src/avm2/call_stack.rs
+++ b/core/src/avm2/call_stack.rs
@@ -56,7 +56,7 @@ impl<'gc> CallStack<'gc> {
                     // added by Ruffle
                     output.push_utf8(&format!("global$init() [TU={}]", name));
                 }
-                CallNode::Method { method, class } => display_function(output, method, *class),
+                CallNode::Method { method, class } => display_function(output, *method, *class),
             }
         }
     }

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -511,16 +511,15 @@ impl<'gc> Class<'gc> {
         if unit.domain().is_playerglobals_domain(activation.avm2()) {
             instance_allocator = activation.avm2().native_instance_allocator_table
                 [class_index as usize]
-                .map(|(_name, ptr)| Allocator(ptr));
+                .map(Allocator);
 
-            if let Some((_name, table_native_call_handler)) =
+            if let Some(table_native_call_handler) =
                 activation.avm2().native_call_handler_table[class_index as usize]
             {
                 call_handler = Some(table_native_call_handler);
             }
 
-            // We only store the `name` for consistency with the other tables
-            if let Some((_name, table_custom_constructor)) =
+            if let Some(table_custom_constructor) =
                 activation.avm2().native_custom_constructor_table[class_index as usize]
             {
                 custom_constructor = Some(table_custom_constructor);

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -822,7 +822,7 @@ pub fn make_mismatch_error<'gc>(
 
     let mut function_name = WString::new();
 
-    display_function(&mut function_name, &method, bound_class);
+    display_function(&mut function_name, method, bound_class);
 
     return Err(Error::AvmError(argument_error(
         activation,

--- a/core/src/avm2/globals/Function.as
+++ b/core/src/avm2/globals/Function.as
@@ -44,9 +44,13 @@ package {
         public native function get prototype():*;
         public native function set prototype(proto:*):*;
 
+        AS3 native function apply(receiver:* = void 0, args:* = void 0):*;
         AS3 native function call(receiver:* = void 0, ...rest):*;
 
-        AS3 native function apply(receiver:* = void 0, args:* = void 0):*;
+        [Ruffle(NativeCallable)]
+        private static function createDummyFunction():Function {
+            return function() { };
+        }
 
         public static const length:int = 1;
     }

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -425,8 +425,9 @@ fn describe_internal_body<'gc>(
 
     let constructor = class_def.instance_init();
     // Flash only shows a <constructor> element if it has at least one parameter
-    if flags.contains(DescribeTypeFlags::INCLUDE_CONSTRUCTOR) && !constructor.signature().is_empty()
-    {
+    if let Some(constructor) = constructor.filter(|c| {
+        !c.signature().is_empty() && flags.contains(DescribeTypeFlags::INCLUDE_CONSTRUCTOR)
+    }) {
         let params = write_params(&constructor, activation)?;
         traits.set_string_property_local(istr!("constructor"), params.into(), activation)?;
     } else {

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -6,21 +6,9 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
 use crate::avm2::traits::Trait;
-use crate::avm2::value::Value;
-use crate::avm2::Error;
 use crate::avm2::QName;
 use ruffle_macros::istr;
-
-/// Implements `global`'s instance constructor.
-pub fn instance_init<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _this: Value<'gc>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(Value::Undefined)
-}
 
 /// Construct `global`'s class.
 pub fn create_class<'gc>(
@@ -31,7 +19,6 @@ pub fn create_class<'gc>(
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), istr!("global")),
         Some(activation.avm2().class_defs().object),
-        Method::from_builtin(instance_init, "<global instance initializer>", mc),
         traits,
         mc,
     );

--- a/core/src/avm2/globals/null.rs
+++ b/core/src/avm2/globals/null.rs
@@ -1,25 +1,13 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
-use crate::avm2::value::Value;
-use crate::avm2::Error;
 use crate::avm2::QName;
 use ruffle_macros::istr;
-
-fn null_init<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _this: Value<'gc>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    unreachable!()
-}
 
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.gc();
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), istr!("null")),
         None,
-        Method::from_builtin(null_init, "", mc),
         vec![],
         mc,
     );

--- a/core/src/avm2/globals/void.rs
+++ b/core/src/avm2/globals/void.rs
@@ -1,25 +1,13 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
-use crate::avm2::value::Value;
-use crate::avm2::Error;
 use crate::avm2::QName;
 use ruffle_macros::istr;
-
-fn void_init<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _this: Value<'gc>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    unreachable!()
-}
 
 pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.gc();
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), istr!("void")),
         None,
-        Method::from_builtin(void_init, "", mc),
         vec![],
         mc,
     );

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -2,17 +2,18 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::error::{verify_error, Error};
+use crate::avm2::error::{make_error_1014, verify_error, Error, Error1014Type};
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::value::{abc_default_value, Value};
-use crate::avm2::verify::{resolve_param_config, VerifiedMethodInfo};
+use crate::avm2::verify::VerifiedMethodInfo;
 use crate::avm2::Multiname;
+use crate::string::AvmString;
 use crate::tag_utils::SwfMovie;
-use gc_arena::barrier::unlock;
+use gc_arena::barrier::{unlock, Write};
 use gc_arena::lock::RefLock;
-use gc_arena::{Collect, Gc, GcCell, Mutation};
+use gc_arena::{Collect, Gc};
 use std::borrow::Cow;
-use std::fmt;
+use std::cell::Ref;
 use std::rc::Rc;
 use std::sync::Arc;
 use swf::avm2::types::{
@@ -90,49 +91,71 @@ impl<'gc> ParamConfig<'gc> {
 }
 
 /// Represents a reference to an AVM2 method and body.
+#[derive(Clone, Collect, Copy)]
+#[collect(no_drop)]
+pub struct Method<'gc>(Gc<'gc, MethodData<'gc>>);
+
 #[derive(Collect)]
 #[collect(no_drop)]
-pub struct BytecodeMethod<'gc> {
+struct MethodData<'gc> {
     /// The translation unit this function was defined in.
-    pub txunit: TranslationUnit<'gc>,
+    txunit: TranslationUnit<'gc>,
 
     /// The underlying ABC file of the above translation unit.
     #[collect(require_static)]
     abc: Rc<AbcFile>,
 
     /// The ABC method this function uses.
-    pub abc_method: u32,
+    abc_method: u32,
 
     /// The ABC method body this function uses.
-    pub abc_method_body: Option<u32>,
+    abc_method_body: Option<u32>,
 
-    pub verified_info: RefLock<Option<VerifiedMethodInfo<'gc>>>,
+    method_kind: MethodKind<'gc>,
 
     /// The parameter signature of this method.
-    pub signature: Vec<ParamConfig<'gc>>,
+    signature: Vec<ParamConfig<'gc>>,
 
     /// The return type of this method, or None if the method does not coerce
     /// its return value.
-    pub return_type: Option<Gc<'gc, Multiname<'gc>>>,
+    return_type: Option<Gc<'gc, Multiname<'gc>>>,
+
+    /// The resolved signature and return type.
+    resolved_info: RefLock<Option<ResolvedMethodInfo<'gc>>>,
 
     /// Whether or not this method was declared as a free-standing function.
     ///
     /// A free-standing function corresponds to the `Function` trait type, and
     /// is instantiated with the `newfunction` opcode.
-    pub is_function: bool,
+    is_function: bool,
 
     /// Whether or not this method substitutes Undefined for missing arguments.
     ///
     /// This is true when the method is a free-standing function and none of the
     /// declared arguments have a type or a default value.
-    pub is_unchecked: bool,
+    is_unchecked: bool,
 }
 
-impl<'gc> BytecodeMethod<'gc> {
-    /// Construct an `BytecodeMethod` from an `AbcFile` and method index.
+impl PartialEq for Method<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        Gc::ptr_eq(self.0, other.0)
+    }
+}
+
+impl core::fmt::Debug for Method<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_struct("Method")
+            .field("ptr", &Gc::as_ptr(self.0))
+            .finish()
+    }
+}
+
+impl<'gc> Method<'gc> {
+    /// Construct a `Method` from an `AbcFile` and method index.
     pub fn from_method_index(
         txunit: TranslationUnit<'gc>,
         abc_method: Index<AbcMethod>,
+        native_method: Option<NativeMethodImpl>,
         is_function: bool,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
@@ -161,76 +184,135 @@ impl<'gc> BytecodeMethod<'gc> {
             }
         }
 
-        Ok(Self {
-            txunit,
-            abc: txunit.abc(),
-            abc_method: abc_method.0,
-            abc_method_body,
-            verified_info: RefLock::new(None),
-            signature,
-            return_type,
-            is_function,
-            is_unchecked: is_function && all_params_unchecked,
-        })
+        let method_kind = if let Some(native_method) = native_method {
+            MethodKind::Native(native_method)
+        } else {
+            MethodKind::Bytecode(RefLock::new(None))
+        };
+
+        Ok(Self(Gc::new(
+            activation.gc(),
+            MethodData {
+                txunit,
+                abc: txunit.abc(),
+                abc_method: abc_method.0,
+                abc_method_body,
+                method_kind,
+                signature,
+                return_type,
+                resolved_info: RefLock::new(None),
+                is_function,
+                is_unchecked: is_function && all_params_unchecked,
+            },
+        )))
     }
 
     /// Get the underlying ABC file.
     pub fn abc(&self) -> Rc<AbcFile> {
-        self.txunit.abc()
+        self.0.txunit.abc()
     }
 
     /// Get the underlying translation unit this method was defined in.
     pub fn translation_unit(&self) -> TranslationUnit<'gc> {
-        self.txunit
+        self.0.txunit
+    }
+
+    pub fn abc_method_index(&self) -> u32 {
+        self.0.abc_method
     }
 
     /// Get a reference to the ABC method entry this refers to.
     pub fn method(&self) -> &AbcMethod {
-        self.abc.methods.get(self.abc_method as usize).unwrap()
+        &self.0.abc.methods[self.0.abc_method as usize]
     }
 
     /// Get a reference to the SwfMovie this method came from.
     pub fn owner_movie(&self) -> Arc<SwfMovie> {
-        self.txunit.movie()
+        self.0.txunit.movie()
     }
 
     /// Get a reference to the ABC method body entry this refers to.
     ///
     /// Some methods do not have bodies; this returns `None` in that case.
     pub fn body(&self) -> Option<&AbcMethodBody> {
-        if let Some(abc_method_body) = self.abc_method_body {
-            self.abc.method_bodies.get(abc_method_body as usize)
+        if let Some(abc_method_body) = self.0.abc_method_body {
+            self.0.abc.method_bodies.get(abc_method_body as usize)
         } else {
             None
         }
     }
 
-    #[inline(never)]
-    pub fn verify(
-        this: Gc<'gc, BytecodeMethod<'gc>>,
-        activation: &mut Activation<'_, 'gc>,
-    ) -> Result<(), Error<'gc>> {
-        // TODO: avmplus seems to eaglerly verify some methods
+    #[inline]
+    pub fn verify(self, activation: &mut Activation<'_, 'gc>) -> Result<(), Error<'gc>> {
+        // TODO: avmplus seems to eagerly verify some methods
 
-        *unlock!(
-            Gc::write(activation.gc(), this),
-            BytecodeMethod,
-            verified_info
-        )
-        .borrow_mut() = Some(crate::avm2::verify::verify_method(activation, this)?);
+        let method_kind = &self.0.method_kind;
 
-        Ok(())
+        match method_kind {
+            MethodKind::Bytecode(verified_info) => {
+                let needs_verify = verified_info.borrow().is_none();
+
+                if needs_verify {
+                    method_kind.verify_bytecode(activation, self)?;
+                }
+
+                Ok(())
+            }
+            _ => Ok(()),
+        }
     }
 
     /// Get the list of method params for this method.
     pub fn signature(&self) -> &[ParamConfig<'gc>] {
-        &self.signature
+        &self.0.signature
+    }
+
+    pub fn resolved_param_config(&self) -> Ref<Vec<ResolvedParamConfig<'gc>>> {
+        let resolved_info = self.0.resolved_info.borrow();
+
+        Ref::map(resolved_info, |b| &b.as_ref().unwrap().param_config)
     }
 
     pub fn resolved_return_type(&self) -> Option<Class<'gc>> {
-        let verified_info = self.verified_info.borrow();
+        let resolved_info = self.0.resolved_info.borrow();
 
-        verified_info.as_ref().unwrap().return_type
+        resolved_info.as_ref().unwrap().return_type
+    }
+
+    pub fn is_info_resolved(self) -> bool {
+        let resolved_info = self.0.resolved_info.borrow();
+
+        resolved_info.is_some()
+    }
+
+    pub fn get_verified_info(&self) -> Ref<VerifiedMethodInfo<'gc>> {
+        match &self.0.method_kind {
+            MethodKind::Bytecode(verified_info) => {
+                Ref::map(verified_info.borrow(), |b| b.as_ref().unwrap())
+            }
+            _ => panic!("get_verified_info should be called on a bytecode method"),
+        }
+    }
+
+    /// Resolve the classes used in this method's signature and return type.
+    #[inline(never)]
+    pub fn resolve_info(self, activation: &mut Activation<'_, 'gc>) -> Result<(), Error<'gc>> {
+        let param_config = resolve_param_config(activation, self.signature())?;
+        let return_type = resolve_return_type(activation, self.return_type())?;
+
+        let resolved_info = ResolvedMethodInfo {
+            param_config,
+            return_type,
+        };
+
+        *unlock!(
+            Gc::write(activation.gc(), self.0),
+            MethodData,
+            resolved_info
+        )
+        .borrow_mut() = Some(resolved_info);
+
+        Ok(())
     }
 
     /// Get the name of this method.
@@ -240,7 +322,8 @@ impl<'gc> BytecodeMethod<'gc> {
             return Cow::Borrowed("");
         }
 
-        self.abc
+        self.0
+            .abc
             .constant_pool
             .strings
             .get(name_index - 1)
@@ -257,6 +340,23 @@ impl<'gc> BytecodeMethod<'gc> {
             .intersects(AbcMethodFlags::NEED_ARGUMENTS | AbcMethodFlags::NEED_REST)
     }
 
+    /// Check if this method needs `arguments`.
+    pub fn needs_arguments_object(&self) -> bool {
+        self.method().flags.contains(AbcMethodFlags::NEED_ARGUMENTS)
+    }
+
+    pub fn method_kind(&self) -> &MethodKind<'gc> {
+        &self.0.method_kind
+    }
+
+    pub fn return_type(&self) -> Option<Gc<'gc, Multiname<'gc>>> {
+        self.0.return_type
+    }
+
+    pub fn is_function(self) -> bool {
+        self.0.is_function
+    }
+
     /// Determine if a given method is unchecked.
     ///
     /// A method is unchecked if both of the following are true:
@@ -264,152 +364,119 @@ impl<'gc> BytecodeMethod<'gc> {
     ///  * The method was declared as a free-standing function
     ///  * The function's parameters have no declared types or default values
     pub fn is_unchecked(&self) -> bool {
-        self.is_unchecked
+        self.0.is_unchecked
     }
 }
 
-/// An uninstantiated method
-#[derive(Clone, Collect)]
+/// Represents info for either a bytecode or native method
+#[derive(Collect)]
 #[collect(no_drop)]
-pub struct NativeMethod<'gc> {
-    /// The function to call to execute the method.
-    #[collect(require_static)]
-    pub method: NativeMethodImpl,
+pub enum MethodKind<'gc> {
+    Bytecode(RefLock<Option<VerifiedMethodInfo<'gc>>>),
 
-    /// The name of the method.
-    pub name: &'static str,
-
-    /// The parameter signature of the method.
-    pub signature: Vec<ParamConfig<'gc>>,
-
-    /// The resolved parameter signature of the method.
-    pub resolved_signature: GcCell<'gc, Option<Vec<ResolvedParamConfig<'gc>>>>,
-
-    /// The return type of this method, or None if the method does not coerce
-    /// its return value.
-    pub return_type: Option<Gc<'gc, Multiname<'gc>>>,
-
-    /// Whether or not this method accepts parameters beyond those
-    /// mentioned in the parameter list.
-    pub is_variadic: bool,
+    Native(#[collect(require_static)] NativeMethodImpl),
 }
 
-impl<'gc> NativeMethod<'gc> {
-    pub fn resolve_signature(
+impl<'gc> MethodKind<'gc> {
+    /// If this MethodKind represents a bytecode method's info, verify it.
+    #[inline(never)]
+    pub fn verify_bytecode(
         &self,
         activation: &mut Activation<'_, 'gc>,
+        method: Method<'gc>,
     ) -> Result<(), Error<'gc>> {
-        *self.resolved_signature.write(activation.gc()) =
-            Some(resolve_param_config(activation, &self.signature)?);
+        match self {
+            MethodKind::Bytecode(verified_info) => {
+                Gc::write(activation.gc(), method.0);
 
-        Ok(())
+                // SAFETY: We just triggered a write barrier on the Gc.
+                let verified_info = unsafe { Write::assume(verified_info) };
+
+                *verified_info.unlock().borrow_mut() =
+                    Some(crate::avm2::verify::verify_method(activation, method)?);
+
+                Ok(())
+            }
+            MethodKind::Native(_) => Ok(()),
+        }
     }
 }
 
-impl fmt::Debug for NativeMethod<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NativeMethod")
-            .field("method", &format!("{:p}", &self.method))
-            .field("name", &self.name)
-            .field("signature", &self.signature)
-            .field("is_variadic", &self.is_variadic)
-            .finish()
-    }
-}
-
-/// An uninstantiated method that can either be natively implemented or sourced
-/// from an ABC file.
-#[derive(Copy, Clone, Collect)]
+/// The resolved parameters and return type of a method.
+#[derive(Collect)]
 #[collect(no_drop)]
-pub enum Method<'gc> {
-    /// A native method.
-    Native(Gc<'gc, NativeMethod<'gc>>),
-
-    /// An ABC-provided method entry.
-    Bytecode(Gc<'gc, BytecodeMethod<'gc>>),
+struct ResolvedMethodInfo<'gc> {
+    param_config: Vec<ResolvedParamConfig<'gc>>,
+    return_type: Option<Class<'gc>>,
 }
 
-impl<'gc> From<Gc<'gc, BytecodeMethod<'gc>>> for Method<'gc> {
-    fn from(bm: Gc<'gc, BytecodeMethod<'gc>>) -> Self {
-        Self::Bytecode(bm)
+fn resolve_param_config<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    param_config: &[ParamConfig<'gc>],
+) -> Result<Vec<ResolvedParamConfig<'gc>>, Error<'gc>> {
+    let mut resolved_param_config = Vec::new();
+
+    for param in param_config {
+        let resolved_class = if let Some(param_type_name) = param.param_type_name {
+            if param_type_name.has_lazy_component() {
+                return Err(make_error_1014(
+                    activation,
+                    Error1014Type::VerifyError,
+                    AvmString::new_utf8(activation.gc(), "[]"),
+                ));
+            }
+
+            Some(
+                activation
+                    .domain()
+                    .get_class(activation.context, &param_type_name)
+                    .ok_or_else(|| {
+                        make_error_1014(
+                            activation,
+                            Error1014Type::VerifyError,
+                            param_type_name.to_qualified_name(activation.gc()),
+                        )
+                    })?,
+            )
+        } else {
+            None
+        };
+
+        resolved_param_config.push(ResolvedParamConfig {
+            param_type: resolved_class,
+            default_value: param.default_value,
+        });
     }
+
+    Ok(resolved_param_config)
 }
 
-impl<'gc> Method<'gc> {
-    /// Define a builtin method with a particular param configuration.
-    pub fn from_builtin_and_params(
-        method: NativeMethodImpl,
-        name: &'static str,
-        signature: Vec<ParamConfig<'gc>>,
-        return_type: Option<Gc<'gc, Multiname<'gc>>>,
-        is_variadic: bool,
-        mc: &Mutation<'gc>,
-    ) -> Self {
-        Self::Native(Gc::new(
-            mc,
-            NativeMethod {
-                method,
-                name,
-                signature,
-                resolved_signature: GcCell::new(mc, None),
-                return_type,
-                is_variadic,
-            },
+fn resolve_return_type<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    return_type: Option<Gc<'gc, Multiname<'gc>>>,
+) -> Result<Option<Class<'gc>>, Error<'gc>> {
+    if let Some(return_type) = return_type {
+        if return_type.has_lazy_component() {
+            return Err(make_error_1014(
+                activation,
+                Error1014Type::VerifyError,
+                AvmString::new_utf8(activation.gc(), "[]"),
+            ));
+        }
+
+        Ok(Some(
+            activation
+                .domain()
+                .get_class(activation.context, &return_type)
+                .ok_or_else(|| {
+                    make_error_1014(
+                        activation,
+                        Error1014Type::VerifyError,
+                        return_type.to_qualified_name(activation.gc()),
+                    )
+                })?,
         ))
-    }
-
-    /// Define a builtin with no parameter constraints.
-    pub fn from_builtin(method: NativeMethodImpl, name: &'static str, mc: &Mutation<'gc>) -> Self {
-        Self::Native(Gc::new(
-            mc,
-            NativeMethod {
-                method,
-                name,
-                signature: Vec::new(),
-                resolved_signature: GcCell::new(mc, None),
-                // FIXME - take in the real return type. This is needed for 'describeType'
-                return_type: None,
-                is_variadic: true,
-            },
-        ))
-    }
-
-    /// Access the bytecode of this method.
-    ///
-    /// This function returns `None` if this is a native method.
-    pub fn into_bytecode(self) -> Option<Gc<'gc, BytecodeMethod<'gc>>> {
-        match self {
-            Method::Native { .. } => None,
-            Method::Bytecode(bm) => Some(bm),
-        }
-    }
-
-    pub fn return_type(&self) -> Option<Gc<'gc, Multiname<'gc>>> {
-        match self {
-            Method::Native(nm) => nm.return_type,
-            Method::Bytecode(bm) => bm.return_type,
-        }
-    }
-
-    pub fn signature(&self) -> &[ParamConfig<'gc>] {
-        match self {
-            Method::Native(nm) => &nm.signature,
-            Method::Bytecode(bm) => bm.signature(),
-        }
-    }
-
-    pub fn is_variadic(&self) -> bool {
-        match self {
-            Method::Native(nm) => nm.is_variadic,
-            Method::Bytecode(bm) => bm.is_variadic(),
-        }
-    }
-
-    /// Check if this method needs `arguments`.
-    pub fn needs_arguments_object(&self) -> bool {
-        match self {
-            Method::Native { .. } => false,
-            Method::Bytecode(bm) => bm.method().flags.contains(AbcMethodFlags::NEED_ARGUMENTS),
-        }
+    } else {
+        Ok(None)
     }
 }

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -153,12 +153,10 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
     }
 
     fn to_string(&self, mc: &Mutation<'gc>) -> AvmString<'gc> {
-        // TODO this should use the ABC method index of the Method held by the
-        // BoundMethod (the same number that appears after "MethodInfo-" in
-        // stack traces)
-        let method_idx = 0;
+        let method = self.0.exec.as_method();
+        let method_index = method.abc_method_index();
 
-        AvmString::new_utf8(mc, format!("[object Function-{method_idx}]"))
+        AvmString::new_utf8(mc, format!("[object Function-{method_index}]"))
     }
 
     fn as_function_object(&self) -> Option<FunctionObject<'gc>> {

--- a/core/src/avm2/optimizer/optimize.rs
+++ b/core/src/avm2/optimizer/optimize.rs
@@ -1,5 +1,5 @@
 use crate::avm2::error::verify_error;
-use crate::avm2::method::{BytecodeMethod, ResolvedParamConfig};
+use crate::avm2::method::{Method, ResolvedParamConfig};
 use crate::avm2::multiname::Multiname;
 use crate::avm2::op::Op;
 use crate::avm2::optimizer::blocks::assemble_blocks;
@@ -535,7 +535,7 @@ struct Types<'gc> {
 
 pub fn optimize<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    method: Gc<'gc, BytecodeMethod<'gc>>,
+    method: Method<'gc>,
     code: &mut Vec<Op<'gc>>,
     resolved_parameters: &[ResolvedParamConfig<'gc>],
     method_exceptions: &[Exception<'gc>],

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -186,9 +186,7 @@ impl<'gc> TranslationUnit<'gc> {
         let mut native_method = None;
 
         if is_global {
-            if let Some((_name, native)) =
-                activation.avm2().native_method_table[method_index.0 as usize]
-            {
+            if let Some(native) = activation.avm2().native_method_table[method_index.0 as usize] {
                 native_method = Some(native);
             }
         }


### PR DESCRIPTION
`Method` is now a single struct (stored behind a Gc). We store separate native and bytecode method info in a `MethodKind` enum.