### PR TITLE
core: don't store the `SwfMovie` in `ChildContainer`

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -338,8 +338,8 @@ impl<'gc> UpdateContext<'gc> {
 
     /// Change the root movie.
     ///
-    /// This should only be called once, as it makes no attempt at removing
-    /// previous stage contents. If you need to load a new root movie, you
+    /// This should only be called once, as it makes no attempt at proper clean-up
+    /// of previous stage contents. If you need to load a new root movie, you
     /// should use `replace_root_movie`.
     pub fn set_root_movie(&mut self, movie: SwfMovie) {
         if !self.forced_frame_rate {

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -75,7 +75,7 @@ impl<'gc> Avm1Button<'gc> {
             Avm1ButtonData {
                 cell: RefLock::new(Avm1ButtonDataMut {
                     base: Default::default(),
-                    container: ChildContainer::new(source_movie.movie.clone()),
+                    container: ChildContainer::new(&source_movie.movie),
                     hit_area: BTreeMap::new(),
                     hit_bounds: Default::default(),
                     text_field_bindings: Vec::new(),

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -47,7 +47,7 @@ impl<'gc> LoaderDisplay<'gc> {
             activation.gc(),
             LoaderDisplayData {
                 base: RefLock::new(Default::default()),
-                container: RefLock::new(ChildContainer::new(movie.clone())),
+                container: RefLock::new(ChildContainer::new(&movie)),
                 avm2_object: Lock::new(None),
                 movie,
             },

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -205,7 +205,7 @@ impl<'gc> MovieClipData<'gc> {
             tag_stream_pos: Cell::new(0),
             current_frame: Cell::new(0),
             audio_stream: Cell::new(None),
-            container: ChildContainer::new(movie),
+            container: ChildContainer::new(&movie),
             object: None,
             clip_event_handlers: Vec::new(),
             clip_event_flags: Cell::new(ClipEventFlag::empty()),
@@ -346,11 +346,12 @@ impl<'gc> MovieClip<'gc> {
         );
 
         mc.base.base.reset_for_movie_load();
+        mc.container = ChildContainer::new(&movie);
         mc.shared = Gc::new(
             context.gc(),
             MovieClipShared::with_data(
                 0,
-                movie.clone().into(),
+                movie.into(),
                 total_frames,
                 loader_info.map(|l| l.into()),
             ),
@@ -360,7 +361,6 @@ impl<'gc> MovieClip<'gc> {
         mc.base.base.set_is_root(is_root);
         mc.current_frame.set(0);
         mc.audio_stream.set(None);
-        mc.container = ChildContainer::new(movie);
         drop(mc);
     }
 

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -152,7 +152,7 @@ impl<'gc> Stage<'gc> {
             gc_context,
             StageData {
                 base: Default::default(),
-                child: RefLock::new(ChildContainer::new(movie.clone())),
+                child: RefLock::new(ChildContainer::new(&movie)),
                 background_color: Cell::new(None),
                 letterbox: Cell::new(Letterbox::Fullscreen),
                 // This is updated when we set the root movie
@@ -229,12 +229,9 @@ impl<'gc> Stage<'gc> {
     }
 
     pub fn set_movie(self, gc_context: &Mutation<'gc>, movie: Arc<SwfMovie>) {
-        self.0.movie.replace(movie.clone());
-
         // Stage is the only DO that has a fake movie set and then gets the real movie set.
-        unlock!(Gc::write(gc_context, self.0), StageData, child)
-            .borrow_mut()
-            .set_movie(movie);
+        *self.raw_container_mut(gc_context) = ChildContainer::new(&movie);
+        self.0.movie.replace(movie.clone());
     }
 
     pub fn set_loader_info(self, gc_context: &Mutation<'gc>, loader_info: Avm2Object<'gc>) {


### PR DESCRIPTION
We only need the movie to know whether the container is in AVM1 or AVM2 mode, so just store a boolean instead.