### PR TITLE
AVM1: Fix MovieClipReference laundering issue

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -16,7 +16,7 @@ mod flv;
 mod fscommand;
 pub(crate) mod globals;
 mod object;
-mod object_reference;
+pub(crate) mod object_reference;
 mod property;
 mod property_map;
 mod runtime;

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -545,14 +545,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn stack_push(&mut self, mut value: Value<'gc>) {
         if let Value::Object(obj) = value {
-            // Note that there currently exists a subtle issue with this logic:
-            // If the cached `Object` in a `MovieClipReference` becomes invalidated, causing it to switch back to path-based object resolution,
-            // it should *never* switch back to cache-based resolution
-            // However, currently if a `MovieClipReference` in this invalidated-cache state is converted back to an `Object`, such as when passed as an argument to a function,
-            // if it pushed back onto the stack then it will be converted into a new `MovieClipReference`, causing it to switch back to cache-based resolution
-            // Fixing this will require a thorough refactor of AVM1 to store `Either<MovieClipReference, Object>
-            // can refer to a MovieClip
-            // There is a ignored test for this issue of "reference laundering" at "avm1/string_paths_reference_launder"
             if let Some(mcr) = MovieClipReference::try_from_stage_object(self, obj) {
                 value = Value::MovieClip(mcr);
             }

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -739,12 +739,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let num_args = num_args.min(self.context.avm1.stack_len());
         let mut args = Vec::with_capacity(num_args);
         for _ in 0..num_args {
-            let arg = self.context.avm1.pop();
-            if let Value::MovieClip(_) = arg {
-                args.push(Value::Object(arg.coerce_to_object(self)));
-            } else {
-                args.push(arg);
-            }
+            args.push(self.context.avm1.pop());
         }
 
         let variable = self.get_variable(fn_name)?;
@@ -769,12 +764,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let num_args = num_args.min(self.context.avm1.stack_len());
         let mut args = Vec::with_capacity(num_args);
         for _ in 0..num_args {
-            let arg = self.context.avm1.pop();
-            if let Value::MovieClip(_) = arg {
-                args.push(Value::Object(arg.coerce_to_object(self)));
-            } else {
-                args.push(arg);
-            }
+            args.push(self.context.avm1.pop());
         }
 
         // Can not call method on undefined/null.
@@ -1667,12 +1657,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let num_args = num_args.min(self.context.avm1.stack_len());
         let mut args = Vec::with_capacity(num_args);
         for _ in 0..num_args {
-            let arg = self.context.avm1.pop();
-            if let Value::MovieClip(_) = arg {
-                args.push(Value::Object(arg.coerce_to_object(self)));
-            } else {
-                args.push(arg);
-            }
+            args.push(self.context.avm1.pop());
         }
 
         // Can not call method on undefined/null.
@@ -1719,12 +1704,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let num_args = num_args.min(self.context.avm1.stack_len());
         let mut args = Vec::with_capacity(num_args);
         for _ in 0..num_args {
-            let arg = self.context.avm1.pop();
-            if let Value::MovieClip(_) = arg {
-                args.push(Value::Object(arg.coerce_to_object(self)));
-            } else {
-                args.push(arg);
-            }
+            args.push(self.context.avm1.pop());
         }
 
         let name_value: Value<'gc> = self.resolve(fn_name)?.into();

--- a/core/src/avm1/object_reference.rs
+++ b/core/src/avm1/object_reference.rs
@@ -1,4 +1,4 @@
-use super::{object::ObjectWeak, Activation, Object, Value};
+use super::{object::ObjectWeak, Activation, NativeObject, Object, Value};
 use crate::{
     display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer},
     string::{AvmString, WStr, WString},
@@ -71,6 +71,14 @@ impl<'gc> MovieClipReference<'gc> {
         activation: &mut Activation<'_, 'gc>,
         object: Object<'gc>,
     ) -> Option<Self> {
+        // If we are creating a reference to a clip which itself was formed by resolving a reference
+        // then return that original reference
+        if let NativeObject::MovieClip(mc) = object.native() {
+            if let Some(mcr) = mc.original_reference() {
+                return Some(mcr);
+            }
+        }
+
         // We can't use as_display_object here as we explicitly don't want to convert `SuperObjects`
         let display_object = object.as_display_object_no_super()?;
         let (path, cached) = if let DisplayObject::MovieClip(mc) = display_object {
@@ -169,11 +177,14 @@ impl<'gc> MovieClipReference<'gc> {
         if let Some(start) = start {
             let display_object = Self::process_swf5_references(activation, start)?;
 
-            Some((
-                false,
-                display_object.object().coerce_to_object(activation),
-                display_object,
-            ))
+            let obj = display_object.object().coerce_to_object(activation);
+
+            // Track the original reference used to produce this clip, so we can get it back later
+            if let NativeObject::MovieClip(mc) = obj.native() {
+                mc.get_original_reference(activation.context, self);
+            }
+
+            Some((false, obj, display_object))
         } else {
             None
         }

--- a/core/src/avm1/object_reference.rs
+++ b/core/src/avm1/object_reference.rs
@@ -181,7 +181,7 @@ impl<'gc> MovieClipReference<'gc> {
 
             // Track the original reference used to produce this clip, so we can get it back later
             if let NativeObject::MovieClip(mc) = obj.native() {
-                mc.get_original_reference(activation.context, self);
+                mc.set_original_reference(activation.context, self);
             }
 
             Some((false, obj, display_object))

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2243,7 +2243,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     /// Mark this `MovieClip` as being originated from resolving the given `MovieClipReference`
-    pub fn get_original_reference(
+    pub fn set_original_reference(
         &self,
         context: &mut UpdateContext<'gc>,
         mcr: MovieClipReference<'gc>,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1,4 +1,7 @@
 //! `MovieClip` display object and support code.
+use super::interactive::Avm2MousePick;
+use super::BitmapClass;
+use crate::avm1::object_reference::MovieClipReference;
 use crate::avm1::Avm1;
 use crate::avm1::{Activation as Avm1Activation, ActivationIdentifier};
 use crate::avm1::{NativeObject as Avm1NativeObject, Object as Avm1Object, Value as Avm1Value};
@@ -52,9 +55,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use swf::extensions::ReadSwfExt;
 use swf::{ClipEventFlag, DefineBitsLossless, FrameLabelData, TagCode, UTF_8};
-
-use super::interactive::Avm2MousePick;
-use super::BitmapClass;
 
 type FrameNumber = u16;
 
@@ -180,6 +180,13 @@ pub struct MovieClipData<'gc> {
     /// `None` in an AVM2 movie.
     next_avm1_clip: Lock<Option<MovieClip<'gc>>>,
 
+    /// When a MovieClip is passed around in AVM1, it is usually passed as a `MovieClipReference`
+    /// however we need to resolve this reference into a concrete `Object` in various places.
+    /// Because references hold observable state, we need to ensure that when we convert this clip
+    /// back into a Reference that we generate the *original* reference, rather than a fresh one
+    /// This stores the original reference that produced this clip
+    original_reference: Lock<Option<MovieClipReference<'gc>>>,
+
     audio_stream: Cell<Option<SoundInstanceHandle>>,
 
     #[collect(require_static)]
@@ -249,6 +256,7 @@ impl<'gc> MovieClipData<'gc> {
             hit_area: Lock::new(None),
             attached_audio: Lock::new(None),
             next_avm1_clip: Lock::new(None),
+            original_reference: Lock::new(None),
             importer_movie: None,
         }
     }
@@ -2232,6 +2240,21 @@ impl<'gc> MovieClip<'gc> {
         if let Some(frame) = goto_frame {
             self.run_goto(context, frame, false);
         }
+    }
+
+    /// Mark this `MovieClip` as being originated from resolving the given `MovieClipReference`
+    pub fn get_original_reference(
+        &self,
+        context: &mut UpdateContext<'gc>,
+        mcr: MovieClipReference<'gc>,
+    ) {
+        let write = Gc::write(context.gc(), self.0);
+        unlock!(write, MovieClipData, original_reference).set(Some(mcr));
+    }
+
+    /// Get the originating `MovieClipReference` of this `MovieClip`, if it exists
+    pub fn original_reference(&self) -> Option<MovieClipReference<'gc>> {
+        self.0.original_reference.get()
     }
 }
 

--- a/tests/tests/swfs/avm1/string_paths_reference_launder/test.toml
+++ b/tests/tests/swfs/avm1/string_paths_reference_launder/test.toml
@@ -1,2 +1,1 @@
 num_frames = 1
-known_failure = true # See the comment in `stack_push` in avm1/activiation.rs for details


### PR DESCRIPTION
This (finally) fixes the "reference  laundering" issue present in AVM1 since the string paths fix was implemented.

Specifically this fixes two different kinds of laundering:
1: Calling a function with a reference to a removed clip, which resolved the clip to undefined before passing it on
2: Converting `MovieClipReference` -> `Object` -> `MovieClipReference` could create a reference that points to a different value due to the weirdness of the logic around the cache

Fixing the former fixes #15265, fixing the later fixes the existing known-failing test