### PR TITLE
web: Include channel in version name if not stable

### DIFF
--- a/web/packages/core/tools/set_version.ts
+++ b/web/packages/core/tools/set_version.ts
@@ -17,10 +17,16 @@ try {
     console.log("Couldn't fetch latest git commit...");
 }
 
-let versionName =
-    versionChannel === "nightly"
-        ? `nightly ${buildDate.substring(0, 10)}`
-        : versionNumber;
+let versionName;
+if (versionChannel === "stable") {
+    versionName = versionNumber;
+} else if (versionChannel === "nightly") {
+    // TODO Try to include the build date in
+    //      the version and drop this branch.
+    versionName = `${versionNumber} nightly ${buildDate.substring(0, 10)}`;
+} else {
+    versionName = `${versionChannel} ${versionNumber}`;
+}
 
 interface VersionInformation {
     version_number: string;

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -57,10 +57,15 @@ function transformManifest(content, env) {
             scripts: ["dist/background.js"],
         };
     } else {
-        manifest.version_name =
-            versionChannel === "nightly"
-                ? `${packageVersion} nightly ${buildDate}`
-                : packageVersion;
+        if (versionChannel === "stable") {
+            manifest.version_name = packageVersion;
+        } else if (versionChannel === "nightly") {
+            // TODO Try to include the build date in
+            //      the version and drop this branch.
+            manifest.version_name = `${packageVersion} nightly ${buildDate}`;
+        } else {
+            manifest.version_name = `${versionChannel} ${packageVersion}`;
+        }
 
         manifest.background = {
             service_worker: "dist/background.js",


### PR DESCRIPTION
Before this patch every channel besides nightly used the version as version name.  This patch adds the channel to version name, so that it's easier to identify the version.