### PR TITLE
core: Add avm_warning for simulating traced FP warnings

### DIFF
--- a/core/src/backend/log.rs
+++ b/core/src/backend/log.rs
@@ -1,5 +1,7 @@
 pub trait LogBackend {
     fn avm_trace(&self, message: &str);
+
+    fn avm_warning(&self, message: &str);
 }
 
 /// Logging backend that just reroutes traces to the log crate
@@ -14,6 +16,10 @@ impl NullLogBackend {
 impl LogBackend for NullLogBackend {
     fn avm_trace(&self, message: &str) {
         tracing::info!(target: "avm_trace", "{}", message);
+    }
+
+    fn avm_warning(&self, message: &str) {
+        tracing::info!(target: "avm_warning", "{}", message);
     }
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -476,6 +476,10 @@ impl<'gc> UpdateContext<'gc> {
     pub fn avm_trace(&self, message: &str) {
         self.log.avm_trace(&message.replace('\r', "\n"));
     }
+
+    pub fn avm_warning(&self, message: &str) {
+        self.log.avm_warning(message);
+    }
 }
 
 /// A queued ActionScript call.

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1267,8 +1267,7 @@ impl<'gc> MovieClip<'gc> {
         place_object: &swf::PlaceObject,
     ) -> Option<DisplayObject<'gc>> {
         if self.has_child_at_depth(depth) {
-            // Flash Player traces
-            //   Warning: Failed to place object at depth X.
+            context.avm_warning(&format!("Failed to place object at depth {depth}."));
             return None;
         }
 

--- a/scanner/src/logging.rs
+++ b/scanner/src/logging.rs
@@ -16,6 +16,7 @@ impl ScanLogBackend {
 
 impl LogBackend for ScanLogBackend {
     fn avm_trace(&self, _message: &str) {}
+    fn avm_warning(&self, _message: &str) {}
 }
 
 thread_local! {

--- a/tests/framework/src/backends/log.rs
+++ b/tests/framework/src/backends/log.rs
@@ -26,4 +26,11 @@ impl LogBackend for TestLogBackend {
         self.trace_output.borrow_mut().push_str(message);
         self.trace_output.borrow_mut().push('\n');
     }
+
+    fn avm_warning(&self, message: &str) {
+        // Match the format used by Flash Player
+        self.trace_output.borrow_mut().push_str("Warning: ");
+        self.trace_output.borrow_mut().push_str(message);
+        self.trace_output.borrow_mut().push('\n');
+    }
 }

--- a/tests/tests/swfs/avm1/placeobject_occupied_depth/output.txt
+++ b/tests/tests/swfs/avm1/placeobject_occupied_depth/output.txt
@@ -1,3 +1,5 @@
+Warning: Failed to place object at depth 1.
+Warning: Failed to place object at depth 1.
 Instantiated ID 3
 Frame 2
 Instantiated ID 4

--- a/web/src/log_adapter.rs
+++ b/web/src/log_adapter.rs
@@ -20,4 +20,8 @@ impl LogBackend for WebLogBackend {
             let _ = function.call1(function, &JsValue::from_str(message));
         }
     }
+
+    fn avm_warning(&self, message: &str) {
+        tracing::info!(target: "avm_warning", "{}", message);
+    }
 }


### PR DESCRIPTION
Simulating traced Flash Player warnings improves our tests, because we can assert on certain code paths taken in our implementations.