### PR TITLE
nit: Be consistent with tracing macro usage in webcodecs.rs

### DIFF
--- a/video/external/src/decoder/webcodecs.rs
+++ b/video/external/src/decoder/webcodecs.rs
@@ -9,7 +9,7 @@ use ruffle_video::error::Error;
 use ruffle_video::frame::{DecodedFrame, EncodedFrame, FrameDependency};
 
 use js_sys::Uint8Array;
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 use tracing_subscriber::{layer::Layered, Registry};
 use tracing_wasm::WASMLayer;
 use wasm_bindgen::prelude::*;
@@ -109,7 +109,7 @@ impl H264Decoder {
                     )));
                 }
                 other_format => {
-                    tracing::error!("Unsupported pixel format: {:?}", other_format);
+                    error!("Unsupported pixel format: {:?}", other_format);
                 }
             };
         };
@@ -117,7 +117,7 @@ impl H264Decoder {
         let log_subscriber_for_error = log_subscriber.clone();
         let error = move |error: &DomException| {
             let _subscriber = tracing::subscriber::set_default(log_subscriber_for_error.clone());
-            tracing::error!("WebCodecs error: {:}", error.message());
+            error!("WebCodecs error: {:}", error.message());
         };
 
         let output_callback = Closure::new(move |frame| output(&frame));
@@ -233,12 +233,12 @@ impl VideoDecoder for H264Decoder {
             // "After the decoding of an IDR picture all following coded pictures in decoding order can
             // be decoded without inter prediction from any picture decoded prior to the IDR picture."
             if nalu_type == NALU_TYPE_IDR {
-                tracing::trace!("is key");
+                trace!("is key");
                 return Ok(FrameDependency::None);
             }
         }
 
-        tracing::trace!("is not key");
+        trace!("is not key");
         Ok(FrameDependency::Past)
     }
 


### PR DESCRIPTION
It's not like I didn't have enough time to clean up https://github.com/ruffle-rs/ruffle/pull/16794 ... :roll_eyes: 