### PR TITLE
core/avm1: Move AVM1-specific XML code into AVM1

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -22,6 +22,7 @@ mod property_map;
 mod runtime;
 mod scope;
 mod value;
+mod xml;
 
 pub use activation::{Activation, ActivationIdentifier};
 pub use debug::VariableDumper;

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -4,11 +4,12 @@ use std::cell::Cell;
 
 use crate::avm1::function::{ExecutionReason, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
+use crate::avm1::xml::{XmlNode, ELEMENT_NODE, TEXT_NODE};
 use crate::avm1::{Activation, Attribute, Error, NativeObject, Object, Value};
 use crate::avm_warn;
 use crate::backend::navigator::Request;
 use crate::string::{AvmString, StringContext, WStr, WString};
-use crate::xml::{custom_unescape, XmlNode, ELEMENT_NODE, TEXT_NODE};
+use crate::xml::custom_unescape;
 use gc_arena::barrier::unlock;
 use gc_arena::lock::Lock;
 use gc_arena::{Collect, Gc};

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -5,9 +5,9 @@ use ruffle_macros::istr;
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
+use crate::avm1::xml::{XmlNode, TEXT_NODE};
 use crate::avm1::{NativeObject, Object, Value};
 use crate::string::{AvmString, StringContext, WStr};
-use crate::xml::{XmlNode, TEXT_NODE};
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "localName" => property(local_name);

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -21,6 +21,7 @@ use crate::avm1::globals::transform::TransformObject;
 use crate::avm1::globals::xml::Xml;
 use crate::avm1::globals::xml_socket::XmlSocket;
 use crate::avm1::object::super_object::SuperObject;
+use crate::avm1::xml::XmlNode;
 use crate::avm1::{Activation, Error, Value};
 use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::display_object::{
@@ -29,7 +30,6 @@ use crate::display_object::{
 use crate::html::TextFormat;
 use crate::streams::NetStream;
 use crate::string::AvmString;
-use crate::xml::XmlNode;
 use gc_arena::{Collect, Gc, Mutation};
 use ruffle_macros::istr;
 use std::cell::{Cell, RefCell};

--- a/core/src/avm1/xml.rs
+++ b/core/src/avm1/xml.rs
@@ -1,0 +1,6 @@
+//! Garbage-collectable XML DOM impl
+
+mod iterators;
+mod tree;
+
+pub use tree::{XmlNode, ELEMENT_NODE, TEXT_NODE};

--- a/core/src/avm1/xml/iterators.rs
+++ b/core/src/avm1/xml/iterators.rs
@@ -1,6 +1,6 @@
 //! Iterator types for XML trees
 
-use crate::xml::XmlNode;
+use crate::avm1::xml::XmlNode;
 
 /// Iterator that yields direct children of an XML node.
 pub struct ChildIter<'gc> {

--- a/core/src/xml.rs
+++ b/core/src/xml.rs
@@ -1,6 +1,41 @@
-//! Garbage-collectable XML DOM impl
+use regress::Regex;
+use std::sync::OnceLock;
 
-mod iterators;
-mod tree;
+static ENTITY_REGEX: OnceLock<Regex> = OnceLock::new();
 
-pub use tree::{custom_unescape, XmlNode, ELEMENT_NODE, TEXT_NODE};
+/// Handles flash-specific XML unescaping behavior.
+/// We accept all XML entities, and also accept standalone '&' without
+/// a corresponding ';'
+pub fn custom_unescape(
+    data: &[u8],
+    decoder: quick_xml::Decoder,
+) -> Result<String, quick_xml::Error> {
+    let input = decoder.decode(data)?;
+
+    let re = ENTITY_REGEX.get_or_init(|| Regex::new(r"&[^;]*;").unwrap());
+    let mut result = String::new();
+    let mut last_end = 0;
+
+    // Find all entities, and try to unescape them.
+    // Our regular expression will skip over '&' without a matching ';',
+    // which will preserve them as-is in the output
+    for cap in re.find_iter(&input) {
+        let start = cap.start();
+        let end = cap.end();
+        result.push_str(&input[last_end..start]);
+
+        let entity = &input[start..end];
+        // Unfortunately, we need to call this on each entity individually,
+        // since it bails out if *any* entities in the string lack a terminating ';'
+        match quick_xml::escape::unescape(entity) {
+            Ok(decoded) => result.push_str(&decoded),
+            // FIXME - check the actual error once https://github.com/tafia/quick-xml/pull/584 is merged
+            Err(_) => result.push_str(entity),
+        }
+
+        last_end = end;
+    }
+
+    result.push_str(&input[last_end..]);
+    Ok(result)
+}


### PR DESCRIPTION
`custom_unescape` was being used by AVM2 XML code, so I moved it to the toplevel `xml.rs`