### PR TITLE
core: use `OnceCell/Lock`s where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,16 +1980,15 @@ dependencies = [
 [[package]]
 name = "gc-arena"
 version = "0.5.3"
-source = "git+https://github.com/kyren/gc-arena.git?rev=d394233a367ec7352a361cf93572c428ec092d66#d394233a367ec7352a361cf93572c428ec092d66"
+source = "git+https://github.com/kyren/gc-arena.git?rev=cef6db5e15bdf27f3c85b83ec0455431f134d2f0#cef6db5e15bdf27f3c85b83ec0455431f134d2f0"
 dependencies = [
  "gc-arena-derive",
- "sptr",
 ]
 
 [[package]]
 name = "gc-arena-derive"
 version = "0.5.3"
-source = "git+https://github.com/kyren/gc-arena.git?rev=d394233a367ec7352a361cf93572c428ec092d66#d394233a367ec7352a361cf93572c428ec092d66"
+source = "git+https://github.com/kyren/gc-arena.git?rev=cef6db5e15bdf27f3c85b83ec0455431f134d2f0#cef6db5e15bdf27f3c85b83ec0455431f134d2f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5188,12 +5187,6 @@ checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.9.1",
 ]
-
-[[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "static_assertions"

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -181,8 +181,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             context,
         };
 
-        // Script initializers should only be run once
-        assert!(!method.is_info_resolved());
         // Resolve signature
         method.resolve_info(&mut created_activation)?;
 
@@ -382,14 +380,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.is_interpreter = false;
 
         // Resolve parameters and return type
-        if !method.is_info_resolved() {
-            method.resolve_info(self)?;
-        }
+        method.resolve_info(self)?;
 
         // Everything is now setup for the verifier to run
         method.verify(self)?;
 
-        let signature = &*method.resolved_param_config();
+        let signature = method.resolved_param_config();
 
         if user_arguments.len() > signature.len() && !has_rest_or_args && !method.is_unchecked() {
             return Err(Error::avm_error(make_mismatch_error(

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -885,14 +885,10 @@ impl<'gc> Class<'gc> {
                                     found_match = true;
 
                                     let instance_method = instance_trait.as_method().unwrap();
-                                    if !instance_method.is_info_resolved() {
-                                        instance_method.resolve_info(activation)?;
-                                    }
+                                    instance_method.resolve_info(activation)?;
 
                                     let super_method = supertrait.as_method().unwrap();
-                                    if !super_method.is_info_resolved() {
-                                        super_method.resolve_info(activation)?;
-                                    }
+                                    super_method.resolve_info(activation)?;
 
                                     // Methods must have same return type
                                     let instance_return_type =

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -196,11 +196,9 @@ pub fn exec<'gc>(
                 caller_movie,
             );
 
-            if !method.is_info_resolved() {
-                method.resolve_info(&mut activation)?;
-            }
+            method.resolve_info(&mut activation)?;
 
-            let signature = &*method.resolved_param_config();
+            let signature = method.resolved_param_config();
 
             // Check for too many arguments
             if arguments.len() > signature.len() && !method.is_variadic() && !method.is_unchecked()

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -997,7 +997,7 @@ pub fn copy_from<'gc>(
             .as_drawing(activation.gc())
             .expect("Missing drawing for target");
 
-        target_drawing.copy_from(&source);
+        target_drawing.clone_from(&source);
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/optimizer/optimize.rs
+++ b/core/src/avm2/optimizer/optimize.rs
@@ -1920,9 +1920,7 @@ fn maybe_optimize_static_call<'gc>(
     passed_args: &[OptValue<'gc>],
     push_return_value: bool,
 ) -> Result<(), Error<'gc>> {
-    if !speculated_method.is_info_resolved() {
-        speculated_method.resolve_info(activation)?;
-    }
+    speculated_method.resolve_info(activation)?;
 
     let declared_params = speculated_method.resolved_param_config();
 

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -530,7 +530,7 @@ pub fn verify_method<'gc>(
         activation,
         method,
         &mut verified_code,
-        &resolved_param_config,
+        resolved_param_config,
         &new_exceptions,
         &jump_targets,
     )?;

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::OnceCell;
 
 use crate::backend::audio::SoundHandle;
 use crate::binary_data::BinaryData;
@@ -21,7 +21,7 @@ pub enum Character<'gc> {
         compressed: CompressedBitmap,
         /// A lazily constructed GPU handle, used when performing fills with this bitmap
         #[collect(require_static)]
-        handle: RefCell<Option<BitmapHandle>>,
+        handle: OnceCell<BitmapHandle>,
         /// The bitmap class set by `SymbolClass` - this is used when we instantaite
         /// a `Bitmap` displayobject.
         avm2_bitmapdata_class: GcCell<'gc, BitmapClass<'gc>>,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3242,7 +3242,7 @@ impl<'gc, 'a> MovieClipShared<'gc> {
                 version: define_bits_lossless.version,
                 data: Cow::Owned(define_bits_lossless.data.into_owned()),
             }),
-            handle: RefCell::new(None),
+            handle: Default::default(),
             avm2_bitmapdata_class: GcCell::new(context.gc(), BitmapClass::NoSubclass),
         };
         self.library_mut(context)
@@ -3374,7 +3374,7 @@ impl<'gc, 'a> MovieClipShared<'gc> {
                     width,
                     height,
                 },
-                handle: RefCell::new(None),
+                handle: Default::default(),
                 avm2_bitmapdata_class: GcCell::new(mc, BitmapClass::NoSubclass),
             },
         );
@@ -3397,7 +3397,7 @@ impl<'gc, 'a> MovieClipShared<'gc> {
                 width,
                 height,
             },
-            handle: RefCell::new(None),
+            handle: Default::default(),
             avm2_bitmapdata_class: GcCell::new(context.gc(), BitmapClass::NoSubclass),
         };
         self.library_mut(context).register_character(id, bitmap);
@@ -3426,7 +3426,7 @@ impl<'gc, 'a> MovieClipShared<'gc> {
                 width,
                 height,
             },
-            handle: RefCell::new(None),
+            handle: Default::default(),
             avm2_bitmapdata_class: GcCell::new(context.gc(), BitmapClass::NoSubclass),
         };
         self.library_mut(context).register_character(id, bitmap);

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -5,15 +5,14 @@ use ruffle_render::commands::CommandHandler;
 use ruffle_render::shape_utils::{
     cubic_curve_bounds, quadratic_curve_bounds, DistilledShape, DrawCommand, DrawPath, FillRule,
 };
-use std::cell::{Cell, RefCell};
+use std::cell::OnceCell;
 use swf::{FillStyle, LineStyle, Point, Rectangle, Twips};
 
 #[derive(Clone, Debug)]
 pub struct Drawing {
-    render_handle: RefCell<Option<ShapeHandle>>,
+    render_handle: OnceCell<ShapeHandle>,
     shape_bounds: Rectangle<Twips>,
     edge_bounds: Rectangle<Twips>,
-    dirty: Cell<bool>,
     paths: Vec<DrawingPath>,
     bitmaps: Vec<BitmapInfo>,
     current_fill: Option<DrawingFill>,
@@ -22,6 +21,8 @@ pub struct Drawing {
     cursor: Point<Twips>,
     fill_start: Point<Twips>,
     default_winding_rule: FillRule,
+    /// Cached for fast emptiness check.
+    is_empty: bool,
 }
 
 impl Default for Drawing {
@@ -33,10 +34,9 @@ impl Default for Drawing {
 impl Drawing {
     pub fn new() -> Self {
         Self {
-            render_handle: RefCell::new(None),
+            render_handle: OnceCell::new(),
             shape_bounds: Default::default(),
             edge_bounds: Default::default(),
-            dirty: Cell::new(false),
             paths: Vec::new(),
             bitmaps: Vec::new(),
             current_fill: None,
@@ -45,15 +45,15 @@ impl Drawing {
             cursor: Point::ZERO,
             fill_start: Point::ZERO,
             default_winding_rule: FillRule::EvenOdd,
+            is_empty: true,
         }
     }
 
     pub fn from_swf_shape(shape: &swf::Shape) -> Self {
         let mut this = Self {
-            render_handle: RefCell::new(None),
+            render_handle: OnceCell::new(),
             shape_bounds: shape.shape_bounds,
             edge_bounds: shape.edge_bounds,
-            dirty: Cell::new(true),
             paths: Vec::new(),
             bitmaps: Vec::new(),
             current_fill: None,
@@ -66,6 +66,7 @@ impl Drawing {
             } else {
                 FillRule::EvenOdd
             },
+            is_empty: true,
         };
 
         let shape: DistilledShape = shape.into();
@@ -103,21 +104,9 @@ impl Drawing {
         this
     }
 
-    pub fn copy_from(&mut self, other: &Drawing) {
-        *self = Drawing {
-            render_handle: RefCell::new(None),
-            dirty: Cell::new(true),
-            shape_bounds: other.shape_bounds,
-            edge_bounds: other.edge_bounds,
-            paths: other.paths.clone(),
-            bitmaps: other.bitmaps.clone(),
-            current_fill: other.current_fill.clone(),
-            current_line: other.current_line.clone(),
-            pending_lines: other.pending_lines.clone(),
-            cursor: other.cursor,
-            fill_start: other.fill_start,
-            default_winding_rule: other.default_winding_rule,
-        }
+    fn mark_dirty(&mut self) {
+        self.is_empty = false;
+        self.render_handle.take();
     }
 
     /// Set fill style and reset fill rule to default.
@@ -157,7 +146,7 @@ impl Drawing {
             });
         }
         self.fill_start = self.cursor;
-        self.dirty.set(true);
+        self.mark_dirty();
     }
 
     pub fn clear(&mut self) {
@@ -170,10 +159,10 @@ impl Drawing {
         self.shape_bounds = Default::default();
         self.cursor = Point::ZERO;
         self.fill_start = Point::ZERO;
+        self.is_empty = true;
 
         // An empty drawing doesn't need to hold onto a `ShapeHandle`.
         self.render_handle.take();
-        self.dirty.set(false);
     }
 
     pub fn set_line_style(&mut self, style: Option<LineStyle>) {
@@ -193,7 +182,7 @@ impl Drawing {
             });
         }
 
-        self.dirty.set(true);
+        self.mark_dirty();
     }
 
     pub fn set_line_fill_style(&mut self, fill_style: FillStyle) {
@@ -241,7 +230,7 @@ impl Drawing {
         }
 
         self.cursor = command.end_point();
-        self.dirty.set(true);
+        self.mark_dirty()
     }
 
     pub fn add_bitmap(&mut self, bitmap: BitmapInfo) -> u16 {
@@ -252,7 +241,11 @@ impl Drawing {
 
     /// Obtain a `ShapeHandle` that represents this `Drawing`, or `None` if it is empty.
     pub fn register_or_replace(&self, renderer: &mut dyn RenderBackend) -> Option<ShapeHandle> {
-        if self.dirty.get() {
+        if self.is_empty {
+            return None;
+        }
+
+        let handle = self.render_handle.get_or_init(|| {
             let mut paths = Vec::with_capacity(self.paths.len());
 
             for path in &self.paths {
@@ -312,24 +305,16 @@ impl Drawing {
                 })
             }
 
-            let handle = if paths.is_empty() {
-                None
-            } else {
-                let shape = DistilledShape {
-                    paths,
-                    shape_bounds: self.shape_bounds,
-                    edge_bounds: self.edge_bounds,
-                    id: 0,
-                };
-                Some(renderer.register_shape(shape, self))
+            let shape = DistilledShape {
+                paths,
+                shape_bounds: self.shape_bounds,
+                edge_bounds: self.edge_bounds,
+                id: 0,
             };
+            renderer.register_shape(shape, self)
+        });
 
-            self.dirty.set(false);
-            self.render_handle.replace(handle.clone());
-            handle
-        } else {
-            self.render_handle.borrow().to_owned()
-        }
+        Some(handle.clone())
     }
 
     pub fn render(&self, context: &mut RenderContext) {
@@ -426,7 +411,7 @@ impl Drawing {
                 if let Some(line) = &mut self.current_line {
                     line.commands.push(DrawCommand::LineTo(self.fill_start));
                 }
-                self.dirty.set(true);
+                self.mark_dirty();
             }
         }
     }

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -390,8 +390,9 @@ impl ruffle_render::bitmap::BitmapSource for MovieLibrarySource<'_, '_> {
         else {
             return None;
         };
-        let mut handle = handle.borrow_mut();
-        if let Some(handle) = &*handle {
+
+        // FIXME - use `OnceCell::get_or_try_init` when stabilized.
+        if let Some(handle) = handle.get() {
             return Some(handle.clone());
         }
         let decoded = match compressed.decode() {
@@ -409,7 +410,7 @@ impl ruffle_render::bitmap::BitmapSource for MovieLibrarySource<'_, '_> {
             }
         };
         // FIXME - do we ever want to release this handle, to avoid taking up GPU memory?
-        *handle = Some(new_handle.clone());
+        handle.set(new_handle.clone()).unwrap();
         Some(new_handle)
     }
 }

--- a/render/src/shape_utils.rs
+++ b/render/src/shape_utils.rs
@@ -1193,7 +1193,7 @@ fn solve_cubic(a: f64, b: f64, c: f64, d: f64) -> SmallVec<[f64; 3]> {
 }
 
 /// Converts an SWF glyph into an SWF shape, for ease of use by rendering backends.
-pub fn swf_glyph_to_shape(glyph: &swf::Glyph) -> swf::Shape {
+pub fn swf_glyph_to_shape(glyph: swf::Glyph) -> swf::Shape {
     // Per SWF19 p.164, the FontBoundsTable can contain empty bounds for every glyph (reserved).
     // SWF19 says this is true through SWFv7, but it seems like it might be generally true?
     // In any case, we have to be sure to calculate the shape bounds ourselves to make a proper
@@ -1217,7 +1217,7 @@ pub fn swf_glyph_to_shape(glyph: &swf::Glyph) -> swf::Shape {
             })],
             line_styles: vec![],
         },
-        shape: glyph.shape_records.clone(),
+        shape: glyph.shape_records,
     }
 }
 

--- a/ruffle_gc_arena/Cargo.toml
+++ b/ruffle_gc_arena/Cargo.toml
@@ -12,4 +12,4 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-gc-arena = { git = "https://github.com/kyren/gc-arena.git", rev = "d394233a367ec7352a361cf93572c428ec092d66" }
+gc-arena = { git = "https://github.com/kyren/gc-arena.git", rev = "cef6db5e15bdf27f3c85b83ec0455431f134d2f0" }


### PR DESCRIPTION
When a field is only set once, using `OnceCell<T>` is better/clearer than `RefCell<Option<T>>`.