### PR TITLE
naga-pixelbender: Implement Opcode::Step

### DIFF
--- a/render/naga-pixelbender/src/lib.rs
+++ b/render/naga-pixelbender/src/lib.rs
@@ -1037,6 +1037,16 @@ impl ShaderBuilder<'_> {
                                 arg3: None,
                             })
                         }
+                        Opcode::Step => {
+                            let right = self.load_src_register(&dst)?;
+                            self.evaluate_expr(Expression::Math {
+                                fun: MathFunction::Step,
+                                arg: src,
+                                arg1: Some(right),
+                                arg2: None,
+                                arg3: None,
+                            })
+                        }
                         Opcode::Normalize => {
                             let src = self.load_src_register_with_padding(src_reg, false)?;
                             let res = self.evaluate_expr(Expression::Math {


### PR DESCRIPTION
Tested on the issues I found:

#12704: doesn't panic, but stumbles upon a null exception and does nothing. Also tries to use Matrix3d.
#14068: loads, but probably unrelated graphical glitches.
#14322: now panics on `Unexpected param type 13` (we're missing bools)

Also @Quasimondo can you please test this PR on the SWF you have you mentioned in #20604 ? This should be enough for it to work, for all I know.