### PR TITLE
core: Replace GcCell with Gc in Video

### DIFF
--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -56,7 +56,7 @@ pub fn init<'gc>(
         let width = args.get_i32(activation, 0)?;
         let height = args.get_i32(activation, 1)?;
 
-        video.set_size(activation.gc(), width, height);
+        video.set_size(width, height);
     }
 
     Ok(Value::Undefined)

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3608,9 +3608,8 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let vframe = reader.read_video_frame()?;
         let library = context.library.library_for_movie_mut(self.movie());
         match library.character_by_id(vframe.stream_id) {
-            Some(Character::Video(mut v)) => {
-                v.preload_swf_frame(vframe, context);
-
+            Some(Character::Video(v)) => {
+                v.preload_swf_frame(vframe);
                 Ok(())
             }
             _ => Err(Error::PreloadVideoIntoInvalidCharacter(vframe.stream_id)),


### PR DESCRIPTION
This refactor replaces GcCell with Gc and uses interior mutability instead.