### PR TITLE
avm1: implement Sound getBytesTotal(), getBytesLoaded()

### DIFF
--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1749,6 +1749,9 @@ impl<'gc> Loader<'gc> {
                     .map_err(|e| e.error)
                     .and_then(|(body, _, _, _)| {
                         let handle = uc.audio.register_mp3(&body)?;
+                        let total_len = body.len();
+                        sound.set_bytes_loaded(Some(total_len as u32));
+                        sound.set_bytes_total(Some(total_len as u32));
                         sound.set_sound(Some(handle));
                         let duration = uc
                             .audio


### PR DESCRIPTION
This PR adds more correct functionality to getBytesLoaded() and getBytesTotal() - returning the actual number of bytes loaded from the network / from disk rather than always returning 1, as well as returning undefined on getBytesLoaded when loadSound has not been called and on getBytesTotal when the total length is unknown (request not completed).

This fixes https://old.homestarrunner.com/qod.swf - with extra debug logging added to aforementioned Flash file, the trace output between Ruffle and Flash matches with this PR applied.