### PR TITLE
web/extension: Also add "debug" and "trace" log levels as options

### DIFF
--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -26,6 +26,12 @@
     "settings_log_level_info": {
         "message": "Info"
     },
+    "settings_log_level_debug": {
+        "message": "Debug"
+    },
+    "settings_log_level_trace": {
+        "message": "Trace"
+    },
     "settings_max_execution_duration": {
         "message": "Maximum allowed ActionScript execution duration (in seconds)"
     },

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -40,9 +40,11 @@
             </div>
             <div class="option select">
                 <select id="log_level">
-                    <option value="info" id="log_level_info">Info</option>
-                    <option value="warn" id="log_level_warn">Warning</option>
                     <option value="error" id="log_level_error">Error</option>
+                    <option value="warn" id="log_level_warn">Warning</option>
+                    <option value="info" id="log_level_info">Info</option>
+                    <option value="debug" id="log_level_debug">Debug</option>
+                    <option value="trace" id="log_level_trace">Trace</option>
                 </select>
                 <label for="log_level">Log level</label>
             </div>


### PR DESCRIPTION
They would have proven useful for me at least twice now during local testing.
Also, I always see them in this order, not as they currently are.