### PR TITLE
chore: Bump `http-proxy-middleware` version in `web/package-lock.json`

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8223,9 +8223,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-            "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
Fixes: https://github.com/ruffle-rs/ruffle/security/dependabot/102
Dependabot choked on it: https://github.com/ruffle-rs/ruffle/actions/runs/14590927990/job/40925812658#step:3:264 😒
