### PR TITLE
core: Get rid of GcCell in EditText

### DIFF
--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -150,12 +150,12 @@ fn get_new_text_format<'gc>(
 
 fn set_new_text_format<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let [Value::Object(text_format), ..] = args {
         if let NativeObject::TextFormat(text_format) = text_format.native() {
-            text_field.set_new_text_format(text_format.borrow().clone(), activation.context);
+            text_field.set_new_text_format(text_format.borrow().clone());
         }
     }
 
@@ -355,7 +355,7 @@ pub fn set_text_color<'gc>(
         text_format.clone(),
         activation.context,
     );
-    this.set_new_text_format(text_format, activation.context);
+    this.set_new_text_format(text_format);
     Ok(())
 }
 
@@ -863,16 +863,16 @@ fn set_restrict<'gc>(
 ) -> Result<(), Error<'gc>> {
     match value {
         Value::Undefined | Value::Null => {
-            this.set_restrict(None, activation.context);
+            this.set_restrict(None);
         }
         _ => {
             let text = value.coerce_to_string(activation)?;
             if text.is_empty() {
                 // According to docs, an empty string means that you cannot enter any character,
                 // but according to reality, an empty string is equivalent to null in AVM1.
-                this.set_restrict(None, activation.context);
+                this.set_restrict(None);
             } else {
-                this.set_restrict(Some(&text), activation.context);
+                this.set_restrict(Some(&text));
             }
         }
     };

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -526,7 +526,7 @@ fn get_text_extent<'gc>(
 
     temp_edittext.set_autosize(AutoSizeMode::Left, activation.context);
     temp_edittext.set_word_wrap(width.is_some(), activation.context);
-    temp_edittext.set_new_text_format(text_format.clone(), activation.context);
+    temp_edittext.set_new_text_format(text_format.clone());
     temp_edittext.set_text(&text, activation.context);
 
     let result = Object::new(&activation.context.strings, None);

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -162,7 +162,7 @@ fn apply_format<'gc>(
 
         display_object.set_is_device_font(activation.context, is_device_font);
         display_object.set_text_format(0, text.len(), format.clone(), activation.context);
-        display_object.set_new_text_format(format, activation.context);
+        display_object.set_new_text_format(format);
     } else {
         display_object.set_is_device_font(activation.context, true);
     }

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -312,7 +312,7 @@ pub fn get_default_text_format<'gc>(
 }
 
 pub fn set_default_text_format<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -326,7 +326,7 @@ pub fn set_default_text_format<'gc>(
 
         if let Some(new_text_format) = new_text_format {
             if let Some(new_text_format) = new_text_format.as_text_format() {
-                this.set_new_text_format(new_text_format.clone(), activation.context);
+                this.set_new_text_format(new_text_format.clone());
             }
         }
     }
@@ -616,7 +616,7 @@ pub fn set_text_color<'gc>(
             desired_format.clone(),
             activation.context,
         );
-        this.set_new_text_format(desired_format, activation.context);
+        this.set_new_text_format(desired_format);
     }
 
     Ok(Value::Undefined)
@@ -1547,10 +1547,7 @@ pub fn set_restrict<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        this.set_restrict(
-            args.try_get_string(activation, 0)?.as_deref(),
-            activation.context,
-        );
+        this.set_restrict(args.try_get_string(activation, 0)?.as_deref());
     }
     Ok(Value::Undefined)
 }
@@ -1598,6 +1595,7 @@ pub fn get_text_runs<'gc>(
 
     let array = this
         .spans()
+        .borrow()
         .iter_spans()
         .filter(|(start, end, _, _)| {
             // Flash never returns empty spans here, but we currently require

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -1595,7 +1595,6 @@ pub fn get_text_runs<'gc>(
 
     let array = this
         .spans()
-        .borrow()
         .iter_spans()
         .filter(|(start, end, _, _)| {
             // Flash never returns empty spans here, but we currently require

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -544,7 +544,7 @@ impl DisplayObjectWindow {
 
                 ui.label("Default Text Format");
                 ui.horizontal(|ui| {
-                    show_text_format_hover(ui, object.spans().borrow().default_format());
+                    show_text_format_hover(ui, object.spans().default_format());
                 });
                 ui.end_row();
 
@@ -615,7 +615,7 @@ impl DisplayObjectWindow {
                         ui.label("Text");
                         ui.end_row();
 
-                        for (start, end, text, format) in object.spans().borrow().iter_spans() {
+                        for (start, end, text, format) in object.spans().iter_spans() {
                             ui.label(format!("{}–{} ({})", start, end, format.span_length));
 
                             ui.horizontal(|ui| {

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -514,7 +514,7 @@ impl DisplayObjectWindow {
                         } else {
                             None
                         };
-                        object.set_restrict(new_restrict, context);
+                        object.set_restrict(new_restrict);
                     }
 
                     if let Some(original_restrict) = restrict {
@@ -522,7 +522,7 @@ impl DisplayObjectWindow {
                         let mut restrict = original_restrict.clone();
                         ui.text_edit_singleline(&mut restrict);
                         if restrict != original_restrict {
-                            object.set_restrict(Some(&WString::from_utf8(&restrict)), context);
+                            object.set_restrict(Some(&WString::from_utf8(&restrict)));
                         }
                     } else {
                         ui.weak("Disabled");
@@ -544,7 +544,7 @@ impl DisplayObjectWindow {
 
                 ui.label("Default Text Format");
                 ui.horizontal(|ui| {
-                    show_text_format_hover(ui, object.spans().default_format());
+                    show_text_format_hover(ui, object.spans().borrow().default_format());
                 });
                 ui.end_row();
 
@@ -615,7 +615,7 @@ impl DisplayObjectWindow {
                         ui.label("Text");
                         ui.end_row();
 
-                        for (start, end, text, format) in object.spans().iter_spans() {
+                        for (start, end, text, format) in object.spans().borrow().iter_spans() {
                             ui.label(format!("{}–{} ({})", start, end, format.span_length));
 
                             ui.horizontal(|ui| {


### PR DESCRIPTION
This refactor replaces GcCell with Gc and uses interior mutability instead.