### PR TITLE
debug_ui: Improve Bitmap tab

### DIFF
--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -235,7 +235,7 @@ pub struct BitmapData<'gc> {
 }
 
 #[derive(Clone, Debug)]
-enum DirtyState {
+pub enum DirtyState {
     // Both the CPU and GPU pixels are up to date. We do not need to wait for any syncs to complete
     Clean,
 
@@ -637,6 +637,10 @@ impl<'gc> BitmapData<'gc> {
 
     pub fn transparency(&self) -> bool {
         self.transparency
+    }
+
+    pub fn dirty_state(&self) -> &DirtyState {
+        &self.dirty_state
     }
 
     pub fn set_gpu_dirty(

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -4,6 +4,7 @@ use ruffle_render::blend::ExtendedBlendMode;
 pub use search::DisplayObjectSearchWindow;
 
 use crate::avm2::object::TObject as _;
+use crate::bitmap::bitmap_data::DirtyState;
 use crate::context::UpdateContext;
 use crate::debug_ui::handle::{AVM1ObjectHandle, AVM2ObjectHandle, DisplayObjectHandle};
 use crate::debug_ui::movie::open_movie_button;
@@ -754,6 +755,20 @@ impl DisplayObjectWindow {
                 } else {
                     ui.label("No");
                 }
+                ui.end_row();
+
+                ui.label("Dirty State");
+                match bitmap_data.dirty_state() {
+                    DirtyState::Clean => ui.label("Clean"),
+                    DirtyState::CpuModified(region) => ui.label(format!(
+                        "CPU Modified ({},{} to {},{})",
+                        region.x_min, region.y_min, region.x_max, region.y_max
+                    )),
+                    DirtyState::GpuModified(_, region) => ui.label(format!(
+                        "GPU Modified ({},{} to {},{})",
+                        region.x_min, region.y_min, region.x_max, region.y_max
+                    )),
+                };
                 ui.end_row();
             });
 

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -728,6 +728,12 @@ impl DisplayObjectWindow {
     ) {
         let bitmap_data = object.bitmap_data(context.renderer);
         let bitmap_data = bitmap_data.read();
+
+        if bitmap_data.width() == 0 || bitmap_data.height() == 0 {
+            ui.weak("(no pixels)");
+            return;
+        }
+
         let mut egui_texture = bitmap_data.egui_texture.borrow_mut();
         let texture = egui_texture.get_or_insert_with(|| {
             let image = egui::ColorImage::from_rgba_premultiplied(


### PR DESCRIPTION
This patch fixes a crash when the bitmap had no pixels (e.g. it was disposed) and adds some debug properties for bitmaps.

<img src="https://github.com/user-attachments/assets/a454e39a-42f4-41e2-b4ba-59ab13afc3bd" height="300px"/>
<img src="https://github.com/user-attachments/assets/25e54329-ceef-430e-8c80-3d3cf09c50aa" height="300px"/>
