### PR TITLE
avm2: Use return type of methods in optimizer

### DIFF
--- a/core/src/avm2/globals/flash/geom/Transform.as
+++ b/core/src/avm2/globals/flash/geom/Transform.as
@@ -27,7 +27,7 @@ package flash.geom {
         public native function get pixelBounds():Rectangle;
 
         public native function get matrix3D():Matrix3D;
-        public native function set matrix3D(m:Matrix3D):void;
+        public native function set matrix3D(m:Matrix3D):*;
 
         public native function get perspectiveProjection():PerspectiveProjection;
         public native function set perspectiveProjection(val: PerspectiveProjection):void;

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -6,6 +6,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::error::Error;
 use crate::avm2::traits::Trait;
 use crate::avm2::QName;
 use ruffle_macros::istr;
@@ -14,7 +15,7 @@ use ruffle_macros::istr;
 pub fn create_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
     traits: Vec<Trait<'gc>>,
-) -> Class<'gc> {
+) -> Result<Class<'gc>, Error<'gc>> {
     let mc = activation.gc();
     let class = Class::custom_new(
         QName::new(activation.avm2().namespaces.public_all(), istr!("global")),
@@ -25,9 +26,10 @@ pub fn create_class<'gc>(
 
     class.set_attributes(mc, ClassAttributes::FINAL);
 
+    class.validate_class(activation, true)?;
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");
 
-    class
+    Ok(class)
 }

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -27,6 +27,7 @@ pub fn create_class<'gc>(
     class.set_attributes(mc, ClassAttributes::FINAL);
 
     class.validate_class(activation, true)?;
+    class.validate_signatures(activation)?;
     class
         .init_vtable(activation.context)
         .expect("Native class's vtable should initialize");

--- a/core/src/avm2/optimizer/optimize.rs
+++ b/core/src/avm2/optimizer/optimize.rs
@@ -6,7 +6,7 @@ use crate::avm2::optimizer::blocks::assemble_blocks;
 use crate::avm2::optimizer::peephole;
 use crate::avm2::property::Property;
 use crate::avm2::verify::Exception;
-use crate::avm2::vtable::VTable;
+use crate::avm2::vtable::{ClassBoundMethod, VTable};
 use crate::avm2::{Activation, Class, Error};
 
 use gc_arena::Gc;
@@ -1413,6 +1413,23 @@ fn abstract_interpret_ops<'gc>(
                                     index: disp_id,
                                     push_return_value: true,
                                 });
+
+                                stack_push_done = true;
+
+                                let full_method = vtable
+                                    .get_full_method(disp_id)
+                                    .expect("Method should exist");
+                                let ClassBoundMethod { method, .. } = full_method;
+                                if !method.is_info_resolved() {
+                                    method.resolve_info(activation)?;
+                                }
+
+                                let return_type = method.resolved_return_type();
+                                if let Some(return_type) = return_type {
+                                    stack.push_class(activation, return_type)?;
+                                } else {
+                                    stack.push_any(activation)?;
+                                }
                             }
                             _ => {}
                         }
@@ -1640,6 +1657,23 @@ fn abstract_interpret_ops<'gc>(
                                     index: disp_id,
                                     push_return_value: true,
                                 });
+
+                                stack_push_done = true;
+
+                                let full_method = vtable
+                                    .get_full_method(disp_id)
+                                    .expect("Method should exist");
+                                let ClassBoundMethod { method, .. } = full_method;
+                                if !method.is_info_resolved() {
+                                    method.resolve_info(activation)?;
+                                }
+
+                                let return_type = method.resolved_return_type();
+                                if let Some(return_type) = return_type {
+                                    stack.push_class(activation, return_type)?;
+                                } else {
+                                    stack.push_any(activation)?;
+                                }
                             }
                             Some(Property::Slot { slot_id })
                             | Some(Property::ConstSlot { slot_id }) => {

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -221,8 +221,8 @@ impl<'gc> TranslationUnit<'gc> {
             .c_class()
             .expect("Class::from_abc_index returns an i_class");
 
-        class.validate_class(activation)?;
-        c_class.validate_class(activation)?;
+        class.validate_class(activation, false)?;
+        c_class.validate_class(activation, false)?;
 
         class.init_vtable(activation.context)?;
         c_class.init_vtable(activation.context)?;
@@ -479,7 +479,7 @@ impl<'gc> Script<'gc> {
         // Now that we have the traits, create the global class for this script
         // and use it to initialize a vtable and global object.
 
-        let global_class = global_scope::create_class(activation, traits);
+        let global_class = global_scope::create_class(activation, traits)?;
 
         let scope = ScopeChain::new(domain);
         let object_class = activation.avm2().classes().object;


### PR DESCRIPTION
Closes #17495

We now verify that overrides of methods use the same return type as the method they override, which allows us to make use of the return type of all methods in the optimizer.

Box2d stats:
```
ConstructSuper -> Pop: 70%

FindPropStrict -> GetScriptGlobals: 82.71%
FindPropStrict -> GetOuterScope: 9%
FindPropStrict -> GetScopeObject: 8.28%

FindProperty -> GetOuterScope: 5.66%
FindProperty -> GetScopeObject: 94.33%

InitProperty -> SetSlot: 6.3% (-2.19%)
InitProperty -> SetSlotNoCoerce: 90.95% (+2.19%)
InitProperty -> CallMethod: 2.73%

SetProperty -> SetSlot: 8.07% (-1.72%)
SetProperty -> SetSlotNoCoerce: 73.88% (+1.72%)
SetProperty -> CallMethod: 2.4%

GetProperty -> GetSlot: 88.89%
GetProperty -> CallMethod: 0.47%

CallProperty -> CallMethod: 83.26%
CallProperty -> CoerceUSwapPop: 5.17%
CallProperty -> CoerceISwapPop: 9.56%

CallPropVoid -> CallMethod: 93.93% (+2.65%)

ConstructProp -> ConstructSlot: 100%

Coerce -> Nop: 73.18% (+5.93%)

CoerceD -> Nop: 98.75% (+8.71%)

CoerceB -> Nop: 97.29% (+70.27%)

CoerceU -> Nop: 64.91% (+2.63%)

CoerceI -> Nop: 52% (+5%)

ReturnValue -> ReturnValueNoCoerce: 96.39% (+12.61%)
```