### PR TITLE
web: Make default quality null

### DIFF
--- a/web/packages/core/src/public/config/default.ts
+++ b/web/packages/core/src/public/config/default.ts
@@ -35,7 +35,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     salign: "",
     fullScreenAspectRatio: "",
     forceAlign: false,
-    quality: "high",
+    quality: null,
     scale: "showAll",
     forceScale: false,
     frameRate: null,

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -531,9 +531,9 @@ export interface BaseLoadOptions {
     /**
      * This is equivalent to Stage.quality.
      *
-     * @default "high"
+     * @default null
      */
-    quality?: string;
+    quality?: string | null;
 
     /**
      * This is equivalent to Stage.scaleMode.


### PR DESCRIPTION
This should fix #20610, because the quality will not be explicit so the builder will change it to low on mobile devices.