### PR TITLE
web: expose more functionality in the FlashAPI

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2312,7 +2312,7 @@ impl Player {
                 .root_clip()
                 .and_then(|root| root.as_movie_clip())
                 .map(|clip| clip.current_frame());
-            
+
             this.total_frames = update_context
                 .stage
                 .root_clip()

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -2088,6 +2088,39 @@ export class InnerPlayer {
         // TODO: Move this to whatever function changes the ReadyState to Loaded when we have streaming support.
         this.element.dispatchEvent(new CustomEvent(InnerPlayer.LOADED_DATA));
     }
+
+    currentFrame() : number {
+        if (this.instance) {
+            return this.instance.current_frame()!;
+        }
+        return 1;
+    }
+
+    totalFrames() : number {
+        if (this.instance) {
+            return this.instance.total_frames()!;
+        }
+        return 0;
+    }
+
+    isPlayingMovie() : boolean {
+        if (this.instance) {
+            return this.instance.is_playing_movie()!;
+        }
+        return false;
+    }
+
+    playMovie() : void {
+        this.instance?.play_movie();
+    }
+
+    stopMovie() : void {
+        this.instance?.stop_movie();
+    }
+
+    gotoFrame(frame: number) : void {
+        this.instance?.goto_frame(frame);
+    }
 }
 
 /**

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -165,6 +165,30 @@ export class RufflePlayerElement extends HTMLElement implements PlayerElement {
         }
     }
 
+    public CurrentFrame(): number {
+        return this.#inner.currentFrame() - 1;
+    }
+
+    public TotalFrames(): number {
+        return this.#inner.totalFrames();
+    }
+
+    public GotoFrame(frame: number) {
+        return this.#inner.gotoFrame(frame + 1);
+    }
+
+    public IsPlaying() : boolean {
+        return this.#inner.isPlayingMovie();
+    }
+
+    public Play() : void {
+        this.#inner.playMovie();
+    }
+
+    public StopPlay() : void {
+        this.#inner.stopMovie();
+    }
+
     get config(): URLLoadOptions | DataLoadOptions | object {
         return this.#inner.config;
     }

--- a/web/packages/core/src/public/player/flash.ts
+++ b/web/packages/core/src/public/player/flash.ts
@@ -2,11 +2,36 @@
  * These are properties and methods that Flash added to its `<embed>/<object>` tags.
  * These don't seem to be documented in full anywhere, and Ruffle adds them as we encounter some.
  * You are discouraged from using these, and they exist only to support legacy websites from decades ago.
+ * 
+ * https://web.archive.org/web/20100710000820/http://www.adobe.com/support/flash/publishexport/scriptingwithflash/scriptingwithflash_03.html
  *
  * Extra methods or properties may appear at any time, due to `ExternalInterface.addCallback()`.
  * It may even overwrite existing methods or properties.
  */
 export interface FlashAPI {
+    /**
+     * Returns the current frame index of the movie.
+     *
+     * @remarks the frame number starts from a 0 index, not 1 like in FP
+     * @returns the current frame of the movie.
+     */
+    CurrentFrame(): number;
+
+    /**
+     * Jumps the movie to a specific frame and stops.
+     *
+     * @remarks the frame number starts from a 0 index, not 1 like in FP
+     */
+    GotoFrame(frame: number) : void;
+
+    /**
+     * Returns whether the movie's root clip is playing or not.
+     * Not to be confused with whether Ruffle is playing.
+     *
+     * @returns true if the movie is playing, otherwise false.
+     */
+    IsPlaying(): boolean;
+
     /**
      * Returns the movies loaded process, in a percent from 0 to 100.
      * Ruffle may just return 0 or 100.
@@ -14,4 +39,22 @@ export interface FlashAPI {
      * @returns a value from 0 to 100, inclusive.
      */
     PercentLoaded(): number;
+
+    /**
+     * Starts playing the root movie clip of the movie.
+     */
+    Play(): void;
+
+    /**
+     * Stops the root movie clip of the movie.
+     */
+    StopPlay(): void;
+
+    /**
+     * Returns the movies loaded process, in a percent from 0 to 100.
+     * Ruffle may just return 0 or 100.
+     *
+     * @returns the total number of frames in the movie.
+     */
+    TotalFrames(): number;
 }

--- a/web/packages/core/src/public/player/flash.ts
+++ b/web/packages/core/src/public/player/flash.ts
@@ -2,7 +2,7 @@
  * These are properties and methods that Flash added to its `<embed>/<object>` tags.
  * These don't seem to be documented in full anywhere, and Ruffle adds them as we encounter some.
  * You are discouraged from using these, and they exist only to support legacy websites from decades ago.
- * 
+ *
  * https://web.archive.org/web/20100710000820/http://www.adobe.com/support/flash/publishexport/scriptingwithflash/scriptingwithflash_03.html
  *
  * Extra methods or properties may appear at any time, due to `ExternalInterface.addCallback()`.
@@ -22,7 +22,7 @@ export interface FlashAPI {
      *
      * @remarks the frame number starts from a 0 index, not 1 like in FP
      */
-    GotoFrame(frame: number) : void;
+    GotoFrame(frame: number): void;
 
     /**
      * Returns whether the movie's root clip is playing or not.

--- a/web/packages/selfhosted/test/js_api/exposed.ts
+++ b/web/packages/selfhosted/test/js_api/exposed.ts
@@ -16,7 +16,13 @@ describe("Exposed RufflePlayer methods/properties", () => {
         }, player);
         expect(keys).to.have.members([
             // FlashAPI
+            "CurrentFrame",
+            "GotoFrame",
+            "IsPlaying",
             "PercentLoaded",
+            "Play",
+            "StopPlay",
+            "TotalFrames",
             // LegacyRuffleAPI
             "onFSCommand",
             "config",

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -457,6 +457,30 @@ impl RuffleHandle {
     pub fn is_wasm_simd_used() -> bool {
         cfg!(target_feature = "simd128")
     }
+
+    pub fn current_frame(&self) -> Option<u16> {
+        self.with_core_mut(|core| core.current_frame()).unwrap_or_default()
+    }
+
+    pub fn total_frames(&self) -> Option<u16> {
+        self.with_core_mut(|core| core.total_frames()).unwrap_or_default()
+    }
+
+    pub fn is_playing_movie(&self) -> bool {
+        self.with_core_mut(|core| core.is_playing_movie()).unwrap_or_default()
+    }
+
+    pub fn goto_frame(&self, frame: u16) {
+        let _ = self.with_core_mut(|core| core.goto_frame(frame));
+    }
+
+    pub fn play_movie(&self) {
+        let _ = self.with_core_mut(|core| core.play_movie());
+    }
+
+    pub fn stop_movie(&self) {
+        let _ = self.with_core_mut(|core| core.stop_movie());
+    }
 }
 
 impl RuffleHandle {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -459,15 +459,18 @@ impl RuffleHandle {
     }
 
     pub fn current_frame(&self) -> Option<u16> {
-        self.with_core_mut(|core| core.current_frame()).unwrap_or_default()
+        self.with_core_mut(|core| core.current_frame())
+            .unwrap_or_default()
     }
 
     pub fn total_frames(&self) -> Option<u16> {
-        self.with_core_mut(|core| core.total_frames()).unwrap_or_default()
+        self.with_core_mut(|core| core.total_frames())
+            .unwrap_or_default()
     }
 
     pub fn is_playing_movie(&self) -> bool {
-        self.with_core_mut(|core| core.is_playing_movie()).unwrap_or_default()
+        self.with_core_mut(|core| core.is_playing_movie())
+            .unwrap_or_default()
     }
 
     pub fn goto_frame(&self, frame: u16) {


### PR DESCRIPTION
This implements more of the JavaScript API exposed by FP (as per https://web.archive.org/web/20100710000820/http://www.adobe.com/support/flash/publishexport/scriptingwithflash/scriptingwithflash_03.html)

* CurrentFrame
* GotoFrame
* IsPlaying
* Play
* StopPlay
* TotalFrames