### PR TITLE
web: Switch from `unload` to `pagehide` event

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -69,9 +69,9 @@ workspace = true
 features = [
     "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext",
     "AudioDestinationNode", "AudioNode", "AudioParam", "Blob", "BlobPropertyBag",
-    "ChannelMergerNode", "ChannelSplitterNode", "ClipboardEvent", "DataTransfer", "Element", "Event",
+    "ChannelMergerNode", "ChannelSplitterNode", "ClipboardEvent", "DataTransfer", "Element",
     "EventTarget", "GainNode", "Headers", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement",
-    "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent",
+    "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PageTransitionEvent", "PointerEvent",
     "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "ReadableStream", "RequestCredentials",
     "Url", "WebGlContextEvent", "Clipboard", "FocusEvent", "ShadowRoot", "Gamepad", "GamepadButton"
 ]

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -2080,29 +2080,63 @@ export class InnerPlayer {
     /**
      * Show a dismissible message in front of the player.
      *
-     * @param message The message shown to the user.
+     * @param message The message shown to the user, which can be a string or element.
      */
-    public displayMessage(message: string): void {
-        const div = document.createElement("div");
-        div.id = "message-overlay";
-        const messageDiv = document.createElement("div");
-        messageDiv.className = "message";
-        const messageP = document.createElement("p");
-        messageP.textContent = message;
-        messageDiv.appendChild(messageP);
-        const buttonDiv = document.createElement("div");
-        const continueButton = document.createElement("button");
-        continueButton.id = "continue-btn";
-        continueButton.textContent = text("continue");
-        buttonDiv.appendChild(continueButton);
-        messageDiv.appendChild(buttonDiv);
-        div.appendChild(messageDiv);
-        this.container.prepend(div);
+    private displayMessageOrElement(message: string | HTMLDivElement): void {
+        const messageOverlay = (
+            <div id="message-overlay">
+                <div class="message">
+                    {message instanceof HTMLDivElement ? (
+                        message
+                    ) : (
+                        <p>{message}</p>
+                    )}
+                    <div>
+                        <button id="continue-btn">{text("continue")}</button>
+                    </div>
+                </div>
+            </div>
+        );
+
+        this.container.prepend(messageOverlay);
+
         (
             this.container.querySelector("#continue-btn") as HTMLButtonElement
         ).onclick = () => {
-            div.parentNode!.removeChild(div);
+            messageOverlay.parentNode!.removeChild(messageOverlay);
         };
+    }
+
+    /**
+     * Show a dismissible message in front of the player.
+     *
+     * @param message The message shown to the user.
+     */
+    public displayMessage(message: string): void {
+        this.displayMessageOrElement(message);
+    }
+
+    /**
+     * Inform the user that the browser restored the file from the back/forward cache.
+     */
+    protected displayRestoredFromBfcacheMessage(): void {
+        // Do not display the message if another one is already shown.
+        if (this.container.querySelector("#message-overlay") !== null) {
+            return;
+        }
+        const message = textAsParagraphs("message-restored-from-bfcache");
+        this.displayMessageOrElement(message);
+
+        // Remove the message element if it doesn't fit in the container, to avoid potential blocking situations.
+        const messageOverlay = this.container.querySelector(
+            "#message-overlay",
+        )! as HTMLElement;
+        if (
+            messageOverlay.scrollWidth > messageOverlay.offsetWidth ||
+            messageOverlay.scrollHeight > messageOverlay.offsetHeight
+        ) {
+            messageOverlay.parentNode!.removeChild(messageOverlay);
+        }
     }
 
     /**

--- a/web/packages/core/texts/en-US/messages.ftl
+++ b/web/packages/core/texts/en-US/messages.ftl
@@ -1,6 +1,9 @@
 message-cant-embed =
     Ruffle wasn't able to run the Flash embedded in this page.
     You can try to open the file in a separate tab, to sidestep this issue.
+message-restored-from-bfcache =
+    Your browser restored this Flash content from a previous session.
+    To start fresh, reload the page.
 panic-title = Something went wrong :(
 more-info = More info
 run-anyway = Run anyway


### PR DESCRIPTION
The `unload` event is deprecated, and Chrome even plans to remove support for it entirely:
https://developer.chrome.com/docs/web-platform/deprecating-unload

The `pagehide` event is now used as a replacement. A side effect of this change, however, is that it makes pages eligible for the back/forward cache (bfcache): as a result, instances of Ruffle may no longer be recreated from scratch when navigating back to the page, but instead "revived" from their previous state. When this happens, the following message is displayed to the user:

![restored](https://github.com/user-attachments/assets/282df10d-1b7b-4a4b-b77a-1e6a6314f518)

Closes #19704.