### PR TITLE
desktop: Add workaround for RTL scripts in GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,6 +4257,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tracy",
  "unic-langid",
+ "unicode-bidi",
  "url",
  "vergen",
  "webbrowser",
@@ -5741,6 +5742,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -50,6 +50,7 @@ tracing-tracy = { version = "0.11.3", optional = true, features = ["demangle"] }
 rand = "0.8.5"
 thiserror.workspace = true
 async-channel.workspace = true
+unicode-bidi = "0.3.18"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = "0.10.2"

--- a/desktop/src/gui/locale.rs
+++ b/desktop/src/gui/locale.rs
@@ -1,0 +1,65 @@
+use fluent_templates::fluent_bundle::FluentValue;
+use fluent_templates::{static_loader, Loader};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use unic_langid::LanguageIdentifier;
+
+static_loader! {
+    static TEXTS = {
+        locales: "./assets/texts",
+        fallback_language: "en-US"
+    };
+}
+
+pub fn text<'a>(locale: &LanguageIdentifier, id: &'a str) -> Cow<'a, str> {
+    TEXTS
+        .try_lookup(locale, id)
+        .map(Cow::Owned)
+        .unwrap_or_else(|| {
+            tracing::error!("Unknown desktop text id '{id}'");
+            Cow::Borrowed(id)
+        })
+}
+
+pub fn optional_text(locale: &LanguageIdentifier, id: &str) -> Option<String> {
+    TEXTS
+        .lookup_single_language::<&str>(locale, id, None)
+        .inspect_err(|e| tracing::trace!("Error looking up text: {e}"))
+        .ok()
+}
+
+pub fn available_languages() -> Vec<&'static LanguageIdentifier> {
+    let mut result: Vec<_> = TEXTS.locales().collect();
+    result.sort();
+    result
+}
+
+#[allow(dead_code)]
+pub fn text_with_args(
+    locale: &LanguageIdentifier,
+    id: &'static str,
+    args: &HashMap<Cow<'static, str>, FluentValue>,
+) -> Cow<'static, str> {
+    TEXTS
+        .try_lookup_with_args(locale, id, args)
+        .map(Cow::Owned)
+        .unwrap_or_else(|| {
+            tracing::error!("Unknown desktop text id '{id}'");
+            Cow::Borrowed(id)
+        })
+}
+
+pub enum LocalizableText {
+    NonLocalizedText(Cow<'static, str>),
+    LocalizedText(&'static str),
+}
+
+impl LocalizableText {
+    pub fn localize(&self, locale: &LanguageIdentifier) -> Cow<'_, str> {
+        match self {
+            LocalizableText::NonLocalizedText(Cow::Borrowed(text)) => Cow::Borrowed(text),
+            LocalizableText::NonLocalizedText(Cow::Owned(text)) => Cow::Borrowed(text),
+            LocalizableText::LocalizedText(id) => text(locale, id),
+        }
+    }
+}

--- a/desktop/src/gui/locale.rs
+++ b/desktop/src/gui/locale.rs
@@ -12,13 +12,14 @@ static_loader! {
 }
 
 pub fn text<'a>(locale: &LanguageIdentifier, id: &'a str) -> Cow<'a, str> {
-    TEXTS
+    let text = TEXTS
         .try_lookup(locale, id)
         .map(Cow::Owned)
         .unwrap_or_else(|| {
             tracing::error!("Unknown desktop text id '{id}'");
-            Cow::Borrowed(id)
-        })
+            Cow::Owned(id.to_string())
+        });
+    reorder_bidi(locale, text)
 }
 
 pub fn optional_text(locale: &LanguageIdentifier, id: &str) -> Option<String> {
@@ -26,6 +27,7 @@ pub fn optional_text(locale: &LanguageIdentifier, id: &str) -> Option<String> {
         .lookup_single_language::<&str>(locale, id, None)
         .inspect_err(|e| tracing::trace!("Error looking up text: {e}"))
         .ok()
+        .map(|s| reorder_bidi(locale, s.into()).into_owned())
 }
 
 pub fn available_languages() -> Vec<&'static LanguageIdentifier> {
@@ -40,13 +42,66 @@ pub fn text_with_args(
     id: &'static str,
     args: &HashMap<Cow<'static, str>, FluentValue>,
 ) -> Cow<'static, str> {
-    TEXTS
+    let text = TEXTS
         .try_lookup_with_args(locale, id, args)
         .map(Cow::Owned)
         .unwrap_or_else(|| {
             tracing::error!("Unknown desktop text id '{id}'");
             Cow::Borrowed(id)
-        })
+        });
+    reorder_bidi(locale, text)
+}
+
+/// Reorder BiDi text so that RTL text runs are reversed.
+/// The default direction is based on the locale.
+///
+/// TODO This is stupid, but it at least allows people to read RTL languages
+///   somewhat correctly. Remove it when egui starts supporting RTL scripts.
+fn reorder_bidi(locale: &LanguageIdentifier, text: Cow<'static, str>) -> Cow<'static, str> {
+    let level = if locale.character_direction() == unic_langid::CharacterDirection::RTL {
+        unicode_bidi::Level::rtl()
+    } else {
+        unicode_bidi::Level::ltr()
+    };
+
+    let bidi_info = unicode_bidi::BidiInfo::new(&text, Some(level));
+    if !unicode_bidi::level::has_rtl(&bidi_info.levels) {
+        // Fast path: no RTL text = no reordering
+        return text;
+    }
+
+    // At this point we know something has to be reversed.
+    let mut reordered_text = String::with_capacity(text.len());
+    for para in &bidi_info.paragraphs {
+        let (levels, runs) = bidi_info.visual_runs(para, para.range.clone());
+        for run in runs {
+            if levels[run.start].is_rtl() {
+                reordered_text.extend(text[run].chars().rev().map(mirror_char));
+            } else {
+                reordered_text.push_str(&text[run]);
+            }
+        }
+    }
+
+    reordered_text.into()
+}
+
+/// Mirror the given character.
+///
+/// It's used as a very simple alternative to glyph mirroring, which we do not
+/// support yet and allows basic characters to be rendered properly in RTL.
+fn mirror_char(c: char) -> char {
+    match c {
+        '(' => ')',
+        ')' => '(',
+        '[' => ']',
+        ']' => '[',
+        '{' => '}',
+        '}' => '{',
+        '<' => '>',
+        '>' => '<',
+        _ => c,
+    }
 }
 
 pub enum LocalizableText {


### PR DESCRIPTION
This patch implements a workaround for egui not supporting RTL scripts. RTL text runs are being reversed and some characters are being mirrored.

It does not fix the interface being LTR though, and I assume ligatures also won't be drawn properly. But at least RTL text is readable now. Also text selection will not work properly (text will be reversed), and user-inputted text will not be fixed.

* Fixes https://github.com/ruffle-rs/ruffle/issues/16653
* Fixes https://github.com/ruffle-rs/ruffle/issues/11538

| Before | After |
|:------:|:-----:|
| <img src="https://github.com/user-attachments/assets/1dc62ab0-3295-4c12-bd4d-c0c54b4bc01a" height="200"/> | <img src="https://github.com/user-attachments/assets/97716569-a412-456d-b4b0-881d978a2832" height="200"/> |
| <img src="https://github.com/user-attachments/assets/64ac38e8-ec11-4476-820c-eacbbec2c189" height="200"/> | <img src="https://github.com/user-attachments/assets/361b9086-600a-4d44-8071-c72f69be4866" height="200"/> |
| <img src="https://github.com/user-attachments/assets/5eca05d5-914b-437c-8255-de9fd2a0cb4c" height="200"/> | <img src="https://github.com/user-attachments/assets/6c951b9e-aec0-4f3f-821c-b5fe3b41dc21" height="200"/> |
