### PR TITLE
avm1: Migrate `super` to `NativeObject`, and kill off `TObject`

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -32,7 +32,7 @@ pub use globals::array::ArrayBuilder;
 pub use globals::context_menu::make_context_menu_state;
 pub use globals::sound::start as start_sound;
 pub use object::script_object::ScriptObject;
-pub use object::{NativeObject, Object, ObjectPtr, TObject};
+pub use object::{NativeObject, Object, ObjectPtr};
 pub use property::Attribute;
 pub use property_map::PropertyMap;
 pub use runtime::Avm1;

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -31,7 +31,6 @@ pub use function::ExecutionReason;
 pub use globals::array::ArrayBuilder;
 pub use globals::context_menu::make_context_menu_state;
 pub use globals::sound::start as start_sound;
-pub use object::script_object::ScriptObject;
 pub use object::{NativeObject, Object, ObjectPtr};
 pub use property::Attribute;
 pub use property_map::PropertyMap;

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1,11 +1,10 @@
 use crate::avm1::callable_value::CallableValue;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Avm1Function, ExecutionReason, FunctionObject};
-use crate::avm1::object::Object;
 use crate::avm1::property::Attribute;
 use crate::avm1::runtime::skip_actions;
 use crate::avm1::scope::{Scope, ScopeClass};
-use crate::avm1::{fscommand, globals, scope, ArrayBuilder, ScriptObject, Value};
+use crate::avm1::{fscommand, globals, scope, ArrayBuilder, Object, Value};
 use crate::backend::navigator::{NavigationMethod, Request};
 use crate::context::UpdateContext;
 use crate::display_object::{
@@ -918,11 +917,10 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             self.base_clip(),
         );
         let name = func.name();
-        let prototype = ScriptObject::new(
+        let prototype = Object::new(
             &self.context.strings,
             Some(self.context.avm1.prototypes().object),
-        )
-        .into();
+        );
         let func_obj = FunctionObject::function(
             &self.context.strings,
             Gc::new(self.gc(), func),
@@ -1107,7 +1105,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .get(istr!(self, "prototype"), self)?
             .coerce_to_object(self);
 
-        let sub_prototype = ScriptObject::new(self.strings(), Some(super_prototype));
+        let sub_prototype = Object::new(self.strings(), Some(super_prototype));
 
         sub_prototype.define_value(
             self.gc(),
@@ -1488,7 +1486,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             // InitArray pops no args and pushes undefined if num_props is out of range.
             Value::Undefined
         } else {
-            let object = ScriptObject::new(
+            let object = Object::new(
                 &self.context.strings,
                 Some(self.context.avm1.prototypes().object),
             );
@@ -1498,7 +1496,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 let name = name_val.coerce_to_string(self)?;
                 object.set(name, value, self)?;
             }
-            Value::Object(object.into())
+            Value::Object(object)
         };
 
         self.stack_push(result);

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1,7 +1,7 @@
 use crate::avm1::callable_value::CallableValue;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Avm1Function, ExecutionReason, FunctionObject};
-use crate::avm1::object::{Object, TObject};
+use crate::avm1::object::Object;
 use crate::avm1::property::Attribute;
 use crate::avm1::runtime::skip_actions;
 use crate::avm1::scope::{Scope, ScopeClass};

--- a/core/src/avm1/callable_value.rs
+++ b/core/src/avm1/callable_value.rs
@@ -1,6 +1,6 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::{Object, TObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::AvmString;
 use gc_arena::Collect;
 

--- a/core/src/avm1/debug.rs
+++ b/core/src/avm1/debug.rs
@@ -1,5 +1,5 @@
 use crate::avm1::activation::Activation;
-use crate::avm1::{Object, ObjectPtr, TObject, Value};
+use crate::avm1::{Object, ObjectPtr, Value};
 use crate::string::AvmString;
 use std::fmt::Write;
 

--- a/core/src/avm1/flv.rs
+++ b/core/src/avm1/flv.rs
@@ -1,4 +1,4 @@
-use crate::avm1::{Activation, ArrayBuilder, ScriptObject, Value as Avm1Value};
+use crate::avm1::{Activation, ArrayBuilder, Object, Value as Avm1Value};
 use crate::string::AvmString;
 use flv_rs::{Value as FlvValue, Variable as FlvVariable};
 
@@ -7,7 +7,7 @@ fn avm1_object_from_flv_variables<'gc>(
     variables: Vec<FlvVariable>,
 ) -> Avm1Value<'gc> {
     let object_proto = activation.context.avm1.prototypes().object;
-    let info_object = ScriptObject::new(activation.strings(), Some(object_proto));
+    let info_object = Object::new(activation.strings(), Some(object_proto));
 
     for value in variables {
         let property_name = value.name;

--- a/core/src/avm1/flv.rs
+++ b/core/src/avm1/flv.rs
@@ -1,4 +1,4 @@
-use crate::avm1::{Activation, ArrayBuilder, ScriptObject, TObject as _, Value as Avm1Value};
+use crate::avm1::{Activation, ArrayBuilder, ScriptObject, Value as Avm1Value};
 use crate::string::AvmString;
 use flv_rs::{Value as FlvValue, Variable as FlvVariable};
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -6,7 +6,7 @@ use crate::avm1::object::super_object::SuperObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::scope::Scope;
 use crate::avm1::value::Value;
-use crate::avm1::{ArrayBuilder, Object, ScriptObject};
+use crate::avm1::{ArrayBuilder, Object};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::string::{AvmString, StringContext, SwfStrExt as _};
 use crate::tag_utils::SwfSlice;
@@ -220,7 +220,7 @@ impl<'gc> Avm1Function<'gc> {
         // `f[""]()` emits a CallMethod op, causing `this` to be undefined, but `super` is a function; what is it?
         let zuper = this.filter(|_| !suppress).map(|this| {
             let zuper = NativeObject::Super(SuperObject::new(frame, this, depth));
-            ScriptObject::new_with_native(frame.strings(), None, zuper).into()
+            Object::new_with_native(frame.strings(), None, zuper).into()
         });
 
         if preload {
@@ -494,7 +494,7 @@ impl<'gc> FunctionObject<'gc> {
         constructor: Option<NativeFunction>,
         fn_proto: Object<'gc>,
     ) -> Object<'gc> {
-        let obj = ScriptObject::new(context, Some(fn_proto));
+        let obj = Object::new(context, Some(fn_proto));
         let native = NativeObject::Function(Gc::new(
             context.gc(),
             Self {
@@ -503,7 +503,7 @@ impl<'gc> FunctionObject<'gc> {
             },
         ));
         obj.set_native(context.gc(), native);
-        obj.into()
+        obj
     }
 
     /// Construct a function with any combination of regular and constructor parts.
@@ -676,7 +676,7 @@ impl<'gc> FunctionObject<'gc> {
         let prototype = callee
             .get(istr!("prototype"), activation)?
             .coerce_to_object(activation);
-        let this = ScriptObject::new(activation.strings(), Some(prototype));
+        let this = Object::new(activation.strings(), Some(prototype));
 
         // TODO: de-duplicate code.
         this.define_value(

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -218,9 +218,10 @@ impl<'gc> Avm1Function<'gc> {
 
         // TODO: `super` should only be defined if this was a method call (depth > 0?)
         // `f[""]()` emits a CallMethod op, causing `this` to be undefined, but `super` is a function; what is it?
-        let zuper = this
-            .filter(|_| !suppress)
-            .map(|this| SuperObject::new(frame, this, depth).into());
+        let zuper = this.filter(|_| !suppress).map(|this| {
+            let zuper = NativeObject::Super(SuperObject::new(frame, this, depth));
+            ScriptObject::new_with_native(frame.strings(), None, zuper).into()
+        });
 
         if preload {
             // The register is set to undefined if both flags are set.

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -6,7 +6,7 @@ use crate::avm1::object::super_object::SuperObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::scope::Scope;
 use crate::avm1::value::Value;
-use crate::avm1::{ArrayBuilder, Object, ScriptObject, TObject};
+use crate::avm1::{ArrayBuilder, Object, ScriptObject};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::string::{AvmString, StringContext, SwfStrExt as _};
 use crate::tag_utils::SwfSlice;

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
 use crate::string::{AvmString, StringContext, WStr, WString};
 use gc_arena::Collect;
@@ -874,7 +874,7 @@ pub fn create_globals<'gc>(
         (system, b"security", system_security, Attribute::empty()),
         (system, b"capabilities", system_capabilities, Attribute::empty()),
 
-        (text_field.raw_script_object(), b"StyleSheet", style_sheet, Attribute::DONT_ENUM | Attribute::VERSION_7),
+        (text_field, b"StyleSheet", style_sheet, Attribute::DONT_ENUM | Attribute::VERSION_7),
     ]);
 
     (

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
 use crate::string::{AvmString, StringContext, WStr, WString};
 use gc_arena::Collect;
@@ -521,7 +521,7 @@ pub fn create_globals<'gc>(
     Object<'gc>,
     as_broadcaster::BroadcasterFunctions<'gc>,
 ) {
-    let object_proto = ScriptObject::new(context, None).into();
+    let object_proto = Object::new(context, None);
     let function_proto = function::create_proto(context, object_proto);
 
     object::fill_proto(context, object_proto, function_proto);
@@ -640,12 +640,12 @@ pub fn create_globals<'gc>(
     let netconnection = netconnection::create_class(context, netconnection_proto, function_proto);
     let xml_socket = xml_socket::create_class(context, xml_socket_proto, function_proto);
 
-    let flash = ScriptObject::new(context, Some(object_proto));
+    let flash = Object::new(context, Some(object_proto));
 
-    let geom = ScriptObject::new(context, Some(object_proto));
-    let filters = ScriptObject::new(context, Some(object_proto));
-    let display = ScriptObject::new(context, Some(object_proto));
-    let net = ScriptObject::new(context, Some(object_proto));
+    let geom = Object::new(context, Some(object_proto));
+    let filters = Object::new(context, Some(object_proto));
+    let display = Object::new(context, Some(object_proto));
+    let net = Object::new(context, Some(object_proto));
 
     let matrix = matrix::create_matrix_object(context, matrix_proto, function_proto);
     let point = point::create_point_object(context, point_proto, function_proto);
@@ -713,10 +713,10 @@ pub fn create_globals<'gc>(
         function_proto,
     );
 
-    let bitmap_data_proto = ScriptObject::new(context, Some(object_proto));
+    let bitmap_data_proto = Object::new(context, Some(object_proto));
     let bitmap_data = bitmap_data::create_constructor(context, bitmap_data_proto, function_proto);
 
-    let external = ScriptObject::new(context, Some(object_proto));
+    let external = Object::new(context, Some(object_proto));
     let external_interface = external_interface::create_external_interface_object(
         context,
         external_interface_proto,
@@ -791,9 +791,9 @@ pub fn create_globals<'gc>(
     let accessibility =
         accessibility::create_accessibility_object(context, object_proto, function_proto);
 
-    let globals = ScriptObject::new(context, None);
+    let globals = Object::new(context, None);
 
-    type GlobalDefinition<'gc> = (ScriptObject<'gc>, &'static [u8], Object<'gc>, Attribute);
+    type GlobalDefinition<'gc> = (Object<'gc>, &'static [u8], Object<'gc>, Attribute);
     #[inline(never)]
     fn define_globals<'gc>(context: &mut StringContext<'gc>, defs: &[GlobalDefinition<'gc>]) {
         for &(obj, field, value, attrs) in defs {
@@ -830,7 +830,7 @@ pub fn create_globals<'gc>(
         (globals, b"ContextMenu", context_menu, Attribute::DONT_ENUM),
         (globals, b"Selection", selection, Attribute::DONT_ENUM),
         (globals, b"ContextMenuItem", context_menu_item, Attribute::DONT_ENUM),
-        (globals, b"System", system.into(), Attribute::DONT_ENUM),
+        (globals, b"System", system, Attribute::DONT_ENUM),
         (globals, b"Math", math, Attribute::DONT_ENUM),
         (globals, b"Mouse", mouse, Attribute::DONT_ENUM),
         (globals, b"Key", key, Attribute::DONT_ENUM),
@@ -844,12 +844,12 @@ pub fn create_globals<'gc>(
 
         (external, b"ExternalInterface", external_interface, Attribute::empty()),
 
-        (globals, b"flash", flash.into(), Attribute::DONT_ENUM),
-        (flash, b"display", display.into(), Attribute::empty()),
-        (flash, b"external", external.into(), Attribute::empty()),
-        (flash, b"filters", filters.into(), Attribute::empty()),
-        (flash, b"geom", geom.into(), Attribute::empty()),
-        (flash, b"net", net.into(), Attribute::empty()),
+        (globals, b"flash", flash, Attribute::DONT_ENUM),
+        (flash, b"display", display, Attribute::empty()),
+        (flash, b"external", external, Attribute::empty()),
+        (flash, b"filters", filters, Attribute::empty()),
+        (flash, b"geom", geom, Attribute::empty()),
+        (flash, b"net", net, Attribute::empty()),
 
         (geom, b"ColorTransform", color_transform, Attribute::empty()),
         (geom, b"Matrix", matrix, Attribute::empty()),
@@ -909,7 +909,7 @@ pub fn create_globals<'gc>(
             context_menu_item: context_menu_item_proto,
             context_menu_item_constructor: context_menu_item,
             date_constructor: date,
-            bitmap_data: bitmap_data_proto.into(),
+            bitmap_data: bitmap_data_proto,
             video: video_proto,
             video_constructor: video,
             blur_filter: blur_filter_proto,
@@ -922,7 +922,7 @@ pub fn create_globals<'gc>(
             gradient_bevel_filter: gradient_bevel_filter_proto,
             gradient_glow_filter: gradient_glow_filter_proto,
         },
-        globals.into(),
+        globals,
         broadcaster_functions,
     )
 }

--- a/core/src/avm1/globals/accessibility.rs
+++ b/core/src/avm1/globals/accessibility.rs
@@ -3,7 +3,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::avm1_stub;
 use crate::string::StringContext;
 
@@ -45,7 +45,7 @@ pub fn create_accessibility_object<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let accessibility = ScriptObject::new(context, Some(proto));
+    let accessibility = Object::new(context, Some(proto));
     define_properties_on(OBJECT_DECLS, context, accessibility, fn_proto);
-    accessibility.into()
+    accessibility
 }

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -5,7 +5,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Attribute, NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{Attribute, NativeObject, Object, Value};
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::string::{AvmString, StringContext};
 use bitflags::bitflags;
@@ -72,7 +72,7 @@ pub struct ArrayBuilder<'gc> {
 }
 
 impl<'gc> ArrayBuilder<'gc> {
-    pub fn empty(activation: &Activation<'_, 'gc>) -> ScriptObject<'gc> {
+    pub fn empty(activation: &Activation<'_, 'gc>) -> Object<'gc> {
         Self::new(activation).with([])
     }
 
@@ -107,8 +107,8 @@ impl<'gc> ArrayBuilder<'gc> {
         this.set_native(self.mc, NativeObject::Array(()));
     }
 
-    pub fn with(self, elements: impl IntoIterator<Item = Value<'gc>>) -> ScriptObject<'gc> {
-        let obj = ScriptObject::new_without_proto(self.mc);
+    pub fn with(self, elements: impl IntoIterator<Item = Value<'gc>>) -> Object<'gc> {
+        let obj = Object::new_without_proto(self.mc);
         obj.define_value(
             self.mc,
             self.proto_prop,
@@ -116,7 +116,7 @@ impl<'gc> ArrayBuilder<'gc> {
             Attribute::DONT_ENUM | Attribute::DONT_DELETE,
         );
 
-        self.init_with(obj.into(), elements);
+        self.init_with(obj, elements);
         obj
     }
 }

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -5,7 +5,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Attribute, NativeObject, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Attribute, NativeObject, Object, ScriptObject, Value};
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::string::{AvmString, StringContext};
 use bitflags::bitflags;
@@ -128,12 +128,11 @@ pub fn create_array_object<'gc>(
 ) -> Object<'gc> {
     let array =
         FunctionObject::constructor(context, constructor, Some(array), fn_proto, array_proto);
-    let object = array.raw_script_object();
 
     // TODO: These were added in Flash Player 7, but are available even to SWFv6 and lower
     // when run in Flash Player 7. Make these conditional if we add a parameter to control
     // target Flash Player version.
-    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, array, fn_proto);
     array
 }
 
@@ -791,7 +790,6 @@ pub fn create_proto<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let array = ArrayBuilder::new_with_proto(context, proto).with([]);
-    let object = array.raw_script_object();
-    define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    define_properties_on(PROTO_DECLS, context, array, fn_proto);
+    array
 }

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -5,7 +5,7 @@ use crate::avm1::function::ExecutionReason;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::Declaration;
-use crate::avm1::{Activation, ArrayBuilder, Object, ScriptObject, Value};
+use crate::avm1::{Activation, ArrayBuilder, Object, Value};
 use crate::string::{AvmString, StringContext};
 use gc_arena::Collect;
 use ruffle_macros::istr;
@@ -22,11 +22,11 @@ pub fn create<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> (BroadcasterFunctions<'gc>, Object<'gc>) {
-    let as_broadcaster_proto = ScriptObject::new(context, Some(proto));
+    let as_broadcaster_proto = Object::new(context, Some(proto));
     // Despite the documentation says that there is no constructor function for the `AsBroadcaster`
     // class, Flash accepts expressions like `new AsBroadcaster()`, and a newly-created object is
     // returned in such cases.
-    let as_broadcaster = FunctionObject::empty(context, fn_proto, as_broadcaster_proto.into());
+    let as_broadcaster = FunctionObject::empty(context, fn_proto, as_broadcaster_proto);
 
     let mut define_as_object = |index: usize| -> Object<'gc> {
         match OBJECT_DECLS[index].define_on(context, as_broadcaster, fn_proto) {

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -3,7 +3,6 @@
 use crate::avm1::error::Error;
 use crate::avm1::function::ExecutionReason;
 use crate::avm1::function::FunctionObject;
-use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::Declaration;
 use crate::avm1::{Activation, ArrayBuilder, Object, ScriptObject, Value};
@@ -28,10 +27,9 @@ pub fn create<'gc>(
     // class, Flash accepts expressions like `new AsBroadcaster()`, and a newly-created object is
     // returned in such cases.
     let as_broadcaster = FunctionObject::empty(context, fn_proto, as_broadcaster_proto.into());
-    let object = as_broadcaster.raw_script_object();
 
     let mut define_as_object = |index: usize| -> Object<'gc> {
-        match OBJECT_DECLS[index].define_on(context, object, fn_proto) {
+        match OBJECT_DECLS[index].define_on(context, as_broadcaster, fn_proto) {
             Value::Object(o) => o,
             _ => panic!("expected object for broadcaster function"),
         }

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Error, Object, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use ruffle_macros::istr;
@@ -526,9 +526,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let bevel_filter_proto = ScriptObject::new(context, Some(proto));
+    let bevel_filter_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, bevel_filter_proto, fn_proto);
-    bevel_filter_proto.into()
+    bevel_filter_proto
 }
 
 pub fn create_constructor<'gc>(

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use ruffle_macros::istr;

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -6,7 +6,7 @@ use crate::avm1::globals::bitmap_filter;
 use crate::avm1::globals::color_transform::ColorTransformObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Attribute, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Attribute, Error, Object, Value};
 use crate::bitmap::bitmap_data::{BitmapData, BitmapDataWrapper};
 use crate::bitmap::bitmap_data::{BitmapDataDrawError, IBitmapDrawable};
 use crate::bitmap::bitmap_data::{ChannelOptions, ThresholdOperation};
@@ -59,12 +59,12 @@ fn new_bitmap_data<'gc>(
     proto: Option<Value<'gc>>,
     bitmap_data: BitmapData<'gc>,
     activation: &mut Activation<'_, 'gc>,
-) -> ScriptObject<'gc> {
+) -> Object<'gc> {
     let gc_context = activation.gc();
 
-    let object = ScriptObject::new_without_proto(gc_context);
-    // Set `__proto__` manually since `ScriptObject::new()` doesn't support primitive prototypes.
-    // TODO: Pass `proto` to `ScriptObject::new()` once possible.
+    let object = Object::new_without_proto(gc_context);
+    // Set `__proto__` manually since `Object::new()` doesn't support primitive prototypes.
+    // TODO: Pass `proto` to `Object::new()` once possible.
     if let Some(proto) = proto {
         object.define_value(
             gc_context,
@@ -1562,13 +1562,13 @@ fn load_bitmap<'gc>(
 
 pub fn create_constructor<'gc>(
     context: &mut StringContext<'gc>,
-    proto: ScriptObject<'gc>,
+    proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     define_properties_on(PROTO_DECLS, context, proto, fn_proto);
 
     let bitmap_data_constructor =
-        FunctionObject::constructor(context, constructor, None, fn_proto, proto.into());
+        FunctionObject::constructor(context, constructor, None, fn_proto, proto);
     define_properties_on(OBJECT_DECLS, context, bitmap_data_constructor, fn_proto);
     bitmap_data_constructor
 }

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -6,7 +6,7 @@ use crate::avm1::globals::bitmap_filter;
 use crate::avm1::globals::color_transform::ColorTransformObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Attribute, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, Attribute, Error, Object, ScriptObject, Value};
 use crate::bitmap::bitmap_data::{BitmapData, BitmapDataWrapper};
 use crate::bitmap::bitmap_data::{BitmapDataDrawError, IBitmapDrawable};
 use crate::bitmap::bitmap_data::{ChannelOptions, ThresholdOperation};
@@ -1569,7 +1569,6 @@ pub fn create_constructor<'gc>(
 
     let bitmap_data_constructor =
         FunctionObject::constructor(context, constructor, None, fn_proto, proto.into());
-    let object = bitmap_data_constructor.raw_script_object();
-    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, bitmap_data_constructor, fn_proto);
     bitmap_data_constructor
 }

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -12,7 +12,7 @@ use crate::avm1::globals::glow_filter::GlowFilter;
 use crate::avm1::globals::gradient_filter::GradientFilter;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Attribute, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Attribute, Object, ScriptObject, Value};
 use crate::context::UpdateContext;
 use crate::string::StringContext;
 use ruffle_macros::istr;

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -12,7 +12,7 @@ use crate::avm1::globals::glow_filter::GlowFilter;
 use crate::avm1::globals::gradient_filter::GradientFilter;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Attribute, Object, ScriptObject, Value};
+use crate::avm1::{Attribute, Object, Value};
 use crate::context::UpdateContext;
 use crate::string::StringContext;
 use ruffle_macros::istr;
@@ -149,10 +149,10 @@ pub fn create_instance<'gc>(
     activation: &mut Activation<'_, 'gc>,
     native: NativeObject<'gc>,
     proto: Option<Value<'gc>>,
-) -> ScriptObject<'gc> {
-    let result = ScriptObject::new(activation.strings(), None);
-    // Set `__proto__` manually since `ScriptObject::new()` doesn't support primitive prototypes.
-    // TODO: Pass `proto` to `ScriptObject::new()` once possible.
+) -> Object<'gc> {
+    let result = Object::new(activation.strings(), None);
+    // Set `__proto__` manually since `Object::new()` doesn't support primitive prototypes.
+    // TODO: Pass `proto` to `Object::new()` once possible.
     if let Some(proto) = proto {
         result.define_value(
             activation.gc(),
@@ -170,7 +170,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::Cell;

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Error, Object, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::Cell;
@@ -184,9 +184,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let blur_filter_proto = ScriptObject::new(context, Some(proto));
+    let blur_filter_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, blur_filter_proto, fn_proto);
-    blur_filter_proto.into()
+    blur_filter_proto
 }
 
 pub fn create_constructor<'gc>(

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -6,7 +6,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, TObject, Value};
+use crate::avm1::{NativeObject, Object, ScriptObject, Value};
 use crate::string::StringContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -6,7 +6,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{NativeObject, Object, Value};
 use crate::string::StringContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -63,9 +63,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let boolean_proto = ScriptObject::new(context, Some(proto));
+    let boolean_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, boolean_proto, fn_proto);
-    boolean_proto.into()
+    boolean_proto
 }
 
 pub fn to_string<'gc>(

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -6,7 +6,7 @@ use crate::avm1::globals::bitmap_filter;
 use crate::avm1::globals::movie_clip::{new_rectangle, object_to_rectangle};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::ArrayBuilder;
-use crate::avm1::{globals, Object, ScriptObject, TObject, Value};
+use crate::avm1::{globals, Object, ScriptObject, Value};
 use crate::avm1_stub;
 use crate::display_object::{Avm1Button, TDisplayObject, TInteractiveObject};
 use crate::string::{AvmString, StringContext};

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -6,7 +6,7 @@ use crate::avm1::globals::bitmap_filter;
 use crate::avm1::globals::movie_clip::{new_rectangle, object_to_rectangle};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::ArrayBuilder;
-use crate::avm1::{globals, Object, ScriptObject, Value};
+use crate::avm1::{globals, Object, Value};
 use crate::avm1_stub;
 use crate::display_object::{Avm1Button, TDisplayObject, TInteractiveObject};
 use crate::string::{AvmString, StringContext};
@@ -55,9 +55,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 fn blend_mode<'gc>(

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -7,7 +7,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::string::{AvmString, StringContext};
 

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -7,7 +7,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::string::{AvmString, StringContext};
 
@@ -43,9 +43,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 /// Gets the target display object of this color transform.
@@ -91,7 +91,7 @@ fn get_transform<'gc>(
     if let Some(target) = target(activation, this)? {
         let base = target.base();
         let color_transform = base.color_transform();
-        let out = ScriptObject::new(
+        let out = Object::new(
             &activation.context.strings,
             Some(activation.context.avm1.prototypes().object),
         );

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::Cell;

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, ArrayBuilder, Error, Object, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::Cell;
@@ -160,9 +160,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let color_matrix_filter_proto = ScriptObject::new(context, Some(proto));
+    let color_matrix_filter_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, color_matrix_filter_proto, fn_proto);
-    color_matrix_filter_proto.into()
+    color_matrix_filter_proto
 }
 
 pub fn create_constructor<'gc>(

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
 use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, GcCell};
 use ruffle_macros::istr;

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Error, Object, Value};
 use crate::string::{AvmString, StringContext};
 use gc_arena::{Collect, GcCell};
 use ruffle_macros::istr;
@@ -269,7 +269,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -1,6 +1,5 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::object::TObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -1,8 +1,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::Object;
-use crate::avm1::{ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::context_menu;
 use crate::display_object::DisplayObject;
 use crate::string::StringContext;
@@ -25,7 +24,7 @@ pub fn constructor<'gc>(
 
     this.set(istr!("onSelect"), callback.into(), activation)?;
 
-    let built_in_items = ScriptObject::new(
+    let built_in_items = Object::new(
         &activation.context.strings,
         Some(activation.context.avm1.prototypes().object),
     );
@@ -146,9 +145,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 pub fn make_context_menu_state<'gc>(

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -1,8 +1,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::Object;
-use crate::avm1::{ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::{AvmString, StringContext};
 use ruffle_macros::istr;
 
@@ -97,7 +96,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -1,6 +1,5 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::object::TObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::{Cell, RefCell};

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, ArrayBuilder, Error, Object, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::{Cell, RefCell};
@@ -169,7 +169,7 @@ impl<'gc> ConvolutionFilter<'gc> {
         Ok(())
     }
 
-    fn matrix(self, activation: &Activation<'_, 'gc>) -> ScriptObject<'gc> {
+    fn matrix(self, activation: &Activation<'_, 'gc>) -> Object<'gc> {
         ArrayBuilder::new(activation).with(self.0.matrix.borrow().iter().map(|&x| x.into()))
     }
 
@@ -410,9 +410,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let convolution_filter_proto = ScriptObject::new(context, Some(proto));
+    let convolution_filter_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, convolution_filter_proto, fn_proto);
-    convolution_filter_proto.into()
+    convolution_filter_proto
 }
 
 pub fn create_constructor<'gc>(

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -2,7 +2,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
 use crate::locale::{get_current_date_time, get_timezone};
 use crate::string::{AvmString, StringContext};
 use gc_arena::Gc;
@@ -580,8 +580,7 @@ pub fn create_constructor<'gc>(
         fn_proto,
         date_proto.into(),
     );
-    let object = date_constructor.raw_script_object();
-    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, date_constructor, fn_proto);
 
     date_constructor
 }

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -2,7 +2,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Error, Object, Value};
 use crate::locale::{get_current_date_time, get_timezone};
 use crate::string::{AvmString, StringContext};
 use gc_arena::Gc;
@@ -570,7 +570,7 @@ pub fn create_constructor<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let date_proto = ScriptObject::new(context, Some(proto));
+    let date_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, date_proto, fn_proto);
 
     let date_constructor = FunctionObject::constructor(
@@ -578,7 +578,7 @@ pub fn create_constructor<'gc>(
         date_method!(256),
         Some(function),
         fn_proto,
-        date_proto.into(),
+        date_proto,
     );
     define_properties_on(OBJECT_DECLS, context, date_constructor, fn_proto);
 

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Error, Object, Value};
 use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::context::UpdateContext;
 use crate::string::StringContext;
@@ -81,9 +81,9 @@ impl<'gc> DisplacementMapFilter<'gc> {
     fn map_bitmap(self, context: &mut UpdateContext<'gc>) -> Option<Object<'gc>> {
         if let Some(map_bitmap) = self.0.map_bitmap.get() {
             let proto = context.avm1.prototypes().bitmap_data;
-            let result = ScriptObject::new(&context.strings, Some(proto));
+            let result = Object::new(&context.strings, Some(proto));
             result.set_native(context.gc(), NativeObject::BitmapData(map_bitmap));
-            Some(result.into())
+            Some(result)
         } else {
             None
         }
@@ -410,14 +410,14 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let displacement_map_filter_proto = ScriptObject::new(context, Some(proto));
+    let displacement_map_filter_proto = Object::new(context, Some(proto));
     define_properties_on(
         PROTO_DECLS,
         context,
         displacement_map_filter_proto,
         fn_proto,
     );
-    displacement_map_filter_proto.into()
+    displacement_map_filter_proto
 }
 
 pub fn create_constructor<'gc>(

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -4,7 +4,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
 use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::context::UpdateContext;
 use crate::string::StringContext;

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::Cell;

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Error, Object, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::Cell;
@@ -436,9 +436,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let drop_shadow_filter_proto = ScriptObject::new(context, Some(proto));
+    let drop_shadow_filter_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, drop_shadow_filter_proto, fn_proto);
-    drop_shadow_filter_proto.into()
+    drop_shadow_filter_proto
 }
 
 pub fn create_constructor<'gc>(

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -3,7 +3,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::string::StringContext;
 use ruffle_macros::istr;
 

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -3,7 +3,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::StringContext;
 use ruffle_macros::istr;
 
@@ -32,9 +32,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 fn to_string<'gc>(

--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -3,7 +3,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::external::{Callback, ExternalInterface, Value as ExternalValue};
 use crate::string::StringContext;
 
@@ -79,12 +79,12 @@ pub fn create_external_interface_object<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(OBJECT_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 pub fn create_proto<'gc>(context: &mut StringContext<'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
-    ScriptObject::new(context, Some(proto)).into()
+    Object::new(context, Some(proto))
 }

--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, TObject, Value};
+use crate::avm1::{NativeObject, Object, ScriptObject, Value};
 use crate::avm1_stub;
 use crate::backend::ui::{FileDialogResult, FileFilter};
 use crate::string::{AvmString, StringContext};
@@ -433,11 +433,6 @@ pub fn create_constructor<'gc>(
     broadcaster_functions.initialize(context, file_reference_proto.into(), array_proto);
     let constructor =
         FunctionObject::native(context, constructor, fn_proto, file_reference_proto.into());
-    define_properties_on(
-        OBJECT_DECLS,
-        context,
-        constructor.raw_script_object(),
-        fn_proto,
-    );
+    define_properties_on(OBJECT_DECLS, context, constructor, fn_proto);
     constructor
 }

--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{NativeObject, Object, Value};
 use crate::avm1_stub;
 use crate::backend::ui::{FileDialogResult, FileFilter};
 use crate::string::{AvmString, StringContext};
@@ -428,11 +428,10 @@ pub fn create_constructor<'gc>(
     array_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let file_reference_proto = ScriptObject::new(context, Some(proto));
+    let file_reference_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, file_reference_proto, fn_proto);
-    broadcaster_functions.initialize(context, file_reference_proto.into(), array_proto);
-    let constructor =
-        FunctionObject::native(context, constructor, fn_proto, file_reference_proto.into());
+    broadcaster_functions.initialize(context, file_reference_proto, array_proto);
+    let constructor = FunctionObject::native(context, constructor, fn_proto, file_reference_proto);
     define_properties_on(OBJECT_DECLS, context, constructor, fn_proto);
     constructor
 }

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{ExecutionName, ExecutionReason};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{ExecutionName, ExecutionReason};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -29,7 +29,7 @@ pub fn function<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(args.get(0).copied().unwrap_or_else(|| {
         // Calling `Function()` seems to give a prototypeless bare object.
-        ScriptObject::new(&activation.context.strings, None).into()
+        Object::new(&activation.context.strings, None).into()
     }))
 }
 
@@ -114,7 +114,7 @@ pub fn apply<'gc>(
 /// returned object is also a bare object, which will need to be linked into
 /// the prototype of `Object`.
 pub fn create_proto<'gc>(context: &mut StringContext<'gc>, proto: Object<'gc>) -> Object<'gc> {
-    let function_proto = ScriptObject::new(context, Some(proto));
-    define_properties_on(PROTO_DECLS, context, function_proto, function_proto.into());
-    function_proto.into()
+    let function_proto = Object::new(context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, function_proto, function_proto);
+    function_proto
 }

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::Cell;

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -3,7 +3,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Error, Object, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use std::cell::Cell;
@@ -343,9 +343,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let glow_filter_proto = ScriptObject::new(context, Some(proto));
+    let glow_filter_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, glow_filter_proto, fn_proto);
-    glow_filter_proto.into()
+    glow_filter_proto
 }
 
 pub fn create_constructor<'gc>(

--- a/core/src/avm1/globals/gradient_filter.rs
+++ b/core/src/avm1/globals/gradient_filter.rs
@@ -5,7 +5,7 @@ use crate::avm1::function::FunctionObject;
 use crate::avm1::globals::bevel_filter::BevelFilterType;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, ArrayBuilder, Error, Object, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use ruffle_macros::istr;
@@ -170,7 +170,7 @@ impl<'gc> GradientFilter<'gc> {
         Ok(())
     }
 
-    fn colors(self, activation: &Activation<'_, 'gc>) -> ScriptObject<'gc> {
+    fn colors(self, activation: &Activation<'_, 'gc>) -> Object<'gc> {
         let num_colors = self.0.num_colors.get();
         ArrayBuilder::new(activation).with(
             self.0.colors.borrow()[..num_colors]
@@ -206,7 +206,7 @@ impl<'gc> GradientFilter<'gc> {
         Ok(())
     }
 
-    fn alphas(self, activation: &Activation<'_, 'gc>) -> ScriptObject<'gc> {
+    fn alphas(self, activation: &Activation<'_, 'gc>) -> Object<'gc> {
         let num_colors = self.0.num_colors.get();
         ArrayBuilder::new(activation).with(
             self.0.colors.borrow()[..num_colors]
@@ -245,7 +245,7 @@ impl<'gc> GradientFilter<'gc> {
         Ok(())
     }
 
-    fn ratios(self, activation: &Activation<'_, 'gc>) -> ScriptObject<'gc> {
+    fn ratios(self, activation: &Activation<'_, 'gc>) -> Object<'gc> {
         let num_colors = self.0.num_colors.get();
         ArrayBuilder::new(activation).with(
             self.0.colors.borrow()[..num_colors]
@@ -534,9 +534,9 @@ pub fn create_bevel_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let gradient_bevel_filter_proto = ScriptObject::new(context, Some(proto));
+    let gradient_bevel_filter_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, gradient_bevel_filter_proto, fn_proto);
-    gradient_bevel_filter_proto.into()
+    gradient_bevel_filter_proto
 }
 
 pub fn create_bevel_constructor<'gc>(
@@ -558,9 +558,9 @@ pub fn create_glow_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let gradient_bevel_filter_proto = ScriptObject::new(context, Some(proto));
+    let gradient_bevel_filter_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, gradient_bevel_filter_proto, fn_proto);
-    gradient_bevel_filter_proto.into()
+    gradient_bevel_filter_proto
 }
 
 pub fn create_glow_constructor<'gc>(

--- a/core/src/avm1/globals/gradient_filter.rs
+++ b/core/src/avm1/globals/gradient_filter.rs
@@ -5,7 +5,7 @@ use crate::avm1::function::FunctionObject;
 use crate::avm1::globals::bevel_filter::BevelFilterType;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, Value};
 use crate::string::StringContext;
 use gc_arena::{Collect, Gc, Mutation};
 use ruffle_macros::istr;

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -2,7 +2,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::events::KeyCode;
 use crate::string::StringContext;
 
@@ -88,8 +88,8 @@ pub fn create_key_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let key = ScriptObject::new(context, Some(proto));
-    broadcaster_functions.initialize(context, key.into(), array_proto);
+    let key = Object::new(context, Some(proto));
+    broadcaster_functions.initialize(context, key, array_proto);
     define_properties_on(OBJECT_DECLS, context, key, fn_proto);
-    key.into()
+    key
 }

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -6,7 +6,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::ExecutionReason;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::avm1_stub;
 use crate::backend::navigator::{NavigationMethod, Request};
 use crate::string::{AvmString, StringContext};

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -6,7 +6,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::ExecutionReason;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::avm1_stub;
 use crate::backend::navigator::{NavigationMethod, Request};
 use crate::string::{AvmString, StringContext};
@@ -31,9 +31,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 fn add_request_header<'gc>(

--- a/core/src/avm1/globals/local_connection.rs
+++ b/core/src/avm1/globals/local_connection.rs
@@ -4,9 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::shared_object::{deserialize_value, serialize};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{
-    ActivationIdentifier, ExecutionReason, NativeObject, Object, ScriptObject, Value,
-};
+use crate::avm1::{ActivationIdentifier, ExecutionReason, NativeObject, Object, Value};
 use crate::context::UpdateContext;
 use crate::display_object::TDisplayObject;
 use crate::local_connection::{LocalConnectionHandle, LocalConnections};
@@ -246,7 +244,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }

--- a/core/src/avm1/globals/local_connection.rs
+++ b/core/src/avm1/globals/local_connection.rs
@@ -3,7 +3,6 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::shared_object::{deserialize_value, serialize};
-use crate::avm1::object::TObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{
     ActivationIdentifier, ExecutionReason, NativeObject, Object, ScriptObject, Value,

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -1,8 +1,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::StringContext;
 
 use rand::Rng;
@@ -166,9 +165,9 @@ pub fn create<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let math = ScriptObject::new(context, Some(proto));
+    let math = Object::new(context, Some(proto));
     define_properties_on(OBJECT_DECLS, context, math, fn_proto);
-    math.into()
+    math
 }
 
 #[cfg(test)]

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::globals::point::{point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::{AvmString, StringContext};
 
 use ruffle_macros::istr;
@@ -493,7 +493,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::globals::point::{point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::string::{AvmString, StringContext};
 
 use ruffle_macros::istr;

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -2,7 +2,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::StringContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
@@ -37,8 +37,8 @@ pub fn create_mouse_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mouse = ScriptObject::new(context, Some(proto));
-    broadcaster_functions.initialize(context, mouse.into(), array_proto);
+    let mouse = Object::new(context, Some(proto));
+    broadcaster_functions.initialize(context, mouse, array_proto);
     define_properties_on(OBJECT_DECLS, context, mouse, fn_proto);
-    mouse.into()
+    mouse
 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -6,7 +6,7 @@ use crate::avm1::globals::matrix::gradient_object_to_matrix;
 use crate::avm1::globals::{self, bitmap_filter, AVM_DEPTH_BIAS, AVM_MAX_DEPTH};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{self, ArrayBuilder, Object, ScriptObject, Value};
+use crate::avm1::{self, ArrayBuilder, Object, Value};
 use crate::backend::navigator::NavigationMethod;
 use crate::context::UpdateContext;
 use crate::display_object::{Bitmap, EditText, MovieClip, TInteractiveObject};
@@ -258,9 +258,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 fn attach_bitmap<'gc>(
@@ -993,7 +993,7 @@ pub fn clone_sprite<'gc>(
         *new_clip.drawing_mut(context.gc()) = drawing;
     }
     // TODO: Any other properties we should copy...?
-    // Definitely not ScriptObject properties.
+    // Definitely not Object properties.
 
     new_clip.post_instantiation(context, init_object, Instantiator::Avm1, true);
 
@@ -1468,7 +1468,7 @@ fn get_bounds<'gc>(
             }
         };
 
-        let out = ScriptObject::new(
+        let out = Object::new(
             &activation.context.strings,
             Some(activation.context.avm1.prototypes().object),
         );

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -6,7 +6,7 @@ use crate::avm1::globals::matrix::gradient_object_to_matrix;
 use crate::avm1::globals::{self, bitmap_filter, AVM_DEPTH_BIAS, AVM_MAX_DEPTH};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{self, ArrayBuilder, Object, ScriptObject, TObject, Value};
+use crate::avm1::{self, ArrayBuilder, Object, ScriptObject, Value};
 use crate::backend::navigator::NavigationMethod;
 use crate::context::UpdateContext;
 use crate::display_object::{Bitmap, EditText, MovieClip, TInteractiveObject};

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -3,7 +3,6 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
-use crate::avm1::object::script_object::ScriptObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayBuilder, Object, Value};
@@ -28,7 +27,7 @@ pub fn constructor<'gc>(
     this.define_value(
         activation.gc(),
         istr!("_listeners"),
-        Value::Object(listeners.into()),
+        Value::Object(listeners),
         Attribute::DONT_ENUM,
     );
     Ok(Value::Undefined)
@@ -137,7 +136,7 @@ fn get_progress<'gc>(
             Value::MovieClip(_) => target.coerce_to_object(activation).as_display_object(),
             _ => return Ok(Value::Undefined),
         };
-        let result = ScriptObject::new(&activation.context.strings, None);
+        let result = Object::new(&activation.context.strings, None);
         if let Some(target) = target {
             result.define_value(
                 activation.gc(),
@@ -165,8 +164,8 @@ pub fn create_proto<'gc>(
     array_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let mcl_proto = ScriptObject::new(context, Some(proto));
-    broadcaster_functions.initialize(context, mcl_proto.into(), array_proto);
+    let mcl_proto = Object::new(context, Some(proto));
+    broadcaster_functions.initialize(context, mcl_proto, array_proto);
     define_properties_on(PROTO_DECLS, context, mcl_proto, fn_proto);
-    mcl_proto.into()
+    mcl_proto
 }

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -4,7 +4,6 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::object::script_object::ScriptObject;
-use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayBuilder, Object, Value};

--- a/core/src/avm1/globals/netconnection.rs
+++ b/core/src/avm1/globals/netconnection.rs
@@ -3,8 +3,7 @@ use crate::avm1::globals::shared_object::{deserialize_value, serialize};
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{
-    Activation, ActivationIdentifier, Error, ExecutionReason, NativeObject, ScriptObject, TObject,
-    Value,
+    Activation, ActivationIdentifier, Error, ExecutionReason, NativeObject, ScriptObject, Value,
 };
 use crate::avm1_stub;
 use crate::context::UpdateContext;

--- a/core/src/avm1/globals/netconnection.rs
+++ b/core/src/avm1/globals/netconnection.rs
@@ -2,9 +2,7 @@ use crate::avm1::function::FunctionObject;
 use crate::avm1::globals::shared_object::{deserialize_value, serialize};
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{
-    Activation, ActivationIdentifier, Error, ExecutionReason, NativeObject, ScriptObject, Value,
-};
+use crate::avm1::{Activation, ActivationIdentifier, Error, ExecutionReason, NativeObject, Value};
 use crate::avm1_stub;
 use crate::context::UpdateContext;
 use crate::net_connection::{NetConnectionHandle, NetConnections, ResponderCallback};
@@ -340,9 +338,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 pub fn create_class<'gc>(

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -1,7 +1,7 @@
 use crate::avm1::function::FunctionObject;
-use crate::avm1::object::{NativeObject, Object};
+use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, ScriptObject, Value};
+use crate::avm1::{Activation, Error, Object, Value};
 use crate::avm1_stub;
 use crate::streams::NetStream;
 use crate::string::StringContext;
@@ -173,9 +173,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 pub fn create_class<'gc>(

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -1,5 +1,5 @@
 use crate::avm1::function::FunctionObject;
-use crate::avm1::object::{NativeObject, Object, TObject};
+use crate::avm1::object::{NativeObject, Object};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, ScriptObject, Value};
 use crate::avm1_stub;

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -8,7 +8,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::BoxedF64;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, TObject, Value};
+use crate::avm1::{NativeObject, Object, ScriptObject, Value};
 use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -73,8 +73,7 @@ pub fn create_number_object<'gc>(
         fn_proto,
         number_proto,
     );
-    let object = number.raw_script_object();
-    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, number, fn_proto);
     number
 }
 

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -8,7 +8,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::object::BoxedF64;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{NativeObject, Object, Value};
 use crate::string::{AvmString, StringContext};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -83,9 +83,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let number_proto = ScriptObject::new(context, Some(proto));
+    let number_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, number_proto, fn_proto);
-    number_proto.into()
+    number_proto
 }
 
 fn to_string<'gc>(

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::avm_warn;
 use crate::display_object::TDisplayObject;
 use crate::string::{AvmString, StringContext};
@@ -244,8 +244,7 @@ pub fn fill_proto<'gc>(
     object_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) {
-    let object = object_proto.raw_script_object();
-    define_properties_on(PROTO_DECLS, context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object_proto, fn_proto);
 }
 
 /// Implements `ASSetPropFlags`.
@@ -320,7 +319,6 @@ pub fn create_object_object<'gc>(
 ) -> Object<'gc> {
     let object_function =
         FunctionObject::constructor(context, constructor, Some(object_function), fn_proto, proto);
-    let object = object_function.raw_script_object();
-    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, object_function, fn_proto);
     object_function
 }

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::avm_warn;
 use crate::display_object::TDisplayObject;
 use crate::string::{AvmString, StringContext};
@@ -45,9 +45,7 @@ pub fn object_function<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let obj = match args.get(0).unwrap_or(&Value::Undefined) {
-        Value::Undefined | Value::Null => {
-            Object::from(ScriptObject::new(&activation.context.strings, None))
-        }
+        Value::Undefined | Value::Null => Object::new(&activation.context.strings, None),
         val => val.coerce_to_object(activation),
     };
     Ok(obj.into())

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{ExecutionReason, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::{AvmString, StringContext};
 
 use ruffle_macros::istr;
@@ -319,7 +319,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{ExecutionReason, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::string::{AvmString, StringContext};
 
 use ruffle_macros::istr;
@@ -310,8 +310,7 @@ pub fn create_point_object<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let point = FunctionObject::native(context, constructor, fn_proto, point_proto);
-    let object = point.raw_script_object();
-    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, point, fn_proto);
     point
 }
 

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::globals::point::{construct_new_point, point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::{AvmString, StringContext};
 use ruffle_macros::istr;
 
@@ -888,7 +888,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::globals::point::{construct_new_point, point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::string::{AvmString, StringContext};
 use ruffle_macros::istr;
 

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::display_object::{EditText, TDisplayObject, TInteractiveObject, TextSelection};
 use crate::string::StringContext;
 
@@ -146,13 +146,13 @@ pub fn create_selection_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
-    broadcaster_functions.initialize(context, object.into(), array_proto);
+    let object = Object::new(context, Some(proto));
+    broadcaster_functions.initialize(context, object, array_proto);
     define_properties_on(OBJECT_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 pub fn create_proto<'gc>(context: &mut StringContext<'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
-    ScriptObject::new(context, Some(proto)).into()
+    Object::new(context, Some(proto))
 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -1,6 +1,6 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Attribute, Error, NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Attribute, Error, NativeObject, Object, Value};
 use crate::avm1_stub;
 use crate::display_object::TDisplayObject;
 use crate::string::{AvmString, StringContext};
@@ -189,7 +189,7 @@ pub fn deserialize_value<'gc>(
         }
         AmfValue::Object(_, elements, _) => {
             // Deserialize Object
-            let obj = ScriptObject::new(
+            let obj = Object::new(
                 &activation.context.strings,
                 Some(activation.context.avm1.prototypes().object),
             );
@@ -246,7 +246,7 @@ fn deserialize_lso<'gc>(
     lso: &Lso,
     decoder: &AMF0Decoder,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let obj = ScriptObject::new(
+    let obj = Object::new(
         &activation.context.strings,
         Some(activation.context.avm1.prototypes().object),
     );
@@ -262,7 +262,7 @@ fn deserialize_lso<'gc>(
         );
     }
 
-    Ok(obj.into())
+    Ok(obj)
 }
 
 fn new_lso<'gc>(activation: &mut Activation<'_, 'gc>, name: &str, data: Object<'gc>) -> Lso {
@@ -425,7 +425,7 @@ fn get_local<'gc>(
 
     if data == Value::Undefined {
         // No data; create a fresh data object.
-        data = ScriptObject::new(
+        data = Object::new(
             &activation.context.strings,
             Some(activation.context.avm1.prototypes().object),
         )
@@ -588,10 +588,9 @@ pub fn create_constructor<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let shared_object_proto = ScriptObject::new(context, Some(proto));
+    let shared_object_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, shared_object_proto, fn_proto);
-    let constructor =
-        FunctionObject::native(context, constructor, fn_proto, shared_object_proto.into());
+    let constructor = FunctionObject::native(context, constructor, fn_proto, shared_object_proto);
     define_properties_on(OBJECT_DECLS, context, constructor, fn_proto);
     constructor
 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -1,8 +1,6 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{
-    Activation, Attribute, Error, NativeObject, Object, ScriptObject, TObject, Value,
-};
+use crate::avm1::{Activation, Attribute, Error, NativeObject, Object, ScriptObject, Value};
 use crate::avm1_stub;
 use crate::display_object::TDisplayObject;
 use crate::string::{AvmString, StringContext};
@@ -594,11 +592,6 @@ pub fn create_constructor<'gc>(
     define_properties_on(PROTO_DECLS, context, shared_object_proto, fn_proto);
     let constructor =
         FunctionObject::native(context, constructor, fn_proto, shared_object_proto.into());
-    define_properties_on(
-        OBJECT_DECLS,
-        context,
-        constructor.raw_script_object(),
-        fn_proto,
-    );
+    define_properties_on(OBJECT_DECLS, context, constructor, fn_proto);
     constructor
 }

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -12,7 +12,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{NativeObject, Object, Value};
 use crate::backend::audio::{SoundHandle, SoundInstanceHandle};
 use crate::backend::navigator::Request;
 use crate::character::Character;
@@ -166,9 +166,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 pub fn create_constructor<'gc>(
@@ -292,7 +292,7 @@ fn get_transform<'gc>(
             .map(|owner| owner.base().sound_transform().clone())
             .unwrap_or_else(|| activation.context.global_sound_transform().clone());
 
-        let obj = ScriptObject::new(
+        let obj = Object::new(
             &activation.context.strings,
             Some(activation.context.avm1.prototypes().object),
         );

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -12,7 +12,7 @@ use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, TObject, Value};
+use crate::avm1::{NativeObject, Object, ScriptObject, Value};
 use crate::backend::audio::{SoundHandle, SoundInstanceHandle};
 use crate::backend::navigator::Request;
 use crate::character::Character;

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -6,7 +6,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::display_object::StageDisplayState;
 use crate::string::{AvmString, StringContext, WStr, WString};
 use ruffle_macros::istr;
@@ -27,10 +27,10 @@ pub fn create_stage_object<'gc>(
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let stage = ScriptObject::new(context, Some(proto));
-    broadcaster_functions.initialize(context, stage.into(), array_proto);
+    let stage = Object::new(context, Some(proto));
+    broadcaster_functions.initialize(context, stage, array_proto);
     define_properties_on(OBJECT_DECLS, context, stage, fn_proto);
-    stage.into()
+    stage
 }
 
 fn align<'gc>(

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -7,7 +7,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{ArrayBuilder, NativeObject, Object, ScriptObject, TObject, Value};
+use crate::avm1::{ArrayBuilder, NativeObject, Object, ScriptObject, Value};
 use crate::string::{utils as string_utils, AvmString, StringContext, WString};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -83,8 +83,7 @@ pub fn create_string_object<'gc>(
         fn_proto,
         string_proto,
     );
-    let object = string.raw_script_object();
-    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, string, fn_proto);
     string
 }
 

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -7,7 +7,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{ArrayBuilder, NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{ArrayBuilder, NativeObject, Object, Value};
 use crate::string::{utils as string_utils, AvmString, StringContext, WString};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -93,9 +93,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let string_proto = ScriptObject::new(context, Some(proto));
+    let string_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, string_proto, fn_proto);
-    string_proto.into()
+    string_proto
 }
 
 fn char_at<'gc>(

--- a/core/src/avm1/globals/style_sheet.rs
+++ b/core/src/avm1/globals/style_sheet.rs
@@ -2,9 +2,7 @@ use std::fmt;
 
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::define_properties_on;
-use crate::avm1::{
-    property_decl::Declaration, ArrayBuilder, ExecutionReason, NativeObject, ScriptObject,
-};
+use crate::avm1::{property_decl::Declaration, ArrayBuilder, ExecutionReason, NativeObject};
 use crate::avm1::{Activation, Error, Value};
 use crate::backend::navigator::Request;
 use crate::html::{transform_dashes_to_camel_case, CssStream, StyleSheet, TextFormat};
@@ -57,7 +55,7 @@ fn shallow_copy<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Value::Object(object) = value {
         let object_proto = activation.context.avm1.prototypes().object;
-        let result = ScriptObject::new(activation.strings(), Some(object_proto));
+        let result = Object::new(activation.strings(), Some(object_proto));
 
         for key in object.get_keys(activation, false) {
             result.set(key, object.get_stored(key, activation)?, activation)?;
@@ -361,7 +359,7 @@ fn transform<'gc>(
     }
 
     let proto = activation.context.avm1.prototypes().text_format;
-    let object = ScriptObject::new(activation.strings(), Some(proto));
+    let object = Object::new(activation.strings(), Some(proto));
     object.set_native(
         activation.gc(),
         NativeObject::TextFormat(Gc::new(activation.gc(), text_format.into())),
@@ -383,7 +381,7 @@ fn parse_css<'gc>(
         for (selector, properties) in css.into_iter() {
             if !selector.is_empty() {
                 let proto = activation.context.avm1.prototypes().object;
-                let object = ScriptObject::new(activation.strings(), Some(proto));
+                let object = Object::new(activation.strings(), Some(proto));
 
                 for (key, value) in properties.into_iter() {
                     object.set(
@@ -443,7 +441,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let style_sheet_proto = ScriptObject::new(context, Some(proto));
+    let style_sheet_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, style_sheet_proto, fn_proto);
-    style_sheet_proto.into()
+    style_sheet_proto
 }

--- a/core/src/avm1/globals/style_sheet.rs
+++ b/core/src/avm1/globals/style_sheet.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::avm1::object::{Object, TObject};
+use crate::avm1::object::Object;
 use crate::avm1::property_decl::define_properties_on;
 use crate::avm1::{
     property_decl::Declaration, ArrayBuilder, ExecutionReason, NativeObject, ScriptObject,

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -1,8 +1,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::avm1_stub;
 use crate::string::StringContext;
 
@@ -125,8 +124,8 @@ pub fn create<'gc>(
     context: &mut StringContext<'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
-) -> ScriptObject<'gc> {
-    let system = ScriptObject::new(context, Some(proto));
+) -> Object<'gc> {
+    let system = Object::new(context, Some(proto));
     define_properties_on(OBJECT_DECLS, context, system, fn_proto);
     system
 }

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -1,8 +1,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::{AvmString, StringContext};
 use crate::system_properties::SystemCapabilities;
 
@@ -251,7 +250,7 @@ pub fn create<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let capabilities = ScriptObject::new(context, Some(proto));
+    let capabilities = Object::new(context, Some(proto));
     define_properties_on(OBJECT_DECLS, context, capabilities, fn_proto);
-    capabilities.into()
+    capabilities
 }

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -1,9 +1,8 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
-use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::{AvmString, StringContext};
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
@@ -87,8 +86,8 @@ pub fn create<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let ime = ScriptObject::new(context, Some(proto));
-    broadcaster_functions.initialize(context, ime.into(), array_proto);
+    let ime = Object::new(context, Some(proto));
+    broadcaster_functions.initialize(context, ime, array_proto);
     define_properties_on(OBJECT_DECLS, context, ime, fn_proto);
-    ime.into()
+    ime
 }

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -1,8 +1,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::avm1_stub;
 use crate::prelude::TDisplayObject;
 use crate::sandbox::SandboxType;
@@ -95,7 +94,7 @@ pub fn create<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let security = ScriptObject::new(context, Some(proto));
+    let security = Object::new(context, Some(proto));
     define_properties_on(OBJECT_DECLS, context, security, fn_proto);
-    security.into()
+    security
 }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::bitmap_filter;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{globals, ArrayBuilder, Object, ScriptObject, TObject, Value};
+use crate::avm1::{globals, ArrayBuilder, Object, ScriptObject, Value};
 use crate::display_object::{
     AutoSizeMode, EditText, TDisplayObject, TInteractiveObject, TextSelection,
 };

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::bitmap_filter;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{globals, ArrayBuilder, Object, ScriptObject, Value};
+use crate::avm1::{globals, ArrayBuilder, Object, Value};
 use crate::display_object::{
     AutoSizeMode, EditText, TDisplayObject, TInteractiveObject, TextSelection,
 };
@@ -105,9 +105,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }
 
 pub fn password<'gc>(
@@ -129,9 +129,9 @@ pub fn set_password<'gc>(
 fn new_text_format<'gc>(
     activation: &mut Activation<'_, 'gc>,
     text_format: TextFormat,
-) -> ScriptObject<'gc> {
+) -> Object<'gc> {
     let proto = activation.context.avm1.prototypes().text_format;
-    let object = ScriptObject::new(&activation.context.strings, Some(proto));
+    let object = Object::new(&activation.context.strings, Some(proto));
     object.set_native(
         activation.gc(),
         NativeObject::TextFormat(Gc::new(activation.gc(), text_format.into())),

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, ArrayBuilder, Error, Object, Value};
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject};
 use crate::ecma_conversions::round_to_even;
 use crate::html::TextFormat;
@@ -529,7 +529,7 @@ fn get_text_extent<'gc>(
     temp_edittext.set_new_text_format(text_format.clone(), activation.context);
     temp_edittext.set_text(&text, activation.context);
 
-    let result = ScriptObject::new(&activation.context.strings, None);
+    let result = Object::new(&activation.context.strings, None);
     let metrics = temp_edittext
         .layout_metrics()
         .expect("All text boxes should have at least one line at all times");
@@ -640,7 +640,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, ArrayBuilder, Error, Object, ScriptObject, Value};
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject};
 use crate::ecma_conversions::round_to_even;
 use crate::html::TextFormat;

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -6,7 +6,7 @@ use crate::avm1::globals::matrix::{matrix_to_value, object_to_matrix};
 use crate::avm1::object::NativeObject;
 use crate::avm1::object_reference::MovieClipReference;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::string::{AvmString, StringContext};
 use gc_arena::Collect;

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -6,7 +6,7 @@ use crate::avm1::globals::matrix::{matrix_to_value, object_to_matrix};
 use crate::avm1::object::NativeObject;
 use crate::avm1::object_reference::MovieClipReference;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Error, Object, Value};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::string::{AvmString, StringContext};
 use gc_arena::Collect;
@@ -183,13 +183,13 @@ pub fn create_constructor<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let transform_proto = ScriptObject::new(context, Some(proto));
+    let transform_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, transform_proto, fn_proto);
     FunctionObject::constructor(
         context,
         transform_method!(0),
         None,
         fn_proto,
-        transform_proto.into(),
+        transform_proto,
     )
 }

--- a/core/src/avm1/globals/video.rs
+++ b/core/src/avm1/globals/video.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::object::{NativeObject, Object, TObject};
+use crate::avm1::object::{NativeObject, Object};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::value::Value;
 use crate::avm1::ScriptObject;

--- a/core/src/avm1/globals/video.rs
+++ b/core/src/avm1/globals/video.rs
@@ -2,10 +2,10 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::object::{NativeObject, Object};
+use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::value::Value;
-use crate::avm1::ScriptObject;
+use crate::avm1::Object;
 use crate::display_object::{TDisplayObject, Video};
 use crate::string::StringContext;
 
@@ -51,7 +51,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(context, Some(proto));
+    let object = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, object, fn_proto);
-    object.into()
+    object
 }

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -4,9 +4,7 @@ use std::cell::Cell;
 
 use crate::avm1::function::{ExecutionReason, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{
-    Activation, Attribute, Error, NativeObject, Object, ScriptObject, TObject, Value,
-};
+use crate::avm1::{Activation, Attribute, Error, NativeObject, Object, ScriptObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::Request;
 use crate::string::{AvmString, StringContext, WStr, WString};

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -4,7 +4,7 @@ use std::cell::Cell;
 
 use crate::avm1::function::{ExecutionReason, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{Activation, Attribute, Error, NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{Activation, Attribute, Error, NativeObject, Object, Value};
 use crate::avm_warn;
 use crate::backend::navigator::Request;
 use crate::string::{AvmString, StringContext, WStr, WString};
@@ -76,7 +76,7 @@ pub struct XmlData<'gc> {
     /// When nodes are parsed into the document by way of `parseXML` or the
     /// document constructor, they get put into this object, which is accessible
     /// through the document's `idMap`.
-    id_map: ScriptObject<'gc>,
+    id_map: Object<'gc>,
 
     /// The last parse error encountered, if any.
     status: Cell<XmlStatus>,
@@ -96,7 +96,7 @@ impl<'gc> Xml<'gc> {
                 root,
                 xml_decl: Lock::new(None),
                 doctype: Lock::new(None),
-                id_map: ScriptObject::new(context, None),
+                id_map: Object::new(context, None),
                 status: Cell::new(XmlStatus::NoError),
             },
         ));
@@ -120,7 +120,7 @@ impl<'gc> Xml<'gc> {
     }
 
     /// Obtain the script object for the document's `idMap` property.
-    fn id_map(self) -> ScriptObject<'gc> {
+    fn id_map(self) -> Object<'gc> {
         self.0.id_map
     }
 
@@ -580,7 +580,7 @@ pub fn create_constructor<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xml_proto = ScriptObject::new(context, Some(proto));
+    let xml_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, xml_proto, fn_proto);
-    FunctionObject::constructor(context, constructor, None, fn_proto, xml_proto.into())
+    FunctionObject::constructor(context, constructor, None, fn_proto, xml_proto)
 }

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -5,7 +5,7 @@ use ruffle_macros::istr;
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, TObject, Value};
+use crate::avm1::{NativeObject, Object, ScriptObject, Value};
 use crate::string::{AvmString, StringContext, WStr};
 use crate::xml::{XmlNode, TEXT_NODE};
 

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -5,7 +5,7 @@ use ruffle_macros::istr;
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
-use crate::avm1::{NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{NativeObject, Object, Value};
 use crate::string::{AvmString, StringContext, WStr};
 use crate::xml::{XmlNode, TEXT_NODE};
 
@@ -399,7 +399,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xml_node_proto = ScriptObject::new(context, Some(proto));
+    let xml_node_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, xml_node_proto, fn_proto);
-    xml_node_proto.into()
+    xml_node_proto
 }

--- a/core/src/avm1/globals/xml_socket.rs
+++ b/core/src/avm1/globals/xml_socket.rs
@@ -2,7 +2,7 @@ use crate::avm1::function::FunctionObject;
 use crate::avm1::object::{NativeObject, Object};
 use crate::avm1::property_decl::define_properties_on;
 use crate::avm1::{property_decl::Declaration, ScriptObject};
-use crate::avm1::{Activation, Error, ExecutionReason, TObject, Value};
+use crate::avm1::{Activation, Error, ExecutionReason, Value};
 use crate::context::UpdateContext;
 use crate::display_object::TDisplayObject;
 use crate::socket::SocketHandle;

--- a/core/src/avm1/globals/xml_socket.rs
+++ b/core/src/avm1/globals/xml_socket.rs
@@ -1,7 +1,7 @@
 use crate::avm1::function::FunctionObject;
-use crate::avm1::object::{NativeObject, Object};
+use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::define_properties_on;
-use crate::avm1::{property_decl::Declaration, ScriptObject};
+use crate::avm1::{property_decl::Declaration, Object};
 use crate::avm1::{Activation, Error, ExecutionReason, Value};
 use crate::context::UpdateContext;
 use crate::display_object::TDisplayObject;
@@ -247,9 +247,9 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xml_socket_proto = ScriptObject::new(context, Some(proto));
+    let xml_socket_proto = Object::new(context, Some(proto));
     define_properties_on(PROTO_DECLS, context, xml_socket_proto, fn_proto);
-    xml_socket_proto.into()
+    xml_socket_proto
 }
 
 pub fn create_class<'gc>(

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -1,6 +1,6 @@
 //! Object trait to expose objects to AVM
 
-use crate::avm1::function::{Executable, ExecutionName, ExecutionReason, FunctionObject};
+use crate::avm1::function::{ExecutionName, ExecutionReason, FunctionObject};
 use crate::avm1::globals::bevel_filter::BevelFilter;
 use crate::avm1::globals::blur_filter::BlurFilter;
 use crate::avm1::globals::color_matrix_filter::ColorMatrixFilter;
@@ -21,7 +21,7 @@ use crate::avm1::globals::transform::TransformObject;
 use crate::avm1::globals::xml::Xml;
 use crate::avm1::globals::xml_socket::XmlSocket;
 use crate::avm1::object::super_object::SuperObject;
-use crate::avm1::{Activation, Attribute, Error, ScriptObject, Value};
+use crate::avm1::{Activation, Error, ScriptObject, Value};
 use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::display_object::{
     Avm1Button, DisplayObject, EditText, MovieClip, TDisplayObject as _, Video,
@@ -31,9 +31,8 @@ use crate::streams::NetStream;
 use crate::string::AvmString;
 use crate::xml::XmlNode;
 use gc_arena::{Collect, Gc, GcCell, Mutation};
-use ruffle_macros::{enum_trait_object, istr};
+use ruffle_macros::istr;
 use std::cell::{Cell, RefCell};
-use std::fmt::Debug;
 use std::marker::PhantomData;
 
 pub mod script_object;
@@ -144,34 +143,12 @@ impl<'gc> NativeObject<'gc> {
 
 /// Represents an object that can be directly interacted with by the AVM
 /// runtime.
-#[enum_trait_object(
-    #[allow(clippy::enum_variant_names)]
-    #[derive(Clone, Collect, Debug, Copy)]
-    #[collect(no_drop)]
-    pub enum Object<'gc> {
-        ScriptObject(ScriptObject<'gc>),
-    }
-)]
-pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
-    /// Get the underlying raw script object.
-    fn raw_script_object(&self) -> ScriptObject<'gc>;
+/// TODO(moulins): remove this type alias.
+pub type Object<'gc> = ScriptObject<'gc>;
 
-    /// Retrieve a named, non-virtual property from this object exclusively.
-    ///
-    /// This function should not inspect prototype chains. Instead, use
-    /// `get_stored` to do ordinary property look-up and resolution.
-    fn get_local_stored(
-        &self,
-        name: impl Into<AvmString<'gc>>,
-        activation: &mut Activation<'_, 'gc>,
-        is_slash_path: bool,
-    ) -> Option<Value<'gc>> {
-        self.raw_script_object()
-            .get_local_stored(name, activation, is_slash_path)
-    }
-
+impl<'gc> Object<'gc> {
     /// Retrieve a named property from the object, or its prototype.
-    fn get_non_slash_path(
+    pub fn get_non_slash_path(
         &self,
         name: impl Into<AvmString<'gc>>,
         activation: &mut Activation<'_, 'gc>,
@@ -189,7 +166,7 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
     }
 
     /// Retrieve a named property from the object, or its prototype.
-    fn get(
+    pub fn get(
         &self,
         name: impl Into<AvmString<'gc>>,
         activation: &mut Activation<'_, 'gc>,
@@ -207,7 +184,7 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
     }
 
     /// Retrieve a non-virtual property from the object, or its prototype.
-    fn get_stored(
+    pub fn get_stored(
         &self,
         name: AvmString<'gc>,
         activation: &mut Activation<'_, 'gc>,
@@ -233,19 +210,8 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
         Ok(Value::Undefined)
     }
 
-    fn set_local(
-        &self,
-        name: AvmString<'gc>,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        this: Object<'gc>,
-    ) -> Result<(), Error<'gc>> {
-        self.raw_script_object()
-            .set_local(name, value, activation, this)
-    }
-
     /// Set a named property on this object, or its prototype.
-    fn set(
+    pub fn set(
         &self,
         name: impl Into<AvmString<'gc>>,
         value: Value<'gc>,
@@ -293,41 +259,6 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
         watcher_result.and(result)
     }
 
-    /// Call the underlying object.
-    ///
-    /// This function takes a  `this` parameter which generally
-    /// refers to the object which has this property, although
-    /// it can be changed by `Function.apply`/`Function.call`.
-    fn call(
-        &self,
-        name: impl Into<ExecutionName<'gc>>,
-        activation: &mut Activation<'_, 'gc>,
-        this: Value<'gc>,
-        args: &[Value<'gc>],
-    ) -> Result<Value<'gc>, Error<'gc>> {
-        self.raw_script_object().call(name, activation, this, args)
-    }
-
-    /// Construct the underlying object, if this is a valid constructor, and returns the result.
-    /// Calling this on something other than a constructor will return a new Undefined object.
-    fn construct(
-        &self,
-        _activation: &mut Activation<'_, 'gc>,
-        _args: &[Value<'gc>],
-    ) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Undefined)
-    }
-
-    /// Takes an already existing object and performs this constructor (if valid) on it.
-    fn construct_on_existing(
-        &self,
-        _activation: &mut Activation<'_, 'gc>,
-        mut _this: Object<'gc>,
-        _args: &[Value<'gc>],
-    ) -> Result<(), Error<'gc>> {
-        Ok(())
-    }
-
     /// Call a method on the object.
     ///
     /// It is highly recommended to use this convenience method to perform
@@ -335,16 +266,14 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
     /// opcode. It will take care of retrieving the method, calculating its
     /// base prototype for `super` calls, and providing it with the correct
     /// `this` parameter.
-    fn call_method(
-        &self,
+    pub fn call_method(
+        self,
         name: AvmString<'gc>,
         args: &[Value<'gc>],
         activation: &mut Activation<'_, 'gc>,
         reason: ExecutionReason,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        let this = (*self).into();
-
-        match this.native_no_super() {
+        match self.native_no_super() {
             NativeObject::Super(zuper) => return zuper.call_method(name, args, activation, reason),
             native => {
                 if native
@@ -357,7 +286,7 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
         }
 
         let (method, depth) =
-            match search_prototype(Value::Object(this), name, activation, this, false)? {
+            match search_prototype(Value::Object(self), name, activation, self, false)? {
                 Some((Value::Object(method), depth)) => (method, depth),
                 _ => return Ok(Value::Undefined),
             };
@@ -370,214 +299,14 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
             Some(exec) => exec.exec(
                 ExecutionName::Dynamic(name),
                 activation,
-                this.into(),
+                self.into(),
                 depth,
                 args,
                 reason,
                 method,
             ),
-            None => method.call(name, activation, this.into(), args),
+            None => method.call(name, activation, self.into(), args),
         }
-    }
-
-    /// Retrieve a getter defined on this object.
-    fn getter(
-        &self,
-        name: AvmString<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-    ) -> Option<Object<'gc>> {
-        self.raw_script_object().getter(name, activation)
-    }
-
-    /// Retrieve a setter defined on this object.
-    fn setter(
-        &self,
-        name: AvmString<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-    ) -> Option<Object<'gc>> {
-        self.raw_script_object().setter(name, activation)
-    }
-
-    /// Delete a named property from the object.
-    ///
-    /// Returns false if the property cannot be deleted.
-    fn delete(&self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) -> bool {
-        self.raw_script_object().delete(activation, name)
-    }
-
-    /// Retrieve the `__proto__` of a given object.
-    ///
-    /// The proto is another object used to resolve methods across a class of
-    /// multiple objects. It should also be accessible as `__proto__` from
-    /// `get`.
-    fn proto(&self, activation: &mut Activation<'_, 'gc>) -> Value<'gc> {
-        self.raw_script_object().proto(activation)
-    }
-
-    /// Define a value on an object.
-    ///
-    /// Unlike setting a value, this function is intended to replace any
-    /// existing virtual or built-in properties already installed on a given
-    /// object. As such, this should not run any setters; the resulting name
-    /// slot should either be completely replaced with the value or completely
-    /// untouched.
-    ///
-    /// It is not guaranteed that all objects accept value definitions,
-    /// especially if a property name conflicts with a built-in property, such
-    /// as `__proto__`.
-    fn define_value(
-        &self,
-        gc_context: &Mutation<'gc>,
-        name: impl Into<AvmString<'gc>>,
-        value: Value<'gc>,
-        attributes: Attribute,
-    ) {
-        self.raw_script_object()
-            .define_value(gc_context, name, value, attributes)
-    }
-
-    /// Set the attributes of a given property.
-    ///
-    /// Leaving `name` unspecified allows setting all properties on a given
-    /// object to the same set of properties.
-    ///
-    /// Attributes can be set, cleared, or left as-is using the pairs of `set_`
-    /// and `clear_attributes` parameters.
-    fn set_attributes(
-        &self,
-        gc_context: &Mutation<'gc>,
-        name: Option<AvmString<'gc>>,
-        set_attributes: Attribute,
-        clear_attributes: Attribute,
-    ) {
-        self.raw_script_object()
-            .set_attributes(gc_context, name, set_attributes, clear_attributes)
-    }
-
-    /// Define a virtual property onto a given object.
-    ///
-    /// A virtual property is a set of get/set functions that are called when a
-    /// given named property is retrieved or stored on an object. These
-    /// functions are then responsible for providing or accepting the value
-    /// that is given to or taken from the AVM.
-    ///
-    /// It is not guaranteed that all objects accept virtual properties,
-    /// especially if a property name conflicts with a built-in property, such
-    /// as `__proto__`.
-    fn add_property(
-        &self,
-        gc_context: &Mutation<'gc>,
-        name: AvmString<'gc>,
-        get: Object<'gc>,
-        set: Option<Object<'gc>>,
-        attributes: Attribute,
-    ) {
-        self.raw_script_object()
-            .add_property(gc_context, name, get, set, attributes)
-    }
-
-    /// Define a virtual property onto a given object.
-    ///
-    /// A virtual property is a set of get/set functions that are called when a
-    /// given named property is retrieved or stored on an object. These
-    /// functions are then responsible for providing or accepting the value
-    /// that is given to or taken from the AVM.
-    ///
-    /// It is not guaranteed that all objects accept virtual properties,
-    /// especially if a property name conflicts with a built-in property, such
-    /// as `__proto__`.
-    fn add_property_with_case(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        name: AvmString<'gc>,
-        get: Object<'gc>,
-        set: Option<Object<'gc>>,
-        attributes: Attribute,
-    ) {
-        self.raw_script_object()
-            .add_property_with_case(activation, name, get, set, attributes)
-    }
-
-    /// Calls the 'watcher' of a given property, if it exists.
-    fn call_watcher(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        name: AvmString<'gc>,
-        value: &mut Value<'gc>,
-        this: Object<'gc>,
-    ) -> Result<(), Error<'gc>> {
-        self.raw_script_object()
-            .call_watcher(activation, name, value, this)
-    }
-
-    /// Set the 'watcher' of a given property.
-    ///
-    /// The property does not need to exist at the time of this being called.
-    fn watch(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        name: AvmString<'gc>,
-        callback: Object<'gc>,
-        user_data: Value<'gc>,
-    ) {
-        self.raw_script_object()
-            .watch(activation, name, callback, user_data)
-    }
-
-    /// Removed any assigned 'watcher' from the given property.
-    ///
-    /// The return value will indicate if there was a watcher present before this method was
-    /// called.
-    fn unwatch(&self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) -> bool {
-        self.raw_script_object().unwatch(activation, name)
-    }
-
-    /// Checks if the object has a given named property.
-    fn has_property(&self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) -> bool {
-        self.raw_script_object().has_property(activation, name)
-    }
-
-    /// Checks if the object has a given named property on itself (and not,
-    /// say, the object's prototype or superclass)
-    fn has_own_property(&self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) -> bool {
-        self.raw_script_object().has_own_property(activation, name)
-    }
-
-    /// Checks if the object has a given named property on itself that is
-    /// virtual.
-    fn has_own_virtual(&self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) -> bool {
-        self.raw_script_object().has_own_virtual(activation, name)
-    }
-
-    /// Checks if a named property appears when enumerating the object.
-    fn is_property_enumerable(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        name: AvmString<'gc>,
-    ) -> bool {
-        self.raw_script_object()
-            .is_property_enumerable(activation, name)
-    }
-
-    /// Enumerate the object.
-    fn get_keys(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        include_hidden: bool,
-    ) -> Vec<AvmString<'gc>> {
-        self.raw_script_object()
-            .get_keys(activation, include_hidden)
-    }
-
-    /// Enumerate all interfaces implemented by this object.
-    fn interfaces(&self) -> Vec<Object<'gc>> {
-        self.raw_script_object().interfaces()
-    }
-
-    /// Set the interface list for this object. (Only useful for prototypes.)
-    fn set_interfaces(&self, gc_context: &Mutation<'gc>, iface_list: Vec<Object<'gc>>) {
-        self.raw_script_object()
-            .set_interfaces(gc_context, iface_list)
     }
 
     /// Determine if this object is an instance of a class.
@@ -591,7 +320,7 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
     /// a new, parallel prototype chain which also needs to be checked. You
     /// can't implement interfaces within interfaces (fortunately), but if you
     /// somehow could this would support that, too.
-    fn is_instance_of(
+    pub fn is_instance_of(
         &self,
         activation: &mut Activation<'_, 'gc>,
         constructor: Object<'gc>,
@@ -627,38 +356,8 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
         Ok(false)
     }
 
-    fn native_no_super(&self) -> NativeObject<'gc> {
-        NativeObject::None
-    }
-
-    fn native(&self) -> NativeObject<'gc> {
-        NativeObject::None
-    }
-
-    fn set_native(&self, _gc_context: &Mutation<'gc>, _native: NativeObject<'gc>) {}
-
-    /// Get the underlying super object, if it exists.
-    fn as_super_object(&self) -> Option<SuperObject<'gc>> {
-        None
-    }
-
-    /// Get the underlying display node for this object, if it exists.
-    fn as_display_object(&self) -> Option<DisplayObject<'gc>> {
-        None
-    }
-
-    /// Get the underlying stage object, if it exists, but doesn't follow `super` objects.
-    fn as_display_object_no_super(&self) -> Option<DisplayObject<'gc>> {
-        None
-    }
-
-    /// Get the underlying executable for this object, if it exists.
-    fn as_executable(&self) -> Option<Executable<'gc>> {
-        None
-    }
-
     /// Get the underlying XML node for this object, if it exists.
-    fn as_xml_node(&self) -> Option<XmlNode<'gc>> {
+    pub fn as_xml_node(&self) -> Option<XmlNode<'gc>> {
         match self.native() {
             NativeObject::Xml(xml) => Some(xml.root()),
             NativeObject::XmlNode(xml_node) => Some(xml_node),
@@ -666,10 +365,12 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
         }
     }
 
-    fn as_ptr(&self) -> *const ObjectPtr;
-
     /// Check if this object is in the prototype chain of the specified test object.
-    fn is_prototype_of(&self, activation: &mut Activation<'_, 'gc>, other: Object<'gc>) -> bool {
+    pub fn is_prototype_of(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        other: Object<'gc>,
+    ) -> bool {
         let mut proto = other.proto(activation);
 
         while let Value::Object(proto_ob) = proto {
@@ -683,54 +384,12 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Into<Object<'gc>> + Clone + Copy {
         false
     }
 
-    /// Gets the length of this object, as if it were an array.
-    fn length(&self, activation: &mut Activation<'_, 'gc>) -> Result<i32, Error<'gc>> {
-        self.raw_script_object().length(activation)
-    }
-
-    /// Sets the length of this object, as if it were an array.
-    fn set_length(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        length: i32,
-    ) -> Result<(), Error<'gc>> {
-        self.raw_script_object().set_length(activation, length)
-    }
-
-    /// Checks if this object has an element.
-    fn has_element(&self, activation: &mut Activation<'_, 'gc>, index: i32) -> bool {
-        self.raw_script_object().has_element(activation, index)
-    }
-
-    /// Gets a property of this object, as if it were an array.
-    fn get_element(&self, activation: &mut Activation<'_, 'gc>, index: i32) -> Value<'gc> {
-        self.raw_script_object().get_element(activation, index)
-    }
-
-    /// Sets a property of this object, as if it were an array.
-    fn set_element(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        index: i32,
-        value: Value<'gc>,
-    ) -> Result<(), Error<'gc>> {
-        self.raw_script_object()
-            .set_element(activation, index, value)
-    }
-
-    /// Deletes a property of this object as if it were an array.
-    fn delete_element(&self, activation: &mut Activation<'_, 'gc>, index: i32) -> bool {
-        self.raw_script_object().delete_element(activation, index)
-    }
-}
-
-pub enum ObjectPtr {}
-
-impl<'gc> Object<'gc> {
     pub fn ptr_eq(a: Object<'gc>, b: Object<'gc>) -> bool {
         std::ptr::eq(a.as_ptr(), b.as_ptr())
     }
 }
+
+pub enum ObjectPtr {}
 
 /// Perform a prototype lookup of a given object.
 ///

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -6,11 +6,9 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::ExecutionReason;
 use crate::avm1::object::{search_prototype, ExecutionName};
-use crate::avm1::property::Attribute;
-use crate::avm1::{NativeObject, Object, ObjectPtr, ScriptObject, TObject, Value};
-use crate::display_object::DisplayObject;
+use crate::avm1::{NativeObject, Object, TObject, Value};
 use crate::string::AvmString;
-use gc_arena::{Collect, Gc, Mutation};
+use gc_arena::{Collect, Gc};
 use ruffle_macros::istr;
 
 /// Implementation of the `super` object in AS2.
@@ -50,7 +48,11 @@ impl<'gc> SuperObject<'gc> {
         self.0.this
     }
 
-    fn base_proto(&self, activation: &mut Activation<'_, 'gc>) -> Object<'gc> {
+    pub fn depth(&self) -> u8 {
+        self.0.depth
+    }
+
+    pub(super) fn base_proto(&self, activation: &mut Activation<'_, 'gc>) -> Object<'gc> {
         let depth = self.0.depth;
         let mut proto = self.0.this;
         for _ in 0..depth {
@@ -58,42 +60,15 @@ impl<'gc> SuperObject<'gc> {
         }
         proto
     }
-}
 
-impl<'gc> TObject<'gc> for SuperObject<'gc> {
-    fn raw_script_object(&self) -> ScriptObject<'gc> {
-        self.0.this.raw_script_object()
+    pub(super) fn proto(&self, activation: &mut Activation<'_, 'gc>) -> Value<'gc> {
+        self.base_proto(activation).proto(activation)
     }
 
-    fn as_ptr(&self) -> *const ObjectPtr {
-        Gc::as_ptr(self.0) as *const ObjectPtr
-    }
-
-    fn get_local_stored(
-        &self,
-        _name: impl Into<AvmString<'gc>>,
-        _activation: &mut Activation<'_, 'gc>,
-        _is_slash_path: bool,
-    ) -> Option<Value<'gc>> {
-        None
-    }
-
-    fn set_local(
-        &self,
-        _name: AvmString<'gc>,
-        _value: Value<'gc>,
-        _activation: &mut Activation<'_, 'gc>,
-        _this: Object<'gc>,
-    ) -> Result<(), Error<'gc>> {
-        //TODO: What happens if you set `super.__proto__`?
-        Ok(())
-    }
-
-    fn call(
+    pub(super) fn call(
         &self,
         name: impl Into<ExecutionName<'gc>>,
         activation: &mut Activation<'_, 'gc>,
-        _this: Value<'gc>,
         args: &[Value<'gc>],
     ) -> Result<Value<'gc>, Error<'gc>> {
         let constructor = self
@@ -116,7 +91,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         )
     }
 
-    fn call_method(
+    pub(super) fn call_method(
         &self,
         name: AvmString<'gc>,
         args: &[Value<'gc>],
@@ -142,138 +117,5 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
             ),
             None => method.call(name, activation, this.into(), args),
         }
-    }
-
-    fn delete(&self, _activation: &mut Activation<'_, 'gc>, _name: AvmString<'gc>) -> bool {
-        //`super` cannot have properties deleted from it
-        false
-    }
-
-    fn proto(&self, activation: &mut Activation<'_, 'gc>) -> Value<'gc> {
-        self.base_proto(activation).proto(activation)
-    }
-
-    fn define_value(
-        &self,
-        _gc_context: &Mutation<'gc>,
-        _name: impl Into<AvmString<'gc>>,
-        _value: Value<'gc>,
-        _attributes: Attribute,
-    ) {
-        //`super` cannot have values defined on it
-    }
-
-    fn set_attributes(
-        &self,
-        _gc_context: &Mutation<'gc>,
-        _name: Option<AvmString<'gc>>,
-        _set_attributes: Attribute,
-        _clear_attributes: Attribute,
-    ) {
-        //TODO: Does ASSetPropFlags work on `super`? What would it even work on?
-    }
-
-    fn add_property(
-        &self,
-        _gc_context: &Mutation<'gc>,
-        _name: AvmString<'gc>,
-        _get: Object<'gc>,
-        _set: Option<Object<'gc>>,
-        _attributes: Attribute,
-    ) {
-        //`super` cannot have properties defined on it
-    }
-
-    fn add_property_with_case(
-        &self,
-        _activation: &mut Activation<'_, 'gc>,
-        _name: AvmString<'gc>,
-        _get: Object<'gc>,
-        _set: Option<Object<'gc>>,
-        _attributes: Attribute,
-    ) {
-        //`super` cannot have properties defined on it
-    }
-
-    fn watch(
-        &self,
-        _activation: &mut Activation<'_, 'gc>,
-        _name: AvmString<'gc>,
-        _callback: Object<'gc>,
-        _user_data: Value<'gc>,
-    ) {
-        //`super` cannot have properties defined on it
-    }
-
-    fn unwatch(&self, _activation: &mut Activation<'_, 'gc>, _name: AvmString<'gc>) -> bool {
-        //`super` cannot have properties defined on it
-        false
-    }
-
-    fn get_keys(
-        &self,
-        _activation: &mut Activation<'_, 'gc>,
-        _include_hidden: bool,
-    ) -> Vec<AvmString<'gc>> {
-        vec![]
-    }
-
-    fn length(&self, _activation: &mut Activation<'_, 'gc>) -> Result<i32, Error<'gc>> {
-        Ok(0)
-    }
-
-    fn set_length(
-        &self,
-        _activation: &mut Activation<'_, 'gc>,
-        _length: i32,
-    ) -> Result<(), Error<'gc>> {
-        Ok(())
-    }
-
-    fn has_element(&self, _activation: &mut Activation<'_, 'gc>, _index: i32) -> bool {
-        false
-    }
-
-    fn get_element(&self, _activation: &mut Activation<'_, 'gc>, _index: i32) -> Value<'gc> {
-        Value::Undefined
-    }
-
-    fn set_element(
-        &self,
-        _activation: &mut Activation<'_, 'gc>,
-        _index: i32,
-        _value: Value<'gc>,
-    ) -> Result<(), Error<'gc>> {
-        Ok(())
-    }
-
-    fn delete_element(&self, _activation: &mut Activation<'_, 'gc>, _index: i32) -> bool {
-        false
-    }
-
-    fn interfaces(&self) -> Vec<Object<'gc>> {
-        //`super` does not implement interfaces
-        vec![]
-    }
-
-    fn set_interfaces(&self, _gc_context: &Mutation<'gc>, _iface_list: Vec<Object<'gc>>) {
-        //`super` probably cannot have interfaces set on it
-    }
-
-    fn as_super_object(&self) -> Option<SuperObject<'gc>> {
-        Some(*self)
-    }
-
-    fn as_display_object(&self) -> Option<DisplayObject<'gc>> {
-        //`super` actually can be used to invoke MovieClip methods
-        self.0.this.as_display_object()
-    }
-
-    fn native(&self) -> NativeObject<'gc> {
-        self.0.this.native()
-    }
-
-    fn set_native(&self, gc_context: &Mutation<'gc>, native: NativeObject<'gc>) {
-        self.0.this.set_native(gc_context, native);
     }
 }

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -6,7 +6,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::ExecutionReason;
 use crate::avm1::object::{search_prototype, ExecutionName};
-use crate::avm1::{NativeObject, Object, TObject, Value};
+use crate::avm1::{NativeObject, Object, Value};
 use crate::string::AvmString;
 use gc_arena::{Collect, Gc};
 use ruffle_macros::istr;

--- a/core/src/avm1/object_reference.rs
+++ b/core/src/avm1/object_reference.rs
@@ -1,4 +1,4 @@
-use super::{object::script_object::ScriptObjectWeak, Activation, Object, TObject, Value};
+use super::{object::script_object::ScriptObjectWeak, Activation, Object, Value};
 use crate::{
     display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer},
     string::{AvmString, WStr, WString},
@@ -83,7 +83,7 @@ impl<'gc> MovieClipReference<'gc> {
             return None;
         };
 
-        let Value::Object(Object::ScriptObject(cached)) = cached else {
+        let Value::Object(cached) = cached else {
             return None;
         };
 

--- a/core/src/avm1/object_reference.rs
+++ b/core/src/avm1/object_reference.rs
@@ -1,4 +1,4 @@
-use super::{object::script_object::ScriptObjectWeak, Activation, Object, Value};
+use super::{object::ObjectWeak, Activation, Object, Value};
 use crate::{
     display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer},
     string::{AvmString, WStr, WString},
@@ -63,7 +63,7 @@ struct MovieClipReferenceData<'gc> {
     /// A weak reference to the target stage object that `path` points to
     /// This is used for fast-path resvoling when possible, as well as for re-generating `path` (in the case the target object is renamed)
     /// If this is `None` then we have previously missed the cache, due to the target object being removed and re-created, causing us to fallback to the slow path resolution
-    cached_object: Lock<Option<ScriptObjectWeak<'gc>>>,
+    cached_object: Lock<Option<ObjectWeak<'gc>>>,
 }
 
 impl<'gc> MovieClipReference<'gc> {
@@ -137,7 +137,7 @@ impl<'gc> MovieClipReference<'gc> {
                     // However, if we remove and re-create the clip, the stored path (the original path) will differ from the path of the cached object (the modified path)
                     // Essentially, changes to `_name` are reverted after the clip is re-created
 
-                    return Some((true, cache.into(), display_object));
+                    return Some((true, cache, display_object));
                 }
             }
         }

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::function::{Executable, FunctionObject, NativeFunction};
 use crate::avm1::property::Attribute;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::string::{StringContext, WStr};
 
 /// Defines a list of properties on a [`ScriptObject`].

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -2,15 +2,15 @@
 
 use crate::avm1::function::{Executable, FunctionObject, NativeFunction};
 use crate::avm1::property::Attribute;
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::string::{StringContext, WStr};
 
-/// Defines a list of properties on a [`ScriptObject`].
+/// Defines a list of properties on a [`Object`].
 #[inline(never)]
 pub fn define_properties_on<'gc>(
     decls: &[Declaration],
     context: &mut StringContext<'gc>,
-    this: ScriptObject<'gc>,
+    this: Object<'gc>,
     fn_proto: Object<'gc>,
 ) {
     for decl in decls {
@@ -19,7 +19,7 @@ pub fn define_properties_on<'gc>(
 }
 
 /// The declaration of a property, method, or simple field, that
-/// can be defined on a [`ScriptObject`].
+/// can be defined on a [`Object`].
 #[derive(Copy, Clone)]
 pub struct Declaration {
     pub name: &'static [u8],
@@ -56,13 +56,13 @@ pub enum DeclKind {
 
 impl Declaration {
     #[inline(never)]
-    /// Defines the field represented by this declaration on a [`ScriptObject`].
+    /// Defines the field represented by this declaration on a [`Object`].
     /// Returns the value defined on the object, or `undefined` if this declaration
     /// defined a property.
     pub fn define_on<'gc>(
         &self,
         context: &mut StringContext<'gc>,
-        this: ScriptObject<'gc>,
+        this: Object<'gc>,
         fn_proto: Object<'gc>,
     ) -> Value<'gc> {
         let mc = context.gc();
@@ -94,7 +94,7 @@ impl Declaration {
     }
 }
 
-/// Declares a list of property [`Declaration`]s that can be later defined on [`ScriptObject`]s.
+/// Declares a list of property [`Declaration`]s that can be later defined on [`Object`]s.
 ///
 /// # Usage:
 ///

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -1,7 +1,7 @@
 use crate::avm1::function::ExecutionReason;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::globals::{as_broadcaster, create_globals};
-use crate::avm1::object::{stage_object, TObject};
+use crate::avm1::object::stage_object;
 use crate::avm1::property_map::PropertyMap;
 use crate::avm1::scope::Scope;
 use crate::avm1::{scope, Activation, ActivationIdentifier, Error, Object, Value};

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::callable_value::CallableValue;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
-use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1::{Object, Value};
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
 use gc_arena::{Collect, Gc, Mutation};
@@ -53,7 +53,7 @@ impl<'gc> Scope<'gc> {
         Scope {
             parent: Some(parent),
             class: ScopeClass::Local,
-            values: ScriptObject::new_without_proto(mc).into(),
+            values: Object::new_without_proto(mc),
         }
     }
 

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::callable_value::CallableValue;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
 use gc_arena::{Collect, Gc, Mutation};

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -43,7 +43,7 @@ macro_rules! test_method {
 
                         $(
                             let args: Vec<Value> = vec![$($arg.into()),*];
-                            let ret = crate::avm1::object::TObject::call_method(&object, name, &args, activation, crate::avm1::function::ExecutionReason::Special)?;
+                            let ret = crate::avm1::object::Object::call_method(object, name, &args, activation, crate::avm1::function::ExecutionReason::Special)?;
 
                             // Do a numeric comparison with tolerance if `@epsilon` was given:
                             $(

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -2,7 +2,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::ExecutionReason;
 use crate::avm1::object::NativeObject;
-use crate::avm1::{Object, ScriptObject, TObject};
+use crate::avm1::{Object, ScriptObject};
 use crate::display_object::TDisplayObject;
 use crate::ecma_conversions::{
     f64_to_wrapping_i16, f64_to_wrapping_i32, f64_to_wrapping_u16, f64_to_wrapping_u32,
@@ -904,7 +904,7 @@ mod test {
     use crate::avm1::function::FunctionObject;
     use crate::avm1::globals::create_globals;
     use crate::avm1::object::script_object::ScriptObject;
-    use crate::avm1::object::{Object, TObject};
+    use crate::avm1::object::Object;
     use crate::avm1::property::Attribute;
     use crate::avm1::test_utils::with_avm;
     use crate::avm1::Value;

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -407,10 +407,7 @@ impl<'gc> Value<'gc> {
                 istr!("0")
             }
             Value::Object(object) => {
-                if let Some(object) = object
-                    .as_display_object()
-                    .filter(|_| !matches!(object, Object::SuperObject(_)))
-                {
+                if let Some(object) = object.as_display_object_no_super() {
                     // StageObjects are special-cased to return their path.
                     AvmString::new(activation.gc(), object.path())
                 } else {

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -2,7 +2,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::ExecutionReason;
 use crate::avm1::object::NativeObject;
-use crate::avm1::{Object, ScriptObject};
+use crate::avm1::Object;
 use crate::display_object::TDisplayObject;
 use crate::ecma_conversions::{
     f64_to_wrapping_i16, f64_to_wrapping_i32, f64_to_wrapping_u16, f64_to_wrapping_u32,
@@ -49,12 +49,9 @@ impl From<bool> for Value<'_> {
     }
 }
 
-impl<'gc, T> From<T> for Value<'gc>
-where
-    Object<'gc>: From<T>,
-{
-    fn from(value: T) -> Self {
-        Value::Object(Object::from(value))
+impl<'gc> From<Object<'gc>> for Value<'gc> {
+    fn from(value: Object<'gc>) -> Self {
+        Value::Object(value)
     }
 }
 
@@ -486,7 +483,7 @@ impl<'gc> Value<'gc> {
             Value::String(_) => (self, Some(activation.context.avm1.prototypes().string)),
         };
 
-        let obj = ScriptObject::new(&activation.context.strings, proto).into();
+        let obj = Object::new(&activation.context.strings, proto);
 
         // Constructor populates the boxed object with the value.
         use crate::avm1::globals;
@@ -903,7 +900,6 @@ mod test {
     use crate::avm1::error::Error;
     use crate::avm1::function::FunctionObject;
     use crate::avm1::globals::create_globals;
-    use crate::avm1::object::script_object::ScriptObject;
     use crate::avm1::object::Object;
     use crate::avm1::property::Attribute;
     use crate::avm1::test_utils::with_avm;
@@ -947,7 +943,7 @@ mod test {
                 protos.function,
             );
 
-            let o = ScriptObject::new(&activation.context.strings, Some(protos.object));
+            let o = Object::new(&activation.context.strings, Some(protos.object));
             o.define_value(
                 activation.gc(),
                 istr!("valueOf"),
@@ -978,7 +974,7 @@ mod test {
             assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
             assert!(n.coerce_to_f64(activation).unwrap().is_nan());
 
-            let o = ScriptObject::new(&activation.context.strings, None);
+            let o = Object::new(&activation.context.strings, None);
 
             assert!(Value::from(o).coerce_to_f64(activation).unwrap().is_nan());
 
@@ -1000,7 +996,7 @@ mod test {
             assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
             assert_eq!(n.coerce_to_f64(activation).unwrap(), 0.0);
 
-            let o = ScriptObject::new(&activation.context.strings, None);
+            let o = Object::new(&activation.context.strings, None);
 
             assert_eq!(Value::from(o).coerce_to_f64(activation).unwrap(), 0.0);
 

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -1,5 +1,5 @@
 use crate::{
-    avm1::{NativeObject, Object as Avm1Object, TObject as _},
+    avm1::{NativeObject, Object as Avm1Object},
     avm2::{Avm2, EventObject as Avm2EventObject, SoundChannelObject},
     buffer::Substream,
     context::UpdateContext,

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -4,7 +4,6 @@ use crate::avm1::Activation;
 use crate::avm1::ActivationIdentifier;
 use crate::avm1::Attribute;
 use crate::avm1::Avm1;
-use crate::avm1::ScriptObject;
 use crate::avm1::{Object as Avm1Object, Value as Avm1Value};
 use crate::avm2::api_version::ApiVersion;
 use crate::avm2::object::LoaderInfoObject;
@@ -397,7 +396,7 @@ impl<'gc> UpdateContext<'gc> {
 
         root.set_depth(self.gc(), 0);
         let flashvars = if !self.swf.parameters().is_empty() {
-            let object = ScriptObject::new(&self.strings, None);
+            let object = Avm1Object::new(&self.strings, None);
             for (key, value) in self.swf.parameters().iter() {
                 object.define_value(
                     self.gc(),
@@ -406,7 +405,7 @@ impl<'gc> UpdateContext<'gc> {
                     Attribute::empty(),
                 );
             }
-            Some(object.into())
+            Some(object)
         } else {
             None
         };

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -5,7 +5,6 @@ use crate::avm1::ActivationIdentifier;
 use crate::avm1::Attribute;
 use crate::avm1::Avm1;
 use crate::avm1::ScriptObject;
-use crate::avm1::TObject;
 use crate::avm1::{Object as Avm1Object, Value as Avm1Value};
 use crate::avm2::api_version::ApiVersion;
 use crate::avm2::object::LoaderInfoObject;

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -1,5 +1,5 @@
 use crate::avm1::globals::style_sheet::StyleSheetObject;
-use crate::avm1::{Activation, ActivationIdentifier, Error, NativeObject, Object, TObject, Value};
+use crate::avm1::{Activation, ActivationIdentifier, Error, NativeObject, Object, Value};
 use crate::context::UpdateContext;
 use crate::debug_ui::display_object::open_display_object_button;
 use crate::debug_ui::handle::{AVM1ObjectHandle, DisplayObjectHandle};

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -3,7 +3,6 @@ mod search;
 use ruffle_render::blend::ExtendedBlendMode;
 pub use search::DisplayObjectSearchWindow;
 
-use crate::avm1::TObject as _;
 use crate::avm2::object::TObject as _;
 use crate::context::UpdateContext;
 use crate::debug_ui::handle::{AVM1ObjectHandle, AVM2ObjectHandle, DisplayObjectHandle};

--- a/core/src/debug_ui/handle.rs
+++ b/core/src/debug_ui/handle.rs
@@ -1,4 +1,3 @@
-use crate::avm1::TObject as _;
 use crate::avm2::object::TObject as _;
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, DisplayObjectPtr, TDisplayObject};

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1,6 +1,5 @@
 use crate::avm1::{
-    ActivationIdentifier as Avm1ActivationIdentifier, Object as Avm1Object, TObject as Avm1TObject,
-    Value as Avm1Value,
+    ActivationIdentifier as Avm1ActivationIdentifier, Object as Avm1Object, Value as Avm1Value,
 };
 use crate::avm2::{
     Activation as Avm2Activation, Avm2, Error as Avm2Error, EventObject as Avm2EventObject,

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -1,6 +1,4 @@
-use crate::avm1::{
-    Activation, ActivationIdentifier, NativeObject, Object, ScriptObject, TObject, Value,
-};
+use crate::avm1::{Activation, ActivationIdentifier, NativeObject, Object, ScriptObject, Value};
 use crate::backend::audio::AudioManager;
 use crate::backend::ui::MouseCursor;
 use crate::context::{ActionType, RenderContext, UpdateContext};

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -1,4 +1,4 @@
-use crate::avm1::{Activation, ActivationIdentifier, NativeObject, Object, ScriptObject, Value};
+use crate::avm1::{Activation, ActivationIdentifier, NativeObject, Object, Value};
 use crate::backend::audio::AudioManager;
 use crate::backend::ui::MouseCursor;
 use crate::context::{ActionType, RenderContext, UpdateContext};
@@ -283,13 +283,13 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         }
 
         if self.0.object.get().is_none() {
-            let object = ScriptObject::new_with_native(
+            let object = Object::new_with_native(
                 &context.strings,
                 Some(context.avm1.prototypes().button),
                 NativeObject::Button(*self),
             );
             let obj = unlock!(Gc::write(context.gc(), self.0), Avm1ButtonData, object);
-            obj.set(Some(object.into()));
+            obj.set(Some(object));
 
             if run_frame {
                 self.run_frame_avm1(context);

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -1,6 +1,6 @@
 //! Container mix-in for display objects
 
-use crate::avm1::{Activation, ActivationIdentifier, TObject};
+use crate::avm1::{Activation, ActivationIdentifier};
 use crate::avm2::{
     Activation as Avm2Activation, Avm2, EventObject as Avm2EventObject, Multiname as Avm2Multiname,
     Value as Avm2Value,

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2,8 +2,7 @@
 
 use crate::avm1::{
     Activation as Avm1Activation, ActivationIdentifier, Avm1, ExecutionReason,
-    NativeObject as Avm1NativeObject, Object as Avm1Object, ScriptObject as Avm1ScriptObject,
-    Value as Avm1Value,
+    NativeObject as Avm1NativeObject, Object as Avm1Object, Value as Avm1Value,
 };
 use crate::avm2::object::{
     ClassObject as Avm2ClassObject, EventObject as Avm2EventObject, Object as Avm2Object,
@@ -2161,13 +2160,13 @@ impl<'gc> EditText<'gc> {
     fn construct_as_avm1_object(self, context: &mut UpdateContext<'gc>, run_frame: bool) {
         let mut text = self.0.write(context.gc());
         if text.object.is_none() {
-            let object = Avm1ScriptObject::new_with_native(
+            let object = Avm1Object::new_with_native(
                 &context.strings,
                 Some(context.avm1.prototypes().text_field),
                 Avm1NativeObject::EditText(self),
             );
 
-            text.object = Some(Avm1Object::from(object).into());
+            text.object = Some(object.into());
         }
         drop(text);
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -3,7 +3,7 @@
 use crate::avm1::{
     Activation as Avm1Activation, ActivationIdentifier, Avm1, ExecutionReason,
     NativeObject as Avm1NativeObject, Object as Avm1Object, ScriptObject as Avm1ScriptObject,
-    TObject as Avm1TObject, Value as Avm1Value,
+    Value as Avm1Value,
 };
 use crate::avm2::object::{
     ClassObject as Avm2ClassObject, EventObject as Avm2EventObject, Object as Avm2Object,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1,8 +1,5 @@
 //! `MovieClip` display object and support code.
-use crate::avm1::{
-    NativeObject as Avm1NativeObject, Object as Avm1Object, ScriptObject as Avm1ScriptObject,
-    Value as Avm1Value,
-};
+use crate::avm1::{NativeObject as Avm1NativeObject, Object as Avm1Object, Value as Avm1Value};
 use crate::avm2::object::LoaderInfoObject;
 use crate::avm2::object::LoaderStream;
 use crate::avm2::script::Script;
@@ -2011,11 +2008,11 @@ impl<'gc> MovieClip<'gc> {
                     .get(istr!("prototype"), &mut activation)
                     .map(|v| v.coerce_to_object(&mut activation))
                 {
-                    let object = Avm1Object::from(Avm1ScriptObject::new_with_native(
+                    let object = Avm1Object::new_with_native(
                         &activation.context.strings,
                         Some(prototype),
                         Avm1NativeObject::MovieClip(self),
-                    ));
+                    );
                     self.0.write(activation.gc()).object = Some(object.into());
 
                     if run_frame {
@@ -2041,11 +2038,11 @@ impl<'gc> MovieClip<'gc> {
                 return;
             }
 
-            let object = Avm1Object::from(Avm1ScriptObject::new_with_native(
+            let object = Avm1Object::new_with_native(
                 &context.strings,
                 Some(context.avm1.prototypes().movie_clip),
                 Avm1NativeObject::MovieClip(self),
-            ));
+            );
             self.0.write(context.gc()).object = Some(object.into());
 
             if run_frame {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1,7 +1,7 @@
 //! `MovieClip` display object and support code.
 use crate::avm1::{
     NativeObject as Avm1NativeObject, Object as Avm1Object, ScriptObject as Avm1ScriptObject,
-    TObject as Avm1TObject, Value as Avm1Value,
+    Value as Avm1Value,
 };
 use crate::avm2::object::LoaderInfoObject;
 use crate::avm2::object::LoaderStream;

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -1,9 +1,6 @@
 //! Video player display object
 
-use crate::avm1::{
-    NativeObject as Avm1NativeObject, Object as Avm1Object, ScriptObject as Avm1ScriptObject,
-    Value as Avm1Value,
-};
+use crate::avm1::{NativeObject as Avm1NativeObject, Object as Avm1Object, Value as Avm1Value};
 use crate::avm2::{
     Activation as Avm2Activation, Object as Avm2Object, StageObject as Avm2StageObject,
     Value as Avm2Value,
@@ -451,11 +448,11 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         write.keyframes = keyframes;
 
         if write.object.is_none() && !movie.is_action_script_3() {
-            let object = Avm1Object::from(Avm1ScriptObject::new_with_native(
+            let object = Avm1Object::new_with_native(
                 &context.strings,
                 Some(context.avm1.prototypes().video),
                 Avm1NativeObject::Video(*self),
-            ));
+            );
             write.object = Some(object.into());
         }
 

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -1,10 +1,7 @@
 use crate::avm1::NativeObject;
 use crate::avm1::Value as Avm1Value;
 use crate::avm1::{Activation as Avm1Activation, ActivationIdentifier as Avm1ActivationIdentifier};
-use crate::avm1::{
-    ArrayBuilder as Avm1ArrayBuilder, Error as Avm1Error, Object as Avm1Object,
-    ScriptObject as Avm1ScriptObject,
-};
+use crate::avm1::{ArrayBuilder as Avm1ArrayBuilder, Error as Avm1Error, Object as Avm1Object};
 use crate::avm2::activation::Activation as Avm2Activation;
 use crate::avm2::error::Error as Avm2Error;
 use crate::avm2::object::{
@@ -172,7 +169,7 @@ impl Value {
                 Avm1Value::String(AvmString::new_utf8(activation.gc(), value))
             }
             Value::Object(values) => {
-                let object = Avm1ScriptObject::new(
+                let object = Avm1Object::new(
                     &activation.context.strings,
                     Some(activation.context.avm1.prototypes().object),
                 );

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -1,5 +1,4 @@
 use crate::avm1::NativeObject;
-use crate::avm1::TObject as _;
 use crate::avm1::Value as Avm1Value;
 use crate::avm1::{Activation as Avm1Activation, ActivationIdentifier as Avm1ActivationIdentifier};
 use crate::avm1::{

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -3,7 +3,7 @@
 use crate::avm1::{Activation, ActivationIdentifier};
 use crate::avm1::{Attribute, Avm1};
 use crate::avm1::{ExecutionReason, NativeObject};
-use crate::avm1::{Object, TObject, Value};
+use crate::avm1::{Object, Value};
 use crate::avm2::bytearray::ByteArrayStorage;
 use crate::avm2::globals::flash::utils::byte_array::strip_bom;
 use crate::avm2::object::{

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1,9 +1,9 @@
 use crate::avm1::Attribute;
 use crate::avm1::Avm1;
 use crate::avm1::Object;
+use crate::avm1::Value;
 use crate::avm1::VariableDumper;
 use crate::avm1::{Activation, ActivationIdentifier};
-use crate::avm1::{TObject, Value};
 use crate::avm2::object::{EventObject as Avm2EventObject, Object as Avm2Object};
 use crate::avm2::{Activation as Avm2Activation, Avm2, CallStack};
 use crate::backend::ui::FontDefinition;

--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -1,6 +1,6 @@
 use crate::avm1::{
     globals::xml_socket::XmlSocket, Activation as Avm1Activation, ActivationIdentifier,
-    ExecutionReason, Object as Avm1Object, TObject as Avm1TObject,
+    ExecutionReason, Object as Avm1Object,
 };
 use crate::avm2::object::{EventObject, SocketObject};
 use crate::avm2::{Activation as Avm2Activation, Avm2};

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -3,7 +3,7 @@
 use crate::avm1::{
     Activation as Avm1Activation, ActivationIdentifier as Avm1ActivationIdentifier,
     ExecutionReason as Avm1ExecutionReason, FlvValueAvm1Ext, ScriptObject as Avm1ScriptObject,
-    TObject as Avm1TObject, Value as Avm1Value,
+    Value as Avm1Value,
 };
 use crate::avm2::{
     Activation as Avm2Activation, Avm2, Error as Avm2Error, EventObject as Avm2EventObject,

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::{
     Activation as Avm1Activation, ActivationIdentifier as Avm1ActivationIdentifier,
-    ExecutionReason as Avm1ExecutionReason, FlvValueAvm1Ext, ScriptObject as Avm1ScriptObject,
+    ExecutionReason as Avm1ExecutionReason, FlvValueAvm1Ext, Object as Avm1Object,
     Value as Avm1Value,
 };
 use crate::avm2::{
@@ -1288,8 +1288,7 @@ impl<'gc> NetStream<'gc> {
                     Avm1ActivationIdentifier::root("[NetStream Status Event]"),
                     root,
                 );
-                let info_object =
-                    Avm1ScriptObject::new(&activation.context.strings, Some(object_proto));
+                let info_object = Avm1Object::new(&activation.context.strings, Some(object_proto));
 
                 for (key, value) in values {
                     let key = AvmString::new_utf8(activation.gc(), key);

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -103,7 +103,7 @@ impl<'gc> Timers<'gc> {
 
                     let mut removed = false;
 
-                    // We can't use as_display_object + as_movie_clip here as we explicitly don't want to convert `SuperObjects`
+                    // We can't use as_display_object + as_movie_clip here as we explicitly don't want to convert `super`s
                     if let Some(DisplayObject::MovieClip(mc)) = this.as_display_object_no_super() {
                         // Note that we don't want to fire the timer here
                         if mc.avm1_removed() {

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -5,9 +5,7 @@
 //! is ready to tick each frame.
 
 use crate::avm1::ExecutionReason;
-use crate::avm1::{
-    Activation, ActivationIdentifier, Object as Avm1Object, TObject as _, Value as Avm1Value,
-};
+use crate::avm1::{Activation, ActivationIdentifier, Object as Avm1Object, Value as Avm1Value};
 use crate::avm2::{Activation as Avm2Activation, Object as Avm2Object, Value as Avm2Value};
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, TDisplayObject};

--- a/core/src/xml/tree.rs
+++ b/core/src/xml/tree.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::Attribute;
 use crate::avm1::{Activation, NativeObject};
-use crate::avm1::{ArrayBuilder, Error, Object, ScriptObject, TObject, Value};
+use crate::avm1::{ArrayBuilder, Error, Object, ScriptObject, Value};
 use crate::string::{AvmString, StringContext, WStr, WString};
 use crate::xml;
 use gc_arena::{Collect, GcCell, Mutation};


### PR DESCRIPTION
`SuperObject` was the last `NativeObject` hold-out, so migrating it lets us completely remove the `TObject` trait and the `Object/ScriptObject` split.

Unfortunately, this leaves the AVM1 object code in a somewhat weird state, but this PR's diff is already big enough as is. In particular:
- the object logic is awkwardly split between `avm1/object.rs`, `avm1/object/script_object.rs` and `avm1/object/super_object.rs`; I'm not yet sure what's the best way forward;
- the `Gc` indirection inside `SuperObject` could be removed;
- I suspect a large portion of the `super` special cases can become implicit, by relying on the fact that `super` objects never have any properties of their own.

---

Most of the interesting changes are in the first commit; the two others are purely mechanical.