### PR TITLE
core: Put some Stage properties in a Cell

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2210,7 +2210,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.context.stage.set_quality(self.context, new_quality);
         self.context
             .stage
-            .set_use_bitmap_downsampling(self.gc(), use_bitmap_downsamping);
+            .set_use_bitmap_downsampling(use_bitmap_downsamping);
         Ok(FrameControl::Continue)
     }
 

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -174,10 +174,7 @@ fn set_show_menu<'gc>(
         .unwrap_or(&true.into())
         .to_owned()
         .as_bool(activation.swf_version());
-    activation
-        .context
-        .stage
-        .set_show_menu(activation.context, show_menu);
+    activation.context.stage.set_show_menu(show_menu);
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -596,10 +596,7 @@ fn set_focus_rect<'gc>(
             Value::Object(_) => false,
             _ => val.coerce_to_f64(activation)? != 0.0,
         };
-        activation
-            .context
-            .stage
-            .set_stage_focus_rect(activation.gc(), val);
+        activation.context.stage.set_stage_focus_rect(val);
     } else if let Some(obj) = this.as_interactive() {
         let val = match val {
             Value::Undefined | Value::Null => None,

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -107,7 +107,7 @@ pub fn set_color<'gc>(
 
     if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         let color = Color::from_rgb(args.get_u32(activation, 0)?, 255);
-        dobj.set_background_color(activation.gc(), Some(color));
+        dobj.set_background_color(Some(color));
     }
 
     Ok(Value::Undefined)
@@ -255,7 +255,7 @@ pub fn set_show_default_context_menu<'gc>(
     activation
         .context
         .stage
-        .set_show_menu(activation.context, show_default_context_menu);
+        .set_show_menu(show_default_context_menu);
     Ok(Value::Undefined)
 }
 
@@ -306,7 +306,7 @@ pub fn get_stage_focus_rect<'gc>(
 
 /// Implement `stageFocusRect`'s setter
 pub fn set_stage_focus_rect<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -314,7 +314,7 @@ pub fn set_stage_focus_rect<'gc>(
 
     if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         let rf = args.get_bool(0);
-        dobj.set_stage_focus_rect(activation.gc(), rf);
+        dobj.set_stage_focus_rect(rf);
     }
 
     Ok(Value::Undefined)
@@ -446,14 +446,14 @@ pub fn get_stage3ds<'gc>(
 
 /// Implement `invalidate`
 pub fn invalidate<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
 
     if let Some(stage) = this.as_display_object().and_then(|this| this.as_stage()) {
-        stage.set_invalidated(activation.gc(), true);
+        stage.set_invalidated(true);
     }
     Ok(Value::Undefined)
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -357,7 +357,6 @@ impl<'gc> UpdateContext<'gc> {
         }
 
         self.stage.set_movie_size(
-            self.gc(),
             self.swf.width().to_pixels() as u32,
             self.swf.height().to_pixels() as u32,
         );

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -895,7 +895,7 @@ impl DisplayObjectWindow {
                 let mut new_stage_focus_rect = object.stage_focus_rect();
                 ui.checkbox(&mut new_stage_focus_rect, "Enabled");
                 if new_stage_focus_rect != object.stage_focus_rect() {
-                    object.set_stage_focus_rect(context.gc(), new_stage_focus_rect);
+                    object.set_stage_focus_rect(new_stage_focus_rect);
                 }
                 ui.end_row();
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -4694,9 +4694,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         // if parent SWF is missing SetBackgroundColor tag.
         let background_color = reader.read_rgb()?;
         if context.stage.background_color().is_none() {
-            context
-                .stage
-                .set_background_color(context.gc(), Some(background_color));
+            context.stage.set_background_color(Some(background_color));
         }
         Ok(())
     }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -914,9 +914,7 @@ impl Player {
     }
 
     pub fn set_background_color(&mut self, color: Option<Color>) {
-        self.mutate_with_update_context(|context| {
-            context.stage.set_background_color(context.gc(), color)
-        })
+        self.mutate_with_update_context(|context| context.stage.set_background_color(color))
     }
 
     pub fn letterbox(&mut self) -> Letterbox {
@@ -924,9 +922,7 @@ impl Player {
     }
 
     pub fn set_letterbox(&mut self, letterbox: Letterbox) {
-        self.mutate_with_update_context(|context| {
-            context.stage.set_letterbox(context.gc(), letterbox)
-        })
+        self.mutate_with_update_context(|context| context.stage.set_letterbox(letterbox))
     }
 
     pub fn movie_width(&mut self) -> u32 {
@@ -951,7 +947,7 @@ impl Player {
     pub fn set_show_menu(&mut self, show_menu: bool) {
         self.mutate_with_update_context(|context| {
             let stage = context.stage;
-            stage.set_show_menu(context, show_menu);
+            stage.set_show_menu(show_menu);
         })
     }
 
@@ -959,7 +955,7 @@ impl Player {
     pub fn set_allow_fullscreen(&mut self, allow_fullscreen: bool) {
         self.mutate_with_update_context(|context| {
             let stage = context.stage;
-            stage.set_allow_fullscreen(context, allow_fullscreen);
+            stage.set_allow_fullscreen(allow_fullscreen);
         })
     }
 
@@ -977,7 +973,7 @@ impl Player {
         self.mutate_with_update_context(|context| {
             let stage = context.stage;
             if let Ok(window_mode) = WindowMode::from_str(window_mode) {
-                stage.set_window_mode(context, window_mode);
+                stage.set_window_mode(window_mode);
             }
         })
     }
@@ -998,7 +994,7 @@ impl Player {
 
     pub fn set_forced_scale_mode(&mut self, force: bool) {
         self.mutate_with_update_context(|context| {
-            context.stage.set_forced_scale_mode(context, force);
+            context.stage.set_forced_scale_mode(force);
         })
     }
 
@@ -2975,10 +2971,10 @@ impl PlayerBuilder {
 
             let stage = context.stage;
             stage.set_align(context, self.align);
-            stage.set_forced_align(context, self.forced_align);
+            stage.set_forced_align(self.forced_align);
             stage.set_scale_mode(context, self.scale_mode, false);
-            stage.set_forced_scale_mode(context, self.forced_scale_mode);
-            stage.set_allow_fullscreen(context, self.allow_fullscreen);
+            stage.set_forced_scale_mode(self.forced_scale_mode);
+            stage.set_allow_fullscreen(self.allow_fullscreen);
             stage.post_instantiation(context, None, Instantiator::Movie, false);
             stage.build_matrices(context);
             #[cfg(feature = "known_stubs")]


### PR DESCRIPTION
This refactor simplifies code and makes some methods not require mutability and GC context.