### PR TITLE
debug_ui/display_object: Remove collapsing header for frame list

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -800,126 +800,126 @@ impl DisplayObjectWindow {
                 });
                 ui.end_row();
             });
-
-        CollapsingHeader::new("Frame List")
-            .id_salt(ui.id().with("frames"))
-            .show(ui, |ui| {
+        ui.separator();
+        ui.horizontal(|ui| {
+            ui.label("Frame list");
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 ui.checkbox(&mut self.track_current_frame, "Track current");
-                // Height of a table row. 2.0 is used for text "padding" between rows
-                let row_h = ui.text_style_height(&egui::TextStyle::Body) + 2.0;
-                let scenes = object.scenes();
-                // This makes sure labels don't wrap in the table, which interferes
-                // with layouting and looks ugly.
-                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
-                let mut table = egui_extras::TableBuilder::new(ui)
-                    .columns(egui_extras::Column::auto(), 4)
-                    .column(egui_extras::Column::remainder())
-                    .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                    .auto_shrink(false);
-                if self.track_current_frame {
-                    table = table
-                        .scroll_to_row(object.current_frame() as usize, Some(egui::Align::Center));
-                }
-                // Due to an API limitation of `Table`, we can't scroll to a row inside the
-                // table UI code, instead, we store which frame to scroll to, and do the scrolling
-                // here.
-                if let Some(frame) = self.scroll_to_frame.take() {
-                    table = table.scroll_to_row(frame, Some(egui::Align::Center))
-                }
-                let mut table = table.header(row_h, |mut row| {
-                    row.col(|ui| {
-                        ui.label("#");
-                    });
-                    row.col(|ui| {
-                        ui.menu_button("Scene", |ui| {
-                            egui::ScrollArea::vertical().show(ui, |ui| {
-                                if scenes.is_empty() {
-                                    ui.label("<no scenes>");
-                                } else {
-                                    for scene in &scenes {
-                                        if ui.button(scene.name.to_string()).clicked() {
-                                            ui.close_menu();
-                                            self.scroll_to_frame = Some(usize::from(scene.start));
-                                        }
-                                    }
+            });
+        });
+        // Height of a table row. 2.0 is used for text "padding" between rows
+        let row_h = ui.text_style_height(&egui::TextStyle::Body) + 2.0;
+        let scenes = object.scenes();
+        // This makes sure labels don't wrap in the table, which interferes
+        // with layouting and looks ugly.
+        ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+        let mut table = egui_extras::TableBuilder::new(ui)
+            .columns(egui_extras::Column::auto(), 4)
+            .column(egui_extras::Column::remainder())
+            .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
+            .auto_shrink(false);
+        if self.track_current_frame {
+            table = table.scroll_to_row(object.current_frame() as usize, Some(egui::Align::Center));
+        }
+        // Due to an API limitation of `Table`, we can't scroll to a row inside the
+        // table UI code, instead, we store which frame to scroll to, and do the scrolling
+        // here.
+        if let Some(frame) = self.scroll_to_frame.take() {
+            table = table.scroll_to_row(frame, Some(egui::Align::Center))
+        }
+        let mut table = table.header(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("#");
+            });
+            row.col(|ui| {
+                ui.menu_button("Scene", |ui| {
+                    egui::ScrollArea::vertical().show(ui, |ui| {
+                        if scenes.is_empty() {
+                            ui.label("<no scenes>");
+                        } else {
+                            for scene in &scenes {
+                                if ui.button(scene.name.to_string()).clicked() {
+                                    ui.close_menu();
+                                    self.scroll_to_frame = Some(usize::from(scene.start));
                                 }
-                            });
-                        });
-                    });
-                    row.col(|ui| {
-                        ui.menu_button("Label", |ui| {
-                            egui::ScrollArea::vertical().show(ui, |ui| {
-                                let labels = object.labels_in_range(0, u16::MAX);
-                                if labels.is_empty() {
-                                    ui.label("<no labels>");
-                                } else {
-                                    for (name, frame) in labels {
-                                        if ui.button(name.to_string()).clicked() {
-                                            ui.close_menu();
-                                            self.scroll_to_frame = Some(usize::from(frame));
-                                        }
-                                    }
-                                }
-                            });
-                        });
-                    });
-                    row.col(|ui| {
-                        ui.label("Has Script");
-                    });
-                    row.col(|ui| {
-                        ui.label("Goto-and-");
-                    });
-                });
-                table.ui_mut().separator();
-                table.body(|body| {
-                    body.rows(row_h, usize::from(object.total_frames()), |mut row| {
-                        let frame = (row.index() + 1) as u16;
-                        row.set_selected(object.current_frame() == frame);
-                        row.col(|ui| {
-                            ui.label(frame.to_string());
-                        });
-                        row.col(|ui| {
-                            ui.label(
-                                scenes
-                                    .iter()
-                                    .find(|s| s.start <= frame && (s.start + s.length) > frame)
-                                    .map(|s| s.name.to_string())
-                                    .unwrap_or_default(),
-                            );
-                        });
-                        row.col(|ui| {
-                            ui.label(
-                                object
-                                    .labels_in_range(frame, frame + 1)
-                                    .first()
-                                    .map(|(l, _)| l.to_string())
-                                    .unwrap_or_default(),
-                            );
-                        });
-                        row.col(|ui| {
-                            if object.has_frame_script(frame) {
-                                ui.add_enabled(false, Button::new("AVM2 Script"));
-                            } else {
-                                ui.label("");
                             }
-                        });
-                        row.col(|ui| {
-                            if object.current_frame() != frame {
-                                ui.horizontal(|ui| {
-                                    if ui.button("Stop").clicked() {
-                                        object.goto_frame(context, frame, true);
-                                    }
-                                    if ui.button("Play").clicked() {
-                                        object.goto_frame(context, frame, false);
-                                    }
-                                });
-                            } else {
-                                ui.label("(current)");
-                            }
-                        });
+                        }
                     });
                 });
             });
+            row.col(|ui| {
+                ui.menu_button("Label", |ui| {
+                    egui::ScrollArea::vertical().show(ui, |ui| {
+                        let labels = object.labels_in_range(0, u16::MAX);
+                        if labels.is_empty() {
+                            ui.label("<no labels>");
+                        } else {
+                            for (name, frame) in labels {
+                                if ui.button(name.to_string()).clicked() {
+                                    ui.close_menu();
+                                    self.scroll_to_frame = Some(usize::from(frame));
+                                }
+                            }
+                        }
+                    });
+                });
+            });
+            row.col(|ui| {
+                ui.label("Has Script");
+            });
+            row.col(|ui| {
+                ui.label("Goto-and-");
+            });
+        });
+        table.ui_mut().separator();
+        table.body(|body| {
+            body.rows(row_h, usize::from(object.total_frames()), |mut row| {
+                let frame = (row.index() + 1) as u16;
+                row.set_selected(object.current_frame() == frame);
+                row.col(|ui| {
+                    ui.label(frame.to_string());
+                });
+                row.col(|ui| {
+                    ui.label(
+                        scenes
+                            .iter()
+                            .find(|s| s.start <= frame && (s.start + s.length) > frame)
+                            .map(|s| s.name.to_string())
+                            .unwrap_or_default(),
+                    );
+                });
+                row.col(|ui| {
+                    ui.label(
+                        object
+                            .labels_in_range(frame, frame + 1)
+                            .first()
+                            .map(|(l, _)| l.to_string())
+                            .unwrap_or_default(),
+                    );
+                });
+                row.col(|ui| {
+                    if object.has_frame_script(frame) {
+                        ui.add_enabled(false, Button::new("AVM2 Script"));
+                    } else {
+                        ui.label("");
+                    }
+                });
+                row.col(|ui| {
+                    if object.current_frame() != frame {
+                        ui.horizontal(|ui| {
+                            if ui.button("Stop").clicked() {
+                                object.goto_frame(context, frame, true);
+                            }
+                            if ui.button("Play").clicked() {
+                                object.goto_frame(context, frame, false);
+                            }
+                        });
+                    } else {
+                        ui.label("(current)");
+                    }
+                });
+            });
+        });
     }
 
     pub fn show_stage<'gc>(


### PR DESCRIPTION
Instead, we embed it directly in a compact way.

My guess is that the original reason it was put into a CollapsingHeader is that the original frame list tanked the performance when shown, but this has been fixed by using `TableBody::rows` to only render the visible rows.

This allows quick access to the frame list, which is helpful for quickly seeking to the parts of a movie we're interested in.