### PR TITLE
desktop: Linux - add `StartupWMClass` to the desktop file

### DIFF
--- a/desktop/packages/linux/rs.ruffle.Ruffle.desktop
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.desktop
@@ -65,7 +65,6 @@ Comment[zh_CN]=播放 Flash 游戏和动画
 Comment[zh_TW]=播放 Flash 遊戲和動畫
 Comment=Play Flash games & movies
 Icon=rs.ruffle.Ruffle
-StartupWMClass=rs.ruffle.Ruffle
 Exec=ruffle %u
 MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie
 Categories=AudioVideo;Player;Graphics;Viewer;VectorGraphics;Emulator;Game

--- a/desktop/packages/linux/rs.ruffle.Ruffle.desktop
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.desktop
@@ -65,6 +65,7 @@ Comment[zh_CN]=播放 Flash 游戏和动画
 Comment[zh_TW]=播放 Flash 遊戲和動畫
 Comment=Play Flash games & movies
 Icon=rs.ruffle.Ruffle
+StartupWMClass=rs.ruffle.Ruffle
 Exec=ruffle %u
 MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie
 Categories=AudioVideo;Player;Graphics;Viewer;VectorGraphics;Emulator;Game

--- a/desktop/packages/linux/rs.ruffle.Ruffle.desktop.in
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.desktop.in
@@ -4,6 +4,7 @@ Name=Ruffle
 GenericName=Flash Player
 Comment=Play Flash games & movies
 Icon=rs.ruffle.Ruffle
+StartupWMClass=rs.ruffle.Ruffle
 Exec=ruffle %u
 MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie
 Categories=AudioVideo;Player;Graphics;Viewer;VectorGraphics;Emulator;Game


### PR DESCRIPTION
It's useful setting this as a fallback, if the `.desktop` file is not named the same as app ID (`rs.ruffle.Ruffle.desktop`).
As flatpaks always name their `.desktop` files as `app-id.desktop`, they are not affected.
As a bonus, another XDG desktop standard is respected.

This is useful for user-wide package managers which name their `.desktop` files differently to not collide with existing `.desktop` files (like [AM AppImage Manager](https://github.com/ivan-hc/AM)).

According to my tests, `wmclass` is the same in both Wayland & X11, so this works well.

Ending result is that Ruffle associates the window & icon correctly, even if `.desktop` file is named differently, while not causing any regressions.