### PR TITLE
tests: Add support for multiple checks for an image & filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-expr"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34e221e91c7eb5e8315b5c9cf1a61670938c0626451f954a51693ed44b37f45"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4437,6 +4446,7 @@ dependencies = [
  "anyhow",
  "approx",
  "async-channel",
+ "cfg-expr",
  "chrono",
  "image",
  "percent-encoding",

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -29,6 +29,7 @@ anyhow = { workspace = true }
 async-channel = { workspace = true }
 vfs = "0.12.1"
 percent-encoding = "2.3.1"
+cfg-expr = "0.20.0"
 
 [features]
 jpegxr = ["ruffle_core/jpegxr"]


### PR DESCRIPTION
Multiple image checks are useful when we want to test more than one tolerance/max_outliers configurtion at one time.

For instance, we might want to check that the image has 0 outliers for tolerance 128, and 10 outliers for tolerance 5.

The configuration above would be written as:

```
[[image_comparisons.output.checks]]
tolerance = 128
max_outliers = 0

[[image_comparisons.output.checks]]
tolerance = 5
max_outliers = 10
```

Filters are useful when e.g. the given check only applies to a specific
platform. It's very common that a test output looks different on
different platforms. With filters we can write specific checks for
specific platforms instead of increasing tolerance for all of them.

An example configuration might look like this:

```
[[image_comparisons.output.checks]]
filter = 'not(arch = "aarch64")'
tolerance = 2

[[image_comparisons.output.checks]]
filter = 'arch = "aarch64"'
tolerance = 2
max_outliers = 10
```

In this configuration, we allow 10 outliers for aarch64, while not
allowing any for all other architectures.

These features will be useful for https://github.com/ruffle-rs/ruffle/pull/19259