### PR TITLE
chore: Remove approximations from some tests

### DIFF
--- a/tests/tests/swfs/avm2/color_matrix_filter/test.toml
+++ b/tests/tests/swfs/avm2/color_matrix_filter/test.toml
@@ -1,4 +1,1 @@
 num_frames = 1
-
-[approximations]
-epsilon = 0.0000000001

--- a/tests/tests/swfs/avm2/convolution_filter/test.toml
+++ b/tests/tests/swfs/avm2/convolution_filter/test.toml
@@ -1,4 +1,1 @@
 num_frames = 1
-
-[approximations]
-epsilon = 0.00001

--- a/tests/tests/swfs/avm2/edittext_align/test.toml
+++ b/tests/tests/swfs/avm2/edittext_align/test.toml
@@ -1,4 +1,1 @@
 num_frames = 1
-
-[approximations]
-epsilon = 3.0

--- a/tests/tests/swfs/avm2/edittext_getlinemetrics/test.toml
+++ b/tests/tests/swfs/avm2/edittext_getlinemetrics/test.toml
@@ -1,4 +1,1 @@
 num_frames = 1
-
-[approximations]
-epsilon = 5.0

--- a/tests/tests/swfs/avm2/edittext_underline/test.toml
+++ b/tests/tests/swfs/avm2/edittext_underline/test.toml
@@ -1,4 +1,1 @@
 num_frames = 1
-
-[approximations]
-epsilon = 3.0


### PR DESCRIPTION
Some tests no longer require approximations.