### PR TITLE
core: Put some MovieClip properties in a Cell

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1788,7 +1788,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     fn action_play(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         if let Some(clip) = self.target_clip() {
             if let Some(clip) = clip.as_movie_clip() {
-                clip.play(self.context)
+                clip.play()
             } else {
                 avm_warn!(self, "Play: Target is not a MovieClip");
             }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1148,10 +1148,10 @@ fn next_frame<'gc>(
 
 fn play<'gc>(
     movie_clip: MovieClip<'gc>,
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    movie_clip.play(activation.context);
+    movie_clip.play();
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -65,7 +65,7 @@ pub fn display_object_initializer<'gc>(
 
     if let Some(dobj) = this.as_display_object() {
         if let Some(clip) = dobj.as_movie_clip() {
-            clip.set_constructing_frame(true, activation.gc());
+            clip.set_constructing_frame(true);
         }
 
         if let Some(container) = dobj.as_container() {
@@ -75,7 +75,7 @@ pub fn display_object_initializer<'gc>(
         }
 
         if let Some(clip) = dobj.as_movie_clip() {
-            clip.set_constructing_frame(false, activation.gc());
+            clip.set_constructing_frame(false);
         }
     }
 

--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -350,7 +350,7 @@ pub fn goto_and_play<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
-        mc.set_programmatically_played(activation.gc());
+        mc.set_programmatically_played();
         goto_frame(activation, mc, args, false)?;
     }
 
@@ -460,7 +460,7 @@ pub fn stop<'gc>(
 
 /// Implements `play`.
 pub fn play<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -470,8 +470,8 @@ pub fn play<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
-        mc.set_programmatically_played(activation.gc());
-        mc.play(activation.context);
+        mc.set_programmatically_played();
+        mc.play();
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -219,7 +219,7 @@ pub fn get_enabled<'gc>(
 }
 
 pub fn set_enabled<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -231,7 +231,7 @@ pub fn set_enabled<'gc>(
     {
         let enabled = args.get_bool(0);
 
-        mc.set_avm2_enabled(activation.context, enabled);
+        mc.set_avm2_enabled(enabled);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -145,7 +145,7 @@ pub fn get_button_mode<'gc>(
 
 /// Implements `buttonMode`'s setter
 pub fn set_button_mode<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -154,7 +154,7 @@ pub fn set_button_mode<'gc>(
     if let Some(mc) = this.as_display_object().and_then(|o| o.as_movie_clip()) {
         let forced_button_mode = args.get_bool(0);
 
-        mc.set_forced_button_mode(activation.context, forced_button_mode);
+        mc.set_forced_button_mode(forced_button_mode);
     }
 
     Ok(Value::Undefined)
@@ -259,7 +259,7 @@ pub fn get_use_hand_cursor<'gc>(
 
 /// Implements `useHandCursor`'s setter
 pub fn set_use_hand_cursor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -269,7 +269,7 @@ pub fn set_use_hand_cursor<'gc>(
         .as_display_object()
         .and_then(|this| this.as_movie_clip())
     {
-        mc.set_avm2_use_hand_cursor(activation.context, args.get_bool(0));
+        mc.set_avm2_use_hand_cursor(args.get_bool(0));
     }
 
     Ok(Value::Undefined)

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -777,7 +777,7 @@ impl DisplayObjectWindow {
                 ui.label("Controls");
                 ui.horizontal(|ui| {
                     if ui.button("Play").clicked() {
-                        object.play(context);
+                        object.play();
                     }
                     if ui.button("Stop").clicked() {
                         object.stop(context);

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -2011,7 +2011,7 @@ pub trait TDisplayObject<'gc>:
             if !obj.is_of_type(movieclip_class) && !movie.is_root() {
                 movie.stop(context);
             }
-            movie.set_initialized(context.gc());
+            movie.set_initialized();
         }
     }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -842,7 +842,7 @@ impl Player {
             if mc.playing() {
                 mc.stop(context);
             } else {
-                mc.play(context);
+                mc.play();
             }
         }
     }


### PR DESCRIPTION
This refactor simplifies code and makes some methods not require mutability and GC context.

Frame related properties are left intact, because they would require a significant amount of additional code to be generated. We'll have to think about something smarter for them.