### PR TITLE
core: Replace GcCell with Gc in NetStream

### DIFF
--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -150,7 +150,7 @@ fn set_buffer_time<'gc>(
             .unwrap_or(Value::Undefined)
             .coerce_to_f64(activation)?;
 
-        ns.set_buffer_time(activation.gc(), buffer_time);
+        ns.set_buffer_time(buffer_time);
     }
 
     Ok(Value::Undefined)

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1896,7 +1896,7 @@ impl<'gc> Loader<'gc> {
 
                         stream.reset_buffer(uc);
                         if let Ok(Some(len)) = expected_length {
-                            stream.set_expected_length(uc, len as usize);
+                            stream.set_expected_length(len as usize);
                         }
 
                         Ok(())
@@ -1915,7 +1915,7 @@ impl<'gc> Loader<'gc> {
 
                             match chunk {
                                 Ok(Some(mut data)) => stream.load_buffer(uc, &mut data),
-                                Ok(None) => stream.finish_buffer(uc),
+                                Ok(None) => stream.finish_buffer(),
                                 Err(err) => stream.report_error(err),
                             }
                             Ok(())


### PR DESCRIPTION
This refactor replaces GcCell with Gc and uses interior mutability instead.