### PR TITLE
core,avm1,avm2: Remove more uses of GcCell

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -531,7 +531,7 @@ fn draw<'gc>(
             let color_transform = args
                 .get(2)
                 .and_then(|v| ColorTransformObject::cast(*v))
-                .map(|color_transform| color_transform.read().clone().into())
+                .map(|color_transform| (*color_transform).clone().into())
                 .unwrap_or_default();
 
             let mut blend_mode = BlendMode::Normal;
@@ -720,7 +720,7 @@ fn color_transform<'gc>(
                 let y_max = (y + height) as u32;
 
                 let color_transform = match ColorTransformObject::cast(*color_transform) {
-                    Some(color_transform) => color_transform.read().clone(),
+                    Some(color_transform) => (*color_transform).clone(),
                     None => return Ok((-3).into()),
                 };
 

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -126,10 +126,7 @@ fn method<'gc>(
             if let [value] = args {
                 // Set only occurs for an object with actual ColorTransform data.
                 if let Some(color_transform) = ColorTransformObject::cast(*value) {
-                    clip.set_color_transform(
-                        activation.gc(),
-                        color_transform.read().clone().into(),
-                    );
+                    clip.set_color_transform(activation.gc(), (*color_transform).clone().into());
                     clip.invalidate_cached_bitmap(activation.gc());
                     clip.set_transformed_by_script(true);
                 }

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -87,7 +87,7 @@ impl<'gc> Xml<'gc> {
     fn empty(context: &StringContext<'gc>, object: Object<'gc>) -> Self {
         let gc_context = context.gc();
 
-        let mut root = XmlNode::new(gc_context, ELEMENT_NODE, None);
+        let root = XmlNode::new(gc_context, ELEMENT_NODE, None);
         root.introduce_script_object(gc_context, object);
 
         let xml = Self(Gc::new(
@@ -176,7 +176,7 @@ impl<'gc> Xml<'gc> {
                     let child =
                         XmlNode::from_start_event(activation, bs, self.id_map(), parser.decoder())?;
                     open_tags
-                        .last_mut()
+                        .last()
                         .unwrap()
                         .append_child(activation.gc(), child);
                     open_tags.push(child);
@@ -185,7 +185,7 @@ impl<'gc> Xml<'gc> {
                     let child =
                         XmlNode::from_start_event(activation, bs, self.id_map(), parser.decoder())?;
                     open_tags
-                        .last_mut()
+                        .last()
                         .unwrap()
                         .append_child(activation.gc(), child);
                 }
@@ -196,18 +196,13 @@ impl<'gc> Xml<'gc> {
                     Self::handle_text_cdata(
                         custom_unescape(&bt.into_inner(), parser.decoder())?.as_bytes(),
                         ignore_white,
-                        &mut open_tags,
+                        &open_tags,
                         activation,
                     );
                 }
                 Event::CData(bt) => {
                     // This is already unescaped
-                    Self::handle_text_cdata(
-                        &bt.into_inner(),
-                        ignore_white,
-                        &mut open_tags,
-                        activation,
-                    );
+                    Self::handle_text_cdata(&bt.into_inner(), ignore_white, &open_tags, activation);
                 }
                 Event::Decl(bd) => {
                     let mut xml_decl = WString::from_buf(b"<?".to_vec());
@@ -240,7 +235,7 @@ impl<'gc> Xml<'gc> {
     fn handle_text_cdata(
         text: &[u8],
         ignore_white: bool,
-        open_tags: &mut [XmlNode<'gc>],
+        open_tags: &[XmlNode<'gc>],
         activation: &mut Activation<'_, 'gc>,
     ) {
         let is_whitespace_char = |c: &u8| matches!(*c, b'\t' | b'\n' | b'\r' | b' ');
@@ -249,7 +244,7 @@ impl<'gc> Xml<'gc> {
             let text = AvmString::new_utf8_bytes(activation.gc(), text);
             let child = XmlNode::new(activation.gc(), TEXT_NODE, Some(text));
             open_tags
-                .last_mut()
+                .last()
                 .unwrap()
                 .append_child(activation.gc(), child);
         }
@@ -303,7 +298,7 @@ fn create_element<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let (NativeObject::Xml(_), [name, ..]) = (this.native(), args) {
         let name = name.coerce_to_string(activation)?;
-        let mut node = XmlNode::new(activation.gc(), ELEMENT_NODE, Some(name));
+        let node = XmlNode::new(activation.gc(), ELEMENT_NODE, Some(name));
         return Ok(node.script_object(activation).into());
     }
 
@@ -317,7 +312,7 @@ fn create_text_node<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let (NativeObject::Xml(_), [text, ..]) = (this.native(), args) {
         let text = text.coerce_to_string(activation)?;
-        let mut node = XmlNode::new(activation.gc(), TEXT_NODE, Some(text));
+        let node = XmlNode::new(activation.gc(), TEXT_NODE, Some(text));
         return Ok(node.script_object(activation).into());
     }
 
@@ -348,7 +343,7 @@ fn parse_xml<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::Xml(xml) = this.native() {
-        for mut child in xml.root().children().rev() {
+        for child in xml.root().children().rev() {
             child.remove_node(activation.gc());
         }
 

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -40,7 +40,7 @@ pub fn constructor<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mc = activation.gc();
-    let mut node = if let [node_type, value, ..] = args {
+    let node = if let [node_type, value, ..] = args {
         let node_type = node_type.coerce_to_u8(activation)?;
         let node_value = value.coerce_to_string(activation)?;
         XmlNode::new(mc, node_type, Some(node_value))
@@ -58,7 +58,7 @@ fn append_child<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let (Some(mut xmlnode), Some(child_xmlnode)) = (
+    if let (Some(xmlnode), Some(child_xmlnode)) = (
         this.as_xml_node(),
         args.get(0)
             .and_then(|n| n.coerce_to_object(activation).as_xml_node()),
@@ -78,7 +78,7 @@ fn insert_before<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let (Some(mut xmlnode), Some(child_xmlnode), Some(insertpoint_xmlnode)) = (
+    if let (Some(xmlnode), Some(child_xmlnode), Some(insertpoint_xmlnode)) = (
         this.as_xml_node(),
         args.get(0)
             .and_then(|n| n.coerce_to_object(activation).as_xml_node()),
@@ -107,7 +107,7 @@ fn clone_node<'gc>(
             .map(|v| v.as_bool(activation.swf_version()))
             .unwrap_or(false),
     ) {
-        let mut clone_node = xmlnode.duplicate(activation.gc(), deep);
+        let clone_node = xmlnode.duplicate(activation.gc(), deep);
         return Ok(clone_node.script_object(activation).into());
     }
 
@@ -176,7 +176,7 @@ fn remove_node<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut node) = this.as_xml_node() {
+    if let Some(node) = this.as_xml_node() {
         let old_parent = node.parent();
         node.remove_node(activation.gc());
         if let Some(old_parent) = old_parent {
@@ -295,7 +295,7 @@ fn first_child<'gc>(
         return Ok(node
             .children()
             .next()
-            .map(|mut child| child.script_object(activation).into())
+            .map(|child| child.script_object(activation).into())
             .unwrap_or_else(|| Value::Null));
     }
 
@@ -311,7 +311,7 @@ fn last_child<'gc>(
         return Ok(node
             .children()
             .next_back()
-            .map(|mut child| child.script_object(activation).into())
+            .map(|child| child.script_object(activation).into())
             .unwrap_or_else(|| Value::Null));
     }
 
@@ -326,7 +326,7 @@ fn parent_node<'gc>(
     if let Some(node) = this.as_xml_node() {
         return Ok(node
             .parent()
-            .map(|mut parent| parent.script_object(activation).into())
+            .map(|parent| parent.script_object(activation).into())
             .unwrap_or_else(|| Value::Null));
     }
 
@@ -341,7 +341,7 @@ fn previous_sibling<'gc>(
     if let Some(node) = this.as_xml_node() {
         return Ok(node
             .prev_sibling()
-            .map(|mut prev| prev.script_object(activation).into())
+            .map(|prev| prev.script_object(activation).into())
             .unwrap_or_else(|| Value::Null));
     }
 
@@ -356,7 +356,7 @@ fn next_sibling<'gc>(
     if let Some(node) = this.as_xml_node() {
         return Ok(node
             .next_sibling()
-            .map(|mut next| next.script_object(activation).into())
+            .map(|next| next.script_object(activation).into())
             .unwrap_or_else(|| Value::Null));
     }
 

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -30,7 +30,7 @@ use crate::html::TextFormat;
 use crate::streams::NetStream;
 use crate::string::AvmString;
 use crate::xml::XmlNode;
-use gc_arena::{Collect, Gc, GcCell, Mutation};
+use gc_arena::{Collect, Gc, Mutation};
 use ruffle_macros::istr;
 use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
@@ -81,7 +81,7 @@ pub enum NativeObject<'gc> {
     ConvolutionFilter(ConvolutionFilter<'gc>),
     GradientBevelFilter(GradientFilter<'gc>),
     GradientGlowFilter(GradientFilter<'gc>),
-    ColorTransform(GcCell<'gc, ColorTransformObject>),
+    ColorTransform(Gc<'gc, ColorTransformObject>),
     Transform(TransformObject<'gc>),
     TextFormat(Gc<'gc, RefCell<TextFormat>>),
     NetStream(NetStream<'gc>),

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -88,7 +88,7 @@ pub enum NativeObject<'gc> {
     BitmapData(BitmapDataWrapper<'gc>),
     Xml(Xml<'gc>),
     XmlNode(XmlNode<'gc>),
-    SharedObject(GcCell<'gc, SharedObject>),
+    SharedObject(Gc<'gc, RefCell<SharedObject>>),
     XmlSocket(XmlSocket<'gc>),
     FileReference(FileReferenceObject<'gc>),
     NetConnection(NetConnection<'gc>),

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -32,7 +32,7 @@ pub struct E4XNode<'gc>(GcCell<'gc, E4XNodeData<'gc>>);
 #[collect(no_drop)]
 pub struct E4XNodeData<'gc> {
     parent: Option<E4XNode<'gc>>,
-    namespace: Option<Box<E4XNamespace<'gc>>>,
+    namespace: Option<E4XNamespace<'gc>>,
     local_name: Option<AvmString<'gc>>,
     kind: E4XNodeKind<'gc>,
     notification: Option<FunctionObject<'gc>>,
@@ -197,7 +197,7 @@ impl<'gc> E4XNode<'gc> {
             mc,
             E4XNodeData {
                 parent,
-                namespace: namespace.map(Box::new),
+                namespace,
                 local_name: Some(name),
                 kind: E4XNodeKind::Element {
                     attributes: vec![],
@@ -220,7 +220,7 @@ impl<'gc> E4XNode<'gc> {
             mc,
             E4XNodeData {
                 parent,
-                namespace: namespace.map(Box::new),
+                namespace,
                 local_name: Some(name),
                 kind: E4XNodeKind::Attribute(value),
                 notification: None,
@@ -338,7 +338,7 @@ impl<'gc> E4XNode<'gc> {
             mc,
             E4XNodeData {
                 parent: None,
-                namespace: this.namespace.clone(),
+                namespace: this.namespace,
                 local_name: this.local_name,
                 kind,
                 notification: None,
@@ -1080,7 +1080,7 @@ impl<'gc> E4XNode<'gc> {
 
             let attribute_data = E4XNodeData {
                 parent: None,
-                namespace: namespace.map(Box::new),
+                namespace,
                 local_name: Some(name),
                 kind: E4XNodeKind::Attribute(value),
                 notification: None,
@@ -1111,7 +1111,7 @@ impl<'gc> E4XNode<'gc> {
 
         let data = E4XNodeData {
             parent: None,
-            namespace: namespace.map(Box::new),
+            namespace,
             local_name: Some(name),
             kind: E4XNodeKind::Element {
                 attributes: attribute_nodes,
@@ -1134,11 +1134,11 @@ impl<'gc> E4XNode<'gc> {
     }
 
     pub fn set_namespace(&self, namespace: Option<E4XNamespace<'gc>>, mc: &Mutation<'gc>) {
-        self.0.write(mc).namespace = namespace.map(Box::new);
+        self.0.write(mc).namespace = namespace;
     }
 
     pub fn namespace(&self) -> Option<E4XNamespace<'gc>> {
-        self.0.read().namespace.as_deref().copied()
+        self.0.read().namespace
     }
 
     pub fn set_local_name(&self, name: AvmString<'gc>, mc: &Mutation<'gc>) {


### PR DESCRIPTION
After this, we have six uses of GcCell left:
- AVM2 `VTable`, `Class`, `Domain`, and `TranslationUnit`;
- `BitmapDataWrapper`
- `MovieClip`