### PR TITLE
ci: Set proper versions for nightly releases

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+from datetime import datetime
+import xml.etree.ElementTree as xml
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+REPO_DIR = os.path.realpath(os.path.join(SCRIPT_DIR, '../../'))
+
+
+# ===== Utilities ==========================================
+
+def get_current_date():
+    now = datetime.now()
+    return now.strftime('%Y-%m-%d')
+
+
+def get_current_time_version():
+    now = datetime.now()
+    return f'{now.year}.{now.month}.{now.day}'
+
+
+def get_current_day_id():
+    now = datetime.now()
+    day = now.strftime('%j')
+    return f'{now.year - 2000}{day}'
+
+
+def github_output(variable, value):
+    line = f'{variable}={value}'
+    print(line)
+    if 'GITHUB_OUTPUT' in os.environ:
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(line + '\n')
+
+
+def log(msg):
+    print(msg, file=sys.stderr)
+
+
+# ===== Commands to execute ================================
+
+def run_command(args, cwd=REPO_DIR):
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout.decode('utf-8')
+
+
+def cargo_get_version():
+    return run_command(['cargo', 'get', 'workspace.package.version']).strip()
+
+
+def cargo_set_version(args):
+    run_command(['cargo', 'set-version', '--exclude', 'swf', *args])
+
+
+# ===== Commands ===========================================
+
+def bump():
+    """
+    Bump the current version of Ruffle nightly.
+    """
+
+    current_version = cargo_get_version()
+    log(f'Current version: {current_version}')
+
+    log('Bumping minor version to get the next planned version')
+    cargo_set_version(['--bump', 'minor'])
+    next_planned_version = cargo_get_version()
+    run_command(['git', 'reset', '--hard', 'HEAD'])
+
+    log(f'Next planned version is {next_planned_version}')
+
+    nightly_version = f'{next_planned_version}-nightly.{get_current_time_version()}'
+    log(f'Nightly version is {nightly_version}')
+
+    cargo_set_version([nightly_version])
+
+    version = cargo_get_version()
+    version4 = f'{next_planned_version}.{get_current_day_id()}'
+
+    npm_dir = f'{REPO_DIR}/web'
+    run_command(['npm', 'install', 'workspace-version'], cwd=npm_dir)
+    run_command(['npm', 'version', '--no-git-tag-version', version], cwd=npm_dir)
+    run_command(['./node_modules/workspace-version/dist/index.js'], cwd=npm_dir)
+
+    github_output('current-version', current_version)
+    github_output('version', version)
+    github_output('version4', version4)
+
+
+def release():
+    """
+    Create a release of Ruffle on GitHub.
+    """
+
+    now = datetime.now()
+    current_time_dashes = now.strftime('%Y-%m-%d')
+    current_time_underscores = now.strftime('%Y_%m_%d')
+
+    tag_name = f'nightly-{current_time_dashes}'
+    release_name = f'Nightly {current_time_dashes}'
+    package_prefix = f'ruffle-nightly-{current_time_underscores}'
+    release_options = ['--generate-notes', '--prerelease']
+
+    release_commit = run_command(['git', 'rev-parse', 'HEAD']).strip()
+    run_command([
+        'gh', 'release', 'create', tag_name,
+        '--title', release_name,
+        '--target', release_commit,
+        *release_options])
+
+    github_output('tag_name', tag_name)
+    github_output('package_prefix', package_prefix)
+
+
+def main():
+    cmd = sys.argv[1]
+    log(f'Running command {cmd}')
+    if cmd == 'bump':
+        bump()
+    elif cmd == 'release':
+        release()
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -8,6 +8,9 @@ on:
   # Allow for manual dispatch on GitHub
   workflow_dispatch:
 
+env:
+  RELEASE_SCRIPT: ./.github/scripts/release.py
+
 jobs:
   create-nightly-release:
     name: Create Nightly Release
@@ -16,8 +19,9 @@ jobs:
       is_active: ${{ steps.activity.outputs.is_active }}
       date: ${{ steps.current_time_underscores.outputs.formattedTime }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
-      package_prefix: ruffle-nightly-${{ steps.current_time_underscores.outputs.formattedTime }}
-      tag_name: nightly-${{ steps.current_time_dashes.outputs.formattedTime }}
+      package_prefix: ${{ steps.create_release.outputs.package_prefix }}
+      tag_name: ${{ steps.create_release.outputs.tag_name }}
+      version4: ${{ steps.version.outputs.version4 }}
 
     # Only run the scheduled workflows on the main repo.
     if: github.repository == 'ruffle-rs/ruffle' || github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
@@ -38,11 +42,47 @@ jobs:
           fi
           echo "is_active=$is_active" >> $GITHUB_OUTPUT
 
-      - name: Get current time with dashes
-        uses: josStorer/get-current-time@v2.1.2
-        id: current_time_dashes
+      - name: Install cargo-edit
+        uses: baptiste0928/cargo-install@v3
         with:
-          format: YYYY-MM-DD
+          crate: cargo-edit
+          version: '^0.12'
+
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+          version: '^1.0'
+
+      - name: Bump version
+        if: steps.activity.outputs.is_active == 'true'
+        id: version
+        run: |
+          $RELEASE_SCRIPT bump
+          # Ensure newlines at the end of file
+          shopt -s globstar
+          sed -i -e '$a\' **/package.json
+
+      - name: Create release commit
+        if: steps.activity.outputs.is_active == 'true'
+        id: commit
+        run: |
+          # Print diff for debugging
+          git diff
+
+          # For nightly we do not want to commit those changes,
+          # save them and then apply when building
+          git diff > /tmp/nightly-release.patch
+
+          revision=$(git rev-parse HEAD)
+          echo "revision=$revision" | tee -a $GITHUB_OUTPUT
+
+      - name: Upload nightly release patch
+        uses: actions/upload-artifact@v4
+        if: steps.activity.outputs.is_active == 'true'
+        with:
+          name: nightly-release-patch
+          path: /tmp/nightly-release.patch
 
       - name: Get current time with underscores
         uses: josStorer/get-current-time@v2.1.2
@@ -53,12 +93,10 @@ jobs:
       - name: Create release
         if: steps.activity.outputs.is_active == 'true'
         id: create_release
-        run: |
-          tag_name="nightly-${{ steps.current_time_dashes.outputs.formattedTime }}"
-          release_name="Nightly ${{ steps.current_time_dashes.outputs.formattedTime }}"
-          gh release create "$tag_name" --title "$release_name" --generate-notes --prerelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $RELEASE_SCRIPT release
 
   build:
     name: Build ${{ matrix.build_name }}
@@ -110,6 +148,15 @@ jobs:
       - name: Clone Ruffle repo
         uses: actions/checkout@v4
 
+      - name: Download nightly release patch
+        uses: actions/download-artifact@v4
+        with:
+          name: nightly-release-patch
+          path: /tmp
+
+      - name: Apply nightly release patch
+        run: git apply --verbose /tmp/nightly-release.patch
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -123,11 +170,11 @@ jobs:
           sudo apt install -y libasound2-dev libudev-dev
 
       - name: Install WiX
+        if: runner.os == 'Windows'
         run: |
           dotnet tool install --global wix --version 5.0.2
           wix extension add -g WixToolset.UI.wixext/5.0.2
           wix extension add -g WixToolset.Util.wixext/5.0.2
-        if: runner.os == 'Windows'
 
       - name: Cargo build
         run: cargo build --locked --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
@@ -147,7 +194,7 @@ jobs:
           cd desktop/packages/windows/wix
           wix build ruffle.wxs -ext WixToolset.UI.wixext -ext WixToolset.Util.wixext -arch ${{ matrix.MSI_ARCH }} -o ../../../../package/setup.msi -pdbtype none
         env:
-          RUFFLE_VERSION: "0.1.0"
+          RUFFLE_VERSION: ${{ needs.create-nightly-release.outputs.version4 }}
           CARGO_BUILD_DIR: ../../../../target/${{ matrix.target }}/release
         if: runner.os == 'Windows'
 
@@ -336,6 +383,15 @@ jobs:
       - name: Clone Ruffle repo
         uses: actions/checkout@v4
 
+      - name: Download nightly release patch
+        uses: actions/download-artifact@master
+        with:
+          name: nightly-release-patch
+          path: /tmp
+
+      - name: Apply nightly release patch
+        run: git apply --verbose /tmp/nightly-release.patch
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -374,7 +430,7 @@ jobs:
         working-directory: web
         env:
           CFG_RELEASE_CHANNEL: nightly
-          BUILD_ID: ${{ github.run_number }}
+          VERSION4: ${{ needs.create-nightly-release.outputs.version4 }}
           ENABLE_VERSION_SEAL: "true"
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
         run: npm run version-seal
@@ -382,7 +438,7 @@ jobs:
       - name: Build web
         env:
           CFG_RELEASE_CHANNEL: nightly
-          BUILD_ID: ${{ github.run_number }}
+          VERSION4: ${{ needs.create-nightly-release.outputs.version4 }}
           CARGO_FEATURES: jpegxr
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
           WASM_SOURCE: cargo_and_store
@@ -488,6 +544,15 @@ jobs:
       - name: Clone Ruffle repo
         uses: actions/checkout@v4
 
+      - name: Download nightly release patch
+        uses: actions/download-artifact@master
+        with:
+          name: nightly-release-patch
+          path: /tmp
+
+      - name: Apply nightly release patch
+        run: git apply --verbose /tmp/nightly-release.patch
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -526,7 +591,7 @@ jobs:
         working-directory: web
         env:
           CFG_RELEASE_CHANNEL: nightly
-          BUILD_ID: ${{ github.run_number }}
+          VERSION4: ${{ needs.create-nightly-release.outputs.version4 }}
           ENABLE_VERSION_SEAL: "true"
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
         run: npm run version-seal
@@ -534,7 +599,7 @@ jobs:
       - name: Build web
         env:
           CFG_RELEASE_CHANNEL: nightly
-          BUILD_ID: ${{ github.run_number }}
+          VERSION4: ${{ needs.create-nightly-release.outputs.version4 }}
           # NOTE: In the future, we might want to enable some features (like `webgpu`) only in
           # the demo build, for limited testing (like a Chrome origin trial) on ruffle.rs.
           CARGO_FEATURES: jpegxr

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -45,7 +45,8 @@
                 "typescript-eslint": "^8.34.1",
                 "webdriverio": "^9.2.2",
                 "webpack": "^5.99.9",
-                "webpack-cli": "^6.0.1"
+                "webpack-cli": "^6.0.1",
+                "workspace-version": "^0.1.4"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -4289,6 +4290,16 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/array-back": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+            "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -5046,6 +5057,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/cli-width": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -5222,6 +5246,136 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/command-line-args": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+            "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-back": "^3.1.0",
+                "find-replace": "^3.0.0",
+                "lodash.camelcase": "^4.3.0",
+                "typical": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/command-line-usage": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+            "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-back": "^4.0.2",
+                "chalk": "^2.4.2",
+                "table-layout": "^1.0.2",
+                "typical": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/array-back": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+            "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/command-line-usage/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/typical": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+            "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/commander": {
@@ -5854,6 +6008,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/deep-is": {
@@ -7411,6 +7575,19 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/find-replace": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+            "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-back": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -9504,6 +9681,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -9905,6 +10089,17 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/message-await": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/message-await/-/message-await-0.3.1.tgz",
+            "integrity": "sha512-sg5eCHSQyfXy8Ida3As3VIssnY+yW/QqUblfQaTvmCYBM0QJX/vV9ILID9RMAPtiiC6WLO0tb6JEVvOIVy4fkw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cli-cursor": "^3.1.0",
+                "log-symbols": "^4.1.0"
+            }
+        },
         "node_modules/methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -9963,6 +10158,16 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimalistic-assert": {
@@ -10392,6 +10597,22 @@
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/open": {
@@ -12085,6 +12306,16 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/reduce-flatten": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+            "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/replace-in-file": {
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-8.3.0.tgz",
@@ -12209,6 +12440,27 @@
             "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/restore-cursor/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/retry": {
             "version": "0.13.1",
@@ -13253,6 +13505,13 @@
                 "safe-buffer": "~5.2.0"
             }
         },
+        "node_modules/string-format": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+            "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
+            "dev": true,
+            "license": "WTFPL OR MIT"
+        },
         "node_modules/string-width": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -13773,6 +14032,42 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/table-layout": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+            "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-back": "^4.0.1",
+                "deep-extend": "~0.6.0",
+                "typical": "^5.2.0",
+                "wordwrapjs": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/table-layout/node_modules/array-back": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+            "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/table-layout/node_modules/typical": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+            "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/table/node_modules/ajv": {
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -14103,6 +14398,68 @@
                 "typescript": ">=4.8.4"
             }
         },
+        "node_modules/ts-command-line-args": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-1.8.1.tgz",
+            "integrity": "sha512-GVinwgIvf1I/8frGhbSfXA2+P4zZkcY6IL9auGk3ZCasYZYUDPdB4K+wGvP/GEB/2a5AbCPhjpoNSUTFiPDkzg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "command-line-args": "^5.1.1",
+                "command-line-usage": "^6.1.0",
+                "string-format": "^2.0.0"
+            },
+            "bin": {
+                "write-markdown": "dist/write-markdown.js"
+            }
+        },
+        "node_modules/ts-command-line-args/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ts-command-line-args/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ts-command-line-args/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ts-loader": {
             "version": "9.5.2",
             "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.2.tgz",
@@ -14412,6 +14769,16 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typical": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+            "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/uc.micro": {
@@ -15313,12 +15680,98 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/wordwrapjs": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+            "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "reduce-flatten": "^2.0.0",
+                "typical": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/wordwrapjs/node_modules/typical": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+            "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/workerpool": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
             "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
             "dev": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/workspace-version": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/workspace-version/-/workspace-version-0.1.4.tgz",
+            "integrity": "sha512-C9f752k8yUO1NzfBvNb0lX7EZaRnlcEe6dHaz7OUj8Cx2k1SpOQAS4dEVJixtAzXEFzFZ/OdpuSHA1hHTDqVLg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "chalk": "^4.1.2",
+                "message-await": "^0.3.1",
+                "rxjs": "^7.5.5",
+                "ts-command-line-args": "^1.5.0"
+            },
+            "bin": {
+                "workspace-version": "dist/index.js"
+            }
+        },
+        "node_modules/workspace-version/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/workspace-version/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/workspace-version/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/wrap-ansi": {
             "version": "6.2.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,10 @@
             "version": "0.1.0",
             "license": "(MIT OR Apache-2.0)",
             "workspaces": [
-                "./packages/*"
+                "./packages/core",
+                "./packages/demo",
+                "./packages/extension",
+                "./packages/selfhosted"
             ],
             "devDependencies": {
                 "@eslint/js": "^9.29.0",

--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,8 @@
         "typescript-eslint": "^8.34.1",
         "webdriverio": "^9.2.2",
         "webpack": "^5.99.9",
-        "webpack-cli": "^6.0.1"
+        "webpack-cli": "^6.0.1",
+        "workspace-version": "^0.1.4"
     },
     "scripts": {
         "build": "npm run build --workspace=ruffle-core && npm run build --workspace=ruffle-demo --workspace=ruffle-extension --workspace=ruffle-selfhosted",

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,10 @@
     "private": true,
     "type": "module",
     "workspaces": [
-        "./packages/*"
+        "./packages/core",
+        "./packages/demo",
+        "./packages/extension",
+        "./packages/selfhosted"
     ],
     "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/web/packages/core/tools/set_version.ts
+++ b/web/packages/core/tools/set_version.ts
@@ -18,12 +18,8 @@ try {
 }
 
 let versionName;
-if (versionChannel === "stable") {
+if (versionChannel === "stable" || versionNumber?.includes(versionChannel)) {
     versionName = versionNumber;
-} else if (versionChannel === "nightly") {
-    // TODO Try to include the build date in
-    //      the version and drop this branch.
-    versionName = `${versionNumber} nightly ${buildDate.substring(0, 10)}`;
 } else {
     versionName = `${versionChannel} ${versionNumber}`;
 }
@@ -34,7 +30,7 @@ interface VersionInformation {
     version_channel: string;
     build_date: string;
     commitHash: string;
-    build_id: string;
+    version4: string;
     firefox_extension_id: string;
 }
 
@@ -62,7 +58,7 @@ if (process.env["ENABLE_VERSION_SEAL"] === "true") {
             version_channel: versionChannel,
             build_date: buildDate,
             commitHash: commitHash,
-            build_id: process.env["BUILD_ID"] ?? "",
+            version4: process.env["VERSION4"] ?? "",
             firefox_extension_id: firefoxExtensionId,
         };
 

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -13,8 +13,7 @@ function transformManifest(content, env) {
 
     let packageVersion = process.env["npm_package_version"];
     let versionChannel = process.env["CFG_RELEASE_CHANNEL"] || "local";
-    let buildDate = new Date().toISOString().substring(0, 10);
-    let buildId = process.env["BUILD_ID"];
+    let version4 = process.env["VERSION4"];
     let firefoxExtensionId =
         process.env["FIREFOX_EXTENSION_ID"] || "ruffle@ruffle.rs";
 
@@ -26,8 +25,7 @@ function transformManifest(content, env) {
 
             packageVersion = versionSeal.version_number;
             versionChannel = versionSeal.version_channel;
-            buildDate = versionSeal.build_date.substring(0, 10);
-            buildId = versionSeal.build_id;
+            version4 = versionSeal.version4;
             firefoxExtensionId = versionSeal.firefox_extension_id;
         } else {
             throw new Error(
@@ -41,11 +39,9 @@ function transformManifest(content, env) {
     // when it gets generated in web/packages/core/tools/set_version.js and then
     // load it in the code above.
 
-    // The extension marketplaces require the version to monotonically increase,
-    // so append the build number onto the end of the manifest version.
-    manifest.version = buildId
-        ? `${packageVersion}.${buildId}`
-        : packageVersion;
+    // The extension marketplaces require the version to monotonically increase
+    // and to be in the format of A.B.C.D.
+    manifest.version = version4 ? version4 : packageVersion;
 
     if (env["firefox"]) {
         manifest.browser_specific_settings = {
@@ -57,12 +53,11 @@ function transformManifest(content, env) {
             scripts: ["dist/background.js"],
         };
     } else {
-        if (versionChannel === "stable") {
+        if (
+            versionChannel === "stable" ||
+            packageVersion?.includes(versionChannel)
+        ) {
             manifest.version_name = packageVersion;
-        } else if (versionChannel === "nightly") {
-            // TODO Try to include the build date in
-            //      the version and drop this branch.
-            manifest.version_name = `${packageVersion} nightly ${buildDate}`;
         } else {
             manifest.version_name = `${versionChannel} ${packageVersion}`;
         }

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -6,21 +6,8 @@ import TerserPlugin from "terser-webpack-plugin";
 function transformPackage(content) {
     const pkg = json5.parse(content);
 
-    const packageVersion = process.env.npm_package_version;
-
-    const versionChannel = process.env.CFG_RELEASE_CHANNEL || "local";
-
-    const buildDate = new Date()
-        .toISOString()
-        .substring(0, 10)
-        .replace(/-/g, ".");
-
-    // The npm registry requires the version to monotonically increase,
-    // so append the build date onto the end of the package version.
-    pkg.version =
-        versionChannel !== "stable"
-            ? `${packageVersion}-${versionChannel}.${buildDate}`
-            : packageVersion;
+    // Note: The npm registry requires the version to monotonically increase.
+    pkg.version = process.env.npm_package_version;
 
     return JSON.stringify(pkg);
 }


### PR DESCRIPTION
This is the first step towards stable releases, versions are automatically updated before building the nightly release.

This patch introduces the release script written in Python, which is used for bumping the version and creating the release on GitHub.

4-part versions are now suffixed with yyddd instead of the build ID (yy is the current year, ddd is the day).

There's a test release based on this PR: https://github.com/kjarosh/ruffle/releases/tag/nightly-2025-06-19