### PR TITLE
desktop: Fix missing characters in UI

### DIFF
--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -575,6 +575,22 @@ fn load_system_fonts(
         ],
     ));
 
+    // Hebrew
+    queries.push((
+        4,
+        vec![
+            Family::Name("Noto Sans Hebrew"), // Open font
+        ],
+    ));
+
+    // Arabic
+    queries.push((
+        5,
+        vec![
+            Family::Name("Noto Sans Arabic"), // Open font
+        ],
+    ));
+
     register_family(
         font_database,
         &mut fd,


### PR DESCRIPTION
Before this patch, we were loading only one font, based on the OS and language selected. This approach was not perfect, as the UI can have characters from multiple fonts, irrespectively of selected language.

This patch changes the way fonts are loaded, and provides multiple fallback fonts for different categories of characters (Korean, Chinese, Japanese, etc.).

This patch makes it possible to see characters from all categories at the same time in UI irrespectively of selected language. Additionally, it adds Hebrew and Arabic fonts.

Before:

![image](https://github.com/user-attachments/assets/1acae202-dd46-4fe8-9138-5488668adefc)

After:

![image](https://github.com/user-attachments/assets/f2099b27-5745-4374-84e1-6bfe11b8250b)

It's a follow-up to https://github.com/ruffle-rs/ruffle/pull/20210