### PR TITLE
web: Don't show CORS error message for the Internet Archive

### DIFF
--- a/web/packages/core/src/internal/ui/panic.tsx
+++ b/web/packages/core/src/internal/ui/panic.tsx
@@ -185,6 +185,8 @@ function createPanicError(error: Error | null): {
 
         if (
             window.location.origin === error.swfUrl?.origin ||
+            // The Internet Archive fetches from itself despite lies about the swfUrl
+            window.location.origin === "https://web.archive.org" ||
             // The extension's internal player page is not restricted by CORS
             window.location.protocol.includes("extension")
         ) {


### PR DESCRIPTION
Not sure how I feel about this, on the one hand it's simple and helps to stop the issues saying "why does the Internet Archive have this CORS error", but on the other hand is a single hard-coded URL. It's tough to do things any other way because the Internet Archive lies about the URL it's actually fetching due to its custom fetch code that redirects all requests to itself.