### PR TITLE
core: Remove `GcCell` usage in `MovieClipShared`

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3801,12 +3801,17 @@ impl<'gc, 'a> MovieClipData<'gc> {
             num_frames,
         );
 
-        context
+        if context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(id, Character::MovieClip(movie_clip));
-
-        shared.preload_progress.cur_preload_symbol.set(Some(id));
+            .register_character(id, Character::MovieClip(movie_clip))
+        {
+            shared.preload_progress.cur_preload_symbol.set(Some(id));
+        } else {
+            // This character was already defined, so we can skip preloading it, as the
+            // character ID refers to the pre-existing character, and not this one.
+            return Ok(ControlFlow::Exit);
+        }
 
         let should_exit = chunk_limit.did_ops_breach_limit(context, 4);
         if should_exit {

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -142,16 +142,22 @@ impl<'gc> MovieLibrary<'gc> {
         }
     }
 
-    pub fn register_character(&mut self, id: CharacterId, character: Character<'gc>) {
-        // TODO(Herschel): What is the behavior if id already exists?
-        if !self.contains_character(id) {
-            if let Character::Font(font) = character {
-                self.fonts.register(font);
+    /// Registers a character; returns `true` if successful, or `false` if a character with
+    /// the given ID already exists.
+    pub fn register_character(&mut self, id: CharacterId, character: Character<'gc>) -> bool {
+        use std::collections::hash_map::Entry;
+        match self.characters.entry(id) {
+            Entry::Vacant(e) => {
+                if let Character::Font(font) = character {
+                    self.fonts.register(font);
+                }
+                e.insert(character);
+                true
             }
-
-            self.characters.insert(id, character);
-        } else {
-            tracing::error!("Character ID collision: Tried to register ID {} twice", id);
+            Entry::Occupied(_) => {
+                tracing::error!("Character ID collision: Tried to register ID {} twice", id);
+                false
+            }
         }
     }
 

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -392,7 +392,7 @@ impl<'gc> LoadManager<'gc> {
                             player.lock().unwrap().mutate_with_update_context(|uc| {
                                 let clip = MovieClip::new_import_assets(uc, movie, importer_movie);
 
-                                clip.set_cur_preload_frame(uc.gc(), 0);
+                                clip.set_cur_preload_frame(0);
                                 let mut execution_limit = ExecutionLimit::none();
 
                                 tracing::debug!("Preloading swf to run exports {:?}", url);
@@ -2483,7 +2483,7 @@ impl<'gc> Loader<'gc> {
 
                 // This sets the MovieClip image state correctly.
                 mc.set_current_frame(uc.gc(), 1);
-                mc.set_cur_preload_frame(uc.gc(), 2);
+                mc.set_cur_preload_frame(2);
             }
         }
 
@@ -2663,7 +2663,7 @@ impl<'gc> Loader<'gc> {
         let error_movie = SwfMovie::error_movie(swf_url);
         // This also sets total_frames correctly
         mc.replace_with_movie(uc, Some(Arc::new(error_movie)), true, None);
-        mc.set_cur_preload_frame(uc.gc(), 0);
+        mc.set_cur_preload_frame(0);
     }
 
     /// Event handler morally equivalent to `onLoad` on a movie clip.


### PR DESCRIPTION
Additionally, preloading now modifies the existing `MovieClipShared` instance instead of swapping a clone on each `preload` call.

This means that duplicating a partially-preloaded `MovieClip` will return a clip sharing the preload state. This seems "more correct" to me (as it means that both clips will properly finish preloading), but I haven't tested this in FP.

EDIT: Added a further refactoring that moves most of the tag preloading methods to `MovieClipShared`, as they mostly don't need access to the actual MC instance.