### PR TITLE
avm1: Remove `Gc` indirection for `SuperObject`

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -219,7 +219,7 @@ impl<'gc> Avm1Function<'gc> {
         // TODO: `super` should only be defined if this was a method call (depth > 0?)
         // `f[""]()` emits a CallMethod op, causing `this` to be undefined, but `super` is a function; what is it?
         let zuper = this.filter(|_| !suppress).map(|this| {
-            let zuper = NativeObject::Super(SuperObject::new(frame, this, depth));
+            let zuper = NativeObject::Super(SuperObject::new(this, depth));
             Object::new_with_native(frame.strings(), None, zuper).into()
         });
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,4 +1,4 @@
-use gc_arena::Gc;
+use gc_arena::{Collect, Gc};
 
 pub use ruffle_macros::HasPrefixField;
 
@@ -33,4 +33,13 @@ pub unsafe trait HasPrefixField<Inner>: Sized {
         // SAFETY: The above asserts guarantee that the layouts are compatible.
         unsafe { Gc::cast(gc) }
     }
+}
+
+/// A `u8` which is always zero. Useful to artificially introduce niches into a struct.
+#[derive(Copy, Clone, Collect, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[collect(require_static)]
+#[repr(u8)]
+pub enum ZeroU8 {
+    #[default]
+    Zero = 0,
 }


### PR DESCRIPTION
Follow-up to #20204.