### PR TITLE
core: Put some DisplayObject properties in a Cell

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2897,7 +2897,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             let level: DisplayObject<'_> =
                 MovieClip::new(self.base_clip().movie(), self.gc()).into();
 
-            level.set_depth(self.gc(), level_id);
+            level.set_depth(level_id);
             level.set_default_root_name(self.context);
             self.get_root_parent_container()
                 .and_then(|c| c.replace_at_depth(self.context, level, level_id));

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -152,10 +152,10 @@ fn set_scale_9_grid<'gc>(
     avm1_stub!(activation, "Button", "scale9Grid");
     if let Value::Object(object) = value {
         if let Some(rectangle) = object_to_rectangle(activation, object)? {
-            this.set_scaling_grid(activation.gc(), rectangle);
+            this.set_scaling_grid(rectangle);
         }
     } else {
-        this.set_scaling_grid(activation.gc(), Default::default());
+        this.set_scaling_grid(Default::default());
     };
     Ok(())
 }

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -131,7 +131,7 @@ fn set_rgb<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(target) = target(activation, this)? {
-        target.set_transformed_by_script(activation.gc(), true);
+        target.set_transformed_by_script(true);
         if let Some(parent) = target.parent() {
             parent.invalidate_cached_bitmap(activation.gc());
         }
@@ -193,7 +193,7 @@ fn set_transform<'gc>(
     }
 
     if let Some(target) = target(activation, this)? {
-        target.set_transformed_by_script(activation.gc(), true);
+        target.set_transformed_by_script(true);
         if let Some(parent) = target.parent() {
             parent.invalidate_cached_bitmap(activation.gc());
         }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -175,12 +175,12 @@ fn set_scroll_rect<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Value::Object(object) = value {
-        this.set_has_scroll_rect(activation.gc(), true);
+        this.set_has_scroll_rect(true);
         if let Some(rectangle) = object_to_rectangle(activation, object)? {
             this.set_next_scroll_rect(activation.gc(), rectangle);
         }
     } else {
-        this.set_has_scroll_rect(activation.gc(), false);
+        this.set_has_scroll_rect(false);
     };
     Ok(())
 }
@@ -1370,7 +1370,7 @@ fn swap_depths<'gc>(
 
         if depth != movie_clip.depth() {
             parent.swap_at_depth(activation.context, movie_clip.into(), depth);
-            movie_clip.set_transformed_by_script(activation.gc(), true);
+            movie_clip.set_transformed_by_script(true);
         }
     }
 
@@ -1678,7 +1678,7 @@ fn set_transform<'gc>(
                     parent.invalidate_cached_bitmap(activation.gc());
                 }
 
-                this.set_transformed_by_script(activation.gc(), true);
+                this.set_transformed_by_script(true);
             }
         }
     }
@@ -1699,7 +1699,7 @@ fn set_lock_root<'gc>(
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let lock_root = value.as_bool(activation.swf_version());
-    this.set_lock_root(activation.gc(), lock_root);
+    this.set_lock_root(lock_root);
     Ok(())
 }
 

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -206,10 +206,10 @@ fn set_scale_9_grid<'gc>(
     avm1_stub!(activation, "MovieClip", "scale9Grid");
     if let Value::Object(object) = value {
         if let Some(rectangle) = object_to_rectangle(activation, object)? {
-            this.set_scaling_grid(activation.gc(), rectangle);
+            this.set_scaling_grid(rectangle);
         }
     } else {
-        this.set_scaling_grid(activation.gc(), Rectangle::default());
+        this.set_scaling_grid(Rectangle::default());
     };
     Ok(())
 }
@@ -1197,7 +1197,7 @@ fn set_mask<'gc>(
     };
     let movie_clip = DisplayObject::MovieClip(movie_clip);
     let mc = activation.gc();
-    movie_clip.set_clip_depth(mc, 0);
+    movie_clip.set_clip_depth(0);
     movie_clip.set_masker(mc, mask, true);
     if let Some(m) = mask {
         m.set_maskee(mc, Some(movie_clip), true);

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -101,7 +101,7 @@ fn method<'gc>(
                 if is_matrix {
                     let matrix = object_to_matrix(object, activation)?;
                     clip.set_matrix(activation.gc(), matrix);
-                    clip.set_transformed_by_script(activation.gc(), true);
+                    clip.set_transformed_by_script(true);
                     if let Some(parent) = clip.parent() {
                         // Self-transform changes are automatically handled,
                         // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
@@ -131,7 +131,7 @@ fn method<'gc>(
                         color_transform.read().clone().into(),
                     );
                     clip.invalidate_cached_bitmap(activation.gc());
-                    clip.set_transformed_by_script(activation.gc(), true);
+                    clip.set_transformed_by_script(true);
                 }
             }
             Value::Undefined

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -345,8 +345,8 @@ fn set_y<'gc>(
     Ok(())
 }
 
-fn x_scale<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.scale_x(activation.gc()).percent().into()
+fn x_scale<'gc>(_activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
+    this.scale_x().percent().into()
 }
 
 fn set_x_scale<'gc>(
@@ -360,8 +360,8 @@ fn set_x_scale<'gc>(
     Ok(())
 }
 
-fn y_scale<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.scale_y(activation.gc()).percent().into()
+fn y_scale<'gc>(_activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
+    this.scale_y().percent().into()
 }
 
 fn set_y_scale<'gc>(
@@ -455,8 +455,8 @@ fn set_height<'gc>(
     Ok(())
 }
 
-fn rotation<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    let degrees: f64 = this.rotation(activation.gc()).into();
+fn rotation<'gc>(_activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
+    let degrees: f64 = this.rotation().into();
     degrees.into()
 }
 

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -181,7 +181,7 @@ pub fn set_scale9grid<'gc>(
             None => Rectangle::default(),
             Some(rect) => object_to_rectangle(activation, rect)?,
         };
-        dobj.set_scaling_grid(activation.gc(), rect);
+        dobj.set_scaling_grid(rect);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -35,7 +35,7 @@ pub fn initialize_for_allocator<'gc>(
     class: ClassObject<'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let obj: StageObject = StageObject::for_display_object(activation, dobj, class)?;
-    dobj.set_placed_by_script(activation.gc(), true);
+    dobj.set_placed_by_script(true);
     dobj.set_object2(activation.context, obj.into());
 
     // [NA] Should these run for everything?
@@ -47,8 +47,7 @@ pub fn initialize_for_allocator<'gc>(
     // and consequently are observed to have their currentFrame lag one
     // frame behind objects placed by the timeline (even if they were
     // both placed in the same frame to begin with).
-    dobj.base_mut(activation.gc())
-        .set_skip_next_enter_frame(true);
+    dobj.base().set_skip_next_enter_frame(true);
     dobj.on_construction_complete(activation.context);
 
     Ok(obj.into())
@@ -190,14 +189,14 @@ pub fn set_scale9grid<'gc>(
 
 /// Implements `scaleY`'s getter.
 pub fn get_scale_y<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        return Ok(dobj.scale_y(activation.gc()).unit().into());
+        return Ok(dobj.scale_y().unit().into());
     }
 
     Ok(Value::Undefined)
@@ -254,14 +253,14 @@ pub fn set_width<'gc>(
 
 /// Implements `scaleX`'s getter.
 pub fn get_scale_x<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        return Ok(dobj.scale_x(activation.gc()).unit().into());
+        return Ok(dobj.scale_x().unit().into());
     }
 
     Ok(Value::Undefined)
@@ -504,14 +503,14 @@ pub fn set_scale_z<'gc>(
 
 /// Implements `rotation`'s getter.
 pub fn get_rotation<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
     if let Some(dobj) = this.as_display_object() {
-        let rot: f64 = dobj.rotation(activation.gc()).into();
+        let rot: f64 = dobj.rotation().into();
         let rem = rot % 360.0;
 
         if rem <= 180.0 {
@@ -962,9 +961,9 @@ pub fn set_scroll_rect<'gc>(
             // `localToGlobal`.
             dobj.set_next_scroll_rect(activation.gc(), object_to_rectangle(activation, rectangle)?);
 
-            dobj.set_has_scroll_rect(activation.gc(), true);
+            dobj.set_has_scroll_rect(true);
         } else {
-            dobj.set_has_scroll_rect(activation.gc(), false);
+            dobj.set_has_scroll_rect(false);
         }
     }
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/display_object_container.rs
+++ b/core/src/avm2/globals/flash/display/display_object_container.rs
@@ -109,7 +109,7 @@ fn validate_remove_operation<'gc>(
 fn remove_child_from_displaylist<'gc>(context: &mut UpdateContext<'gc>, child: DisplayObject<'gc>) {
     if let Some(parent) = child.parent() {
         if let Some(mut ctr) = parent.as_container() {
-            child.set_placed_by_script(context.gc(), true);
+            child.set_placed_by_script(true);
             ctr.remove_child(context, child);
         }
     }
@@ -123,7 +123,7 @@ pub(super) fn add_child_to_displaylist<'gc>(
     index: usize,
 ) {
     if let Some(mut ctr) = parent.as_container() {
-        child.set_placed_by_script(context.gc(), true);
+        child.set_placed_by_script(true);
         ctr.insert_at_index(context, child, index);
     }
 }
@@ -348,7 +348,7 @@ pub fn remove_child_at<'gc>(
             }
 
             let child = ctr.child_by_index(target_child as usize).unwrap();
-            child.set_placed_by_script(activation.gc(), true);
+            child.set_placed_by_script(true);
 
             ctr.remove_child(activation.context, child);
 
@@ -485,8 +485,8 @@ pub fn swap_children_at<'gc>(
             let child0 = ctr.child_by_index(index0 as usize).unwrap();
             let child1 = ctr.child_by_index(index1 as usize).unwrap();
 
-            child0.set_placed_by_script(activation.gc(), true);
-            child1.set_placed_by_script(activation.gc(), true);
+            child0.set_placed_by_script(true);
+            child1.set_placed_by_script(true);
 
             ctr.swap_at_index(activation.context, index0 as usize, index1 as usize);
         }
@@ -523,8 +523,8 @@ pub fn swap_children<'gc>(
                 .position(|a| DisplayObject::ptr_eq(a, child1))
                 .ok_or(make_error_2025(activation))?;
 
-            child0.set_placed_by_script(activation.gc(), true);
-            child1.set_placed_by_script(activation.gc(), true);
+            child0.set_placed_by_script(true);
+            child1.set_placed_by_script(true);
 
             ctr.swap_at_index(activation.context, index0, index1);
         }

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -76,7 +76,7 @@ pub fn set_matrix<'gc>(
 
     let dobj = get_display_object(this);
     let Some(obj) = args.try_get_object(activation, 0) else {
-        dobj.base_mut(activation.gc()).set_has_matrix3d_stub(true);
+        dobj.base().set_has_matrix3d_stub(true);
         return Ok(Value::Undefined);
     };
 
@@ -87,7 +87,7 @@ pub fn set_matrix<'gc>(
         // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
         parent.invalidate_cached_bitmap(activation.gc());
     }
-    dobj.base_mut(activation.gc()).set_has_matrix3d_stub(false);
+    dobj.base().set_has_matrix3d_stub(false);
     Ok(Value::Undefined)
 }
 
@@ -377,9 +377,7 @@ pub fn set_matrix_3d<'gc>(
         // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
         parent.invalidate_cached_bitmap(activation.gc());
     }
-    display_object
-        .base_mut(activation.gc())
-        .set_has_matrix3d_stub(has_matrix3d);
+    display_object.base().set_has_matrix3d_stub(has_matrix3d);
 
     Ok(Value::Undefined)
 }
@@ -449,7 +447,7 @@ pub fn set_perspective_projection<'gc>(
         .unwrap_or_default();
     let display_object = get_display_object(this);
     display_object
-        .base_mut(activation.gc())
+        .base()
         .set_has_perspective_projection_stub(set);
     Ok(Value::Undefined)
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -394,7 +394,7 @@ impl<'gc> UpdateContext<'gc> {
 
         drop(activation);
 
-        root.set_depth(self.gc(), 0);
+        root.set_depth(0);
         let flashvars = if !self.swf.parameters().is_empty() {
             let object = Avm1Object::new(&self.strings, None);
             for (key, value) in self.swf.parameters().iter() {

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -406,7 +406,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
 
         // Do *not* unregister text field bindings.
 
-        self.set_avm1_removed(context.gc(), true);
+        self.set_avm1_removed(true);
     }
 
     fn avm1_text_field_bindings(&self) -> Option<Ref<'_, [Avm1TextFieldBinding<'gc>]>> {

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -162,7 +162,7 @@ impl<'gc> Avm1Button<'gc> {
                         {
                             // New child that did not previously exist, create it.
                             child.set_parent(context, Some(self.into()));
-                            child.set_depth(context.gc(), record.depth.into());
+                            child.set_depth(record.depth.into());
 
                             children.push((child, record.depth));
                             child
@@ -318,7 +318,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
                         Some(child) => {
                             child.set_matrix(context.gc(), record.matrix.into());
                             child.set_parent(context, Some(self_display_object));
-                            child.set_depth(context.gc(), record.depth.into());
+                            child.set_depth(record.depth.into());
                             new_children.push((child, record.depth.into()));
                         }
                         None => {

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -206,7 +206,7 @@ impl<'gc> Avm2Button<'gc> {
                 {
                     Some(child) => {
                         child.set_matrix(context.gc(), record.matrix.into());
-                        child.set_depth(context.gc(), record.depth.into());
+                        child.set_depth(record.depth.into());
 
                         if swf_state != swf::ButtonState::HIT_TEST {
                             child.set_color_transform(context.gc(), record.color_transform);

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -277,7 +277,7 @@ pub trait TDisplayObjectContainer<'gc>:
         child.set_place_frame(context.gc(), 0);
         child.set_parent(context, Some(this));
         if !self.raw_container().movie().is_action_script_3() {
-            child.set_avm1_removed(context.gc(), false);
+            child.set_avm1_removed(false);
         }
 
         self.raw_container_mut(context.gc())
@@ -433,7 +433,7 @@ pub trait TDisplayObjectContainer<'gc>:
         for removed in removed_list {
             // The `remove_range` method is only ever called as a result of an ActionScript
             // call
-            removed.set_placed_by_script(context.gc(), true);
+            removed.set_placed_by_script(true);
             write.remove_child_from_depth_list(removed);
             drop(write);
 
@@ -993,7 +993,7 @@ impl<'gc> ChildContainer<'gc> {
             child.set_clip_depth(context.gc(), 0);
             prev_child.set_depth(context.gc(), prev_depth);
             prev_child.set_clip_depth(context.gc(), 0);
-            prev_child.set_transformed_by_script(context.gc(), true);
+            prev_child.set_transformed_by_script(true);
             self.depth_list.insert(prev_depth, prev_child);
 
             let prev_position = self
@@ -1107,7 +1107,7 @@ impl<'gc> ChildContainer<'gc> {
         let cur_depth = child.depth();
         // Note that the depth returned by AS will be offset by the `AVM_DEPTH_BIAS`, so this is really `-(cur_depth+1+AVM_DEPTH_BIAS)`
         child.set_depth(context.gc(), -cur_depth - 1);
-        child.set_avm1_pending_removal(context.gc(), true);
+        child.set_avm1_pending_removal(true);
 
         if let Some(mc) = child.as_movie_clip() {
             // Clip events should still fire

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -204,8 +204,8 @@ pub trait TDisplayObjectContainer<'gc>:
             .replace_at_depth(child, depth);
 
         child.set_parent(context, Some(self.into()));
-        child.set_place_frame(context.gc(), 0);
-        child.set_depth(context.gc(), depth);
+        child.set_place_frame(0);
+        child.set_depth(depth);
 
         if let Some(removed_child) = removed_child {
             if !self.raw_container().movie().is_action_script_3() {
@@ -274,7 +274,7 @@ pub trait TDisplayObjectContainer<'gc>:
 
         let child_was_on_stage = child.is_on_stage(context);
 
-        child.set_place_frame(context.gc(), 0);
+        child.set_place_frame(0);
         child.set_parent(context, Some(this));
         if !self.raw_container().movie().is_action_script_3() {
             child.set_avm1_removed(false);
@@ -384,7 +384,7 @@ pub trait TDisplayObjectContainer<'gc>:
     ) {
         let this: DisplayObject<'_> = (*self).into();
 
-        child.set_depth(context.gc(), depth);
+        child.set_depth(depth);
         child.set_parent(context, Some(this));
         self.raw_container_mut(context.gc())
             .insert_child_into_depth_list(depth, child);
@@ -986,13 +986,13 @@ impl<'gc> ChildContainer<'gc> {
         depth: Depth,
     ) {
         let prev_depth = child.depth();
-        child.set_depth(context.gc(), depth);
+        child.set_depth(depth);
         child.set_parent(context, Some(parent));
 
         if let Some(prev_child) = self.depth_list.insert(depth, child) {
-            child.set_clip_depth(context.gc(), 0);
-            prev_child.set_depth(context.gc(), prev_depth);
-            prev_child.set_clip_depth(context.gc(), 0);
+            child.set_clip_depth(0);
+            prev_child.set_depth(prev_depth);
+            prev_child.set_clip_depth(0);
             prev_child.set_transformed_by_script(true);
             self.depth_list.insert(prev_depth, prev_child);
 
@@ -1106,7 +1106,7 @@ impl<'gc> ChildContainer<'gc> {
 
         let cur_depth = child.depth();
         // Note that the depth returned by AS will be offset by the `AVM_DEPTH_BIAS`, so this is really `-(cur_depth+1+AVM_DEPTH_BIAS)`
-        child.set_depth(context.gc(), -cur_depth - 1);
+        child.set_depth(-cur_depth - 1);
         child.set_avm1_pending_removal(true);
 
         if let Some(mc) = child.as_movie_clip() {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2680,7 +2680,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     fn set_width(&self, context: &mut UpdateContext<'gc>, value: f64) {
         self.apply_autosize_bounds();
 
-        let mut edit_text = self.0.write(context.gc());
+        let edit_text = self.0.read();
         let bounds = &edit_text.bounds;
         bounds.set(bounds.get().with_width(Twips::from_pixels(value)));
         edit_text.base.base.set_transformed_by_script(true);
@@ -2701,7 +2701,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     fn set_height(&self, context: &mut UpdateContext<'gc>, value: f64) {
         self.apply_autosize_bounds();
 
-        let mut edit_text = self.0.write(context.gc());
+        let edit_text = self.0.read();
         let bounds = &edit_text.bounds;
         bounds.set(bounds.get().with_height(Twips::from_pixels(value)));
         edit_text.base.base.set_transformed_by_script(true);
@@ -2819,7 +2819,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
                 .retain(|&text_field| !DisplayObject::ptr_eq(text_field.into(), (*self).into()));
         }
 
-        self.set_avm1_removed(context.gc(), true);
+        self.set_avm1_removed(true);
     }
 
     fn avm1_text_field_bindings(&self) -> Option<Ref<'_, [Avm1TextFieldBinding<'gc>]>> {

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -53,7 +53,7 @@ impl<'gc> LoaderDisplay<'gc> {
             },
         ));
 
-        obj.set_placed_by_script(activation.gc(), true);
+        obj.set_placed_by_script(true);
         activation.context.avm2.add_orphan_obj(obj.into());
         obj
     }
@@ -118,11 +118,11 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
         for child in self.iter_render_list() {
             // See MovieClip::enter_frame for an explanation of this.
             if skip_frame {
-                child.base_mut(context.gc()).set_skip_next_enter_frame(true);
+                child.base().set_skip_next_enter_frame(true);
             }
             child.enter_frame(context);
         }
-        self.base_mut(context.gc()).set_skip_next_enter_frame(false);
+        self.base().set_skip_next_enter_frame(false);
     }
 
     fn construct_frame(&self, context: &mut UpdateContext<'gc>) {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1600,9 +1600,9 @@ impl<'gc> MovieClip<'gc> {
                 {
                     // Set initial properties for child.
                     child.set_instantiated_by_timeline(true);
-                    child.set_depth(context.gc(), depth);
+                    child.set_depth(depth);
                     child.set_parent(context, Some(self.into()));
-                    child.set_place_frame(context.gc(), self.current_frame());
+                    child.set_place_frame(self.current_frame());
 
                     // Apply PlaceObject parameters.
                     child.apply_place_object(context, place_object);
@@ -1613,7 +1613,7 @@ impl<'gc> MovieClip<'gc> {
                         child.set_has_explicit_name(true);
                     }
                     if let Some(clip_depth) = place_object.clip_depth {
-                        child.set_clip_depth(context.gc(), clip_depth.into());
+                        child.set_clip_depth(clip_depth.into());
                     }
                     // Clip events only apply to movie clips.
                     if let (Some(clip_actions), Some(clip)) =
@@ -1912,7 +1912,7 @@ impl<'gc> MovieClip<'gc> {
                 (swf::PlaceObjectAction::Replace(id), Some(prev_child), _) => {
                     prev_child.replace_with(context, id);
                     prev_child.apply_place_object(context, &params.place_object);
-                    prev_child.set_place_frame(context.gc(), params.frame);
+                    prev_child.set_place_frame(params.frame);
                 }
                 (PlaceObjectAction::Place(id), _, _)
                 | (swf::PlaceObjectAction::Replace(id), _, _) => {
@@ -1920,7 +1920,7 @@ impl<'gc> MovieClip<'gc> {
                         clip.instantiate_child(context, id, params.depth(), &params.place_object)
                     {
                         // Set the place frame to the frame where the object *would* have been placed.
-                        child.set_place_frame(context.gc(), params.frame);
+                        child.set_place_frame(params.frame);
                     }
                 }
                 _ => {
@@ -3516,7 +3516,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let library = context.library.library_for_movie_mut(self.movie());
         if let Some(character) = library.character_by_id(id) {
             if let Character::MovieClip(clip) = character {
-                clip.set_scaling_grid(context.gc_context, rect);
+                clip.set_scaling_grid(rect);
             } else {
                 tracing::warn!("DefineScalingGrid for invalid ID {}", id);
             }
@@ -4615,7 +4615,7 @@ impl<'gc, 'a> MovieClip<'gc> {
                 if let Some(child) = self.child_by_depth(place_object.depth.into()) {
                     child.replace_with(context, id);
                     child.apply_place_object(context, &place_object);
-                    child.set_place_frame(context.gc(), self.current_frame());
+                    child.set_place_frame(self.current_frame());
                 }
             }
             PlaceObjectAction::Modify => {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -458,7 +458,7 @@ impl<'gc> MovieClip<'gc> {
                 .unwrap();
             loader_info.set_loader_stream(LoaderStream::Swf(movie, mc.into()), activation.gc());
         }
-        mc.set_is_root(activation.gc(), true);
+        mc.set_is_root(true);
         mc
     }
 
@@ -1599,7 +1599,7 @@ impl<'gc> MovieClip<'gc> {
                 let prev_child = self.replace_at_depth(context, child, depth);
                 {
                     // Set initial properties for child.
-                    child.set_instantiated_by_timeline(context.gc(), true);
+                    child.set_instantiated_by_timeline(true);
                     child.set_depth(context.gc(), depth);
                     child.set_parent(context, Some(self.into()));
                     child.set_place_frame(context.gc(), self.current_frame());
@@ -1610,7 +1610,7 @@ impl<'gc> MovieClip<'gc> {
                         let encoding = swf::SwfStr::encoding_for_version(self.swf_version());
                         let name = AvmString::new(context.gc(), name.decode(encoding));
                         child.set_name(context.gc(), name);
-                        child.set_has_explicit_name(context.gc(), true);
+                        child.set_has_explicit_name(true);
                     }
                     if let Some(clip_depth) = place_object.clip_depth {
                         child.set_clip_depth(context.gc(), clip_depth.into());
@@ -1728,7 +1728,7 @@ impl<'gc> MovieClip<'gc> {
         }
 
         let frame_before_rewind = self.current_frame();
-        self.base_mut(context.gc()).set_skip_next_enter_frame(false);
+        self.base().set_skip_next_enter_frame(false);
 
         // Flash gotos are tricky:
         // 1) Conceptually, a goto should act like the playhead is advancing forward or
@@ -2523,13 +2523,13 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                 // executing parent can add a child that should have its first frame skipped.
 
                 // FIXME - does this propagate through non-movie-clip children (Loader/Button)?
-                child.base_mut(context.gc()).set_skip_next_enter_frame(true);
+                child.base().set_skip_next_enter_frame(true);
             }
             child.enter_frame(context);
         }
 
         if skip_frame {
-            self.base_mut(context.gc()).set_skip_next_enter_frame(false);
+            self.base().set_skip_next_enter_frame(false);
             return;
         }
 
@@ -2878,7 +2878,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             self.event_dispatch(context, ClipEvent::Unload);
         }
 
-        self.set_avm1_removed(context.gc(), true);
+        self.set_avm1_removed(true);
     }
 
     fn avm1_text_field_bindings(&self) -> Option<Ref<'_, [Avm1TextFieldBinding<'gc>]>> {

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -192,7 +192,7 @@ impl<'gc> Stage<'gc> {
                 focus_tracker: FocusTracker::new(gc_context),
             },
         ));
-        stage.set_is_root(gc_context, true);
+        stage.set_is_root(true);
         stage
     }
 

--- a/core/src/frame_lifecycle.rs
+++ b/core/src/frame_lifecycle.rs
@@ -136,9 +136,7 @@ pub fn run_inner_goto_frame<'gc>(
         initial_clip.construct_frame(context);
         // We skip the next `enter_frame` call, so that we will still run the framescripts
         // queued for our target frame.
-        initial_clip
-            .base_mut(context.gc())
-            .set_skip_next_enter_frame(true);
+        initial_clip.base().set_skip_next_enter_frame(true);
 
         return;
     }

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -2123,7 +2123,7 @@ impl<'gc> Loader<'gc> {
                         // When an AVM2 movie loads an AVM1 movie, we need to call `post_instantiation` here.
                         mc.post_instantiation(uc, None, Instantiator::Movie, false);
 
-                        mc.set_depth(uc.gc(), LOADER_INSERTED_AVM1_DEPTH);
+                        mc.set_depth(LOADER_INSERTED_AVM1_DEPTH);
                     }
 
                     if from_bytes {

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -2412,7 +2412,7 @@ impl<'gc> Loader<'gc> {
                 // and consequently are observed to have their currentFrame lag one
                 // frame behind objects placed by the timeline (even if they were
                 // both placed in the same frame to begin with).
-                dobj.base_mut(uc.gc()).set_skip_next_enter_frame(true);
+                dobj.base().set_skip_next_enter_frame(true);
 
                 let flashvars = movie.clone().unwrap().parameters().to_owned();
                 if !flashvars.is_empty() {


### PR DESCRIPTION
This refactor simplifies code and makes some methods not require mutability and GC context.