### PR TITLE
stubs

### DIFF
--- a/core/src/avm2/globals/flash/system/MessageChannel.as
+++ b/core/src/avm2/globals/flash/system/MessageChannel.as
@@ -2,10 +2,13 @@ package flash.system {
     import flash.events.EventDispatcher;
 
     [API("682")]
-    [Ruffle(Abstract)]
     public final class MessageChannel extends EventDispatcher {
         public function MessageChannel() {
             super();
+        }
+
+        public function send(arg:*, queueLimit:int = -1):void {
+            stub_method("flash.system.MessageChannel", "send");
         }
     }
 }

--- a/core/src/avm2/globals/flash/system/MessageChannel.as
+++ b/core/src/avm2/globals/flash/system/MessageChannel.as
@@ -1,5 +1,6 @@
 package flash.system {
     import flash.events.EventDispatcher;
+    import __ruffle__.stub_method;
 
     [API("682")]
     public final class MessageChannel extends EventDispatcher {

--- a/core/src/avm2/globals/flash/system/Worker.as
+++ b/core/src/avm2/globals/flash/system/Worker.as
@@ -1,11 +1,47 @@
 package flash.system {
+
+    import flash.utils.Dictionary;
+    import flash.events.Event;
     import flash.events.EventDispatcher;
+    import flash.system.MessageChannel;
+    import __ruffle__.stub_method;
 
     [API("682")]
-    [Ruffle(Abstract)]
     public final class Worker extends EventDispatcher {
-        public static function get isSupported():Boolean {
-            return false;
+        public static const isSupported:Boolean = false;
+
+        private static var _current:Worker;
+
+        private static var dictionary: Dictionary = new Dictionary();
+        
+        public static function get current():Worker {
+            if (!_current) {
+                _current = new Worker();
+            }
+            return _current;
+        }
+
+        public function Worker() {
+        }
+
+        public function createMessageChannel(received:Worker): MessageChannel {
+            stub_method("flash.system.Worker", "createMessageChannel");
+
+            return new MessageChannel();
+        }
+
+        public function setSharedProperty(key:String, value:*):void {
+            stub_method("flash.system.Worker", "setSharedProperty");
+        }
+
+        public function getSharedProperty(key:String):* {
+            stub_method("flash.system.Worker", "getSharedProperty");
+        }
+
+        public function start():void {
+            this.dispatchEvent(new Event(Event.WORKER_STATE));
+
+            stub_method("flash.system.Worker", "start");
         }
     }
 }

--- a/core/src/avm2/globals/flash/system/WorkerDomain.as
+++ b/core/src/avm2/globals/flash/system/WorkerDomain.as
@@ -2,6 +2,7 @@ package flash.system {
 
     import flash.utils.ByteArray;
     import flash.system.Worker;
+    import __ruffle__.stub_method;
 
     [API("680")] // the docs say 682, that's wrong
     public final class WorkerDomain {
@@ -20,7 +21,7 @@ package flash.system {
 
         public function createWorker(swf:ByteArray, giveAppPrivileges:Boolean = false):Worker {
             stub_method("flash.system.WorkerDomain", "createWorker");
-            
+
             return new Worker();
         }
     }

--- a/core/src/avm2/globals/flash/system/WorkerDomain.as
+++ b/core/src/avm2/globals/flash/system/WorkerDomain.as
@@ -1,10 +1,27 @@
 package flash.system {
+
+    import flash.utils.ByteArray;
+    import flash.system.Worker;
+
     [API("680")] // the docs say 682, that's wrong
     public final class WorkerDomain {
         public static const isSupported:Boolean = false;
+        
+        private static var _current:WorkerDomain;
+        
+        public static function get current():WorkerDomain {
+            if (!_current) {
+                _current = new WorkerDomain();
+            }
+            return _current;
+        }
 
-        public function WorkerDomain() {
-            throw new ArgumentError("Error #2012: WorkerDomain$ class cannot be instantiated.", 2012)
+        public function WorkerDomain() {}
+
+        public function createWorker(swf:ByteArray, giveAppPrivileges:Boolean = false):Worker {
+            stub_method("flash.system.WorkerDomain", "createWorker");
+            
+            return new Worker();
         }
     }
 }

--- a/core/src/avm2/globals/flash/utils/ByteArray.as
+++ b/core/src/avm2/globals/flash/utils/ByteArray.as
@@ -2,6 +2,7 @@ package flash.utils {
     [Ruffle(InstanceAllocator)]
     public class ByteArray implements IDataInput2, IDataOutput2 {
         private static var _defaultObjectEncoding:uint = 3;
+        public var shareable:Boolean = false;
 
         public static function get defaultObjectEncoding():uint {
             return _defaultObjectEncoding;


### PR DESCRIPTION
Progresses #16776 and #14253. Not sure what the correct implmentation of these should be. 

It is now possible to get ingame, although all the shapes are black, possible because of 

2025-06-29T18:07:08.013767Z  WARN ruffle_render_wgpu::filters: Unsupported filter GradientBevelFilter(GradientFilter { colors: [GradientRecord { ratio: 255, color: Color(0xc69951ff) }, GradientRecord { ratio: 255, color: Color(0xf1d5a6ff) }], blur_x: 6.25, blur_y: 6.25, angle: 1.5707855224609375, distance: 7.0, strength: 1.0, flags: GradientFilterFlags(INNER_SHADOW | COMPOSITE_SOURCE | 0x1) })