### PR TITLE
core: Add deriveable `HasPrefixField` trait

### DIFF
--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -17,6 +17,7 @@ use crate::avm2::Multiname;
 use crate::avm2::QName;
 use crate::avm2::TranslationUnit;
 use crate::string::AvmString;
+use crate::utils::HasPrefixField;
 use fnv::FnvHashMap;
 use gc_arena::barrier::unlock;
 use gc_arena::{
@@ -36,7 +37,7 @@ pub struct ClassObject<'gc>(pub Gc<'gc, ClassObjectData<'gc>>);
 #[collect(no_drop)]
 pub struct ClassObjectWeak<'gc>(pub GcWeak<'gc, ClassObjectData<'gc>>);
 
-#[derive(Collect, Clone)]
+#[derive(Collect, Clone, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct ClassObjectData<'gc> {
@@ -75,10 +76,6 @@ pub struct ClassObjectData<'gc> {
     /// VTable used for instances of this class.
     instance_vtable: VTable<'gc>,
 }
-
-const _: () = assert!(std::mem::offset_of!(ClassObjectData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<ClassObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> ClassObject<'gc> {
     /// Allocate the prototype for this class.
@@ -730,11 +727,7 @@ impl<'gc> ClassObject<'gc> {
 
 impl<'gc> TObject<'gc> for ClassObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -8,6 +8,7 @@ use crate::avm2::Error;
 use crate::avm2_stub_method;
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::context::RenderContext;
+use crate::utils::HasPrefixField;
 use gc_arena::{Collect, Gc, GcCell, GcWeak};
 use ruffle_render::backend::{
     BufferUsage, Context3D, Context3DBlendFactor, Context3DCommand, Context3DCompareMode,
@@ -477,7 +478,7 @@ impl<'gc> Context3DObject<'gc> {
     }
 }
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct Context3DData<'gc> {
@@ -490,17 +491,9 @@ pub struct Context3DData<'gc> {
     stage3d: Stage3DObject<'gc>,
 }
 
-const _: () = assert!(std::mem::offset_of!(Context3DData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<Context3DData>() == std::mem::align_of::<ScriptObjectData>());
-
 impl<'gc> TObject<'gc> for Context3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -3,6 +3,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Hint;
 use crate::avm2::Error;
+use crate::utils::HasPrefixField;
 use chrono::{DateTime, Utc};
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak};
@@ -69,7 +70,7 @@ impl<'gc> DateObject<'gc> {
     }
 }
 
-#[derive(Clone, Collect)]
+#[derive(Clone, Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct DateObjectData<'gc> {
@@ -79,17 +80,9 @@ pub struct DateObjectData<'gc> {
     date_time: Cell<Option<DateTime<Utc>>>,
 }
 
-const _: () = assert!(std::mem::offset_of!(DateObjectData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<DateObjectData>() == std::mem::align_of::<ScriptObjectData>());
-
 impl<'gc> TObject<'gc> for DateObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -7,6 +7,7 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak, Mutation};
 
@@ -41,18 +42,13 @@ impl fmt::Debug for DictionaryObject<'_> {
     }
 }
 
-#[derive(Clone, Collect)]
+#[derive(Clone, Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct DictionaryObjectData<'gc> {
     /// Base script object
     base: ScriptObjectData<'gc>,
 }
-
-const _: () = assert!(std::mem::offset_of!(DictionaryObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<DictionaryObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
 
 impl<'gc> DictionaryObject<'gc> {
     /// Retrieve a value in the dictionary's object space.
@@ -89,11 +85,7 @@ impl<'gc> DictionaryObject<'gc> {
 
 impl<'gc> TObject<'gc> for DictionaryObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -8,6 +8,7 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::{WStr, WString};
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak};
 use std::fmt::Debug;
@@ -48,7 +49,7 @@ impl fmt::Debug for ErrorObject<'_> {
     }
 }
 
-#[derive(Clone, Collect)]
+#[derive(Clone, Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct ErrorObjectData<'gc> {
@@ -57,10 +58,6 @@ pub struct ErrorObjectData<'gc> {
 
     call_stack: CallStack<'gc>,
 }
-
-const _: () = assert!(std::mem::offset_of!(ErrorObjectData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<ErrorObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> ErrorObject<'gc> {
     pub fn display(&self) -> WString {
@@ -104,11 +101,7 @@ impl<'gc> ErrorObject<'gc> {
 
 impl<'gc> TObject<'gc> for ErrorObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -10,6 +10,7 @@ use crate::avm2::scope::ScopeChain;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::Lock, Collect, Gc, GcWeak, Mutation};
@@ -32,7 +33,7 @@ impl fmt::Debug for FunctionObject<'_> {
     }
 }
 
-#[derive(Collect, Clone)]
+#[derive(Collect, Clone, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct FunctionObjectData<'gc> {
@@ -45,10 +46,6 @@ pub struct FunctionObjectData<'gc> {
     /// Attached prototype (note: not the same thing as base object's proto)
     prototype: Lock<Option<Object<'gc>>>,
 }
-
-const _: () = assert!(std::mem::offset_of!(FunctionObjectData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<FunctionObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> FunctionObject<'gc> {
     /// Construct a function from an ABC method and the current closure scope.
@@ -141,11 +138,7 @@ impl<'gc> FunctionObject<'gc> {
 
 impl<'gc> TObject<'gc> for FunctionObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/index_buffer_3d_object.rs
+++ b/core/src/avm2/object/index_buffer_3d_object.rs
@@ -4,6 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::Error;
+use crate::utils::HasPrefixField;
 use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::backend::IndexBuffer;
 use std::cell::{Cell, RefCell, RefMut};
@@ -59,7 +60,7 @@ impl<'gc> IndexBuffer3DObject<'gc> {
     }
 }
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct IndexBuffer3DObjectData<'gc> {
@@ -73,18 +74,9 @@ pub struct IndexBuffer3DObjectData<'gc> {
     context3d: Context3DObject<'gc>,
 }
 
-const _: () = assert!(std::mem::offset_of!(IndexBuffer3DObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<IndexBuffer3DObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
-
 impl<'gc> TObject<'gc> for IndexBuffer3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -5,6 +5,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::Error;
 use crate::net_connection::NetConnectionHandle;
+use crate::utils::HasPrefixField;
 use gc_arena::{Collect, Gc, GcWeak};
 use std::cell::Cell;
 use std::fmt;
@@ -35,7 +36,7 @@ pub struct NetConnectionObject<'gc>(pub Gc<'gc, NetConnectionObjectData<'gc>>);
 #[collect(no_drop)]
 pub struct NetConnectionObjectWeak<'gc>(pub GcWeak<'gc, NetConnectionObjectData<'gc>>);
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct NetConnectionObjectData<'gc> {
@@ -44,18 +45,9 @@ pub struct NetConnectionObjectData<'gc> {
     handle: Cell<Option<NetConnectionHandle>>,
 }
 
-const _: () = assert!(std::mem::offset_of!(NetConnectionObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<NetConnectionObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
-
 impl<'gc> TObject<'gc> for NetConnectionObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/netstream_object.rs
+++ b/core/src/avm2/object/netstream_object.rs
@@ -5,6 +5,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::Error;
 use crate::streams::NetStream;
+use crate::utils::HasPrefixField;
 use gc_arena::{Collect, Gc, GcWeak};
 use std::fmt::Debug;
 
@@ -33,7 +34,7 @@ pub struct NetStreamObject<'gc>(pub Gc<'gc, NetStreamObjectData<'gc>>);
 #[collect(no_drop)]
 pub struct NetStreamObjectWeak<'gc>(pub GcWeak<'gc, NetStreamObjectData<'gc>>);
 
-#[derive(Clone, Collect)]
+#[derive(Clone, Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct NetStreamObjectData<'gc> {
@@ -41,18 +42,9 @@ pub struct NetStreamObjectData<'gc> {
     ns: NetStream<'gc>,
 }
 
-const _: () = assert!(std::mem::offset_of!(NetStreamObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<NetStreamObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
-
 impl<'gc> TObject<'gc> for NetStreamObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -4,6 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::Error;
+use crate::utils::HasPrefixField;
 use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::backend::ShaderModule;
 use std::cell::RefCell;
@@ -51,7 +52,7 @@ impl<'gc> Program3DObject<'gc> {
     }
 }
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct Program3DObjectData<'gc> {
@@ -63,18 +64,9 @@ pub struct Program3DObjectData<'gc> {
     shader_module_handle: RefCell<Option<Rc<dyn ShaderModule>>>,
 }
 
-const _: () = assert!(std::mem::offset_of!(Program3DObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<Program3DObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
-
 impl<'gc> TObject<'gc> for Program3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -5,6 +5,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::regexp::RegExp;
 use crate::avm2::Error;
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
@@ -44,7 +45,7 @@ impl fmt::Debug for RegExpObject<'_> {
     }
 }
 
-#[derive(Clone, Collect)]
+#[derive(Clone, Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct RegExpObjectData<'gc> {
@@ -53,10 +54,6 @@ pub struct RegExpObjectData<'gc> {
 
     regexp: RefLock<RegExp<'gc>>,
 }
-
-const _: () = assert!(std::mem::offset_of!(RegExpObjectData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<RegExpObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> RegExpObject<'gc> {
     pub fn from_regexp(
@@ -83,11 +80,7 @@ impl<'gc> RegExpObject<'gc> {
 
 impl<'gc> TObject<'gc> for RegExpObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/shader_data_object.rs
+++ b/core/src/avm2/object/shader_data_object.rs
@@ -4,6 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::Error;
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::pixel_bender::PixelBenderShaderHandle;
@@ -52,7 +53,7 @@ impl ShaderDataObject<'_> {
     }
 }
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct ShaderDataObjectData<'gc> {
@@ -62,18 +63,9 @@ pub struct ShaderDataObjectData<'gc> {
     shader: Cell<Option<PixelBenderShaderHandle>>,
 }
 
-const _: () = assert!(std::mem::offset_of!(ShaderDataObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<ShaderDataObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
-
 impl<'gc> TObject<'gc> for ShaderDataObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/socket_object.rs
+++ b/core/src/avm2/object/socket_object.rs
@@ -4,6 +4,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::Activation;
 use crate::socket::SocketHandle;
+use crate::utils::HasPrefixField;
 use gc_arena::GcWeak;
 use gc_arena::{Collect, Gc};
 use std::cell::{Cell, RefCell, RefMut};
@@ -42,11 +43,7 @@ pub struct SocketObjectWeak<'gc>(pub GcWeak<'gc, SocketObjectData<'gc>>);
 
 impl<'gc> TObject<'gc> for SocketObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {
@@ -196,7 +193,7 @@ macro_rules! impl_read{
 impl_write!(write_float f32, write_double f64, write_int i32, write_unsigned_int u32, write_short i16, write_unsigned_short u16);
 impl_read!(read_float 4; f32, read_double 8; f64, read_int 4; i32, read_unsigned_int 4; u32, read_short 2; i16, read_unsigned_short 2; u16, read_byte 1; i8, read_unsigned_byte 1; u8);
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct SocketObjectData<'gc> {
@@ -213,10 +210,6 @@ pub struct SocketObjectData<'gc> {
     read_buffer: RefCell<Vec<u8>>,
     write_buffer: RefCell<Vec<u8>>,
 }
-
-const _: () = assert!(std::mem::offset_of!(SocketObjectData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<SocketObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl fmt::Debug for SocketObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/avm2/object/soundtransform_object.rs
+++ b/core/src/avm2/object/soundtransform_object.rs
@@ -2,6 +2,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::Error;
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak};
 use std::cell::Cell;
@@ -43,7 +44,7 @@ impl fmt::Debug for SoundTransformObject<'_> {
     }
 }
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct SoundTransformObjectData<'gc> {
@@ -57,11 +58,6 @@ pub struct SoundTransformObjectData<'gc> {
 
     volume: Cell<f64>,
 }
-
-const _: () = assert!(std::mem::offset_of!(SoundTransformObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<SoundTransformObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
 
 impl SoundTransformObject<'_> {
     pub fn left_to_left(self) -> f64 {
@@ -107,11 +103,7 @@ impl SoundTransformObject<'_> {
 
 impl<'gc> TObject<'gc> for SoundTransformObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/stage3d_object.rs
+++ b/core/src/avm2/object/stage3d_object.rs
@@ -4,6 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::Error;
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::lock::Lock;
@@ -60,7 +61,7 @@ impl<'gc> Stage3DObject<'gc> {
     }
 }
 
-#[derive(Clone, Collect)]
+#[derive(Clone, Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct Stage3DObjectData<'gc> {
@@ -73,17 +74,9 @@ pub struct Stage3DObjectData<'gc> {
     visible: Cell<bool>,
 }
 
-const _: () = assert!(std::mem::offset_of!(Stage3DObjectData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<Stage3DObjectData>() == std::mem::align_of::<ScriptObjectData>());
-
 impl<'gc> TObject<'gc> for Stage3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/stylesheet_object.rs
+++ b/core/src/avm2/object/stylesheet_object.rs
@@ -3,6 +3,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::Error;
 use crate::html::{StyleSheet, TextFormat};
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_wstr::{WStr, WString};
@@ -41,7 +42,7 @@ impl fmt::Debug for StyleSheetObject<'_> {
     }
 }
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct StyleSheetObjectData<'gc> {
@@ -51,18 +52,9 @@ pub struct StyleSheetObjectData<'gc> {
     style_sheet: StyleSheet<'gc>,
 }
 
-const _: () = assert!(std::mem::offset_of!(StyleSheetObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<StyleSheetObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
-
 impl<'gc> TObject<'gc> for StyleSheetObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -5,6 +5,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::Error;
 use crate::html::{TextDisplay, TextFormat};
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak};
 use std::cell::{Ref, RefCell, RefMut};
@@ -43,7 +44,7 @@ impl fmt::Debug for TextFormatObject<'_> {
     }
 }
 
-#[derive(Clone, Collect)]
+#[derive(Clone, Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct TextFormatObjectData<'gc> {
@@ -52,11 +53,6 @@ pub struct TextFormatObjectData<'gc> {
 
     text_format: RefCell<TextFormat>,
 }
-
-const _: () = assert!(std::mem::offset_of!(TextFormatObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<TextFormatObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
 
 impl<'gc> TextFormatObject<'gc> {
     pub fn from_text_format(
@@ -80,11 +76,7 @@ impl<'gc> TextFormatObject<'gc> {
 
 impl<'gc> TObject<'gc> for TextFormatObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/texture_object.rs
+++ b/core/src/avm2/object/texture_object.rs
@@ -4,6 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::Error;
+use crate::utils::HasPrefixField;
 use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::backend::{Context3DTextureFormat, Texture};
 use std::rc::Rc;
@@ -55,7 +56,7 @@ impl<'gc> TextureObject<'gc> {
     }
 }
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct TextureObjectData<'gc> {
@@ -71,17 +72,9 @@ pub struct TextureObjectData<'gc> {
     handle: Rc<dyn Texture>,
 }
 
-const _: () = assert!(std::mem::offset_of!(TextureObjectData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<TextureObjectData>() == std::mem::align_of::<ScriptObjectData>());
-
 impl<'gc> TObject<'gc> for TextureObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -7,6 +7,7 @@ use crate::avm2::value::Value;
 use crate::avm2::vector::VectorStorage;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
+use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::barrier::unlock;
 use gc_arena::{lock::RefLock, Collect, Gc, GcWeak, Mutation};
@@ -51,7 +52,7 @@ impl fmt::Debug for VectorObject<'_> {
     }
 }
 
-#[derive(Collect, Clone)]
+#[derive(Collect, Clone, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct VectorObjectData<'gc> {
@@ -61,10 +62,6 @@ pub struct VectorObjectData<'gc> {
     /// Vector-structured properties
     vector: RefLock<VectorStorage<'gc>>,
 }
-
-const _: () = assert!(std::mem::offset_of!(VectorObjectData, base) == 0);
-const _: () =
-    assert!(std::mem::align_of::<VectorObjectData>() == std::mem::align_of::<ScriptObjectData>());
 
 impl<'gc> VectorObject<'gc> {
     /// Wrap an existing vector in an object.
@@ -92,11 +89,7 @@ impl<'gc> VectorObject<'gc> {
 
 impl<'gc> TObject<'gc> for VectorObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -4,6 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::Error;
+use crate::utils::HasPrefixField;
 use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_render::backend::VertexBuffer;
 use std::rc::Rc;
@@ -56,7 +57,7 @@ impl<'gc> VertexBuffer3DObject<'gc> {
     }
 }
 
-#[derive(Collect)]
+#[derive(Collect, HasPrefixField)]
 #[collect(no_drop)]
 #[repr(C, align(8))]
 pub struct VertexBuffer3DObjectData<'gc> {
@@ -74,18 +75,9 @@ pub struct VertexBuffer3DObjectData<'gc> {
     data32_per_vertex: u8,
 }
 
-const _: () = assert!(std::mem::offset_of!(VertexBuffer3DObjectData, base) == 0);
-const _: () = assert!(
-    std::mem::align_of::<VertexBuffer3DObjectData>() == std::mem::align_of::<ScriptObjectData>()
-);
-
 impl<'gc> TObject<'gc> for VertexBuffer3DObject<'gc> {
     fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
-        // SAFETY: Object data is repr(C), and a compile-time assert ensures
-        // that the ScriptObjectData stays at offset 0 of the struct- so the
-        // layouts are compatible
-
-        unsafe { Gc::cast(self.0) }
+        HasPrefixField::as_prefix_gc(self.0)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,6 +49,7 @@ mod system_properties;
 pub mod tag_utils;
 pub mod timer;
 mod types;
+pub mod utils;
 mod vminterface;
 mod xml;
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,0 +1,36 @@
+use gc_arena::Gc;
+
+pub use ruffle_macros::HasPrefixField;
+
+/// A trait indicating that `Self` has `Inner` as an initial prefix.
+///
+/// A field prefix is the first field in a struct that has the same address as the struct
+/// in the memory. If a struct has a prefix field, we can reinterpret the struct pointer
+/// as a pointer to the field.
+///
+/// Implementing this trait provides various methods to cast `Self` references to `Inner`
+/// references, which can be used e.g. to implement OOP-style class hierarchies.
+///
+/// This trait can be automatically derived on `repr(C)` structs with `#[derive(HasPrefixField)]`.
+///
+/// # Safety
+/// - `Self` must have a field of type `Inner` at the start of its layout;
+/// - `Self` must not impose additional safety invariants on the `Inner` prefix;
+/// - The methods of this trait should not be overriden;
+/// - Any layout constraints that can't be checked by the type-system should
+///   be checked by assertions in the `ASSERT_PREFIX_FIELD` constant.
+pub unsafe trait HasPrefixField<Inner>: Sized {
+    /// This constant should *always* be evaluated before relying on the safety
+    /// guarantees of this trait.
+    const ASSERT_PREFIX_FIELD: () = ();
+
+    /// Casts a GC'd object to its prefix field.
+    #[inline(always)]
+    fn as_prefix_gc(gc: Gc<'_, Self>) -> Gc<'_, Inner> {
+        // Casting between `Gc`s currently requires matching alignment.
+        const { assert!(align_of::<Self>() == align_of::<Inner>()) };
+        let () = Self::ASSERT_PREFIX_FIELD;
+        // SAFETY: The above asserts guarantee that the layouts are compatible.
+        unsafe { Gc::cast(gc) }
+    }
+}


### PR DESCRIPTION
And use it instead of the manual layout assertions in AVM2 object structs.

This will make it easier to use `Gc` prefix casting as a part of the `GcCell` refactors on the `DisplayObject` hierarchy.