### PR TITLE
core: Rename `UpdateContext::swf` to `root_swf`

### DIFF
--- a/core/src/avm1/globals/local_connection.rs
+++ b/core/src/avm1/globals/local_connection.rs
@@ -49,7 +49,7 @@ impl<'gc> LocalConnection<'gc> {
         }
 
         let connection_handle = activation.context.local_connections.connect(
-            &LocalConnections::get_domain(activation.context.swf.url()),
+            &LocalConnections::get_domain(activation.context.root_swf.url()),
             this,
             &name,
         );
@@ -202,7 +202,7 @@ pub fn send<'gc>(
     }
 
     activation.context.local_connections.send(
-        &LocalConnections::get_domain(activation.context.swf.url()),
+        &LocalConnections::get_domain(activation.context.root_swf.url()),
         this,
         *connection_name,
         *method_name,

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1427,7 +1427,7 @@ fn get_bounds<'gc>(
         if !activation.context.avm1.get_use_new_invalid_bounds_value() {
             // The value is set to true if the activation SWF version is >= 8 or if the SWF
             // version of the root movie is >= 8.
-            if activation.swf_version() >= 8 || activation.context.swf.version() >= 8 {
+            if activation.swf_version() >= 8 || activation.context.root_swf.version() >= 8 {
                 // If only the activation SWF version (and not the root movie SWF version)
                 // is >= 8 and the movie clip equals the target, the value sometimes isn't set
                 // in Flash Player 10.

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -562,7 +562,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     /// Like `caller_movie()`, but returns the root movie if `caller_movie`
     /// is `None`. This matches what FP does in most cases.
     pub fn caller_movie_or_root(&self) -> Arc<SwfMovie> {
-        self.caller_movie().unwrap_or(self.context.swf.clone())
+        self.caller_movie().unwrap_or(self.context.root_swf.clone())
     }
 
     /// Returns the global scope of this activation.

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1718,7 +1718,7 @@ pub fn maybe_escape_child<'gc>(
     child: Value<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     // NOTE: This depends on root SWF version, not caller movie version.
-    if activation.context.swf.version() <= 9 {
+    if activation.context.root_swf.version() <= 9 {
         if child
             .as_object()
             .is_some_and(|x| x.as_xml_object().is_some() || x.as_xml_list_object().is_some())

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -137,7 +137,7 @@ pub fn init<'gc>(
         let transparency = args.get_bool(2);
         let fill_color = args.get_u32(activation, 3)?;
 
-        if !is_size_valid(activation.context.swf.version(), width, height) {
+        if !is_size_valid(activation.context.root_swf.version(), width, height) {
             return Err(Error::avm_error(argument_error(
                 activation,
                 "Error #2015: Invalid BitmapData.",

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -30,7 +30,8 @@ pub fn loader_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     // Loader does not have an associated `Character` variant, and can never be
     // instantiated from the timeline.
-    let display_object = LoaderDisplay::empty(activation, activation.context.swf.clone()).into();
+    let display_object =
+        LoaderDisplay::empty(activation, activation.context.root_swf.clone()).into();
     let loader = initialize_for_allocator(activation, display_object, class)?;
 
     // Note that the initialization of `_contentLoaderInfo` is intentionally done here,
@@ -40,7 +41,7 @@ pub fn loader_allocator<'gc>(
     // Some LoaderInfo properties (such as 'bytesLoaded' and 'bytesTotal') are always
     // accessible, even before the 'init' event has fired. Using an empty movie gives
     // us the correct value (0) for them.
-    let movie = &activation.context.swf;
+    let movie = &activation.context.root_swf;
     let loader_info = LoaderInfoObject::not_yet_loaded(
         activation,
         Arc::new(SwfMovie::empty(movie.version(), Some(movie.url().into()))),
@@ -88,7 +89,7 @@ pub fn load<'gc>(
     loader_info.unload(activation);
 
     // This is a dummy MovieClip, which will get overwritten in `Loader`
-    let movie = &activation.context.swf;
+    let movie = &activation.context.root_swf;
     let content = MovieClip::new(
         Arc::new(SwfMovie::empty(movie.version(), Some(movie.url().into()))),
         activation.gc(),
@@ -259,7 +260,7 @@ pub fn load_bytes<'gc>(
     loader_info.unload(activation);
 
     // This is a dummy MovieClip, which will get overwritten in `Loader`
-    let movie = &activation.context.swf;
+    let movie = &activation.context.root_swf;
     let content = MovieClip::new(
         Arc::new(SwfMovie::empty(movie.version(), Some(movie.url().into()))),
         activation.gc(),

--- a/core/src/avm2/globals/flash/display/loader_info.rs
+++ b/core/src/avm2/globals/flash/display/loader_info.rs
@@ -296,7 +296,8 @@ pub fn get_child_allows_parent<'gc>(
                 // Only the root movie is LoaderStream::Swf but missing a loader.
                 // In that case, return true.
                 assert!(
-                    Arc::ptr_eq(root, activation.context.swf) && dobj.as_movie_clip().is_some()
+                    Arc::ptr_eq(root, activation.context.root_swf)
+                        && dobj.as_movie_clip().is_some()
                 );
                 Ok(true.into())
             }
@@ -337,7 +338,8 @@ pub fn get_parent_allows_child<'gc>(
             } else {
                 // See comment on childAllowsParent
                 assert!(
-                    Arc::ptr_eq(root, activation.context.swf) && dobj.as_movie_clip().is_some()
+                    Arc::ptr_eq(root, activation.context.root_swf)
+                        && dobj.as_movie_clip().is_some()
                 );
                 Ok(true.into())
             }

--- a/core/src/avm2/globals/flash/display3D/context_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/context_3d.rs
@@ -90,7 +90,7 @@ pub fn configure_back_buffer<'gc>(
         let anti_alias = args.get_u32(activation, 2)?;
         let enable_depth_and_stencil = args.get_bool(3);
 
-        let old_swf = activation.context.swf.version() < 30;
+        let old_swf = activation.context.root_swf.version() < 30;
 
         if old_swf && width == 0 && height == 0 && anti_alias == 0 && !enable_depth_and_stencil {
             return Ok(Value::Undefined);

--- a/core/src/avm2/globals/flash/net/local_connection.rs
+++ b/core/src/avm2/globals/flash/net/local_connection.rs
@@ -15,7 +15,7 @@ pub fn get_domain<'gc>(
     _this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let movie = &activation.context.swf;
+    let movie = &activation.context.root_swf;
     let domain = LocalConnections::get_domain(movie.url());
 
     Ok(Value::String(AvmString::new_utf8(activation.gc(), domain)))
@@ -58,7 +58,7 @@ pub fn send<'gc>(
 
     if let Some(local_connection) = this.as_local_connection_object() {
         activation.context.local_connections.send(
-            &LocalConnections::get_domain(activation.context.swf.url()),
+            &LocalConnections::get_domain(activation.context.root_swf.url()),
             (activation.domain(), local_connection),
             connection_name,
             method_name,

--- a/core/src/avm2/globals/flash/net/shared_object.rs
+++ b/core/src/avm2/globals/flash/net/shared_object.rs
@@ -53,7 +53,7 @@ pub fn get_local<'gc>(
         return Ok(Value::Null);
     }
 
-    let mut movie_url = if let Ok(url) = url::Url::parse(activation.context.swf.url()) {
+    let mut movie_url = if let Ok(url) = url::Url::parse(activation.context.root_swf.url()) {
         url
     } else {
         tracing::error!("SharedObject::get_local: Unable to parse movie URL");

--- a/core/src/avm2/globals/flash/net/xml_socket.rs
+++ b/core/src/avm2/globals/flash/net/xml_socket.rs
@@ -10,7 +10,7 @@ pub fn get_domain<'gc>(
     _this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let movie = &activation.context.swf;
+    let movie = &activation.context.root_swf;
 
     let domain = if let Ok(url) = url::Url::parse(movie.url()) {
         if url.scheme() == "file" {

--- a/core/src/avm2/globals/toplevel.rs
+++ b/core/src/avm2/globals/toplevel.rs
@@ -72,7 +72,7 @@ pub fn parse_float<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let string = args.get_string(activation, 0)?;
-    let swf_version = activation.context.swf.version();
+    let swf_version = activation.context.root_swf.version();
 
     if let Some(result) = crate::avm2::value::string_to_f64(&string, swf_version, false) {
         Ok(result.into())

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -1226,7 +1226,7 @@ pub fn replace<'gc>(
     } else {
         // NOTE: Depends on root swf version.
         // See https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/XMLObject.cpp#L1540
-        if activation.context.swf.version() <= 9 {
+        if activation.context.root_swf.version() <= 9 {
             // SWF version 9 edge case, call XML constructor.
             // https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/XMLObject.cpp#L2241-L2242
             activation

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -350,7 +350,7 @@ impl<'gc> LoaderInfoObject<'gc> {
 
     pub fn unload(&self, activation: &mut Activation<'_, 'gc>) {
         // Reset properties
-        let movie = &activation.context.swf;
+        let movie = &activation.context.root_swf;
         let empty_swf = Arc::new(SwfMovie::empty(movie.version(), Some(movie.url().into())));
         let loader_stream = LoaderStream::NotYetLoaded(empty_swf, None, false);
         self.set_loader_stream(loader_stream, activation.gc());

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -83,7 +83,7 @@ impl<'gc> LocalConnectionObject<'gc> {
         }
 
         let connection_handle = activation.context.local_connections.connect(
-            &LocalConnections::get_domain(activation.context.swf.url()),
+            &LocalConnections::get_domain(activation.context.root_swf.url()),
             (activation.domain(), *self),
             &name,
         );

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -690,7 +690,7 @@ impl<'gc> Value<'gc> {
             Value::Number(n) => *n,
             Value::Integer(i) => *i as f64,
             Value::String(s) => {
-                let swf_version = activation.context.swf.version();
+                let swf_version = activation.context.root_swf.version();
                 string_to_f64(s, swf_version, true).unwrap_or_else(|| string_to_int(s, 0, true))
             }
             Value::Object(_) => self
@@ -1390,7 +1390,7 @@ impl<'gc> Value<'gc> {
                 function_object.construct(activation, args).map(Into::into)
             }
             _ => {
-                let error = if activation.context.swf.version() < 11 {
+                let error = if activation.context.root_swf.version() < 11 {
                     type_error(activation, "Error #1115: value is not a constructor.", 1115)
                 } else {
                     type_error(

--- a/core/src/debug_ui.rs
+++ b/core/src/debug_ui.rs
@@ -115,7 +115,8 @@ impl DebugUi {
                     self.movies.insert(movie, Default::default());
                 }
                 Message::TrackTopLevelMovie => {
-                    self.movies.insert(context.swf.clone(), Default::default());
+                    self.movies
+                        .insert(context.root_swf.clone(), Default::default());
                 }
                 Message::TrackAVM1Object(object) => {
                     self.avm1_objects.insert(object, Default::default());

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -143,7 +143,7 @@ impl<'gc> Avm2Button<'gc> {
     }
 
     pub fn empty_button(context: &mut UpdateContext<'gc>) -> Self {
-        let movie = context.swf.clone();
+        let movie = context.root_swf.clone();
         let button_record = swf::Button {
             id: 0,
             is_track_as_menu: false,

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -91,7 +91,7 @@ impl<'gc> Graphic<'gc> {
                 },
                 shape: Vec::new(),
             },
-            movie: context.swf.clone(),
+            movie: context.root_swf.clone(),
         };
 
         Graphic(Gc::new(

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -564,7 +564,7 @@ impl<'gc> MovieClip<'gc> {
         context: &mut UpdateContext<'gc>,
         reader: &mut SwfStream<'_>,
     ) -> Result<Option<Script<'gc>>, Error> {
-        if !context.swf.is_action_script_3() {
+        if !context.root_swf.is_action_script_3() {
             tracing::warn!("DoABC tag with non-AVM2 root");
             return Ok(None);
         }
@@ -600,7 +600,7 @@ impl<'gc> MovieClip<'gc> {
         context: &mut UpdateContext<'gc>,
         reader: &mut SwfStream<'_>,
     ) -> Result<Option<Script<'gc>>, Error> {
-        if !context.swf.is_action_script_3() {
+        if !context.root_swf.is_action_script_3() {
             tracing::warn!("DoABC2 tag with non-AVM2 root");
             return Ok(None);
         }

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -312,7 +312,7 @@ impl<'gc> Callback<'gc> {
 
                 let domain = context
                     .library
-                    .library_for_movie(context.swf.clone())
+                    .library_for_movie(context.root_swf.clone())
                     .unwrap()
                     .avm2_domain();
                 let mut activation = Avm2Activation::from_domain(context, domain);

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1290,7 +1290,7 @@ impl<'gc> Loader<'gc> {
             mc.replace_with_movie(uc, None, false, None);
         }
 
-        let loader_url = Some(uc.swf.url().to_string());
+        let loader_url = Some(uc.root_swf.url().to_string());
 
         if replacing_root_movie {
             ContentType::sniff(&bytes).expect(ContentType::Swf)?;
@@ -1356,7 +1356,7 @@ impl<'gc> Loader<'gc> {
                     // Convert the text into UTF-8
                     utf8_string = encoding.decode(&body).0;
                     utf8_string.as_bytes()
-                } else if activation.context.swf.version() <= 5 {
+                } else if activation.context.root_swf.version() <= 5 {
                     utf8_string = WINDOWS_1252.decode(&body).0;
                     utf8_string.as_bytes()
                 } else {
@@ -2077,7 +2077,7 @@ impl<'gc> Loader<'gc> {
         if let MovieLoaderVMData::Avm2 { loader_info, .. } = vm_data {
             loader_info.set_content_type(sniffed_type);
             let fake_movie = Arc::new(SwfMovie::fake_with_compressed_len(
-                activation.context.swf.version(),
+                activation.context.root_swf.version(),
                 loader_url.clone(),
                 data.len(),
             ));
@@ -2215,7 +2215,7 @@ impl<'gc> Loader<'gc> {
 
                 if let MovieLoaderVMData::Avm2 { loader_info, .. } = vm_data {
                     let fake_movie = Arc::new(SwfMovie::fake_with_compressed_len(
-                        activation.context.swf.version(),
+                        activation.context.root_swf.version(),
                         loader_url.clone(),
                         data.len(),
                     ));
@@ -2230,7 +2230,7 @@ impl<'gc> Loader<'gc> {
 
                 if let MovieLoaderVMData::Avm2 { loader_info, .. } = vm_data {
                     let fake_movie = Arc::new(SwfMovie::fake_with_compressed_data(
-                        activation.context.swf.version(),
+                        activation.context.root_swf.version(),
                         loader_url,
                         data.to_vec(),
                     ));
@@ -2292,7 +2292,7 @@ impl<'gc> Loader<'gc> {
                     }
                     MovieLoaderVMData::Avm2 { loader_info, .. } => {
                         let fake_movie = Arc::new(SwfMovie::fake_with_compressed_len(
-                            activation.context.swf.version(),
+                            activation.context.root_swf.version(),
                             loader_url,
                             data.len(),
                         ));

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2200,7 +2200,7 @@ impl Player {
             let mut update_context = UpdateContext {
                 player_version: this.player_version,
                 player_mode: this.player_mode,
-                swf: &mut this.swf,
+                root_swf: &mut this.swf,
                 library,
                 rng: &mut this.rng,
                 renderer: this.renderer.deref_mut(),

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -560,8 +560,8 @@ impl<'gc> NetStream<'gc> {
     /// available in the buffer.
     pub fn play(self, context: &mut UpdateContext<'gc>, name: Option<AvmString<'gc>>) {
         if let Some(name) = name {
-            let request = if let Ok(stream_url) =
-                Url::parse(context.swf.url()).and_then(|url| url.join(name.to_string().as_str()))
+            let request = if let Ok(stream_url) = Url::parse(context.root_swf.url())
+                .and_then(|url| url.join(name.to_string().as_str()))
             {
                 Request::get(stream_url.to_string())
             } else {


### PR DESCRIPTION
The name "swf" was ambiguous, because in case of a child SWF file, it won't reference that file, but the root SWF, even if the update context is passed to objects from the child SWF.