### PR TITLE
avm2: Move PerspectiveProjection computation to render crate

### DIFF
--- a/core/src/avm2/globals/flash/geom/PerspectiveProjection.as
+++ b/core/src/avm2/globals/flash/geom/PerspectiveProjection.as
@@ -28,14 +28,6 @@ package flash.geom {
 
         public native function set projectionCenter(value:Point);
 
-        public function toMatrix3D():Matrix3D {
-            var fl: Number = this.focalLength;
-            return new Matrix3D(new <Number>[
-                fl, 0, 0, 0,
-                0, fl, 0, 0,
-                0, 0, 1, 1,
-                0, 0, 0, 0
-            ]);
-        }
+        public native function toMatrix3D():Matrix3D;
     }
 }

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -211,7 +211,7 @@ pub fn color_transform_to_object<'gc>(
     Ok(object)
 }
 
-fn matrix3d_to_object<'gc>(
+pub fn matrix3d_to_object<'gc>(
     matrix: Matrix3D,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/render/src/perspective_projection.rs
+++ b/render/src/perspective_projection.rs
@@ -1,3 +1,7 @@
+use std::f64::consts::PI;
+
+use crate::matrix3d::Matrix3D;
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct PerspectiveProjection {
     /// Unit: degree. Must be greater than 0 and less than 180.
@@ -12,6 +16,51 @@ impl Default for PerspectiveProjection {
         Self {
             field_of_view: 55.0,
             center: (250.0, 250.0),
+        }
+    }
+}
+
+impl PerspectiveProjection {
+    const DEG2RAD: f64 = PI / 180.0;
+
+    pub fn from_focal_length(focal_length: f64, width: f64) -> Self {
+        Self {
+            field_of_view: f64::atan((width / 2.0) / focal_length) / Self::DEG2RAD * 2.0,
+            ..Default::default()
+        }
+    }
+
+    pub fn focal_length(&self, width: f32) -> f32 {
+        let rad = self.field_of_view * Self::DEG2RAD;
+        (width / 2.0) * f64::tan((PI - rad) / 2.0) as f32
+    }
+
+    pub fn to_matrix3d(&self, width: f32) -> Matrix3D {
+        let focal_length = self.focal_length(width) as f64;
+
+        Matrix3D {
+            raw_data: [
+                //
+                focal_length,
+                0.0,
+                0.0,
+                0.0,
+                //
+                0.0,
+                focal_length,
+                0.0,
+                0.0,
+                //
+                0.0,
+                0.0,
+                1.0,
+                1.0,
+                //
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ],
         }
     }
 }


### PR DESCRIPTION
Continued from https://github.com/ruffle-rs/ruffle/pull/19670
Continue to https://github.com/ruffle-rs/ruffle/pull/19405 ?

This PR refactors flash.geom.PerspectiveProjection computation logics from ruffle_core to ruffle_render.
We can use those later from inside ruffle_render.