### PR TITLE
ci: Release dual-wasm extensions as assets

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -541,7 +541,8 @@ jobs:
         shell: bash -l {0}
         run: npm run build:dual-wasm-repro
 
-      - name: Upload generic extension
+      # NOTE: This is done here because the job that builds the extensions for publication doesn't have the vanilla (MVP) WASM modules, but for the selfhosted package we build them both
+      - name: Upload dual-wasm generic extension
         run: |
           tag_name="${{ needs.create-nightly-release.outputs.tag_name }}"
           package_file="${{ needs.create-nightly-release.outputs.package_prefix }}-web-extension-dual-wasm.zip"
@@ -551,7 +552,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload Firefox extension (unsigned)
+      - name: Upload dual-wasm Firefox extension (unsigned)
         run: |
           tag_name="${{ needs.create-nightly-release.outputs.tag_name }}"
           package_file="${{ needs.create-nightly-release.outputs.package_prefix }}-web-extension-firefox-dual-wasm-unsigned.xpi"

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -469,7 +469,7 @@ jobs:
         run: npm run sign-firefox
 
   build-web-demo-and-selfhosted:
-    name: Build web demo and selfhosted package with docs
+    name: Build web demo and selfhosted package with docs, and release assets for dual-wasm extensions
     needs: create-nightly-release
     if: needs.create-nightly-release.outputs.is_active == 'true'
     runs-on: ubuntu-24.04
@@ -540,6 +540,26 @@ jobs:
         working-directory: web
         shell: bash -l {0}
         run: npm run build:dual-wasm-repro
+
+      - name: Upload generic extension
+        run: |
+          tag_name="${{ needs.create-nightly-release.outputs.tag_name }}"
+          package_file="${{ needs.create-nightly-release.outputs.package_prefix }}-web-extension-dual-wasm.zip"
+          cp "./web/packages/extension/dist/ruffle_extension.zip" "$package_file"
+          gh release upload "$tag_name" "$package_file"
+          rm "$package_file"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Firefox extension (unsigned)
+        run: |
+          tag_name="${{ needs.create-nightly-release.outputs.tag_name }}"
+          package_file="${{ needs.create-nightly-release.outputs.package_prefix }}-web-extension-firefox-dual-wasm-unsigned.xpi"
+          cp "./web/packages/extension/dist/firefox_unsigned.xpi" "$package_file"
+          gh release upload "$tag_name" "$package_file"
+          rm "$package_file"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build web docs
         working-directory: web


### PR DESCRIPTION
We're building them anyway so I suppose it doesn't hurt to release them, though I'm open to opinions. Based on a user on Discord using super old hardware with a modern browser whose hardware actually doesn't allow the with extensions module to work.