### PR TITLE
docs: Remove Linux dependencies that don't seem to be required anymore

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -117,7 +117,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev libudev-dev
+          sudo apt install -y libasound2-dev libudev-dev
 
       - name: Install WiX
         run: |

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -77,7 +77,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
+          sudo apt install -y libasound2-dev mesa-vulkan-drivers libudev-dev
 
       # Needed after: https://github.com/rust-lang/rust/pull/124129
       # See also: https://github.com/dtolnay/linkme/issues/94
@@ -142,7 +142,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
+          sudo apt install -y libasound2-dev mesa-vulkan-drivers libudev-dev
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/README.md
+++ b/README.md
@@ -60,15 +60,8 @@ For more detailed instructions, see our [wiki page](https://github.com/ruffle-rs
 The following are typical dependencies for Linux:
 
 * libasound2-dev
-* libxcb-shape0-dev
-* libxcb-xfixes0-dev
-* libgtk-3-dev
 * libudev-dev
-* libxcb-xinput-dev
-* libxcb-xkb-dev
-* libxcb-cursor-dev
 * default-jre-headless
-* cmake
 * g++
 
 ### Desktop


### PR DESCRIPTION
Testing on the `rust:1.86` docker image, I built `ruffle_desktop` with `cargo build --release`, installing any missing packages
that caused a build error.
Then I checked which of the listed dependencies are installed:
```
dpkg -l libasound2-dev  libxcb-shape0-dev  libxcb-xfixes0-dev  libgtk-3-dev  libudev-dev  libxcb-xinput-dev  libxcb-xkb-dev  libxcb-cursor-dev  default-jre-headless cmake g++
dpkg-query: no packages found matching libxcb-shape0-dev
dpkg-query: no packages found matching libxcb-xfixes0-dev
dpkg-query: no packages found matching libgtk-3-dev
dpkg-query: no packages found matching libxcb-xinput-dev
dpkg-query: no packages found matching libxcb-xkb-dev
dpkg-query: no packages found matching libxcb-cursor-dev
dpkg-query: no packages found matching cmake
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                 Version          Architecture Description
+++-====================-================-============-=========================================================
ii  default-jre-headless 2:1.17-74        amd64        Standard Java or Java compatible Runtime (headless)
ii  g++                  4:12.2.0-3       amd64        GNU C++ compiler
ii  libasound2-dev:amd64 1.2.8-1+b1       amd64        shared library for ALSA applications -- development files
ii  libudev-dev:amd64    252.36-1~deb12u1 amd64        libudev development files
```

The ones with `no packages found` are packages that don't seem to be required for building anymore.
But there might be special build configurations that require them, so this needs careful review.

Additionally, here is a `lddtree` of `ruffle_desktop` just as supplementary info:
```
$ lddtree ruffle_desktop
ruffle_desktop (interpreter => /lib64/ld-linux-x86-64.so.2)
    libasound.so.2 => /usr/lib/libasound.so.2
    libudev.so.1 => /usr/lib/libudev.so.1
        libcap.so.2 => /usr/lib/libcap.so.2
    libgcc_s.so.1 => /usr/lib/libgcc_s.so.1
    libm.so.6 => /usr/lib/libm.so.6
    libc.so.6 => /usr/lib/libc.so.6
    ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2
```

I tested the resulting `ruffle_desktop` binary both on X11 and Wayland:
- [X] Clipboard works (x11rb, pure Rust library using X11 protocol)
- [X] File dialog works (Uses XDG portals)
- [ ] I don't have a gamepad to test with, so I can't test gamepad support