### PR TITLE
avm2: Speed up some native calls

### DIFF
--- a/core/build_playerglobal/src/lib.rs
+++ b/core/build_playerglobal/src/lib.rs
@@ -44,6 +44,9 @@ const METADATA_ABSTRACT: &str = "Abstract";
 const METADATA_NATIVE_ACCESSIBLE: &str = "NativeAccessible";
 /// Like `METADATA_NATIVE_ACCESSIBLE`, but for methods instead of slots.
 const METADATA_NATIVE_CALLABLE: &str = "NativeCallable";
+/// Indicates that this method does not read any properties of the Activation
+/// passed to it except UpdateContext fields. This is used as an optimization.
+const METADATA_FAST_CALL: &str = "FastCall";
 // The name for metadata for namespace versioning- the Flex SDK doesn't
 // strip versioning metadata, so we have to allow this metadata name
 const API_METADATA_NAME: &str = "API";
@@ -442,6 +445,7 @@ fn write_native_table(data: &[u8], out_dir: &Path) -> Result<Vec<u8>, Box<dyn st
     let mut rust_instance_allocators = vec![none_tokens.clone(); abc.classes.len()];
     let mut rust_call_handlers = vec![none_tokens.clone(); abc.classes.len()];
     let mut rust_custom_constructors = vec![none_tokens; abc.classes.len()];
+    let mut rust_fast_calls = vec![];
 
     let mut rust_accessible_slots: HashMap<String, Vec<_>> = HashMap::new();
     let mut rust_accessible_methods: HashMap<String, Vec<_>> = HashMap::new();
@@ -504,12 +508,16 @@ fn write_native_table(data: &[u8], out_dir: &Path) -> Result<Vec<u8>, Box<dyn st
                     }
                 }
 
-                let method_id = method.0;
+                let method_id = method.0 as usize;
 
-                let abc_method = &abc.methods[method_id as usize];
+                let abc_method = &abc.methods[method_id];
                 // We only want to process native methods
                 if !abc_method.flags.contains(MethodFlags::NATIVE) {
                     return;
+                }
+
+                if trait_has_metadata(&abc, trait_, METADATA_FAST_CALL) {
+                    rust_fast_calls.push(quote! { #method_id });
                 }
 
                 // Note - technically, this could conflict with
@@ -523,8 +531,7 @@ fn write_native_table(data: &[u8], out_dir: &Path) -> Result<Vec<u8>, Box<dyn st
                     _ => "",
                 };
 
-                rust_paths[method_id as usize] =
-                    rust_method_path(&abc, trait_, parent, method_prefix, "");
+                rust_paths[method_id] = rust_method_path(&abc, trait_, parent, method_prefix, "");
             }
             TraitKind::Function { .. } => {
                 panic!("TraitKind::Function is not supported: {trait_:?}")
@@ -724,6 +731,15 @@ fn write_native_table(data: &[u8], out_dir: &Path) -> Result<Vec<u8>, Box<dyn st
         // constructor for the corresponding class when we load it into Ruffle.
         pub const NATIVE_CUSTOM_CONSTRUCTOR_TABLE: &[Option<crate::avm2::class::CustomConstructorFn>] = &[
             #(#rust_custom_constructors,)*
+        ];
+
+        // This is an array containing the method ids of every method marked
+        // "[Ruffle(FastCall)]". Unlike the rest, it is not indexed by method id-
+        // instead, every item in the list is a method id.
+        //
+        // FIXME: should this be some sort of hashset?
+        pub const NATIVE_FAST_CALL_LIST: &[usize] = &[
+            #(#rust_fast_calls,)*
         ];
 
         pub mod slots {

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -155,6 +155,8 @@ pub struct Avm2<'gc> {
     #[collect(require_static)]
     native_custom_constructor_table: &'static [Option<CustomConstructorFn>],
 
+    native_fast_call_list: &'static [usize],
+
     /// A list of objects which are capable of receiving broadcasts.
     ///
     /// Certain types of events are "broadcast events" that are emitted on all
@@ -225,6 +227,7 @@ impl<'gc> Avm2<'gc> {
             native_instance_allocator_table: Default::default(),
             native_call_handler_table: Default::default(),
             native_custom_constructor_table: Default::default(),
+            native_fast_call_list: Default::default(),
             broadcast_list: Default::default(),
 
             orphan_objects: Default::default(),

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -182,7 +182,7 @@ pub fn exec<'gc>(
     callee: Value<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let ret = match method.method_kind() {
-        MethodKind::Native(native_method) => {
+        MethodKind::Native { native_method, .. } => {
             let arguments = &arguments.to_slice(activation);
 
             let caller_domain = activation.caller_domain();
@@ -234,7 +234,7 @@ pub fn exec<'gc>(
 
             native_method(&mut activation, receiver, &arguments)
         }
-        MethodKind::Bytecode(_) => {
+        MethodKind::Bytecode { .. } => {
             // This used to be a one step called Activation::from_method,
             // but avoiding moving an Activation around helps perf
             let mut activation = Activation::from_nothing(activation.context);

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -776,6 +776,7 @@ pub fn load_playerglobal<'gc>(
     activation.avm2().native_instance_allocator_table = native::NATIVE_INSTANCE_ALLOCATOR_TABLE;
     activation.avm2().native_call_handler_table = native::NATIVE_CALL_HANDLER_TABLE;
     activation.avm2().native_custom_constructor_table = native::NATIVE_CUSTOM_CONSTRUCTOR_TABLE;
+    activation.avm2().native_fast_call_list = native::NATIVE_FAST_CALL_LIST;
 
     let movie = Arc::new(
         SwfMovie::from_data(PLAYERGLOBAL, "file:///".into(), None)

--- a/core/src/avm2/globals/Class.as
+++ b/core/src/avm2/globals/Class.as
@@ -5,6 +5,7 @@ package {
             // Unreachable because InstanceAllocator always throws an error
         }
 
+        [Ruffle(FastCall)]
         public final native function get prototype():*;
 
         public static const length:int = 1;

--- a/core/src/avm2/globals/Function.as
+++ b/core/src/avm2/globals/Function.as
@@ -41,7 +41,9 @@ package {
 
         public native function get length() : int;
 
+        [Ruffle(FastCall)]
         public native function get prototype():*;
+        [Ruffle(FastCall)]
         public native function set prototype(proto:*):*;
 
         AS3 native function apply(receiver:* = void 0, args:* = void 0):*;

--- a/core/src/avm2/globals/Math.as
+++ b/core/src/avm2/globals/Math.as
@@ -38,12 +38,23 @@ package {
         [Ruffle(FastCall)]
         public static native function tan(x: Number): Number;
 
+        [Ruffle(FastCall)]
         public static native function atan2(y: Number, x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function pow(x: Number, y: Number): Number;
 
         // This is a hacky way to specify `-Infinity` as a default value.
         private static const NegInfinity: Number = -1 / 0;
+
+        // NOTE: These methods are marked as FastCall despite their ability to
+        // throw an error (when Objects are passed in the restargs). This is fine
+        // because the optimizer will only convert calls to these methods to
+        // CallNative calls when the methods are called with exactly two
+        // parameters; the methods cannot error if called with only two parameters.
+
+        [Ruffle(FastCall)]
         public static native function max(x: Number = NegInfinity, y: Number = NegInfinity, ...rest): Number;
+        [Ruffle(FastCall)]
         public static native function min(x: Number = Infinity, y: Number = Infinity, ...rest): Number;
 
         [Ruffle(FastCall)]

--- a/core/src/avm2/globals/Math.as
+++ b/core/src/avm2/globals/Math.as
@@ -11,19 +11,33 @@ package {
         public static const SQRT1_2: Number = 0.7071067811865476;
         public static const SQRT2: Number = 1.4142135623730951;
 
+        [Ruffle(FastCall)]
         public static native function abs(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function acos(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function asin(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function atan(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function ceil(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function cos(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function exp(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function floor(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function log(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function round(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function sin(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function sqrt(x: Number): Number;
+        [Ruffle(FastCall)]
         public static native function tan(x: Number): Number;
+
         public static native function atan2(y: Number, x: Number): Number;
         public static native function pow(x: Number, y: Number): Number;
 
@@ -32,6 +46,7 @@ package {
         public static native function max(x: Number = NegInfinity, y: Number = NegInfinity, ...rest): Number;
         public static native function min(x: Number = Infinity, y: Number = Infinity, ...rest): Number;
 
+        [Ruffle(FastCall)]
         public static native function random(): Number;
     }
 }

--- a/core/src/avm2/globals/Namespace.as
+++ b/core/src/avm2/globals/Namespace.as
@@ -19,7 +19,9 @@ package {
             // this AS-defined method does nothing
         }
 
+        [Ruffle(FastCall)]
         public native function get prefix():*;
+        [Ruffle(FastCall)]
         public native function get uri():String;
 
         AS3 function toString():String {

--- a/core/src/avm2/globals/QName.as
+++ b/core/src/avm2/globals/QName.as
@@ -9,10 +9,15 @@ package {
             // this AS-defined method does nothing
         }
 
+        [Ruffle(FastCall)]
         public native function get localName():String;
+
+        [Ruffle(FastCall)]
         public native function get uri():*;
 
+        [Ruffle(FastCall)]
         AS3 native function toString():String;
+
         AS3 function valueOf():QName {
             return this;
         }

--- a/core/src/avm2/globals/README.md
+++ b/core/src/avm2/globals/README.md
@@ -77,6 +77,35 @@ class is loaded.
 
 See `flash/events/Event.as` for an example
 
+## Accessing fields and calling methods from native code
+
+You can access fields of ActionScript objects from Rust code by annotating the
+field in the class definition with `[Ruffle(NativeAccessible)]`, which will
+record the slot id of the field. After doing so, `Object::get_slot` can be used
+to access the slot. See `flash/display/Loader.as` and `flash/display/loader.rs`
+for an example.
+
+Similarly, you can also call methods of ActionScript objects from Rust code by
+annotating methods with `[Ruffle(NativeCallable)]` and using `Value::call_method`.
+See `flash/utils/Proxy.as` and `proxy_object.rs` for example usage.
+
+## `[Ruffle(FastCall)]` annotation
+
+As an optimization, native methods defined in playerglobals can be annotated with
+`[Ruffle(FastCall)]` to make calling them faster under certain conditions. However,
+the following conditions must all be met before declaring a method `FastCall`:
+
+- the method is declared as `static`, or the class the method is declared in is `final`;
+- the method has zero, one, or two arguments;
+- the method does not use default values for any of these arguments;
+- the method does not use `...rest` arguments;
+- the Rust function that defines the method does not throw exceptions (does not ever return `Err`);
+- and the method's Rust function does not access any fields on the provided `activation` except for the `activation.context` field.
+
+Only if all of these conditions are met can the method safely be annotated with
+`[Ruffle(FastCall)]`. In general, methods should not be marked `FastCall` unless
+there is a clear performance improvement when doing so.
+
 ## API Versioning
 
 Ruffle supports Flash's API versioning, which hides newer playerglobal definitions

--- a/core/src/avm2/globals/String.as
+++ b/core/src/avm2/globals/String.as
@@ -143,10 +143,13 @@ package {
         public static native function fromCharCode(... rest):String;
 
         // Instance methods
+        [Ruffle(FastCall)]
         public native function get length():int;
 
+        [Ruffle(FastCall)]
         AS3 native function charAt(index:Number = 0):String;
 
+        [Ruffle(FastCall)]
         AS3 native function charCodeAt(index:Number = 0):Number;
 
         AS3 native function concat(... rest):String;
@@ -168,12 +171,15 @@ package {
 
         AS3 native function search(pattern:* = void 0):int;
 
+        [Ruffle(FastCall)]
         AS3 native function slice(start:Number = 0, end:Number = 2147483647.0):String;
 
         AS3 native function split(delimiter:* = void 0, limit:* = 4294967295):Array;
 
+        [Ruffle(FastCall)]
         AS3 native function substr(start:Number = 0, length:Number = 2147483647.0):String;
 
+        [Ruffle(FastCall)]
         AS3 native function substring(start:Number = 0, end:Number = 2147483647.0):String;
 
         AS3 function toLocaleLowerCase() : String {
@@ -184,8 +190,10 @@ package {
             return this.toUpperCase();
         }
 
+        [Ruffle(FastCall)]
         AS3 native function toLowerCase() : String;
 
+        [Ruffle(FastCall)]
         AS3 native function toUpperCase() : String;
 
         AS3 function toString() : String {

--- a/core/src/avm2/globals/Toplevel.as
+++ b/core/src/avm2/globals/Toplevel.as
@@ -18,10 +18,14 @@ package {
 
     public native function isXMLName(string:* = undefined):Boolean;
 
+    [Ruffle(FastCall)]
     public native function isFinite(value:Number = undefined):Boolean;
+    [Ruffle(FastCall)]
     public native function isNaN(value:Number = undefined):Boolean;
 
+    [Ruffle(FastCall)]
     public native function parseFloat(number:String = "NaN"):Number;
+    [Ruffle(FastCall)]
     public native function parseInt(string:String = "NaN", base:int = 0):Number;
 
     public native function trace(... rest):void;

--- a/core/src/avm2/globals/VectorDouble.as
+++ b/core/src/avm2/globals/VectorDouble.as
@@ -145,6 +145,7 @@ package __AS3__.vec {
 
         public native function set fixed(isFixed:Boolean):*;
 
+        [Ruffle(FastCall)]
         public native function get length():uint;
 
         public native function set length(length:uint):*;

--- a/core/src/avm2/globals/VectorInt.as
+++ b/core/src/avm2/globals/VectorInt.as
@@ -145,6 +145,7 @@ package __AS3__.vec {
 
         public native function set fixed(isFixed:Boolean):*;
 
+        [Ruffle(FastCall)]
         public native function get length():uint;
 
         public native function set length(length:uint):*;

--- a/core/src/avm2/globals/VectorObject.as
+++ b/core/src/avm2/globals/VectorObject.as
@@ -147,6 +147,7 @@ package __AS3__.vec {
 
         public native function set fixed(isFixed:Boolean):*;
 
+        [Ruffle(FastCall)]
         public native function get length():uint;
 
         public native function set length(length:uint):*;

--- a/core/src/avm2/globals/VectorUint.as
+++ b/core/src/avm2/globals/VectorUint.as
@@ -145,6 +145,7 @@ package __AS3__.vec {
 
         public native function set fixed(isFixed:Boolean):*;
 
+        [Ruffle(FastCall)]
         public native function get length():uint;
 
         public native function set length(length:uint):*;

--- a/core/src/avm2/globals/XML.as
+++ b/core/src/avm2/globals/XML.as
@@ -64,7 +64,11 @@ package {
         AS3 native function normalize(): XML;
         AS3 native function parent():*;
         AS3 native function text():XMLList;
+
+        [Ruffle(FastCall)]
         AS3 native function toString():String;
+
+        [Ruffle(FastCall)]
         AS3 native function toXMLString():String;
 
         AS3 native function attributes():XMLList;
@@ -129,6 +133,7 @@ package {
         [Ruffle(NativeCallable)]
         AS3 native function insertChildBefore(child1:*, child2:*):*;
 
+        [Ruffle(FastCall)]
         [Ruffle(NativeCallable)]
         AS3 native function localName():Object;
 

--- a/core/src/avm2/globals/XMLList.as
+++ b/core/src/avm2/globals/XMLList.as
@@ -9,9 +9,10 @@ package {
 
         private native function init(value:*, ignoreComments:Boolean, ignoreProcessingInstructions:Boolean, ignoreWhitespace:Boolean): void;
 
+        [Ruffle(FastCall)]
+        AS3 native function length():int;
         AS3 native function hasComplexContent():Boolean;
         AS3 native function hasSimpleContent():Boolean;
-        AS3 native function length():int;
         AS3 native function child(name:Object):XMLList;
         AS3 native function children():XMLList;
         AS3 native function contains(value:*):Boolean;
@@ -20,7 +21,9 @@ package {
         AS3 native function attributes():XMLList;
         AS3 native function descendants(name:* = "*"):XMLList;
         AS3 native function text():XMLList;
+        [Ruffle(FastCall)]
         AS3 native function toXMLString():String;
+        [Ruffle(FastCall)]
         AS3 native function toString():String;
         AS3 native function comments():XMLList;
         AS3 native function parent():*;

--- a/core/src/avm2/globals/flash/display/Graphics.as
+++ b/core/src/avm2/globals/flash/display/Graphics.as
@@ -12,6 +12,7 @@ package flash.display
         }
 
         public native function beginBitmapFill(bitmap:BitmapData, matrix:Matrix = null, repeat:Boolean = true, smooth:Boolean = false):void;
+        [Ruffle(FastCall)]
         public native function beginFill(color:uint, alpha:Number = 1.0):void;
         public native function beginGradientFill(
             type:String, colors:Array, alphas:Array, ratios:Array, matrix:Matrix = null, spreadMethod:String = "pad", interpolationMethod:String = "rgb", focalPointRatio:Number = 0
@@ -19,17 +20,21 @@ package flash.display
         public function beginShaderFill(shader:Shader, matrix:Matrix = null):void {
             stub_method("flash.display.Graphics", "beginShaderFill");
         }
+        [Ruffle(FastCall)]
         public native function clear(): void;
         public native function curveTo(controlX:Number, controlY:Number, anchorX:Number, anchorY:Number): void;
         public native function drawCircle(x:Number, y:Number, radius:Number): void;
         public native function drawEllipse(x:Number, y:Number, width:Number, height:Number): void;
         public native function drawRect(x:Number, y:Number, width:Number, height:Number): void;
         public native function drawRoundRect(x:Number, y:Number, width:Number, height:Number, ellipseWidth:Number, ellipseHeight:Number = NaN): void;
+        [Ruffle(FastCall)]
         public native function endFill(): void;
         public native function lineStyle(
             thickness:Number = NaN, color:uint = 0, alpha:Number = 1.0, pixelHinting:Boolean = false, scaleMode:String = "normal", caps:String = null, joints:String = null, miterLimit:Number = 3
         ): void;
+        [Ruffle(FastCall)]
         public native function lineTo(x:Number, y:Number): void;
+        [Ruffle(FastCall)]
         public native function moveTo(x:Number, y:Number): void;
         //public native function beginShaderFill(shader:Shader, matrix:Matrix = null):void;
         public native function lineGradientStyle(

--- a/core/src/avm2/globals/flash/display/loader_info.rs
+++ b/core/src/avm2/globals/flash/display/loader_info.rs
@@ -57,7 +57,7 @@ pub fn get_application_domain<'gc>(
                     .try_avm2_domain();
 
                 if let Some(domain) = domain {
-                    return Ok(DomainObject::from_domain(activation, domain)?.into());
+                    return Ok(DomainObject::from_domain(activation, domain).into());
                 } else {
                     return Ok(Value::Null);
                 }
@@ -70,7 +70,7 @@ pub fn get_application_domain<'gc>(
                     .library
                     .library_for_movie_mut(movie.clone())
                     .avm2_domain();
-                return Ok(DomainObject::from_domain(activation, domain)?.into());
+                return Ok(DomainObject::from_domain(activation, domain).into());
             }
         }
     }

--- a/core/src/avm2/globals/flash/media/SoundTransform.as
+++ b/core/src/avm2/globals/flash/media/SoundTransform.as
@@ -6,22 +6,34 @@ package flash.media {
             this.pan = panning;
         }
 
+        [Ruffle(FastCall)]
         public native function get leftToLeft():Number;
+        [Ruffle(FastCall)]
         public native function set leftToLeft(value:Number):void;
 
+        [Ruffle(FastCall)]
         public native function get leftToRight():Number;
+        [Ruffle(FastCall)]
         public native function set leftToRight(value:Number):void;
 
+        [Ruffle(FastCall)]
         public native function get rightToLeft():Number;
+        [Ruffle(FastCall)]
         public native function set rightToLeft(value:Number):void;
 
+        [Ruffle(FastCall)]
         public native function get rightToRight():Number;
+        [Ruffle(FastCall)]
         public native function set rightToRight(value:Number):void;
 
+        [Ruffle(FastCall)]
         public native function get volume():Number;
+        [Ruffle(FastCall)]
         public native function set volume(volume:Number):void;
 
+        [Ruffle(FastCall)]
         public native function get pan():Number;
+        [Ruffle(FastCall)]
         public native function set pan(value:Number):void;
     }
 }

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -43,7 +43,7 @@ pub fn get_current_domain<'gc>(
         .caller_domain()
         .expect("Missing caller domain in ApplicationDomain.currentDomain");
 
-    Ok(DomainObject::from_domain(activation, appdomain)?.into())
+    Ok(DomainObject::from_domain(activation, appdomain).into())
 }
 
 /// `parentDomain` property
@@ -59,7 +59,7 @@ pub fn get_parent_domain<'gc>(
             if parent_domain.is_playerglobals_domain(activation.avm2()) {
                 return Ok(Value::Null);
             }
-            return Ok(DomainObject::from_domain(activation, parent_domain)?.into());
+            return Ok(DomainObject::from_domain(activation, parent_domain).into());
         }
     }
 

--- a/core/src/avm2/globals/flash/utils.as
+++ b/core/src/avm2/globals/flash/utils.as
@@ -3,6 +3,8 @@ package flash.utils {
     public native function getDefinitionByName(name:String):Object;
     public native function getQualifiedClassName(value:*):String;
     public native function getQualifiedSuperclassName(value:*):String;
+
+    [Ruffle(FastCall)]
     public native function getTimer():int;
 
     public function describeType(value:*): XML {

--- a/core/src/avm2/globals/math.rs
+++ b/core/src/avm2/globals/math.rs
@@ -10,15 +10,12 @@ use rand::Rng;
 macro_rules! wrap_std {
     ($name:ident, $std:expr) => {
         pub fn $name<'gc>(
-            activation: &mut Activation<'_, 'gc>,
+            _activation: &mut Activation<'_, 'gc>,
             _this: Value<'gc>,
             args: &[Value<'gc>],
         ) -> Result<Value<'gc>, Error<'gc>> {
-            if let Some(input) = args.get(0) {
-                Ok($std(input.coerce_to_number(activation)?).into())
-            } else {
-                Ok(f64::NAN.into())
-            }
+            let input = args[0].as_f64();
+            Ok($std(input).into())
         }
     };
 }
@@ -60,33 +57,26 @@ pub fn math_allocator<'gc>(
 }
 
 pub fn round<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     _this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(x) = args.get(0) {
-        let x = x.coerce_to_number(activation)?;
-        // Note that Flash Math.round always rounds toward infinity,
-        // unlike Rust f32::round which rounds away from zero.
-        let ret = (x + 0.5).floor();
-        return Ok(ret.into());
-    }
-    Ok(f64::NAN.into())
+    let x = args[0].as_f64();
+
+    // Note that Flash Math.round always rounds toward infinity,
+    // unlike Rust f32::round which rounds away from zero.
+    let ret = (x + 0.5).floor();
+    Ok(ret.into())
 }
 
 pub fn atan2<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     _this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let y = args
-        .get(0)
-        .unwrap_or(&Value::Undefined)
-        .coerce_to_number(activation)?;
-    let x = args
-        .get(1)
-        .unwrap_or(&Value::Undefined)
-        .coerce_to_number(activation)?;
+    let y = args[0].as_f64();
+    let x = args[1].as_f64();
+
     Ok(f64::atan2(y, x).into())
 }
 
@@ -125,18 +115,13 @@ pub fn min<'gc>(
 }
 
 pub fn pow<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     _this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let n = args
-        .get(0)
-        .unwrap_or(&Value::Undefined)
-        .coerce_to_number(activation)?;
-    let p = args
-        .get(1)
-        .unwrap_or(&Value::Undefined)
-        .coerce_to_number(activation)?;
+    let n = args[0].as_f64();
+    let p = args[1].as_f64();
+
     Ok(f64::powf(n, p).into())
 }
 

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -60,28 +60,16 @@ impl<'gc> DomainObject<'gc> {
     ///
     /// This function will call instance initializers. You do not need to do so
     /// yourself.
-    pub fn from_domain(
-        activation: &mut Activation<'_, 'gc>,
-        domain: Domain<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
+    pub fn from_domain(activation: &mut Activation<'_, 'gc>, domain: Domain<'gc>) -> Self {
         let class = activation.avm2().classes().application_domain;
         let base = ScriptObjectData::new(class);
-        let this: Object<'gc> = DomainObject(Gc::new(
+        DomainObject(Gc::new(
             activation.gc(),
             DomainObjectData {
                 base,
                 domain: Lock::new(domain),
             },
         ))
-        .into();
-
-        // Note - we do *not* call the normal constructor, since that
-        // creates a new domain using the system domain as a parent.
-        class
-            .superclass_object()
-            .unwrap()
-            .call_init(this.into(), &[], activation)?;
-        Ok(this)
     }
 }
 

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -1,4 +1,5 @@
 use crate::avm2::class::Class;
+use crate::avm2::method::NativeMethodImpl;
 use crate::avm2::multiname::Multiname;
 use crate::avm2::namespace::Namespace;
 use crate::avm2::script::Script;
@@ -32,6 +33,12 @@ pub enum Op<'gc> {
     },
     CallMethod {
         index: u32,
+        num_args: u32,
+        push_return_value: bool,
+    },
+    CallNative {
+        #[collect(require_static)]
+        method: NativeMethodImpl,
         num_args: u32,
         push_return_value: bool,
     },

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -180,19 +180,9 @@ impl<'gc> TranslationUnit<'gc> {
             return Ok(*method);
         }
 
-        let is_global = read.domain.is_playerglobals_domain(activation.avm2());
         drop(read);
 
-        let mut native_method = None;
-
-        if is_global {
-            if let Some(native) = activation.avm2().native_method_table[method_index.0 as usize] {
-                native_method = Some(native);
-            }
-        }
-
-        let method =
-            Method::from_method_index(self, method_index, native_method, is_function, activation)?;
+        let method = Method::from_method_index(self, method_index, is_function, activation)?;
 
         self.0.write(activation.gc()).methods[method_index.0 as usize] = Some(method);
 


### PR DESCRIPTION
This allows us to optimize some calls to native functions when
1. the function has a `[Ruffle(FastCall)]` annotation,
2. the arguments are of the correct count and type, and
3. the class of the value the function is being called on is `final`.

For example, `Math.abs` runs more than twice as fast with this PR as it does on current `master`. From my testing, in most SWFs, 5-20% of calls that would be `CallMethod` are now `CallNative`.

Box2d stats:
```
ConstructSuper -> Pop: 70%

FindPropStrict -> GetScriptGlobals: 82.67%
FindPropStrict -> GetOuterScope: 8.96%
FindPropStrict -> GetScopeObject: 8.36%

FindProperty -> GetOuterScope: 5.66%
FindProperty -> GetScopeObject: 94.33%

InitProperty -> SetSlot: 6.28%
InitProperty -> SetSlotNoCoerce: 90.98%
InitProperty -> CallMethod: 2.73%

SetProperty -> SetSlot: 8.07%
SetProperty -> SetSlotNoCoerce: 73.88%
SetProperty -> CallMethod: 2.4%

GetProperty -> GetSlot: 88.92%
GetProperty -> CallMethod: 0.47%

CallProperty -> CallMethod: 74.1% (-9.16%)
CallProperty -> CallNative: 9.16% (+9.16%)
CallProperty -> CoerceUSwapPop: 5.17%
CallProperty -> CoerceISwapPop: 9.56%

CallPropVoid -> CallMethod: 91.72% (-2.25%)
CallPropVoid -> CallNative: 2.25% (+2.25%)

ConstructProp -> ConstructSlot: 100%

Coerce -> Nop: 73.18%

CoerceD -> Nop: 98.75%

CoerceB -> Nop: 97.29%

CoerceU -> Nop: 64.91%

CoerceI -> Nop: 52%

ReturnValue -> ReturnValueNoCoerce: 96.39%
```

TODO:
- [x] Record box2d optimization stats
- [x] Add documentation on FastCall to the globals README
- [ ] ~~Use a HashSet for the FastCall methods...?~~