### PR TITLE
tests: Fix assertion comparison message order

### DIFF
--- a/tests/framework/src/runner/trace.rs
+++ b/tests/framework/src/runner/trace.rs
@@ -112,13 +112,13 @@ impl std::fmt::Debug for PrettyString<'_> {
 }
 
 fn assert_text_matches(ruffle: &str, flash: &str) -> anyhow::Result<()> {
-    if flash != ruffle {
+    if ruffle != flash {
         let left_pretty = PrettyString(ruffle);
         let right_pretty = PrettyString(flash);
         let comparison = Comparison::new(&left_pretty, &right_pretty);
 
         Err(anyhow!(
-            "assertion failed: `(flash_expected == ruffle_actual)`\
+            "assertion failed: `(ruffle_actual == flash_expected)`\
                        \n\
                        \n{}\
                        \n",


### PR DESCRIPTION
The left value is from Ruffle, and the right value is from Flash Player.
The error message should follow the same order? Isn't it confusing?

```
fn assert_text_matches(ruffle: &str, flash: &str) -> Result<()> {
```

```
        let left_pretty = PrettyString(ruffle);
        let right_pretty = PrettyString(flash);
```