### PR TITLE
ci: Remove lld workaround for linkme

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -79,13 +79,6 @@ jobs:
           sudo apt-get update
           sudo apt install -y libasound2-dev mesa-vulkan-drivers libudev-dev
 
-      # Needed after: https://github.com/rust-lang/rust/pull/124129
-      # See also: https://github.com/dtolnay/linkme/issues/94
-      # Additionally: https://lld.llvm.org/ELF/start-stop-gc
-      - name: Disable linker start-stop-gc
-        if: runner.os == 'Linux'
-        run: echo RUSTFLAGS=${RUSTFLAGS}\ --cfg=web_sys_unstable_apis\ -Clink-args=-znostart-stop-gc >> $GITHUB_ENV
-
       - name: Enable image tests
         if: runner.os != 'macOS'
         shell: bash


### PR DESCRIPTION
This reverts https://github.com/ruffle-rs/ruffle/pull/16390 and https://github.com/ruffle-rs/ruffle/pull/16682, as https://github.com/dtolnay/linkme/issues/94 is claimed to be fixed by https://github.com/rust-lang/rust/pull/137685. See also: https://github.com/dtolnay/linkme/pull/88 and then https://github.com/dtolnay/linkme/pull/112.