### PR TITLE
web/extension: nit: "Wgpu" -> "wgpu"

### DIFF
--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -50,7 +50,7 @@
                 <select id="preferred_renderer">
                     <option value="" id="preferred_renderer_auto">Automatic</option>
                     <option value="webgpu">WebGPU</option>
-                    <option value="wgpu-webgl">Wgpu (via WebGL)</option>
+                    <option value="wgpu-webgl">wgpu (via WebGL)</option>
                     <option value="webgl">WebGL</option>
                     <option value="canvas">Canvas2D</option>
                 </select>


### PR DESCRIPTION
Call me a hair-splitter all you want, but this has bothered me since forever...
I know about English and its rules, but this is the name of a project, and it's confusing among all those other Ws that should actually be upper-case.
_Jeez, so much effort and resource use for a single letter change..._