### PR TITLE
chore: Bump rust-flash-lso to latest git master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "flash-lso"
 version = "0.6.0"
-source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=a5e938d9bb1909095f2340c2435867f6aae930b0#a5e938d9bb1909095f2340c2435867f6aae930b0"
+source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=998f47c926b9986aabd518fbb7394ff56936d0b0#998f47c926b9986aabd518fbb7394ff56936d0b0"
 dependencies = [
  "enumset",
  "nom",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,7 +42,7 @@ serde = { workspace = true }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "073eb48d907201f46dea0c8feb4e8d9a1d92208c", optional = true }
 regress = { git = "https://github.com/ruffle-rs/regras3", rev = "5fcb02513c5ab4e00df4346459f5a8d0521d8fed" }
-flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "a5e938d9bb1909095f2340c2435867f6aae930b0" }
+flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "998f47c926b9986aabd518fbb7394ff56936d0b0" }
 lzma-rs = {version = "0.3.0", optional = true }
 dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.4", default-features = false, optional = true }


### PR DESCRIPTION
This pulls in https://github.com/ruffle-rs/rust-flash-lso/pull/74 (and https://github.com/ruffle-rs/rust-flash-lso/pull/75), although I'm not sure what significance either would bear...