### PR TITLE
video: Also invalidate bitmap cache after decoding AVC (H.264) video frames

### DIFF
--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -1015,6 +1015,10 @@ impl<'gc> NetStream<'gc> {
                 ) {
                     Ok(bitmap_info) => {
                         write.last_decoded_bitmap = Some(bitmap_info);
+                        if let Some(mc) = write.attached_to {
+                            mc.invalidate_cached_bitmap(context.gc());
+                            *context.needs_render = true;
+                        }
                     }
                     Err(e) => {
                         tracing::error!("Decoding video frame {} failed: {}", frame_id, e);


### PR DESCRIPTION
https://github.com/ruffle-rs/ruffle/pull/16244 couldn't have fixed this too, because it was done in between https://github.com/ruffle-rs/ruffle/pull/14654 (which added this code) being created and merged.
I'm not aware of any actual problems that this fixes; it just caught my eye; but it looks logical to me.