### PR TITLE
core/render/web: replace uses of the `Downcast` trait with `Any`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,12 +1293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
-
-[[package]]
 name = "dpi"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,7 +4165,6 @@ dependencies = [
  "chrono",
  "clap",
  "dasp",
- "downcast-rs 2.0.1",
  "egui",
  "egui_extras",
  "either",
@@ -4328,7 +4321,6 @@ dependencies = [
  "approx",
  "byteorder",
  "clap",
- "downcast-rs 2.0.1",
  "enum-map",
  "flate2",
  "gif",
@@ -5999,7 +5991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
 dependencies = [
  "cc",
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "rustix",
  "scoped-tls",
  "smallvec",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,7 +30,6 @@ smallvec = { version = "1.15.0", features = ["union"] }
 num-traits = { workspace = true }
 num-derive = { workspace = true }
 quick-xml = "0.37.5"
-downcast-rs = "2.0.1"
 url = { workspace = true }
 weak-table = "0.3.2"
 percent-encoding = "2.3.1"

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -19,6 +19,7 @@ use ruffle_macros::istr;
 use ruffle_render::filters::{
     DisplacementMapFilter, DisplacementMapFilterMode, Filter, ShaderFilter, ShaderObject,
 };
+use std::any::Any;
 use std::fmt::Debug;
 use swf::{
     BevelFilter, BevelFilterFlags, BlurFilter, BlurFilterFlags, Color, ColorMatrixFilter,
@@ -50,7 +51,7 @@ impl ShaderObject for ObjectWrapper {
     }
 
     fn equals(&self, other: &dyn ShaderObject) -> bool {
-        if let Some(other_wrapper) = other.downcast_ref::<ObjectWrapper>() {
+        if let Some(other_wrapper) = <dyn Any>::downcast_ref::<ObjectWrapper>(other) {
             std::ptr::eq(self.root.as_ptr(), other_wrapper.root.as_ptr())
         } else {
             false
@@ -857,9 +858,7 @@ fn shader_filter_to_avm2<'gc>(
     activation: &mut Activation<'_, 'gc>,
     filter: &ShaderFilter<'static>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let object_wrapper: &ObjectWrapper = filter
-        .shader_object
-        .downcast_ref::<ObjectWrapper>()
+    let object_wrapper: &ObjectWrapper = <dyn Any>::downcast_ref(filter.shader_object.as_ref())
         .expect("ShaderObject was not an ObjectWrapper");
 
     let obj = *activation.context.dynamic_root.fetch(&object_wrapper.root);

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use crate::{
     avm1::{NativeObject, Object as Avm1Object},
     avm2::{Avm2, EventObject as Avm2EventObject, SoundChannelObject},
@@ -6,7 +8,6 @@ use crate::{
     display_object::{self, DisplayObject, MovieClip, TDisplayObject},
     string::AvmString,
 };
-use downcast_rs::Downcast;
 use gc_arena::Collect;
 use slotmap::{new_key_type, Key, SlotMap};
 
@@ -84,7 +85,7 @@ pub enum RegisterError {
     ShortMp3,
 }
 
-pub trait AudioBackend: Downcast {
+pub trait AudioBackend: Any {
     fn play(&mut self);
     fn pause(&mut self);
 
@@ -193,8 +194,6 @@ pub trait AudioBackend: Downcast {
         self.get_sound_position(instance).is_some()
     }
 }
-
-impl_downcast!(AudioBackend);
 
 /// Information about a sound provided to `NullAudioBackend`.
 struct NullSound {

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -4,9 +4,9 @@ use crate::loader::Error;
 use crate::socket::{ConnectionState, SocketAction, SocketHandle};
 use crate::string::WStr;
 use async_channel::{Receiver, Sender};
-use downcast_rs::Downcast;
 use encoding_rs::Encoding;
 use indexmap::IndexMap;
+use std::any::Any;
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Display;
@@ -227,7 +227,7 @@ pub struct ErrorResponse {
 pub type OwnedFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + 'static>>;
 
 /// A backend interacting with a browser environment.
-pub trait NavigatorBackend: Downcast {
+pub trait NavigatorBackend: Any {
     /// Cause a browser navigation to a given URL.
     ///
     /// The URL given may be any URL scheme a browser can support. This may not
@@ -302,7 +302,6 @@ pub trait NavigatorBackend: Downcast {
         sender: Sender<SocketAction>,
     );
 }
-impl_downcast!(NavigatorBackend);
 
 #[cfg(not(target_family = "wasm"))]
 pub struct NullExecutor(futures::executor::LocalPool);

--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -1,10 +1,9 @@
 use crate::backend::navigator::OwnedFuture;
 pub use crate::loader::Error as DialogLoaderError;
 use chrono::{DateTime, Utc};
-use downcast_rs::Downcast;
 use fluent_templates::loader::langid;
 pub use fluent_templates::LanguageIdentifier;
-use std::borrow::Cow;
+use std::{any::Any, borrow::Cow};
 use url::Url;
 
 pub type FullscreenError = Cow<'static, str>;
@@ -38,7 +37,7 @@ pub struct FileFilter {
 }
 
 /// A result of a file selection
-pub trait FileDialogResult: Downcast {
+pub trait FileDialogResult: Any {
     /// Was the file selection canceled by the user
     fn is_cancelled(&self) -> bool;
     fn creation_time(&self) -> Option<DateTime<Utc>>;
@@ -55,12 +54,11 @@ pub trait FileDialogResult: Downcast {
     /// the state at the time of the last refresh
     fn write_and_refresh(&mut self, data: &[u8]);
 }
-impl_downcast!(FileDialogResult);
 
 /// Future representing a file selection in process
 pub type DialogResultFuture = OwnedFuture<Box<dyn FileDialogResult>, DialogLoaderError>;
 
-pub trait UiBackend: Downcast {
+pub trait UiBackend: Any {
     fn mouse_visible(&self) -> bool;
 
     fn set_mouse_visible(&mut self, visible: bool);
@@ -129,7 +127,6 @@ pub trait UiBackend: Downcast {
     /// Mark that any previously open dialog has been closed
     fn close_file_dialog(&mut self);
 }
-impl_downcast!(UiBackend);
 
 /// A mouse cursor icon displayed by the Flash Player.
 /// Communicated from the core to the UI backend via `UiBackend::set_mouse_cursor`.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,9 +13,6 @@ pub use display_object::{StageAlign, StageDisplayState, StageScaleMode};
 extern crate smallvec;
 
 #[macro_use]
-extern crate downcast_rs;
-
-#[macro_use]
 extern crate num_derive;
 
 #[macro_use]

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -13,6 +13,7 @@ use ruffle_core::{Player, PlayerEvent};
 use ruffle_render_wgpu::backend::{request_adapter_and_device, WgpuRenderBackend};
 use ruffle_render_wgpu::descriptors::Descriptors;
 use ruffle_render_wgpu::utils::{format_list, get_backend_names};
+use std::any::Any;
 use std::sync::{Arc, MutexGuard};
 use std::time::{Duration, Instant};
 use url::Url;
@@ -329,11 +330,10 @@ impl GuiController {
         // If we're not in a UI, tell egui which cursor we prefer to use instead
         if !self.egui_winit.egui_ctx().wants_pointer_input() {
             if let Some(player) = player.as_deref() {
-                full_output.platform_output.cursor_icon = player
-                    .ui()
-                    .downcast_ref::<DesktopUiBackend>()
-                    .unwrap_or_else(|| panic!("UI Backend should be DesktopUiBackend"))
-                    .cursor();
+                full_output.platform_output.cursor_icon =
+                    <dyn Any>::downcast_ref::<DesktopUiBackend>(player.ui())
+                        .unwrap_or_else(|| panic!("UI Backend should be DesktopUiBackend"))
+                        .cursor();
             }
         }
         self.egui_winit
@@ -375,10 +375,9 @@ impl GuiController {
         );
 
         let movie_view = if let Some(player) = player.as_deref_mut() {
-            let renderer = player
-                .renderer_mut()
-                .downcast_mut::<WgpuRenderBackend<MovieView>>()
-                .expect("Renderer must be correct type");
+            let renderer =
+                <dyn Any>::downcast_ref::<WgpuRenderBackend<MovieView>>(player.renderer_mut())
+                    .expect("Renderer must be correct type");
             Some(renderer.target())
         } else {
             None

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -11,6 +11,7 @@ use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use ruffle_render_wgpu::descriptors::Descriptors;
 use ruffle_render_wgpu::target::TextureTarget;
 use ruffle_render_wgpu::wgpu;
+use std::any::Any;
 use std::fs::create_dir_all;
 use std::io::{self, Write};
 use std::panic::catch_unwind;
@@ -135,10 +136,10 @@ fn take_screenshot(
             let image = || {
                 player.lock().unwrap().render();
                 let mut player = player.lock().unwrap();
-                let renderer = player
-                    .renderer_mut()
-                    .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
-                    .unwrap();
+                let renderer = <dyn Any>::downcast_mut::<WgpuRenderBackend<TextureTarget>>(
+                    player.renderer_mut(),
+                )
+                .unwrap();
                 renderer.capture_frame()
             };
             match catch_unwind(image) {

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -18,7 +18,6 @@ gif = "0.13.1"
 png = "0.17.16"
 flate2 = { workspace = true }
 smallvec = { version = "1.15.0", features = ["union"] }
-downcast-rs = "2.0.1"
 lyon = { version = "1.0.1", optional = true }
 lyon_geom = "1.0.6"
 thiserror = { workspace = true }

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -17,6 +17,7 @@ use ruffle_render::quality::StageQuality;
 use ruffle_render::shape_utils::{DistilledShape, DrawCommand, LineScaleMode, LineScales};
 use ruffle_render::transform::Transform;
 use ruffle_web_common::{JsError, JsResult};
+use std::any::Any;
 use std::borrow::Cow;
 use std::sync::Arc;
 use swf::{BlendMode, Color, ColorTransform, Point, Twips};
@@ -52,8 +53,7 @@ struct ShapeData(Vec<CanvasDrawCommand>);
 impl ShapeHandleImpl for ShapeData {}
 
 fn as_shape_data(handle: &ShapeHandle) -> &ShapeData {
-    <dyn ShapeHandleImpl>::downcast_ref(&*handle.0)
-        .expect("Shape handle must be a Canvas ShapeData")
+    <dyn Any>::downcast_ref(&*handle.0).expect("Shape handle must be a Canvas ShapeData")
 }
 
 #[derive(Debug)]
@@ -155,8 +155,7 @@ struct BitmapData {
 impl BitmapHandleImpl for BitmapData {}
 
 fn as_bitmap_data(handle: &BitmapHandle) -> &BitmapData {
-    <dyn BitmapHandleImpl>::downcast_ref(&*handle.0)
-        .expect("Bitmap handle must be a Canvas BitmapData")
+    <dyn Any>::downcast_ref(&*handle.0).expect("Bitmap handle must be a Canvas BitmapData")
 }
 
 impl BitmapData {

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -1,8 +1,8 @@
 use h263_rs_yuv::bt601::yuv420_to_rgba;
+use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use downcast_rs::{impl_downcast, Downcast};
 use swf::{Rectangle, Twips};
 
 use crate::backend::RenderBackend;
@@ -17,8 +17,7 @@ impl PartialEq for BitmapHandle {
     }
 }
 
-pub trait BitmapHandleImpl: Downcast + Debug {}
-impl_downcast!(BitmapHandleImpl);
+pub trait BitmapHandleImpl: Any + Debug {}
 
 /// Info returned by the `register_bitmap` methods.
 #[derive(Clone, Debug)]
@@ -45,8 +44,7 @@ pub trait BitmapSource {
 
 pub type RgbaBufRead<'a> = Box<dyn FnOnce(&[u8], u32) + 'a>;
 
-pub trait SyncHandle: Downcast + Debug {}
-impl_downcast!(SyncHandle);
+pub trait SyncHandle: Any + Debug {}
 
 impl Clone for Box<dyn SyncHandle> {
     fn clone(&self) -> Box<dyn SyncHandle> {

--- a/render/src/filters.rs
+++ b/render/src/filters.rs
@@ -2,8 +2,7 @@ use crate::{
     bitmap::BitmapHandle,
     pixel_bender::{PixelBenderShaderArgument, PixelBenderShaderHandle},
 };
-use downcast_rs::{impl_downcast, Downcast};
-use std::fmt::Debug;
+use std::{any::Any, fmt::Debug};
 use swf::{Color, Rectangle, Twips};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -47,12 +46,11 @@ impl PartialEq for ShaderFilter<'_> {
     }
 }
 
-pub trait ShaderObject: Downcast + Debug {
+pub trait ShaderObject: Any + Debug {
     fn clone_box(&self) -> Box<dyn ShaderObject>;
 
     fn equals(&self, other: &dyn ShaderObject) -> bool;
 }
-impl_downcast!(ShaderObject);
 
 impl Clone for Box<dyn ShaderObject> {
     fn clone(&self) -> Self {

--- a/render/src/pixel_bender.rs
+++ b/render/src/pixel_bender.rs
@@ -5,9 +5,9 @@
 mod tests;
 
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
-use downcast_rs::{impl_downcast, Downcast};
 use num_traits::FromPrimitive;
 use std::{
+    any::Any,
     fmt::{Debug, Display, Formatter},
     io::Read,
     sync::Arc,
@@ -28,10 +28,9 @@ impl PartialEq for PixelBenderShaderHandle {
     }
 }
 
-pub trait PixelBenderShaderImpl: Downcast + Debug {
+pub trait PixelBenderShaderImpl: Any + Debug {
     fn parsed_shader(&self) -> &PixelBenderShader;
 }
-impl_downcast!(PixelBenderShaderImpl);
 
 #[repr(u8)]
 #[derive(Debug, Clone, PartialEq)]

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -21,6 +21,7 @@ use ruffle_render::tessellator::{
 };
 use ruffle_render::transform::Transform;
 use ruffle_web_common::{JsError, JsResult};
+use std::any::Any;
 use std::borrow::Cow;
 use std::sync::Arc;
 use swf::{BlendMode, Color, Twips};
@@ -169,8 +170,7 @@ impl Drop for RegistryData {
 impl BitmapHandleImpl for RegistryData {}
 
 fn as_registry_data(handle: &BitmapHandle) -> &RegistryData {
-    <dyn BitmapHandleImpl>::downcast_ref(&*handle.0)
-        .expect("Bitmap handle must be webgl RegistryData")
+    <dyn Any>::downcast_ref(&*handle.0).expect("Bitmap handle must be webgl RegistryData")
 }
 
 const MAX_GRADIENT_COLORS: usize = 15;
@@ -1647,7 +1647,7 @@ impl Drop for Mesh {
 impl ShapeHandleImpl for Mesh {}
 
 fn as_mesh(handle: &ShapeHandle) -> &Mesh {
-    <dyn ShapeHandleImpl>::downcast_ref(&*handle.0).expect("Shape handle must be a WebGL ShapeData")
+    <dyn Any>::downcast_ref(&*handle.0).expect("Shape handle must be a WebGL ShapeData")
 }
 
 #[derive(Debug)]

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -31,6 +31,7 @@ use ruffle_render::pixel_bender::{
 use ruffle_render::quality::StageQuality;
 use ruffle_render::shape_utils::DistilledShape;
 use ruffle_render::tessellator::ShapeTessellator;
+use std::any::Any;
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::path::Path;
@@ -413,10 +414,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
 
     #[instrument(level = "debug", skip_all)]
     fn context3d_present(&mut self, context: &mut dyn Context3D) -> Result<(), BitmapError> {
-        let context = context
-            .as_any_mut()
-            .downcast_mut::<WgpuContext3D>()
-            .unwrap();
+        let context = <dyn Any>::downcast_mut::<WgpuContext3D>(context).unwrap();
         context.present();
         Ok(())
     }
@@ -1084,7 +1082,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         handle: Box<dyn SyncHandle>,
         with_rgba: RgbaBufRead,
     ) -> Result<(), ruffle_render::error::Error> {
-        let handle = handle.downcast::<QueueSyncHandle>().unwrap();
+        let handle = Box::<dyn Any>::downcast::<QueueSyncHandle>(handle).unwrap();
         handle.capture(with_rgba, &mut self.active_frame);
         Ok(())
     }

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -21,6 +21,7 @@ use ruffle_render::backend::RawTexture;
 use ruffle_render::bitmap::{BitmapHandle, BitmapHandleImpl, PixelRegion, SyncHandle};
 use ruffle_render::shape_utils::GradientType;
 use ruffle_render::tessellator::{Gradient as TessGradient, Vertex as TessVertex};
+use std::any::Any;
 use std::cell::{Cell, OnceCell};
 use std::sync::Arc;
 use swf::GradientSpread;
@@ -55,11 +56,11 @@ mod surface;
 impl BitmapHandleImpl for Texture {}
 
 pub fn as_texture(handle: &BitmapHandle) -> &Texture {
-    <dyn BitmapHandleImpl>::downcast_ref(&*handle.0).unwrap()
+    <dyn Any>::downcast_ref(&*handle.0).unwrap()
 }
 
 pub fn raw_texture_as_texture(handle: &dyn RawTexture) -> &wgpu::Texture {
-    <dyn RawTexture>::downcast_ref(handle).unwrap()
+    <dyn Any>::downcast_ref(handle).unwrap()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -3,6 +3,7 @@ use crate::target::RenderTarget;
 use crate::{
     as_texture, Descriptors, GradientUniforms, PosColorVertex, PosVertex, TextureTransforms,
 };
+use std::any::Any;
 use std::ops::Range;
 use wgpu::util::DeviceExt;
 
@@ -25,7 +26,7 @@ pub struct Mesh {
 impl ShapeHandleImpl for Mesh {}
 
 pub fn as_mesh(handle: &ShapeHandle) -> &Mesh {
-    <dyn ShapeHandleImpl>::downcast_ref(&*handle.0).expect("Shape handle must be a WGPU ShapeData")
+    <dyn Any>::downcast_ref(&*handle.0).expect("Shape handle must be a WGPU ShapeData")
 }
 
 #[derive(Debug)]

--- a/render/wgpu/src/pixel_bender.rs
+++ b/render/wgpu/src/pixel_bender.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::num::NonZeroU64;
@@ -102,7 +103,7 @@ impl PixelBenderShaderImpl for PixelBenderWgpuShader {
 }
 
 pub fn as_cache_holder(handle: &PixelBenderShaderHandle) -> &PixelBenderWgpuShader {
-    <dyn PixelBenderShaderImpl>::downcast_ref(&*handle.0).unwrap()
+    <dyn Any>::downcast_ref(&*handle.0).unwrap()
 }
 
 impl PixelBenderWgpuShader {

--- a/tests/framework/src/environment.rs
+++ b/tests/framework/src/environment.rs
@@ -42,5 +42,5 @@ pub trait RenderInterface {
     /// Capture the stage rendered out by the given render backend.
     ///
     /// The provided backend is guaranteed to be the same one paired with this interface.
-    fn capture(&self, renderer: &mut Box<dyn RenderBackend>) -> image::RgbaImage;
+    fn capture(&self, renderer: &mut dyn RenderBackend) -> image::RgbaImage;
 }

--- a/tests/tests/environment.rs
+++ b/tests/tests/environment.rs
@@ -33,7 +33,8 @@ mod renderer {
     use ruffle_render_wgpu::wgpu;
     use ruffle_test_framework::environment::{RenderBackend, RenderInterface};
     use ruffle_test_framework::options::RenderOptions;
-    use {std::sync::Arc, std::sync::OnceLock};
+    use std::any::Any;
+    use std::sync::{Arc, OnceLock};
 
     pub struct NativeRenderInterface;
 
@@ -68,9 +69,8 @@ mod renderer {
         }
 
         fn capture(&self, backend: &mut dyn RenderBackend) -> RgbaImage {
-            let renderer = backend
-                .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
-                .unwrap();
+            let renderer =
+                <dyn Any>::downcast_mut::<WgpuRenderBackend<TextureTarget>>(backend).unwrap();
 
             renderer.capture_frame().expect("Failed to capture image")
         }

--- a/tests/tests/environment.rs
+++ b/tests/tests/environment.rs
@@ -67,7 +67,7 @@ mod renderer {
             }
         }
 
-        fn capture(&self, backend: &mut Box<dyn RenderBackend>) -> RgbaImage {
+        fn capture(&self, backend: &mut dyn RenderBackend) -> RgbaImage {
             let renderer = backend
                 .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
                 .unwrap();

--- a/tests/tests/shared_object/mod.rs
+++ b/tests/tests/shared_object/mod.rs
@@ -36,7 +36,7 @@ pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_
     // Save the storage backend for next run.
     {
         let mut player = runner.player().lock().unwrap();
-        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+        player.swap_storage(&mut memory_storage_backend);
     }
 
     // Verify that the flash cookie matches the expected one
@@ -63,7 +63,7 @@ pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_
     {
         // Swap in the previous storage backend.
         let mut player = runner.player().lock().unwrap();
-        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+        player.swap_storage(&mut memory_storage_backend);
     }
 
     loop {
@@ -110,7 +110,7 @@ pub fn shared_object_self_ref_avm1(
     {
         // Save the storage backend for next run.
         let mut player = runner.player().lock().unwrap();
-        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+        player.swap_storage(&mut memory_storage_backend);
     }
 
     // Verify that the flash cookie matches the expected one
@@ -136,7 +136,7 @@ pub fn shared_object_self_ref_avm1(
     {
         // Swap in the previous storage backend.
         let mut player = runner.player().lock().unwrap();
-        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+        player.swap_storage(&mut memory_storage_backend);
     }
 
     loop {
@@ -181,7 +181,7 @@ pub fn shared_object_avm2(environment: &impl Environment) -> Result<(), libtest_
     {
         // Save the storage backend for next run.
         let mut player = runner.player().lock().unwrap();
-        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+        player.swap_storage(&mut memory_storage_backend);
     }
 
     // Verify that the flash cookie matches the expected one
@@ -207,7 +207,7 @@ pub fn shared_object_avm2(environment: &impl Environment) -> Result<(), libtest_
     {
         // Swap in the previous storage backend.
         let mut player = runner.player().lock().unwrap();
-        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+        player.swap_storage(&mut memory_storage_backend);
     }
 
     loop {

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -19,6 +19,7 @@ use ruffle_render::backend::RenderBackend;
 use ruffle_render::quality::StageQuality;
 use ruffle_video_external::backend::ExternalVideoBackend;
 use ruffle_web_common::JsResult;
+use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::error::Error;
@@ -688,8 +689,7 @@ impl RuffleInstanceBuilder {
             let mut core = core
                 .lock()
                 .expect("Failed to lock player after construction");
-            core.navigator_mut()
-                .downcast_mut::<WebNavigatorBackend>()
+            <dyn Any>::downcast_mut::<WebNavigatorBackend>(core.navigator_mut())
                 .expect("Expected WebNavigatorBackend")
                 .set_player(player_weak);
             // Set config parameters.

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -24,6 +24,7 @@ use ruffle_core::{Player, PlayerEvent, StaticCallstack, ViewportDimensions};
 use ruffle_web_common::JsResult;
 use serde::Serialize;
 use slotmap::{new_key_type, SlotMap};
+use std::any::Any;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Once;
@@ -387,9 +388,7 @@ impl RuffleHandle {
         if !clipboard.is_empty() {
             let _ = self.with_core_mut(|core| {
                 core.mutate_with_update_context(|context| {
-                    context
-                        .ui
-                        .downcast_mut::<WebUiBackend>()
+                    <dyn Any>::downcast_mut::<WebUiBackend>(context.ui)
                         .expect("Web UI backend")
                         .set_clipboard_content_buffer(clipboard);
                 });
@@ -444,8 +443,7 @@ impl RuffleHandle {
     /// Returns `None` if the audio backend does not use Web Audio.
     pub fn audio_context(&self) -> Option<web_sys::AudioContext> {
         self.with_core_mut(|core| {
-            core.audio()
-                .downcast_ref::<audio::WebAudioBackend>()
+            <dyn Any>::downcast_ref::<audio::WebAudioBackend>(core.audio())
                 .map(|audio| audio.audio_context().clone())
         })
         .unwrap_or_default()
@@ -744,8 +742,7 @@ impl RuffleHandle {
                                     } else {
                                         "".into()
                                     };
-                                core.ui_mut()
-                                    .downcast_mut::<WebUiBackend>()
+                                <dyn Any>::downcast_mut::<WebUiBackend>(core.ui_mut())
                                     .expect("Web UI backend")
                                     .set_clipboard_content_buffer(clipboard_content);
                                 core.handle_event(PlayerEvent::TextControl {


### PR DESCRIPTION
Now that Rust supports trait upcasting, the direct dependency on `downcast-rs` isn't needed anymore.

`downcast-rs` still appears to be transitively used by `wayland-backend`, so I haven't removed it from the `LICENSE.md` list.