### PR TITLE
core: Narrow the scope of Library's unsafe Collect impl

### DIFF
--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -64,7 +64,8 @@ impl Hash for FontQuery {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Collect)]
+#[collect(require_static)]
 pub enum DefaultFont {
     /// `_sans`, a Sans-Serif font (similar to Helvetica or Arial)
     Sans,


### PR DESCRIPTION
This refactor makes the scope of the Collect impl narrower so that it's less probable to make a mistake and leave out a field from the impl.