### PR TITLE
core: Remove double self pointers

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1531,7 +1531,7 @@ fn load_bitmap<'gc>(
     let library = &*activation.context.library;
 
     let movie = <DisplayObject as crate::display_object::TDisplayObject>::movie(
-        &activation.target_clip_or_root(),
+        activation.target_clip_or_root(),
     );
 
     let character = library

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1130,18 +1130,19 @@ pub trait TDisplayObject<'gc>:
 
     /// The `SCALE_ROTATION_CACHED` flag should only be set in SWFv5+.
     /// So scaling/rotation values always have to get recalculated from the matrix in SWFv4.
-    fn set_scale_rotation_cached(&self) {
+    fn set_scale_rotation_cached(self) {
         if self.swf_version() >= 5 {
             self.base().set_scale_rotation_cached(true);
         }
     }
 
-    fn id(&self) -> CharacterId;
-    fn depth(&self) -> Depth {
+    fn id(self) -> CharacterId;
+
+    fn depth(self) -> Depth {
         self.base().depth()
     }
 
-    fn set_depth(&self, depth: Depth) {
+    fn set_depth(self, depth: Depth) {
         self.base().set_depth(depth)
     }
 
@@ -1152,30 +1153,30 @@ pub trait TDisplayObject<'gc>:
     /// Implementors must override this method.
     /// Leaf DisplayObjects should return their bounds.
     /// Composite DisplayObjects that only contain children should return `&Default::default()`
-    fn self_bounds(&self) -> Rectangle<Twips>;
+    fn self_bounds(self) -> Rectangle<Twips>;
 
     /// The untransformed bounding box of this object including children.
-    fn bounds(&self) -> Rectangle<Twips> {
+    fn bounds(self) -> Rectangle<Twips> {
         self.bounds_with_transform(&Matrix::default())
     }
 
     /// The local bounding box of this object including children, in its parent's coordinate system.
-    fn local_bounds(&self) -> Rectangle<Twips> {
+    fn local_bounds(self) -> Rectangle<Twips> {
         self.bounds_with_transform(self.base().matrix())
     }
 
     /// The world bounding box of this object including children, relative to the stage.
-    fn world_bounds(&self) -> Rectangle<Twips> {
+    fn world_bounds(self) -> Rectangle<Twips> {
         self.bounds_with_transform(&self.local_to_global_matrix())
     }
 
     /// The world bounding box of this object, as reported by `Transform.pixelBounds`.
-    fn pixel_bounds(&self) -> Rectangle<Twips> {
+    fn pixel_bounds(self) -> Rectangle<Twips> {
         self.world_bounds()
     }
 
     /// Bounds used for drawing debug rects and picking objects.
-    fn debug_rect_bounds(&self) -> Rectangle<Twips> {
+    fn debug_rect_bounds(self) -> Rectangle<Twips> {
         // Make the rect at least as big as highlight bounds to ensure that anything
         // interactive is also highlighted even if not included in world bounds.
         let highlight_bounds = self
@@ -1189,7 +1190,7 @@ pub trait TDisplayObject<'gc>:
     /// This function recurses down and transforms the AABB each child before adding
     /// it to the bounding box. This gives a tighter AABB then if we simply transformed
     /// the overall AABB.
-    fn bounds_with_transform(&self, matrix: &Matrix) -> Rectangle<Twips> {
+    fn bounds_with_transform(self, matrix: &Matrix) -> Rectangle<Twips> {
         // A scroll rect completely overrides an object's bounds,
         // and can even grow the bounding box to be larger than the actual content
         if let Some(scroll_rect) = self.scroll_rect() {
@@ -1219,7 +1220,7 @@ pub trait TDisplayObject<'gc>:
     /// - It may be larger if filters are applied which will increase the size of what's shown
     /// - It does not respect scroll rects
     fn render_bounds_with_transform(
-        &self,
+        self,
         matrix: &Matrix,
         include_own_filters: bool,
         view_matrix: &Matrix,
@@ -1245,24 +1246,25 @@ pub trait TDisplayObject<'gc>:
         bounds
     }
 
-    fn place_frame(&self) -> u16 {
+    fn place_frame(self) -> u16 {
         self.base().place_frame()
     }
-    fn set_place_frame(&self, frame: u16) {
+
+    fn set_place_frame(self, frame: u16) {
         self.base().set_place_frame(frame)
     }
 
     /// Sets the matrix of this object.
     /// This does NOT invalidate the cache, as it's often used with other operations.
     /// It is the callers responsibility to do so.
-    fn set_matrix(&self, gc_context: &Mutation<'gc>, matrix: Matrix) {
+    fn set_matrix(self, gc_context: &Mutation<'gc>, matrix: Matrix) {
         self.base_mut(gc_context).set_matrix(matrix);
     }
 
     /// Sets the color transform of this object.
     /// This does NOT invalidate the cache, as it's often used with other operations.
     /// It is the callers responsibility to do so.
-    fn set_color_transform(&self, gc_context: &Mutation<'gc>, color_transform: ColorTransform) {
+    fn set_color_transform(self, gc_context: &Mutation<'gc>, color_transform: ColorTransform) {
         self.base_mut(gc_context)
             .set_color_transform(color_transform)
     }
@@ -1270,7 +1272,7 @@ pub trait TDisplayObject<'gc>:
     /// Sets the perspective projection of this object.
     /// This invalidates any ancestors cacheAsBitmap automatically.
     fn set_perspective_projection(
-        &self,
+        self,
         gc_context: &Mutation<'gc>,
         perspective_projection: Option<PerspectiveProjection>,
     ) {
@@ -1287,7 +1289,7 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Should only be used to implement 'Transform.concatenatedMatrix'
-    fn local_to_global_matrix_without_own_scroll_rect(&self) -> Matrix {
+    fn local_to_global_matrix_without_own_scroll_rect(self) -> Matrix {
         let mut node = self.parent();
         let mut matrix = *self.base().matrix();
         while let Some(display_object) = node {
@@ -1306,7 +1308,7 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Returns the matrix for transforming from this object's local space to global stage space.
-    fn local_to_global_matrix(&self) -> Matrix {
+    fn local_to_global_matrix(self) -> Matrix {
         let mut matrix = Matrix::IDENTITY;
         if let Some(rect) = self.scroll_rect() {
             matrix = Matrix::translate(-rect.x_min, -rect.y_min) * matrix;
@@ -1316,25 +1318,25 @@ pub trait TDisplayObject<'gc>:
 
     /// Returns the matrix for transforming from global stage to this object's local space.
     /// `None` is returned if the object has zero scale.
-    fn global_to_local_matrix(&self) -> Option<Matrix> {
+    fn global_to_local_matrix(self) -> Option<Matrix> {
         self.local_to_global_matrix().inverse()
     }
 
     /// Converts a local position to a global stage position
-    fn local_to_global(&self, local: Point<Twips>) -> Point<Twips> {
+    fn local_to_global(self, local: Point<Twips>) -> Point<Twips> {
         self.local_to_global_matrix() * local
     }
 
     /// Converts a local position on the stage to a local position on this display object
     /// Returns `None` if the object has zero scale.
-    fn global_to_local(&self, global: Point<Twips>) -> Option<Point<Twips>> {
+    fn global_to_local(self, global: Point<Twips>) -> Option<Point<Twips>> {
         self.global_to_local_matrix().map(|matrix| matrix * global)
     }
 
     /// Converts the mouse position on the stage to a local position on this display object.
     /// If the object has zero scale, then the stage `TWIPS_TO_PIXELS` matrix will be used.
     /// This matches Flash's behavior for `mouseX`/`mouseY` on an object with zero scale.
-    fn local_mouse_position(&self, context: &UpdateContext<'gc>) -> Point<Twips> {
+    fn local_mouse_position(self, context: &UpdateContext<'gc>) -> Point<Twips> {
         let stage = context.stage;
         let pixel_ratio = stage.view_matrix().a;
         let virtual_to_device = Matrix::scale(pixel_ratio, pixel_ratio);
@@ -1359,14 +1361,14 @@ pub trait TDisplayObject<'gc>:
 
     /// The `x` position in pixels of this display object in local space.
     /// Returned by the `_x`/`x` ActionScript properties.
-    fn x(&self) -> Twips {
+    fn x(self) -> Twips {
         self.base().x()
     }
 
     /// Sets the `x` position in pixels of this display object in local space.
     /// Set by the `_x`/`x` ActionScript properties.
     /// This invalidates any ancestors cacheAsBitmap automatically.
-    fn set_x(&self, gc_context: &Mutation<'gc>, x: Twips) {
+    fn set_x(self, gc_context: &Mutation<'gc>, x: Twips) {
         if self.base_mut(gc_context).set_x(x) {
             if let Some(parent) = self.parent() {
                 // Self-transform changes are automatically handled,
@@ -1378,14 +1380,14 @@ pub trait TDisplayObject<'gc>:
 
     /// The `y` position in pixels of this display object in local space.
     /// Returned by the `_y`/`y` ActionScript properties.
-    fn y(&self) -> Twips {
+    fn y(self) -> Twips {
         self.base().y()
     }
 
     /// Sets the `y` position in pixels of this display object in local space.
     /// Set by the `_y`/`y` ActionScript properties.
     /// This invalidates any ancestors cacheAsBitmap automatically.
-    fn set_y(&self, gc_context: &Mutation<'gc>, y: Twips) {
+    fn set_y(self, gc_context: &Mutation<'gc>, y: Twips) {
         if self.base_mut(gc_context).set_y(y) {
             if let Some(parent) = self.parent() {
                 // Self-transform changes are automatically handled,
@@ -1397,7 +1399,7 @@ pub trait TDisplayObject<'gc>:
 
     /// The rotation in degrees this display object in local space.
     /// Returned by the `_rotation`/`rotation` ActionScript properties.
-    fn rotation(&self) -> Degrees {
+    fn rotation(self) -> Degrees {
         let degrees = self.base().rotation();
         self.set_scale_rotation_cached();
         degrees
@@ -1406,7 +1408,7 @@ pub trait TDisplayObject<'gc>:
     /// Sets the rotation in degrees this display object in local space.
     /// Set by the `_rotation`/`rotation` ActionScript properties.
     /// This invalidates any ancestors cacheAsBitmap automatically.
-    fn set_rotation(&self, gc_context: &Mutation<'gc>, radians: Degrees) {
+    fn set_rotation(self, gc_context: &Mutation<'gc>, radians: Degrees) {
         if self.base_mut(gc_context).set_rotation(radians) {
             self.set_scale_rotation_cached();
             if let Some(parent) = self.parent() {
@@ -1419,7 +1421,7 @@ pub trait TDisplayObject<'gc>:
 
     /// The X axis scale for this display object in local space.
     /// Returned by the `_xscale`/`scaleX` ActionScript properties.
-    fn scale_x(&self) -> Percent {
+    fn scale_x(self) -> Percent {
         let percent = self.base().scale_x();
         self.set_scale_rotation_cached();
         percent
@@ -1428,7 +1430,7 @@ pub trait TDisplayObject<'gc>:
     /// Sets the X axis scale for this display object in local space.
     /// Set by the `_xscale`/`scaleX` ActionScript properties.
     /// This invalidates any ancestors cacheAsBitmap automatically.
-    fn set_scale_x(&self, gc_context: &Mutation<'gc>, value: Percent) {
+    fn set_scale_x(self, gc_context: &Mutation<'gc>, value: Percent) {
         if self.base_mut(gc_context).set_scale_x(value) {
             self.set_scale_rotation_cached();
             if let Some(parent) = self.parent() {
@@ -1441,7 +1443,7 @@ pub trait TDisplayObject<'gc>:
 
     /// The Y axis scale for this display object in local space.
     /// Returned by the `_yscale`/`scaleY` ActionScript properties.
-    fn scale_y(&self) -> Percent {
+    fn scale_y(self) -> Percent {
         let percent = self.base().scale_y();
         self.set_scale_rotation_cached();
         percent
@@ -1450,7 +1452,7 @@ pub trait TDisplayObject<'gc>:
     /// Sets the Y axis scale for this display object in local space.
     /// Returned by the `_yscale`/`scaleY` ActionScript properties.
     /// This invalidates any ancestors cacheAsBitmap automatically.
-    fn set_scale_y(&self, gc_context: &Mutation<'gc>, value: Percent) {
+    fn set_scale_y(self, gc_context: &Mutation<'gc>, value: Percent) {
         if self.base_mut(gc_context).set_scale_y(value) {
             self.set_scale_rotation_cached();
             if let Some(parent) = self.parent() {
@@ -1463,7 +1465,7 @@ pub trait TDisplayObject<'gc>:
 
     /// Gets the pixel width of the AABB containing this display object in local space.
     /// Returned by the ActionScript `_width`/`width` properties.
-    fn width(&self) -> f64 {
+    fn width(self) -> f64 {
         self.local_bounds().width().to_pixels()
     }
 
@@ -1471,7 +1473,7 @@ pub trait TDisplayObject<'gc>:
     /// The width is based on the AABB of the object.
     /// Set by the ActionScript `_width`/`width` properties.
     /// This does odd things on rotated clips to match the behavior of Flash.
-    fn set_width(&self, context: &mut UpdateContext<'gc>, value: f64) {
+    fn set_width(self, context: &mut UpdateContext<'gc>, value: f64) {
         let gc_context = context.gc();
         let object_bounds = self.bounds();
         let object_width = object_bounds.width().to_pixels();
@@ -1512,14 +1514,14 @@ pub trait TDisplayObject<'gc>:
 
     /// Gets the pixel height of the AABB containing this display object in local space.
     /// Returned by the ActionScript `_height`/`height` properties.
-    fn height(&self) -> f64 {
+    fn height(self) -> f64 {
         self.local_bounds().height().to_pixels()
     }
 
     /// Sets the pixel height of this display object in local space.
     /// Set by the ActionScript `_height`/`height` properties.
     /// This does odd things on rotated clips to match the behavior of Flash.
-    fn set_height(&self, context: &mut UpdateContext<'gc>, value: f64) {
+    fn set_height(self, context: &mut UpdateContext<'gc>, value: f64) {
         let gc_context = context.gc();
         let object_bounds = self.bounds();
         let object_width = object_bounds.width().to_pixels();
@@ -1561,7 +1563,7 @@ pub trait TDisplayObject<'gc>:
     /// The opacity of this display object.
     /// 1 is fully opaque.
     /// Returned by the `_alpha`/`alpha` ActionScript properties.
-    fn alpha(&self) -> f64 {
+    fn alpha(self) -> f64 {
         self.base().alpha()
     }
 
@@ -1569,7 +1571,7 @@ pub trait TDisplayObject<'gc>:
     /// 1 is fully opaque.
     /// Set by the `_alpha`/`alpha` ActionScript properties.
     /// This invalidates any cacheAsBitmap automatically.
-    fn set_alpha(&self, gc_context: &Mutation<'gc>, value: f64) {
+    fn set_alpha(self, gc_context: &Mutation<'gc>, value: f64) {
         if self.base_mut(gc_context).set_alpha(value) {
             if let Some(parent) = self.parent() {
                 // Self-transform changes are automatically handled
@@ -1578,25 +1580,26 @@ pub trait TDisplayObject<'gc>:
         }
     }
 
-    fn name(&self) -> Option<AvmString<'gc>> {
+    fn name(self) -> Option<AvmString<'gc>> {
         self.base().name()
     }
-    fn set_name(&self, gc_context: &Mutation<'gc>, name: AvmString<'gc>) {
+
+    fn set_name(self, gc_context: &Mutation<'gc>, name: AvmString<'gc>) {
         self.base_mut(gc_context).set_name(name)
     }
 
-    fn filters(&self) -> Vec<Filter> {
+    fn filters(self) -> Vec<Filter> {
         self.base().filters()
     }
 
-    fn set_filters(&self, gc_context: &Mutation<'gc>, filters: Vec<Filter>) {
+    fn set_filters(self, gc_context: &Mutation<'gc>, filters: Vec<Filter>) {
         if self.base_mut(gc_context).set_filters(filters) {
             self.invalidate_cached_bitmap(gc_context);
         }
     }
 
     /// Returns the dot-syntax path to this display object, e.g. `_level0.foo.clip`
-    fn path(&self) -> WString {
+    fn path(self) -> WString {
         if let Some(parent) = self.avm1_parent() {
             let mut path = parent.path();
             path.push_byte(b'.');
@@ -1611,7 +1614,7 @@ pub trait TDisplayObject<'gc>:
 
     /// Returns the Flash 4 slash-syntax path to this display object, e.g. `/foo/clip`.
     /// Returned by the `_target` property in AVM1.
-    fn slash_path(&self) -> WString {
+    fn slash_path(self) -> WString {
         fn build_slash_path(object: DisplayObject<'_>) -> WString {
             if let Some(parent) = object.avm1_parent() {
                 let mut path = build_slash_path(parent);
@@ -1633,17 +1636,18 @@ pub trait TDisplayObject<'gc>:
         }
 
         if self.avm1_parent().is_some() {
-            build_slash_path((*self).into())
+            build_slash_path(self.into())
         } else {
             // _target of _level0 should just be '/'.
             WString::from_unit(b'/'.into())
         }
     }
 
-    fn clip_depth(&self) -> Depth {
+    fn clip_depth(self) -> Depth {
         self.base().clip_depth()
     }
-    fn set_clip_depth(&self, depth: Depth) {
+
+    fn set_clip_depth(self, depth: Depth) {
         self.base().set_clip_depth(depth);
     }
 
@@ -1651,12 +1655,12 @@ pub trait TDisplayObject<'gc>:
     ///
     /// This version of the function merely exposes the display object parent,
     /// without any further filtering.
-    fn parent(&self) -> Option<DisplayObject<'gc>> {
+    fn parent(self) -> Option<DisplayObject<'gc>> {
         self.base().parent()
     }
 
     /// Set the parent of this display object.
-    fn set_parent(&self, context: &mut UpdateContext<'gc>, parent: Option<DisplayObject<'gc>>) {
+    fn set_parent(self, context: &mut UpdateContext<'gc>, parent: Option<DisplayObject<'gc>>) {
         let had_parent = self.parent().is_some();
         self.base_mut(context.gc())
             .set_parent_ignoring_orphan_list(parent);
@@ -1674,7 +1678,7 @@ pub trait TDisplayObject<'gc>:
 
     /// This method is called when the parent is removed.
     /// It may be overwritten to inject some implementation-specific behavior.
-    fn on_parent_removed(&self, _context: &mut UpdateContext<'gc>) {}
+    fn on_parent_removed(self, _context: &mut UpdateContext<'gc>) {}
 
     /// Retrieve the parent of this display object.
     ///
@@ -1682,7 +1686,7 @@ pub trait TDisplayObject<'gc>:
     /// seen in AVM1. Notably, it disallows access to the `Stage` and to
     /// non-AVM1 DisplayObjects; for an unfiltered concept of parent,
     /// use the `parent` method.
-    fn avm1_parent(&self) -> Option<DisplayObject<'gc>> {
+    fn avm1_parent(self) -> Option<DisplayObject<'gc>> {
         self.parent()
             .filter(|p| p.as_stage().is_none())
             .filter(|p| !p.movie().is_action_script_3())
@@ -1692,21 +1696,24 @@ pub trait TDisplayObject<'gc>:
     ///
     /// This version of the function implements the concept of parenthood as
     /// seen in AVM2. Notably, it disallows access to non-container parents.
-    fn avm2_parent(&self) -> Option<DisplayObject<'gc>> {
+    fn avm2_parent(self) -> Option<DisplayObject<'gc>> {
         self.parent().filter(|p| p.as_container().is_some())
     }
 
-    fn next_avm1_clip(&self) -> Option<DisplayObject<'gc>> {
+    fn next_avm1_clip(self) -> Option<DisplayObject<'gc>> {
         self.base().next_avm1_clip()
     }
-    fn set_next_avm1_clip(&self, gc_context: &Mutation<'gc>, node: Option<DisplayObject<'gc>>) {
+
+    fn set_next_avm1_clip(self, gc_context: &Mutation<'gc>, node: Option<DisplayObject<'gc>>) {
         self.base_mut(gc_context).set_next_avm1_clip(node);
     }
-    fn masker(&self) -> Option<DisplayObject<'gc>> {
+
+    fn masker(self) -> Option<DisplayObject<'gc>> {
         self.base().masker()
     }
+
     fn set_masker(
-        &self,
+        self,
         gc_context: &Mutation<'gc>,
         node: Option<DisplayObject<'gc>>,
         remove_old_link: bool,
@@ -1723,11 +1730,13 @@ pub trait TDisplayObject<'gc>:
         }
         self.base_mut(gc_context).set_masker(node);
     }
-    fn maskee(&self) -> Option<DisplayObject<'gc>> {
+
+    fn maskee(self) -> Option<DisplayObject<'gc>> {
         self.base().maskee()
     }
+
     fn set_maskee(
-        &self,
+        self,
         gc_context: &Mutation<'gc>,
         node: Option<DisplayObject<'gc>>,
         remove_old_link: bool,
@@ -1742,15 +1751,15 @@ pub trait TDisplayObject<'gc>:
         self.base_mut(gc_context).set_maskee(node);
     }
 
-    fn scroll_rect(&self) -> Option<Rectangle<Twips>> {
+    fn scroll_rect(self) -> Option<Rectangle<Twips>> {
         self.base().scroll_rect.get()
     }
 
-    fn next_scroll_rect(&self) -> Rectangle<Twips> {
+    fn next_scroll_rect(self) -> Rectangle<Twips> {
         self.base().next_scroll_rect.get()
     }
 
-    fn set_next_scroll_rect(&self, gc_context: &Mutation<'gc>, rectangle: Rectangle<Twips>) {
+    fn set_next_scroll_rect(self, gc_context: &Mutation<'gc>, rectangle: Rectangle<Twips>) {
         self.base().next_scroll_rect.set(rectangle);
 
         // Scroll rect is natively handled by cacheAsBitmap - don't invalidate self, only parents
@@ -1759,44 +1768,44 @@ pub trait TDisplayObject<'gc>:
         }
     }
 
-    fn scaling_grid(&self) -> Rectangle<Twips> {
+    fn scaling_grid(self) -> Rectangle<Twips> {
         self.base().scaling_grid.get()
     }
 
-    fn set_scaling_grid(&self, rect: Rectangle<Twips>) {
+    fn set_scaling_grid(self, rect: Rectangle<Twips>) {
         self.base().scaling_grid.set(rect);
     }
 
     /// Whether this object has been removed. Only applies to AVM1.
-    fn avm1_removed(&self) -> bool {
+    fn avm1_removed(self) -> bool {
         self.base().avm1_removed()
     }
 
     // Sets whether this object has been removed. Only applies to AVM1
-    fn set_avm1_removed(&self, value: bool) {
+    fn set_avm1_removed(self, value: bool) {
         self.base().set_avm1_removed(value)
     }
 
     /// Is this object waiting to be removed on the start of the next frame
-    fn avm1_pending_removal(&self) -> bool {
+    fn avm1_pending_removal(self) -> bool {
         self.base().avm1_pending_removal()
     }
 
-    fn set_avm1_pending_removal(&self, value: bool) {
+    fn set_avm1_pending_removal(self, value: bool) {
         self.base().set_avm1_pending_removal(value)
     }
 
     /// Whether this display object is visible.
     /// Invisible objects are not rendered, but otherwise continue to exist normally.
     /// Returned by the `_visible`/`visible` ActionScript properties.
-    fn visible(&self) -> bool {
+    fn visible(self) -> bool {
         self.base().visible()
     }
 
     /// Sets whether this display object will be visible.
     /// Invisible objects are not rendered, but otherwise continue to exist normally.
     /// Returned by the `_visible`/`visible` ActionScript properties.
-    fn set_visible(&self, context: &mut UpdateContext<'gc>, value: bool) {
+    fn set_visible(self, context: &mut UpdateContext<'gc>, value: bool) {
         if self.base().set_visible(value) {
             if let Some(parent) = self.parent() {
                 // We don't need to invalidate ourselves, we're just toggling if the bitmap is rendered.
@@ -1812,23 +1821,23 @@ pub trait TDisplayObject<'gc>:
         }
     }
 
-    fn meta_data(&self) -> Option<Avm2Object<'gc>> {
+    fn meta_data(self) -> Option<Avm2Object<'gc>> {
         self.base().meta_data()
     }
 
-    fn set_meta_data(&self, gc_context: &Mutation<'gc>, value: Avm2Object<'gc>) {
+    fn set_meta_data(self, gc_context: &Mutation<'gc>, value: Avm2Object<'gc>) {
         self.base_mut(gc_context).set_meta_data(value);
     }
 
     /// The blend mode used when rendering this display object.
     /// Values other than the default `BlendMode::Normal` implicitly cause cache-as-bitmap behavior.
-    fn blend_mode(&self) -> ExtendedBlendMode {
+    fn blend_mode(self) -> ExtendedBlendMode {
         self.base().blend_mode()
     }
 
     /// Sets the blend mode used when rendering this display object.
     /// Values other than the default `BlendMode::Normal` implicitly cause cache-as-bitmap behavior.
-    fn set_blend_mode(&self, gc_context: &Mutation<'gc>, value: ExtendedBlendMode) {
+    fn set_blend_mode(self, gc_context: &Mutation<'gc>, value: ExtendedBlendMode) {
         if self.base().set_blend_mode(value) {
             if let Some(parent) = self.parent() {
                 // We don't need to invalidate ourselves, we're just toggling how the bitmap is rendered.
@@ -1840,17 +1849,17 @@ pub trait TDisplayObject<'gc>:
         }
     }
 
-    fn blend_shader(&self) -> Option<PixelBenderShaderHandle> {
+    fn blend_shader(self) -> Option<PixelBenderShaderHandle> {
         self.base().blend_shader()
     }
 
-    fn set_blend_shader(&self, gc_context: &Mutation<'gc>, value: Option<PixelBenderShaderHandle>) {
+    fn set_blend_shader(self, gc_context: &Mutation<'gc>, value: Option<PixelBenderShaderHandle>) {
         self.base_mut(gc_context).set_blend_shader(value);
         self.set_blend_mode(gc_context, ExtendedBlendMode::Shader);
     }
 
     /// The opaque background color of this display object.
-    fn opaque_background(&self) -> Option<Color> {
+    fn opaque_background(self) -> Option<Color> {
         self.base().opaque_background()
     }
 
@@ -1858,25 +1867,25 @@ pub trait TDisplayObject<'gc>:
     /// The bounding box of the display object will be filled with the given color. This also
     /// triggers cache-as-bitmap behavior. Only solid backgrounds are supported; the alpha channel
     /// is ignored.
-    fn set_opaque_background(&self, gc_context: &Mutation<'gc>, value: Option<Color>) {
+    fn set_opaque_background(self, gc_context: &Mutation<'gc>, value: Option<Color>) {
         if self.base().set_opaque_background(value) {
             self.invalidate_cached_bitmap(gc_context);
         }
     }
 
     /// Whether this display object represents the root of loaded content.
-    fn is_root(&self) -> bool {
+    fn is_root(self) -> bool {
         self.base().is_root()
     }
 
     /// Sets whether this display object represents the root of loaded content.
-    fn set_is_root(&self, value: bool) {
+    fn set_is_root(self, value: bool) {
         self.base().set_is_root(value);
     }
 
     /// The sound transform for sounds played inside this display object.
     fn set_sound_transform(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         sound_transform: SoundTransform,
     ) {
@@ -1887,82 +1896,82 @@ pub trait TDisplayObject<'gc>:
 
     /// Whether this display object is used as the _root of itself and its children.
     /// Returned by the `_lockroot` ActionScript property.
-    fn lock_root(&self) -> bool {
+    fn lock_root(self) -> bool {
         self.base().lock_root()
     }
 
     /// Sets whether this display object is used as the _root of itself and its children.
     /// Returned by the `_lockroot` ActionScript property.
-    fn set_lock_root(&self, value: bool) {
+    fn set_lock_root(self, value: bool) {
         self.base().set_lock_root(value);
     }
 
     /// Whether this display object has been transformed by ActionScript.
     /// When this flag is set, changes from SWF `PlaceObject` tags are ignored.
-    fn transformed_by_script(&self) -> bool {
+    fn transformed_by_script(self) -> bool {
         self.base().transformed_by_script()
     }
 
     /// Sets whether this display object has been transformed by ActionScript.
     /// When this flag is set, changes from SWF `PlaceObject` tags are ignored.
-    fn set_transformed_by_script(&self, value: bool) {
+    fn set_transformed_by_script(self, value: bool) {
         self.base().set_transformed_by_script(value)
     }
 
     /// Whether this display object prefers to be cached into a bitmap rendering.
     /// This is the PlaceObject `cacheAsBitmap` flag - and may be overridden if filters are applied.
     /// Consider `is_bitmap_cached` for if a bitmap cache is actually in use.
-    fn is_bitmap_cached_preference(&self) -> bool {
+    fn is_bitmap_cached_preference(self) -> bool {
         self.base().is_bitmap_cached_preference()
     }
 
     /// Whether this display object is using a bitmap cache, whether by preference or necessity.
-    fn is_bitmap_cached(&self) -> bool {
+    fn is_bitmap_cached(self) -> bool {
         self.base().cache.is_some()
     }
 
     /// Explicitly sets the preference of this display object to be cached into a bitmap rendering.
     /// Note that the object will still be bitmap cached if a filter is active.
-    fn set_bitmap_cached_preference(&self, gc_context: &Mutation<'gc>, value: bool) {
+    fn set_bitmap_cached_preference(self, gc_context: &Mutation<'gc>, value: bool) {
         self.base_mut(gc_context)
             .set_bitmap_cached_preference(value)
     }
 
     /// Whether this display object has a scroll rectangle applied.
-    fn has_scroll_rect(&self) -> bool {
+    fn has_scroll_rect(self) -> bool {
         self.base().has_scroll_rect()
     }
 
     /// Sets whether this display object has a scroll rectangle applied.
-    fn set_has_scroll_rect(&self, value: bool) {
+    fn set_has_scroll_rect(self, value: bool) {
         self.base().set_has_scroll_rect(value)
     }
 
     /// Whether this display object has been created by ActionScript 3.
     /// When this flag is set, changes from SWF `RemoveObject` tags are
     /// ignored.
-    fn placed_by_script(&self) -> bool {
+    fn placed_by_script(self) -> bool {
         self.base().placed_by_script()
     }
 
     /// Sets whether this display object has been created by ActionScript 3.
     /// When this flag is set, changes from SWF `RemoveObject` tags are
     /// ignored.
-    fn set_placed_by_script(&self, value: bool) {
+    fn set_placed_by_script(self, value: bool) {
         self.base().set_placed_by_script(value)
     }
 
     /// Whether this display object has been instantiated by the timeline.
     /// When this flag is set, attempts to change the object's name from AVM2
     /// throw an exception.
-    fn instantiated_by_timeline(&self) -> bool {
+    fn instantiated_by_timeline(self) -> bool {
         self.base().instantiated_by_timeline()
     }
 
     /// Sets whether this display object has been instantiated by the timeline.
     /// When this flag is set, attempts to change the object's name from AVM2
     /// throw an exception.
-    fn set_instantiated_by_timeline(&self, value: bool) {
+    fn set_instantiated_by_timeline(self, value: bool) {
         self.base().set_instantiated_by_timeline(value);
     }
 
@@ -1971,7 +1980,7 @@ pub trait TDisplayObject<'gc>:
     ///
     /// When this flag is set, the object will attempt to set a dynamic property
     /// on the parent with the same name as itself.
-    fn has_explicit_name(&self) -> bool {
+    fn has_explicit_name(self) -> bool {
         self.base().has_explicit_name()
     }
 
@@ -1980,7 +1989,7 @@ pub trait TDisplayObject<'gc>:
     ///
     /// When this flag is set, the object will attempt to set a dynamic property
     /// on the parent with the same name as itself.
-    fn set_has_explicit_name(&self, value: bool) {
+    fn set_has_explicit_name(self, value: bool) {
         self.base().set_has_explicit_name(value);
     }
     fn state(&self) -> Option<ButtonState> {
@@ -1990,7 +1999,7 @@ pub trait TDisplayObject<'gc>:
     /// Run any start-of-frame actions for this display object.
     ///
     /// When fired on `Stage`, this also emits the AVM2 `enterFrame` broadcast.
-    fn enter_frame(&self, _context: &mut UpdateContext<'gc>) {}
+    fn enter_frame(self, _context: &mut UpdateContext<'gc>) {}
 
     /// Construct all display objects that the timeline indicates should exist
     /// this frame, and their children.
@@ -2001,7 +2010,7 @@ pub trait TDisplayObject<'gc>:
     /// 1. That the object itself has been allocated, if not constructed
     /// 2. That newly created children have been instantiated and are present
     ///    as properties on the class
-    fn construct_frame(&self, _context: &mut UpdateContext<'gc>) {}
+    fn construct_frame(self, _context: &mut UpdateContext<'gc>) {}
 
     /// To be called when an AVM2 display object has finished being constructed.
     ///
@@ -2020,7 +2029,7 @@ pub trait TDisplayObject<'gc>:
     /// placed on the render list, these steps have to be done by the child
     /// object to signal to its parent that it was added.
     #[inline(never)]
-    fn on_construction_complete(&self, context: &mut UpdateContext<'gc>) {
+    fn on_construction_complete(self, context: &mut UpdateContext<'gc>) {
         let placed_by_script = self.placed_by_script();
         self.fire_added_events(context);
         // Check `self.placed_by_script()` before we fire events, since those
@@ -2046,7 +2055,7 @@ pub trait TDisplayObject<'gc>:
         }
     }
 
-    fn fire_added_events(&self, context: &mut UpdateContext<'gc>) {
+    fn fire_added_events(self, context: &mut UpdateContext<'gc>) {
         if !self.placed_by_script() {
             // Since we construct AVM2 display objects after they are
             // allocated and placed on the render list, we have to emit all
@@ -2054,15 +2063,15 @@ pub trait TDisplayObject<'gc>:
             //
             // Children added to buttons by the timeline do not emit events.
             if self.parent().and_then(|p| p.as_avm2_button()).is_none() {
-                dispatch_added_event_only((*self).into(), context);
+                dispatch_added_event_only(self.into(), context);
                 if self.avm2_stage(context).is_some() {
-                    dispatch_added_to_stage_event_only((*self).into(), context);
+                    dispatch_added_to_stage_event_only(self.into(), context);
                 }
             }
         }
     }
 
-    fn set_on_parent_field(&self, context: &mut UpdateContext<'gc>) {
+    fn set_on_parent_field(self, context: &mut UpdateContext<'gc>) {
         //TODO: Don't report missing property errors.
         //TODO: Don't attempt to set properties if object was placed without a name.
         if self.has_explicit_name() {
@@ -2093,11 +2102,11 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Execute all other timeline actions on this object.
-    fn run_frame_avm1(&self, _context: &mut UpdateContext<'gc>) {}
+    fn run_frame_avm1(self, _context: &mut UpdateContext<'gc>) {}
 
     /// Emit a `frameConstructed` event on this DisplayObject and any children it
     /// may have.
-    fn frame_constructed(&self, context: &mut UpdateContext<'gc>) {
+    fn frame_constructed(self, context: &mut UpdateContext<'gc>) {
         let frame_constructed_evt =
             Avm2EventObject::bare_default_event(context, "frameConstructed");
         let dobject_constr = context.avm2.classes().display_object;
@@ -2114,7 +2123,7 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Emit an `exitFrame` broadcast event.
-    fn exit_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn exit_frame(self, context: &mut UpdateContext<'gc>) {
         let exit_frame_evt = Avm2EventObject::bare_default_event(context, "exitFrame");
         let dobject_constr = context.avm2.classes().display_object;
         Avm2::broadcast_event(context, exit_frame_evt, dobject_constr);
@@ -2125,24 +2134,24 @@ pub trait TDisplayObject<'gc>:
     /// Called before the child is about to be rendered.
     /// Note that this happens even if the child is invisible
     /// (as long as the child is still on a render list)
-    fn pre_render(&self, _context: &mut RenderContext<'_, 'gc>) {
+    fn pre_render(self, _context: &mut RenderContext<'_, 'gc>) {
         let this = self.base();
         this.clear_invalidate_flag();
         this.scroll_rect
             .set(this.has_scroll_rect().then(|| this.next_scroll_rect.get()));
     }
 
-    fn render_self(&self, _context: &mut RenderContext<'_, 'gc>) {}
+    fn render_self(self, _context: &mut RenderContext<'_, 'gc>) {}
 
-    fn render(&self, context: &mut RenderContext<'_, 'gc>) {
-        render_base((*self).into(), context)
+    fn render(self, context: &mut RenderContext<'_, 'gc>) {
+        render_base(self.into(), context)
     }
 
     #[cfg(not(feature = "avm_debug"))]
-    fn display_render_tree(&self, _depth: usize) {}
+    fn display_render_tree(self, _depth: usize) {}
 
     #[cfg(feature = "avm_debug")]
-    fn display_render_tree(&self, depth: usize) {
+    fn display_render_tree(self, depth: usize) {
         let mut self_str = &*format!("{self:?}");
         if let Some(end_char) = self_str.find(|c: char| !c.is_ascii_alphanumeric()) {
             self_str = &self_str[..end_char];
@@ -2174,7 +2183,7 @@ pub trait TDisplayObject<'gc>:
         }
     }
 
-    fn avm1_unload(&self, context: &mut UpdateContext<'gc>) {
+    fn avm1_unload(self, context: &mut UpdateContext<'gc>) {
         // Unload children.
         if let Some(ctr) = self.as_container() {
             for child in ctr.iter_render_list() {
@@ -2189,7 +2198,7 @@ pub trait TDisplayObject<'gc>:
         }
 
         // Unregister any text field variable bindings, and replace them on the unbound list.
-        Avm1TextFieldBinding::unregister_bindings((*self).into(), context);
+        Avm1TextFieldBinding::unregister_bindings(self.into(), context);
 
         self.set_avm1_removed(true);
     }
@@ -2205,48 +2214,55 @@ pub trait TDisplayObject<'gc>:
         None
     }
 
-    fn as_stage(&self) -> Option<Stage<'gc>> {
+    fn as_stage(self) -> Option<Stage<'gc>> {
         None
     }
-    fn as_avm1_button(&self) -> Option<Avm1Button<'gc>> {
+
+    fn as_avm1_button(self) -> Option<Avm1Button<'gc>> {
         None
     }
-    fn as_avm2_button(&self) -> Option<Avm2Button<'gc>> {
+
+    fn as_avm2_button(self) -> Option<Avm2Button<'gc>> {
         None
     }
-    fn as_movie_clip(&self) -> Option<MovieClip<'gc>> {
+
+    fn as_movie_clip(self) -> Option<MovieClip<'gc>> {
         None
     }
-    fn as_edit_text(&self) -> Option<EditText<'gc>> {
+
+    fn as_edit_text(self) -> Option<EditText<'gc>> {
         None
     }
-    fn as_text(&self) -> Option<Text<'gc>> {
+
+    fn as_text(self) -> Option<Text<'gc>> {
         None
     }
-    fn as_morph_shape(&self) -> Option<MorphShape<'gc>> {
+
+    fn as_morph_shape(self) -> Option<MorphShape<'gc>> {
         None
     }
+
     fn as_container(self) -> Option<DisplayObjectContainer<'gc>> {
         None
     }
+
     fn as_video(self) -> Option<Video<'gc>> {
         None
     }
+
     fn as_drawing(&self, _gc_context: &Mutation<'gc>) -> Option<RefMut<'_, Drawing>> {
         None
     }
+
     fn as_bitmap(self) -> Option<Bitmap<'gc>> {
         None
     }
+
     fn as_interactive(self) -> Option<InteractiveObject<'gc>> {
         None
     }
 
-    fn apply_place_object(
-        &self,
-        context: &mut UpdateContext<'gc>,
-        place_object: &swf::PlaceObject,
-    ) {
+    fn apply_place_object(self, context: &mut UpdateContext<'gc>, place_object: &swf::PlaceObject) {
         // PlaceObject tags only apply if this object has not been dynamically moved by AS code.
         if !self.transformed_by_script() {
             if let Some(matrix) = place_object.matrix {
@@ -2302,34 +2318,34 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Called when this object should be replaced by a PlaceObject tag.
-    fn replace_with(&self, _context: &mut UpdateContext<'gc>, _id: CharacterId) {
+    fn replace_with(self, _context: &mut UpdateContext<'gc>, _id: CharacterId) {
         // Noop for most symbols; only shapes can replace their innards with another Graphic.
     }
 
-    fn object(&self) -> Avm1Value<'gc> {
+    fn object(self) -> Avm1Value<'gc> {
         Avm1Value::Undefined // TODO: Implement for every type and delete this fallback.
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         Avm2Value::Undefined // TODO: See above. Also, unconstructed objects should return null.
     }
 
-    fn set_object2(&self, _context: &mut UpdateContext<'gc>, _to: Avm2Object<'gc>) {}
+    fn set_object2(self, _context: &mut UpdateContext<'gc>, _to: Avm2Object<'gc>) {}
 
     /// Tests if a given stage position point intersects with the world bounds of this object.
-    fn hit_test_bounds(&self, point: Point<Twips>) -> bool {
+    fn hit_test_bounds(self, point: Point<Twips>) -> bool {
         self.world_bounds().contains(point)
     }
 
     /// Tests if a given object's world bounds intersects with the world bounds
     /// of this object.
-    fn hit_test_object(&self, other: DisplayObject<'gc>) -> bool {
+    fn hit_test_object(self, other: DisplayObject<'gc>) -> bool {
         self.world_bounds().intersects(&other.world_bounds())
     }
 
     /// Tests if a given stage position point intersects within this object, considering the art.
     fn hit_test_shape(
-        &self,
+        self,
         _context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         options: HitTestOptions,
@@ -2340,7 +2356,7 @@ pub trait TDisplayObject<'gc>:
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
@@ -2352,24 +2368,25 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Return the version of the SWF that created this movie clip.
-    fn swf_version(&self) -> u8 {
+    fn swf_version(self) -> u8 {
         self.movie().version()
     }
 
     /// Return the SWF that defines this display object.
-    fn movie(&self) -> Arc<SwfMovie>;
+    fn movie(self) -> Arc<SwfMovie>;
 
-    fn loader_info(&self) -> Option<Avm2Object<'gc>> {
+    fn loader_info(self) -> Option<Avm2Object<'gc>> {
         None
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc>;
-    fn as_ptr(&self) -> *const DisplayObjectPtr;
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc>;
+
+    fn as_ptr(self) -> *const DisplayObjectPtr;
 
     /// Whether this object can be used as a mask.
     /// If this returns false and this object is used as a mask, the mask will not be applied.
     /// This is used by movie clips to disable the mask when there are no children, for example.
-    fn allow_as_mask(&self) -> bool {
+    fn allow_as_mask(self) -> bool {
         true
     }
 
@@ -2377,8 +2394,8 @@ pub trait TDisplayObject<'gc>:
     ///
     /// This function implements the AVM1 concept of root clips. For the AVM2
     /// version, see `avm2_root`.
-    fn avm1_root(&self) -> DisplayObject<'gc> {
-        let mut root = (*self).into();
+    fn avm1_root(self) -> DisplayObject<'gc> {
+        let mut root = self.into();
         loop {
             if root.lock_root() {
                 break;
@@ -2398,8 +2415,8 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// `avm1_root`, but disregards _lockroot
-    fn avm1_root_no_lock(&self) -> DisplayObject<'gc> {
-        let mut root = (*self).into();
+    fn avm1_root_no_lock(self) -> DisplayObject<'gc> {
+        let mut root = self.into();
         while let Some(parent) = root.avm1_parent() {
             if !parent.movie().is_action_script_3() {
                 root = parent;
@@ -2412,8 +2429,8 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Obtain the top-most Stage or LoaderDisplay object of the display tree hierarchy, for use in mixed AVM.
-    fn avm1_stage(&self) -> DisplayObject<'gc> {
-        let mut root = (*self).into();
+    fn avm1_stage(self) -> DisplayObject<'gc> {
+        let mut root = self.into();
         loop {
             if let Some(parent) = root.parent() {
                 if matches!(
@@ -2434,8 +2451,8 @@ pub trait TDisplayObject<'gc>:
     ///
     /// This function implements the AVM2 concept of root clips. For the AVM1
     /// version, see `avm1_root`.
-    fn avm2_root(&self) -> Option<DisplayObject<'gc>> {
-        let mut parent = Some((*self).into());
+    fn avm2_root(self) -> Option<DisplayObject<'gc>> {
+        let mut parent = Some(self.into());
         while let Some(p) = parent {
             if p.is_root() {
                 return parent;
@@ -2458,8 +2475,8 @@ pub trait TDisplayObject<'gc>:
     /// will fail to locate the current player's stage for objects that are not
     /// rooted to the DisplayObject hierarchy correctly. If you just want to
     /// access the current player's stage, grab it from the context.
-    fn avm2_stage(&self, _context: &UpdateContext<'gc>) -> Option<DisplayObject<'gc>> {
-        let mut parent = Some((*self).into());
+    fn avm2_stage(self, _context: &UpdateContext<'gc>) -> Option<DisplayObject<'gc>> {
+        let mut parent = Some(self.into());
         while let Some(p) = parent {
             if p.as_stage().is_some() {
                 return parent;
@@ -2485,7 +2502,7 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Assigns a default instance name `instanceN` to this object.
-    fn set_default_instance_name(&self, context: &mut UpdateContext<'gc>) {
+    fn set_default_instance_name(self, context: &mut UpdateContext<'gc>) {
         if self.base().name().is_none() {
             let name = format!("instance{}", *context.instance_counter);
             self.set_name(context.gc(), AvmString::new_utf8(context.gc(), name));
@@ -2497,7 +2514,7 @@ pub trait TDisplayObject<'gc>:
     ///
     /// The default root names change based on the AVM configuration of the
     /// clip; AVM2 clips get `rootN` while AVM1 clips get blank strings.
-    fn set_default_root_name(&self, context: &mut UpdateContext<'gc>) {
+    fn set_default_root_name(self, context: &mut UpdateContext<'gc>) {
         if self.movie().is_action_script_3() {
             let name = AvmString::new_utf8(context.gc(), format!("root{}", self.depth() + 1));
             self.set_name(context.gc(), name);
@@ -2508,7 +2525,7 @@ pub trait TDisplayObject<'gc>:
 
     /// Inform this object and its ancestors that it has visually changed and must be redrawn.
     /// If this object or any ancestor is marked as cacheAsBitmap, it will invalidate that cache.
-    fn invalidate_cached_bitmap(&self, mc: &Mutation<'gc>) {
+    fn invalidate_cached_bitmap(self, mc: &Mutation<'gc>) {
         if self.base_mut(mc).invalidate_cached_bitmap() {
             // Don't inform ancestors if we've already done so this frame
             if let Some(parent) = self.parent() {

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -204,7 +204,7 @@ impl<'gc> Avm1Button<'gc> {
         self.invalidate_cached_bitmap(context.gc());
     }
 
-    pub fn state(&self) -> Option<ButtonState> {
+    pub fn state(self) -> Option<ButtonState> {
         Some(self.0.state.get())
     }
 
@@ -252,25 +252,25 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         RefMut::map(data.borrow_mut(), |w| &mut w.base.base)
     }
 
-    fn instantiate(&self, mc: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, mc: &Mutation<'gc>) -> DisplayObject<'gc> {
         let data: &Avm1ButtonData = &self.0;
         Self(Gc::new(mc, data.clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         self.0.shared.id
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.movie()
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Object<'gc>>,
         _instantiated_by: Instantiator,
@@ -279,14 +279,14 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         self.set_default_instance_name(context);
 
         if !self.movie().is_action_script_3() {
-            context.avm1.add_to_exec_list(context.gc(), (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), self.into());
         }
 
         if self.0.object.get().is_none() {
             let object = Object::new_with_native(
                 &context.strings,
                 Some(context.avm1.prototypes().button),
-                NativeObject::Button(*self),
+                NativeObject::Button(self),
             );
             let obj = unlock!(Gc::write(context.gc(), self.0), Avm1ButtonData, object);
             obj.set(Some(object));
@@ -297,8 +297,8 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         }
     }
 
-    fn run_frame_avm1(&self, context: &mut UpdateContext<'gc>) {
-        let self_display_object = (*self).into();
+    fn run_frame_avm1(self, context: &mut UpdateContext<'gc>) {
+        let self_display_object = self.into();
         let initialized = self.0.initialized.get();
 
         // TODO: Move this to post_instantiation.
@@ -343,17 +343,17 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         }
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(self, context: &mut RenderContext<'_, 'gc>) {
         self.render_children(context);
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         // No inherent bounds; contains child DisplayObjects.
         Default::default()
     }
 
     fn hit_test_shape(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         options: HitTestOptions,
@@ -367,7 +367,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         false
     }
 
-    fn object(&self) -> Value<'gc> {
+    fn object(self) -> Value<'gc> {
         self.0
             .object
             .get()
@@ -375,8 +375,8 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
             .unwrap_or(Value::Undefined)
     }
 
-    fn as_avm1_button(&self) -> Option<Self> {
-        Some(*self)
+    fn as_avm1_button(self) -> Option<Self> {
+        Some(self)
     }
 
     fn as_interactive(self) -> Option<InteractiveObject<'gc>> {
@@ -387,11 +387,11 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         Some(self.into())
     }
 
-    fn allow_as_mask(&self) -> bool {
+    fn allow_as_mask(self) -> bool {
         !self.is_empty()
     }
 
-    fn avm1_unload(&self, context: &mut UpdateContext<'gc>) {
+    fn avm1_unload(self, context: &mut UpdateContext<'gc>) {
         for child in self.iter_render_list() {
             child.avm1_unload(context);
         }
@@ -575,7 +575,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
     }
 
     fn mouse_pick_avm1(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         require_button_mode: bool,
@@ -593,7 +593,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
 
             for child in self.0.cell.borrow().hit_area.values() {
                 if child.hit_test_shape(context, point, HitTestOptions::MOUSE_PICK) {
-                    return Some((*self).into());
+                    return Some(self.into());
                 }
             }
         }
@@ -601,7 +601,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
     }
 
     fn mouse_pick_avm2(
-        &self,
+        self,
         _context: &mut UpdateContext<'gc>,
         _point: Point<Twips>,
         _require_button_mode: bool,
@@ -617,7 +617,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
         }
     }
 
-    fn tab_enabled_default(&self, _context: &mut UpdateContext<'gc>) -> bool {
+    fn tab_enabled_default(self, _context: &mut UpdateContext<'gc>) -> bool {
         true
     }
 

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -420,24 +420,24 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
         RefMut::map(data.borrow_mut(), |w| &mut w.base)
     }
 
-    fn instantiate(&self, mc: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, mc: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(Gc::new(mc, (*self.0).clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         self.0.shared.id
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.shared.swf.clone()
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
@@ -446,13 +446,13 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
         self.set_default_instance_name(context);
     }
 
-    fn enter_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn enter_frame(self, context: &mut UpdateContext<'gc>) {
         for state in self.all_state_children(false) {
             state.enter_frame(context);
         }
     }
 
-    fn construct_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn construct_frame(self, context: &mut UpdateContext<'gc>) {
         for state in self.all_state_children(false) {
             state.construct_frame(context);
         }
@@ -464,7 +464,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
             if needs_avm2_construction {
                 let object_cell = unlock!(Gc::write(context.gc(), self.0), Avm2ButtonData, object);
                 let mut activation = Avm2Activation::from_nothing(context);
-                match Avm2StageObject::for_display_object(&mut activation, (*self).into(), class) {
+                match Avm2StageObject::for_display_object(&mut activation, self.into(), class) {
                     Ok(object) => object_cell.set(Some(object.into())),
                     Err(e) => tracing::error!("Got {} when constructing AVM2 side of button", e),
                 };
@@ -526,12 +526,12 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
 
             // The `added` event for the state itself, as well as the `addedToStage` events, all see
             // the actual parent
-            dispatch_added_event((*self).into(), up_state, true, context);
+            dispatch_added_event(self.into(), up_state, true, context);
             if self.avm2_stage(context).is_some() {
                 // note: AFAIK we can only get here if we were created by timeline,
                 // which means that `self` can't have listeners set yet,
                 // but up_state can.
-                dispatch_added_to_stage_event((*self).into(), context);
+                dispatch_added_to_stage_event(self.into(), context);
             }
 
             if needs_avm2_construction {
@@ -568,7 +568,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
         }
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(self, context: &mut RenderContext<'_, 'gc>) {
         let current_state = self.get_state_child(self.0.state.get().into());
 
         if let Some(state) = current_state {
@@ -576,12 +576,12 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
         }
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         // No inherent bounds; contains child DisplayObjects.
         Default::default()
     }
 
-    fn bounds_with_transform(&self, matrix: &Matrix) -> Rectangle<Twips> {
+    fn bounds_with_transform(self, matrix: &Matrix) -> Rectangle<Twips> {
         // A scroll rect completely overrides an object's bounds,
         // and can even grow the bounding box to be larger than the actual content
         if let Some(scroll_rect) = self.scroll_rect() {
@@ -608,7 +608,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
     }
 
     fn render_bounds_with_transform(
-        &self,
+        self,
         matrix: &Matrix,
         include_own_filters: bool,
         view_matrix: &Matrix,
@@ -632,7 +632,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
     }
 
     fn hit_test_shape(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         options: HitTestOptions,
@@ -660,7 +660,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
         false
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .object
             .get()
@@ -668,20 +668,20 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
             .unwrap_or(Avm2Value::Null)
     }
 
-    fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
         let write = Gc::write(context.gc(), self.0);
         unlock!(write, Avm2ButtonData, object).set(Some(to));
     }
 
-    fn as_avm2_button(&self) -> Option<Self> {
-        Some(*self)
+    fn as_avm2_button(self) -> Option<Self> {
+        Some(self)
     }
 
     fn as_interactive(self) -> Option<InteractiveObject<'gc>> {
         Some(self.into())
     }
 
-    fn allow_as_mask(&self) -> bool {
+    fn allow_as_mask(self) -> bool {
         let current_state = self.get_state_child(self.0.state.get().into());
 
         if let Some(current_state) = current_state.and_then(|cs| cs.as_container()) {
@@ -770,7 +770,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm2Button<'gc> {
     }
 
     fn mouse_pick_avm2(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         mut point: Point<Twips>,
         require_button_mode: bool,
@@ -786,7 +786,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm2Button<'gc> {
                 match mouse_pick {
                     None | Some(Avm2MousePick::Miss) => {}
                     // Selecting a child of a button is equivalent to selecting the button itself
-                    _ => return Avm2MousePick::Hit((*self).into()),
+                    _ => return Avm2MousePick::Hit(self.into()),
                 };
             }
 
@@ -802,7 +802,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm2Button<'gc> {
                     }
                 }
                 if hit_area.hit_test_shape(context, point, HitTestOptions::MOUSE_PICK) {
-                    return Avm2MousePick::Hit((*self).into());
+                    return Avm2MousePick::Hit(self.into());
                 }
             }
         }
@@ -818,7 +818,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm2Button<'gc> {
         }
     }
 
-    fn tab_enabled_default(&self, _context: &mut UpdateContext<'gc>) -> bool {
+    fn tab_enabled_default(self, _context: &mut UpdateContext<'gc>) -> bool {
         true
     }
 

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -309,19 +309,19 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         unlock!(Gc::write(mc, self.0), BitmapGraphicData, base).borrow_mut()
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         self.0.id
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         Rectangle {
             x_min: Twips::ZERO,
             y_min: Twips::ZERO,
@@ -331,7 +331,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         _init_object: Option<avm1::Object<'gc>>,
         instantiated_by: Instantiator,
@@ -351,7 +351,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
 
                 let bitmap = Avm2StageObject::for_display_object_childless(
                     &mut activation,
-                    (*self).into(),
+                    self.into(),
                     bitmap_cls,
                 )
                 .expect("can't throw from post_instantiation -_-");
@@ -375,7 +375,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
 
             self.on_construction_complete(context);
         } else {
-            context.avm1.add_to_exec_list(context.gc(), (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), self.into());
 
             if run_frame {
                 self.run_frame_avm1(context);
@@ -383,7 +383,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         }
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(self, context: &mut RenderContext<'_, 'gc>) {
         if !context.is_offscreen && !self.world_bounds().intersects(&context.stage.view_bounds()) {
             // Off-screen; culled
             return;
@@ -396,7 +396,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         );
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .avm2_object
             .get()
@@ -404,7 +404,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
             .unwrap_or(Avm2Value::Null)
     }
 
-    fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
         self.set_avm2_object(context.gc(), Some(to));
     }
 
@@ -412,7 +412,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         Some(self)
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.movie.clone()
     }
 }

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -205,11 +205,11 @@ impl<'gc> Bitmap<'gc> {
     // Important - we read 'width' and 'height' from the cached
     // values on this object. See the definition of these fields
     // for more information
-    pub fn width(self) -> u16 {
+    pub fn bitmap_width(self) -> u16 {
         self.0.width.get() as u16
     }
 
-    pub fn height(self) -> u16 {
+    pub fn bitmap_height(self) -> u16 {
         self.0.height.get() as u16
     }
 
@@ -325,8 +325,8 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         Rectangle {
             x_min: Twips::ZERO,
             y_min: Twips::ZERO,
-            x_max: Twips::from_pixels(Bitmap::width(*self).into()),
-            y_max: Twips::from_pixels(Bitmap::height(*self).into()),
+            x_max: Twips::from_pixels(self.bitmap_width().into()),
+            y_max: Twips::from_pixels(self.bitmap_height().into()),
         }
     }
 

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -476,7 +476,7 @@ pub trait TDisplayObjectContainer<'gc>:
         RenderIter::from_container(self.into())
     }
 
-    fn is_tab_children_avm1(&self, _context: &mut UpdateContext<'gc>) -> bool {
+    fn is_tab_children_avm1(self, _context: &mut UpdateContext<'gc>) -> bool {
         true
     }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2512,36 +2512,36 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         RefMut::map(base_mut, |w| &mut w.base)
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         self.0.shared.id
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.shared.swf.clone()
     }
 
     /// Construct objects placed on this frame.
-    fn construct_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn construct_frame(self, context: &mut UpdateContext<'gc>) {
         if self.movie().is_action_script_3() && matches!(self.object2(), Avm2Value::Null) {
-            self.construct_as_avm2_object(context, (*self).into());
+            self.construct_as_avm2_object(context, self.into());
             self.on_construction_complete(context);
         }
     }
 
-    fn run_frame_avm1(&self, _context: &mut UpdateContext) {
+    fn run_frame_avm1(self, _context: &mut UpdateContext) {
         // Noop
     }
 
-    fn as_edit_text(&self) -> Option<EditText<'gc>> {
-        Some(*self)
+    fn as_edit_text(self) -> Option<EditText<'gc>> {
+        Some(self)
     }
 
     fn as_interactive(self) -> Option<InteractiveObject<'gc>> {
@@ -2549,7 +2549,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
@@ -2558,12 +2558,12 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.set_default_instance_name(context);
 
         if !self.movie().is_action_script_3() {
-            context.avm1.add_to_exec_list(context.gc(), (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), self.into());
             self.construct_as_avm1_object(context, run_frame);
         }
     }
 
-    fn object(&self) -> Avm1Value<'gc> {
+    fn object(self) -> Avm1Value<'gc> {
         self.0
             .object
             .get()
@@ -2572,7 +2572,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             .unwrap_or(Avm1Value::Undefined)
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .object
             .get()
@@ -2581,17 +2581,17 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             .unwrap_or(Avm2Value::Null)
     }
 
-    fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
         self.set_object(Some(to.into()), context.gc());
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         self.apply_autosize_bounds();
 
         self.0.bounds.get()
     }
 
-    fn pixel_bounds(&self) -> Rectangle<Twips> {
+    fn pixel_bounds(self) -> Rectangle<Twips> {
         // For pixel bounds we can't apply lazy autosize bounds.
         // It's a bit hacky, but it seems that pixelBounds are
         // an exception to the rule that lazy autosize bounds
@@ -2603,38 +2603,38 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     // The returned position x and y of a text field is offset by the text bounds.
-    fn x(&self) -> Twips {
+    fn x(self) -> Twips {
         self.apply_autosize_bounds();
         self.base().x() + self.bounds_x_offset()
     }
 
-    fn set_x(&self, gc_context: &Mutation<'gc>, x: Twips) {
+    fn set_x(self, gc_context: &Mutation<'gc>, x: Twips) {
         self.apply_autosize_bounds();
         let offset = self.bounds_x_offset();
         self.base_mut(gc_context).set_x(x - offset);
         self.invalidate_cached_bitmap(gc_context);
     }
 
-    fn y(&self) -> Twips {
+    fn y(self) -> Twips {
         self.apply_autosize_bounds();
         self.base().y() + self.bounds_y_offset()
     }
 
-    fn set_y(&self, gc_context: &Mutation<'gc>, y: Twips) {
+    fn set_y(self, gc_context: &Mutation<'gc>, y: Twips) {
         self.apply_autosize_bounds();
         let offset = self.bounds_y_offset();
         self.base_mut(gc_context).set_y(y - offset);
         self.invalidate_cached_bitmap(gc_context);
     }
 
-    fn width(&self) -> f64 {
+    fn width(self) -> f64 {
         self.apply_autosize_bounds();
 
         let bounds = self.0.bounds.get();
         (self.base().transform.matrix * bounds).width().to_pixels()
     }
 
-    fn set_width(&self, context: &mut UpdateContext<'gc>, value: f64) {
+    fn set_width(self, context: &mut UpdateContext<'gc>, value: f64) {
         self.apply_autosize_bounds();
 
         let bounds = &self.0.bounds;
@@ -2643,14 +2643,14 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.relayout(context);
     }
 
-    fn height(&self) -> f64 {
+    fn height(self) -> f64 {
         self.apply_autosize_bounds();
 
         let bounds = self.0.bounds.get();
         (self.base().transform.matrix * bounds).height().to_pixels()
     }
 
-    fn set_height(&self, context: &mut UpdateContext<'gc>, value: f64) {
+    fn set_height(self, context: &mut UpdateContext<'gc>, value: f64) {
         self.apply_autosize_bounds();
 
         let bounds = &self.0.bounds;
@@ -2659,12 +2659,12 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.relayout(context);
     }
 
-    fn set_matrix(&self, mc: &Mutation<'gc>, matrix: Matrix) {
+    fn set_matrix(self, mc: &Mutation<'gc>, matrix: Matrix) {
         self.base_mut(mc).set_matrix(matrix);
         self.invalidate_cached_bitmap(mc);
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(self, context: &mut RenderContext<'_, 'gc>) {
         self.apply_autosize_bounds();
 
         if !context.is_offscreen && !self.world_bounds().intersects(&context.stage.view_bounds()) {
@@ -2745,11 +2745,11 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         }
     }
 
-    fn allow_as_mask(&self) -> bool {
+    fn allow_as_mask(self) -> bool {
         false
     }
 
-    fn avm1_unload(&self, context: &mut UpdateContext<'gc>) {
+    fn avm1_unload(self, context: &mut UpdateContext<'gc>) {
         self.drop_focus(context);
 
         if let Some(node) = self.maskee() {
@@ -2760,16 +2760,16 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
 
         // Unbind any display objects bound to this text.
         if let Some(dobj) = self.0.bound_display_object.take() {
-            Avm1TextFieldBinding::clear_binding(dobj, *self, context.gc());
+            Avm1TextFieldBinding::clear_binding(dobj, self, context.gc());
         }
 
         // Unregister any text fields that may be bound to *this* text field.
-        Avm1TextFieldBinding::unregister_bindings((*self).into(), context);
+        Avm1TextFieldBinding::unregister_bindings(self.into(), context);
 
         if self.variable().is_some() {
             context
                 .unbound_text_fields
-                .retain(|&text_field| !DisplayObject::ptr_eq(text_field.into(), (*self).into()));
+                .retain(|&text_field| !DisplayObject::ptr_eq(text_field.into(), self.into()));
         }
 
         self.set_avm1_removed(true);
@@ -3051,7 +3051,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
     }
 
     fn mouse_pick_avm1(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         _require_button_mode: bool,
@@ -3067,14 +3067,14 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
             && (self.is_selectable() || self.is_link_at(point))
             && self.hit_test_shape(context, point, HitTestOptions::MOUSE_PICK)
         {
-            Some((*self).into())
+            Some(self.into())
         } else {
             None
         }
     }
 
     fn mouse_pick_avm2(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         _require_button_mode: bool,
@@ -3093,7 +3093,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
             if self.mouse_enabled()
                 && (self.is_selectable() || self.is_link_at(point) || !self.was_static())
             {
-                Avm2MousePick::Hit((*self).into())
+                Avm2MousePick::Hit(self.into())
             } else {
                 Avm2MousePick::PropagateToParent
             }
@@ -3113,7 +3113,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
     }
 
     fn on_focus_changed(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         focused: bool,
         _other: Option<InteractiveObject<'gc>>,
@@ -3144,16 +3144,16 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
         }));
     }
 
-    fn is_focusable_by_mouse(&self, _context: &mut UpdateContext<'gc>) -> bool {
+    fn is_focusable_by_mouse(self, _context: &mut UpdateContext<'gc>) -> bool {
         self.movie().is_action_script_3() || self.is_editable() || self.is_selectable()
     }
 
-    fn is_highlightable(&self, _context: &mut UpdateContext<'gc>) -> bool {
+    fn is_highlightable(self, _context: &mut UpdateContext<'gc>) -> bool {
         // TextField is incapable of rendering a highlight.
         false
     }
 
-    fn is_tabbable(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn is_tabbable(self, context: &mut UpdateContext<'gc>) -> bool {
         if !self.is_editable() {
             // Non-editable text fields are never tabbable.
             return false;
@@ -3161,7 +3161,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
         self.tab_enabled(context)
     }
 
-    fn tab_enabled_default(&self, _context: &mut UpdateContext<'gc>) -> bool {
+    fn tab_enabled_default(self, _context: &mut UpdateContext<'gc>) -> bool {
         self.is_editable()
     }
 }
@@ -3218,7 +3218,8 @@ struct ClickEventData {
 
 impl ClickEventData {
     /// Selection mode that results from this click index.
-    fn selection_mode(&self) -> TextSelectionMode {
+    #[inline]
+    fn selection_mode(self) -> TextSelectionMode {
         TextSelectionMode::from_click_index(self.click_index)
     }
 }
@@ -3622,15 +3623,15 @@ enum EditTextStyleSheet<'gc> {
 }
 
 impl<'gc> EditTextStyleSheet<'gc> {
-    fn is_some(&self) -> bool {
+    fn is_some(self) -> bool {
         self.style_sheet().is_some()
     }
 
-    fn is_none(&self) -> bool {
+    fn is_none(self) -> bool {
         self.style_sheet().is_none()
     }
 
-    fn style_sheet(&self) -> Option<StyleSheet<'gc>> {
+    fn style_sheet(self) -> Option<StyleSheet<'gc>> {
         match self {
             EditTextStyleSheet::None => None,
             EditTextStyleSheet::Avm1(object) => {

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -130,19 +130,19 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         unlock!(Gc::write(mc, self.0), GraphicData, base).borrow_mut()
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         self.0.shared.get().id
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         if let Some(drawing) = self.0.drawing.borrow().as_ref() {
             drawing.self_bounds()
         } else {
@@ -150,7 +150,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         }
     }
 
-    fn construct_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn construct_frame(self, context: &mut UpdateContext<'gc>) {
         if self.movie().is_action_script_3() && matches!(self.object2(), Avm2Value::Null) {
             let class_object = self
                 .0
@@ -162,7 +162,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
 
             match Avm2StageObject::for_display_object_childless(
                 &mut activation,
-                (*self).into(),
+                self.into(),
                 class_object,
             ) {
                 Ok(object) => self.set_object2(activation.context, object.into()),
@@ -175,7 +175,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         }
     }
 
-    fn replace_with(&self, context: &mut UpdateContext<'gc>, id: CharacterId) {
+    fn replace_with(self, context: &mut UpdateContext<'gc>, id: CharacterId) {
         // Static assets like Graphics can replace themselves via a PlaceObject tag with PlaceObjectAction::Replace.
         // This does not create a new instance, but instead swaps out the underlying static data to point to the new art.
         if let Some(new_graphic) = context
@@ -190,11 +190,11 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         self.invalidate_cached_bitmap(context.gc());
     }
 
-    fn run_frame_avm1(&self, _context: &mut UpdateContext) {
+    fn run_frame_avm1(self, _context: &mut UpdateContext) {
         // Noop
     }
 
-    fn render_self(&self, context: &mut RenderContext) {
+    fn render_self(self, context: &mut RenderContext) {
         if !context.is_offscreen && !self.world_bounds().intersects(&context.stage.view_bounds()) {
             // Off-screen; culled
             return;
@@ -210,7 +210,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 
     fn hit_test_shape(
-        &self,
+        self,
         _context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         options: HitTestOptions,
@@ -237,7 +237,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
@@ -246,7 +246,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         if self.movie().is_action_script_3() {
             self.set_default_instance_name(context);
         } else {
-            context.avm1.add_to_exec_list(context.gc(), (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), self.into());
 
             if run_frame {
                 self.run_frame_avm1(context);
@@ -254,11 +254,11 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         }
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.shared.get().movie.clone()
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .avm2_object
             .get()
@@ -266,7 +266,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
             .unwrap_or(Avm2Value::Null)
     }
 
-    fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
         let mc = context.gc();
         unlock!(Gc::write(mc, self.0), GraphicData, avm2_object).set(Some(to));
     }

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -539,7 +539,7 @@ pub trait TInteractiveObject<'gc>:
     /// mouse events. As a result of this, the returned object will always be
     /// an `InteractiveObject`.
     fn mouse_pick_avm1(
-        &self,
+        self,
         _context: &mut UpdateContext<'gc>,
         _point: Point<Twips>,
         _require_button_mode: bool,
@@ -548,7 +548,7 @@ pub trait TInteractiveObject<'gc>:
     }
 
     fn mouse_pick_avm2(
-        &self,
+        self,
         _context: &mut UpdateContext<'gc>,
         _point: Point<Twips>,
         _require_button_mode: bool,
@@ -562,7 +562,7 @@ pub trait TInteractiveObject<'gc>:
     }
 
     /// Whether this object is focusable for keyboard input.
-    fn is_focusable(&self, _context: &mut UpdateContext<'gc>) -> bool {
+    fn is_focusable(self, _context: &mut UpdateContext<'gc>) -> bool {
         // By default, all interactive objects are focusable.
         true
     }
@@ -573,7 +573,7 @@ pub trait TInteractiveObject<'gc>:
     /// The default behavior is following:
     /// * in AVM1 objects cannot be focused by mouse,
     /// * in AVM2 objects can be focused by mouse when they are tab enabled.
-    fn is_focusable_by_mouse(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn is_focusable_by_mouse(self, context: &mut UpdateContext<'gc>) -> bool {
         let self_do = self.as_displayobject();
         self_do.movie().is_action_script_3() && self.tab_enabled(context)
     }
@@ -582,7 +582,7 @@ pub trait TInteractiveObject<'gc>:
     /// of being the currently focused object.
     /// This should only be called by the focus manager. To change a focus, go through that.
     fn on_focus_changed(
-        &self,
+        self,
         _context: &mut UpdateContext<'gc>,
         _focused: bool,
         _other: Option<InteractiveObject<'gc>>,
@@ -590,7 +590,7 @@ pub trait TInteractiveObject<'gc>:
     }
 
     /// If this object has focus, this method drops it.
-    fn drop_focus(&self, context: &mut UpdateContext<'gc>) {
+    fn drop_focus(self, context: &mut UpdateContext<'gc>) {
         if self.has_focus() {
             let tracker = context.focus_tracker;
             tracker.set(None, context);
@@ -598,7 +598,7 @@ pub trait TInteractiveObject<'gc>:
     }
 
     fn call_focus_handler(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         focused: bool,
         other: Option<InteractiveObject<'gc>>,
@@ -625,7 +625,7 @@ pub trait TInteractiveObject<'gc>:
     }
 
     /// Whether this object may be highlighted when focused.
-    fn is_highlightable(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn is_highlightable(self, context: &mut UpdateContext<'gc>) -> bool {
         self.is_highlight_enabled(context)
     }
 
@@ -633,7 +633,7 @@ pub trait TInteractiveObject<'gc>:
     ///
     /// Note: This value does not mean that a highlight should actually be rendered,
     /// for that see [`Self::is_highlightable()`].
-    fn is_highlight_enabled(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn is_highlight_enabled(self, context: &mut UpdateContext<'gc>) -> bool {
         if self.as_displayobject().movie().version() >= 6 {
             self.focus_rect()
                 .unwrap_or_else(|| context.stage.stage_focus_rect())
@@ -648,7 +648,7 @@ pub trait TInteractiveObject<'gc>:
     }
 
     /// Whether this object is included in tab ordering.
-    fn is_tabbable(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn is_tabbable(self, context: &mut UpdateContext<'gc>) -> bool {
         self.tab_enabled(context)
     }
 
@@ -656,7 +656,7 @@ pub trait TInteractiveObject<'gc>:
     ///
     /// Some objects may be excluded from tab ordering
     /// even if it's enabled, see [`Self::is_tabbable()`].
-    fn tab_enabled(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn tab_enabled(self, context: &mut UpdateContext<'gc>) -> bool {
         if self.as_displayobject().movie().is_action_script_3() {
             self.raw_interactive()
                 .tab_enabled
@@ -670,11 +670,11 @@ pub trait TInteractiveObject<'gc>:
         }
     }
 
-    fn tab_enabled_default(&self, _context: &mut UpdateContext<'gc>) -> bool {
+    fn tab_enabled_default(self, _context: &mut UpdateContext<'gc>) -> bool {
         false
     }
 
-    fn set_tab_enabled(&self, context: &mut UpdateContext<'gc>, value: bool) {
+    fn set_tab_enabled(self, context: &mut UpdateContext<'gc>, value: bool) {
         if self.as_displayobject().movie().is_action_script_3() {
             self.raw_interactive_mut(context.gc()).tab_enabled = Some(value)
         } else {
@@ -689,11 +689,11 @@ pub trait TInteractiveObject<'gc>:
     /// Used to customize tab ordering.
     /// When not `None`, a custom ordering is used, and
     /// objects are ordered according to this value.
-    fn tab_index(&self) -> Option<i32> {
+    fn tab_index(self) -> Option<i32> {
         self.raw_interactive().tab_index
     }
 
-    fn set_tab_index(&self, context: &mut UpdateContext<'gc>, value: Option<i32>) {
+    fn set_tab_index(self, context: &mut UpdateContext<'gc>, value: Option<i32>) {
         // tabIndex = -1 is always equivalent to unset tabIndex
         let value = if matches!(value, Some(-1)) {
             None
@@ -705,7 +705,7 @@ pub trait TInteractiveObject<'gc>:
 
     /// Whether event handlers (e.g. onKeyUp, onPress) should be fired for the given event.
     fn should_fire_event_handlers(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         event: ClipEvent,
     ) -> bool {

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -72,27 +72,27 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
         RefMut::map(self.raw_interactive_mut(mc), |w| &mut w.base)
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         u16::MAX
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(self, context: &mut RenderContext<'_, 'gc>) {
         self.render_children(context);
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         Default::default()
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .avm2_object
             .get()
@@ -100,7 +100,7 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
             .unwrap_or(Avm2Value::Null)
     }
 
-    fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
         let mc = context.gc();
         unlock!(Gc::write(mc, self.0), LoaderDisplayData, avm2_object).set(Some(to))
     }
@@ -113,7 +113,7 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
         Some(self.into())
     }
 
-    fn enter_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn enter_frame(self, context: &mut UpdateContext<'gc>) {
         let skip_frame = self.base().should_skip_next_enter_frame();
         for child in self.iter_render_list() {
             // See MovieClip::enter_frame for an explanation of this.
@@ -125,19 +125,19 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
         self.base().set_skip_next_enter_frame(false);
     }
 
-    fn construct_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn construct_frame(self, context: &mut UpdateContext<'gc>) {
         for child in self.iter_render_list() {
             child.construct_frame(context);
         }
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.movie.clone()
     }
 
-    fn on_parent_removed(&self, context: &mut UpdateContext<'gc>) {
+    fn on_parent_removed(self, context: &mut UpdateContext<'gc>) {
         if self.movie().is_action_script_3() {
-            context.avm2.add_orphan_obj((*self).into())
+            context.avm2.add_orphan_obj(self.into())
         }
     }
 }
@@ -175,7 +175,7 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
     }
 
     fn mouse_pick_avm1(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         require_button_mode: bool,
@@ -204,7 +204,7 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
     }
 
     fn mouse_pick_avm2(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         require_button_mode: bool,
@@ -223,7 +223,7 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
                 if int.as_displayobject().movie().is_action_script_3() {
                     return int
                         .mouse_pick_avm2(context, point, require_button_mode)
-                        .combine_with_parent((*self).into());
+                        .combine_with_parent(self.into());
                 } else {
                     let avm1_result = int.mouse_pick_avm1(context, point, require_button_mode);
                     if let Some(result) = avm1_result {
@@ -234,7 +234,7 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
                 }
             } else if child.hit_test_shape(context, point, options) {
                 if self.mouse_enabled() {
-                    return Avm2MousePick::Hit((*self).into());
+                    return Avm2MousePick::Hit(self.into());
                 } else {
                     return Avm2MousePick::PropagateToParent;
                 }

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -75,23 +75,23 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         unlock!(Gc::write(mc, self.0), MorphShapeData, base).borrow_mut()
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         self.0.shared.get().id
     }
 
-    fn as_morph_shape(&self) -> Option<Self> {
-        Some(*self)
+    fn as_morph_shape(self) -> Option<Self> {
+        Some(self)
     }
 
-    fn replace_with(&self, context: &mut UpdateContext<'gc>, id: CharacterId) {
+    fn replace_with(self, context: &mut UpdateContext<'gc>, id: CharacterId) {
         if let Some(new_morph_shape) = context
             .library
             .library_for_movie_mut(self.movie())
@@ -105,11 +105,11 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         self.invalidate_cached_bitmap(context.gc());
     }
 
-    fn run_frame_avm1(&self, _context: &mut UpdateContext) {
+    fn run_frame_avm1(self, _context: &mut UpdateContext) {
         // Noop
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .object
             .get()
@@ -117,21 +117,18 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
             .unwrap_or(Avm2Value::Null)
     }
 
-    fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
         let mc = context.gc();
         unlock!(Gc::write(mc, self.0), MorphShapeData, object).set(Some(to))
     }
 
     /// Construct objects placed on this frame.
-    fn construct_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn construct_frame(self, context: &mut UpdateContext<'gc>) {
         if self.movie().is_action_script_3() && matches!(self.object2(), Avm2Value::Null) {
             let class = context.avm2.classes().morphshape;
             let mut activation = Avm2Activation::from_nothing(context);
-            match Avm2StageObject::for_display_object_childless(
-                &mut activation,
-                (*self).into(),
-                class,
-            ) {
+            match Avm2StageObject::for_display_object_childless(&mut activation, self.into(), class)
+            {
                 Ok(object) => self.set_object2(context, object.into()),
                 Err(e) => tracing::error!("Got {} when constructing AVM2 side of MorphShape", e),
             };
@@ -139,7 +136,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         }
     }
 
-    fn render_self(&self, context: &mut RenderContext) {
+    fn render_self(self, context: &mut RenderContext) {
         let ratio = self.0.ratio.get();
         let shared = self.0.shared.get();
         let shape_handle = shared.get_shape(context, context.library, ratio);
@@ -148,7 +145,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
             .render_shape(shape_handle, context.transform_stack.transform());
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         let ratio = self.0.ratio.get();
         let shared = self.0.shared.get();
         let frame = shared.get_frame(ratio);
@@ -156,7 +153,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
     }
 
     fn hit_test_shape(
-        &self,
+        self,
         _context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         options: HitTestOptions,
@@ -181,7 +178,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         false
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.shared.get().movie.clone()
     }
 }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2251,23 +2251,23 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         RefMut::map(self.0.write(mc), |w| &mut w.base.base)
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(GcCell::new(gc_context, self.0.read().clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         self.0.as_ptr() as *const DisplayObjectPtr
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         self.0.read().id()
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.read().movie()
     }
 
-    fn enter_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn enter_frame(self, context: &mut UpdateContext<'gc>) {
         let skip_frame = self.base().should_skip_next_enter_frame();
         //Child removals from looping gotos appear to resolve in reverse order.
         for child in self.iter_render_list().rev() {
@@ -2320,7 +2320,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     /// Construct objects placed on this frame.
-    fn construct_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn construct_frame(self, context: &mut UpdateContext<'gc>) {
         // AVM1 code expects to execute in line with timeline instructions, so
         // it's exempted from frame construction.
         if self.movie().is_action_script_3()
@@ -2328,7 +2328,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         {
             let is_load_frame = !self.0.read().initialized();
             let needs_construction = if matches!(self.object2(), Avm2Value::Null) {
-                self.allocate_as_avm2_object(context, (*self).into());
+                self.allocate_as_avm2_object(context, self.into());
                 true
             } else {
                 false
@@ -2372,7 +2372,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         read.has_pending_script.set(has_pending_script);
     }
 
-    fn run_frame_avm1(&self, context: &mut UpdateContext<'gc>) {
+    fn run_frame_avm1(self, context: &mut UpdateContext<'gc>) {
         if !self.movie().is_action_script_3() {
             // Run my load/enterFrame clip event.
             let is_load_frame = !self.0.read().contains_flag(MovieClipFlags::INITIALIZED);
@@ -2401,19 +2401,19 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(self, context: &mut RenderContext<'_, 'gc>) {
         if let Some(drawing) = self.drawing() {
             drawing.render(context);
         }
         self.render_children(context);
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         self.drawing().map(|d| d.self_bounds()).unwrap_or_default()
     }
 
     fn hit_test_shape(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         options: HitTestOptions,
@@ -2472,8 +2472,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         false
     }
 
-    fn as_movie_clip(&self) -> Option<MovieClip<'gc>> {
-        Some(*self)
+    fn as_movie_clip(self) -> Option<MovieClip<'gc>> {
+        Some(self)
     }
 
     fn as_container(self) -> Option<DisplayObjectContainer<'gc>> {
@@ -2489,7 +2489,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         init_object: Option<Avm1Object<'gc>>,
         instantiated_by: Instantiator,
@@ -2510,13 +2510,13 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         self.set_default_instance_name(context);
 
         if !self.movie().is_action_script_3() {
-            context.avm1.add_to_exec_list(context.gc(), (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), self.into());
 
             self.construct_as_avm1_object(context, init_object, instantiated_by, run_frame);
         }
     }
 
-    fn object(&self) -> Avm1Value<'gc> {
+    fn object(self) -> Avm1Value<'gc> {
         self.0
             .read()
             .object
@@ -2525,7 +2525,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             .unwrap_or(Avm1Value::Undefined)
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .read()
             .object
@@ -2534,15 +2534,15 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             .unwrap_or(Avm2Value::Null)
     }
 
-    fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
         self.0.write(context.gc()).object = Some(to.into());
         if self.parent().is_none() {
-            context.avm2.add_orphan_obj((*self).into());
+            context.avm2.add_orphan_obj(self.into());
         }
     }
 
     fn set_perspective_projection(
-        &self,
+        self,
         gc_context: &Mutation<'gc>,
         mut perspective_projection: Option<PerspectiveProjection>,
     ) {
@@ -2569,13 +2569,13 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
     }
 
-    fn on_parent_removed(&self, context: &mut UpdateContext<'gc>) {
+    fn on_parent_removed(self, context: &mut UpdateContext<'gc>) {
         if self.movie().is_action_script_3() {
-            context.avm2.add_orphan_obj((*self).into())
+            context.avm2.add_orphan_obj(self.into())
         }
     }
 
-    fn avm1_unload(&self, context: &mut UpdateContext<'gc>) {
+    fn avm1_unload(self, context: &mut UpdateContext<'gc>) {
         for child in self.iter_render_list() {
             child.avm1_unload(context);
         }
@@ -2587,7 +2587,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
 
         // Unregister any text field variable bindings.
-        Avm1TextFieldBinding::unregister_bindings((*self).into(), context);
+        Avm1TextFieldBinding::unregister_bindings(self.into(), context);
 
         self.drop_focus(context);
 
@@ -2599,7 +2599,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         if self.is_root() {
             context
                 .audio_manager
-                .stop_sounds_on_parent_and_children(context.audio, (*self).into());
+                .stop_sounds_on_parent_and_children(context.audio, self.into());
         }
 
         // If this clip is currently pending removal, then it unload event will have already been dispatched
@@ -2628,11 +2628,11 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             .map(|_| RefMut::map(write, |w| &mut w.avm1_text_field_bindings))
     }
 
-    fn loader_info(&self) -> Option<Avm2Object<'gc>> {
+    fn loader_info(self) -> Option<Avm2Object<'gc>> {
         self.0.read().shared.loader_info
     }
 
-    fn allow_as_mask(&self) -> bool {
+    fn allow_as_mask(self) -> bool {
         !self.is_empty()
     }
 }
@@ -2646,7 +2646,7 @@ impl<'gc> TDisplayObjectContainer<'gc> for MovieClip<'gc> {
         RefMut::map(self.0.write(gc_context), |this| &mut this.container)
     }
 
-    fn is_tab_children_avm1(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn is_tab_children_avm1(self, context: &mut UpdateContext<'gc>) -> bool {
         self.get_avm1_boolean_property(istr!(context, "tabChildren"), context, |_| true)
     }
 }
@@ -2759,7 +2759,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
     }
 
     fn mouse_pick_avm1(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         require_button_mode: bool,
@@ -2770,7 +2770,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
         }
 
         if self.visible() {
-            let this: InteractiveObject<'gc> = (*self).into();
+            let this: InteractiveObject<'gc> = self.into();
             let local_matrix = self.global_to_local_matrix()?;
 
             if let Some(masker) = self.masker() {
@@ -2862,7 +2862,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
     }
 
     fn mouse_pick_avm2(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         point: Point<Twips>,
         require_button_mode: bool,
@@ -2873,7 +2873,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
         }
 
         if self.visible() {
-            let this: InteractiveObject<'gc> = (*self).into();
+            let this: InteractiveObject<'gc> = self.into();
             let Some(local_matrix) = self.global_to_local_matrix() else {
                 return Avm2MousePick::Miss;
             };
@@ -2978,7 +2978,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
 
                 match res {
                     Avm2MousePick::Hit(_) => {
-                        return res.combine_with_parent((*self).into());
+                        return res.combine_with_parent(self.into());
                     }
                     Avm2MousePick::PropagateToParent => {
                         found_propagate = Some(res);
@@ -2989,7 +2989,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
 
             // A 'propagated' event from a child seems to have lower 'priority' than anything else.
             if let Some(propagate) = found_propagate {
-                return propagate.combine_with_parent((*self).into());
+                return propagate.combine_with_parent(self.into());
             }
 
             // Check drawing, because this selects the current clip, it must have mouse enabled
@@ -2999,7 +2999,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
                 if let Some(drawing) = self.drawing() {
                     if drawing.hit_test(point, &local_matrix) {
                         return if self.mouse_enabled() {
-                            Avm2MousePick::Hit((*self).into())
+                            Avm2MousePick::Hit(self.into())
                         } else {
                             Avm2MousePick::PropagateToParent
                         };
@@ -3019,7 +3019,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
         }
     }
 
-    fn is_focusable(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn is_focusable(self, context: &mut UpdateContext<'gc>) -> bool {
         if self.is_root() {
             false
         } else if self.is_button_mode(context) {
@@ -3029,13 +3029,13 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
         }
     }
 
-    fn is_highlightable(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn is_highlightable(self, context: &mut UpdateContext<'gc>) -> bool {
         // Root movie clips are not highlightable.
         // This applies only to AVM2, as in AVM1 they are also not focusable.
         !self.is_root() && self.is_highlight_enabled(context)
     }
 
-    fn is_tabbable(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn is_tabbable(self, context: &mut UpdateContext<'gc>) -> bool {
         if self.is_root() {
             // Root movie clips are never tabbable.
             return false;
@@ -3043,7 +3043,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
         self.tab_enabled(context)
     }
 
-    fn tab_enabled_default(&self, context: &mut UpdateContext<'gc>) -> bool {
+    fn tab_enabled_default(self, context: &mut UpdateContext<'gc>) -> bool {
         if self.is_button_mode(context) {
             return true;
         }

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -741,21 +741,21 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         RefMut::map(base_mut, |w| &mut w.base)
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
-    fn local_to_global_matrix(&self) -> Matrix {
+    fn local_to_global_matrix(self) -> Matrix {
         // The stage is in Stage coordinates by definition
         Default::default()
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
@@ -770,7 +770,7 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         let mut activation = Avm2Activation::from_domain(context, global_domain);
         let avm2_stage = Avm2StageObject::for_display_object_childless(
             &mut activation,
-            (*self).into(),
+            self.into(),
             stage_constr,
         );
 
@@ -798,11 +798,11 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         }
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         u16::MAX
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         Default::default()
     }
 
@@ -814,15 +814,15 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         Some(self.into())
     }
 
-    fn as_stage(&self) -> Option<Stage<'gc>> {
-        Some(*self)
+    fn as_stage(self) -> Option<Stage<'gc>> {
+        Some(self)
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(self, context: &mut RenderContext<'_, 'gc>) {
         self.render_children(context);
     }
 
-    fn render(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render(self, context: &mut RenderContext<'_, 'gc>) {
         context.transform_stack.push(&Transform {
             matrix: self.0.viewport_matrix.get(),
             color_transform: Default::default(),
@@ -846,7 +846,7 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
             }
         }
 
-        render_base((*self).into(), context);
+        render_base(self.into(), context);
 
         self.focus_tracker().render_highlight(context);
 
@@ -857,7 +857,7 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         context.transform_stack.pop();
     }
 
-    fn enter_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn enter_frame(self, context: &mut UpdateContext<'gc>) {
         for child in self.iter_render_list() {
             child.enter_frame(context);
         }
@@ -867,13 +867,13 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         Avm2::broadcast_event(context, enter_frame_evt, dobject_constr);
     }
 
-    fn construct_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn construct_frame(self, context: &mut UpdateContext<'gc>) {
         for child in self.iter_render_list() {
             child.construct_frame(context);
         }
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .avm2_object
             .get()
@@ -882,7 +882,7 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
     }
 
     fn set_perspective_projection(
-        &self,
+        self,
         gc_context: &Mutation<'gc>,
         mut perspective_projection: Option<PerspectiveProjection>,
     ) {
@@ -902,11 +902,11 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         }
     }
 
-    fn loader_info(&self) -> Option<Avm2Object<'gc>> {
+    fn loader_info(self) -> Option<Avm2Object<'gc>> {
         self.0.loader_info.get()
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.movie.borrow().clone()
     }
 }
@@ -954,7 +954,7 @@ impl<'gc> TInteractiveObject<'gc> for Stage<'gc> {
         MouseCursor::Arrow
     }
 
-    fn is_highlightable(&self, _context: &mut UpdateContext<'gc>) -> bool {
+    fn is_highlightable(self, _context: &mut UpdateContext<'gc>) -> bool {
         // Stage cannot be highlighted.
         false
     }

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -105,27 +105,27 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         unlock!(Gc::write(mc, self.0), TextData, base).borrow_mut()
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
-    fn as_text(&self) -> Option<Text<'gc>> {
-        Some(*self)
+    fn as_text(self) -> Option<Text<'gc>> {
+        Some(self)
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         self.0.shared.get().id
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.shared.get().swf.clone()
     }
 
-    fn replace_with(&self, context: &mut UpdateContext<'gc>, id: CharacterId) {
+    fn replace_with(self, context: &mut UpdateContext<'gc>, id: CharacterId) {
         if let Some(new_text) = context
             .library
             .library_for_movie_mut(self.movie())
@@ -138,11 +138,11 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         self.invalidate_cached_bitmap(context.gc());
     }
 
-    fn run_frame_avm1(&self, _context: &mut UpdateContext) {
+    fn run_frame_avm1(self, _context: &mut UpdateContext) {
         // Noop
     }
 
-    fn render_self(&self, context: &mut RenderContext) {
+    fn render_self(self, context: &mut RenderContext) {
         let shared = self.0.shared.get();
         context.transform_stack.push(&Transform {
             matrix: shared.text_transform,
@@ -197,12 +197,12 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         context.transform_stack.pop();
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         self.0.shared.get().bounds
     }
 
     fn hit_test_shape(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         mut point: Point<Twips>,
         options: HitTestOptions,
@@ -270,7 +270,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         _init_object: Option<crate::avm1::Object<'gc>>,
         _instantiated_by: Instantiator,
@@ -286,7 +286,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
             let statictext = activation.avm2().classes().statictext;
             match Avm2StageObject::for_display_object_childless(
                 &mut activation,
-                (*self).into(),
+                self.into(),
                 statictext,
             ) {
                 Ok(object) => self.set_object2(context, object.into()),
@@ -297,7 +297,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         }
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .avm2_object
             .get()
@@ -305,7 +305,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
             .unwrap_or(Avm2Value::Null)
     }
 
-    fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
         let mc = context.gc();
         unlock!(Gc::write(mc, self.0), TextData, avm2_object).set(Some(to));
     }

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -354,11 +354,11 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         unlock!(Gc::write(mc, self.0), VideoData, base).borrow_mut()
     }
 
-    fn instantiate(&self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
+    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
         Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
-    fn as_ptr(&self) -> *const DisplayObjectPtr {
+    fn as_ptr(self) -> *const DisplayObjectPtr {
         Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
@@ -367,14 +367,14 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
     }
 
     fn post_instantiation(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
         run_frame: bool,
     ) {
         if !self.movie().is_action_script_3() {
-            context.avm1.add_to_exec_list(context.gc(), (*self).into());
+            context.avm1.add_to_exec_list(context.gc(), self.into());
         }
 
         let movie = self.0.movie.clone();
@@ -447,7 +447,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
             let object = Avm1Object::new_with_native(
                 &context.strings,
                 Some(context.avm1.prototypes().video),
-                Avm1NativeObject::Video(*self),
+                Avm1NativeObject::Video(self),
             );
             self.set_object(context, object.into());
         }
@@ -459,14 +459,14 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         }
     }
 
-    fn construct_frame(&self, context: &mut UpdateContext<'gc>) {
+    fn construct_frame(self, context: &mut UpdateContext<'gc>) {
         if self.movie().is_action_script_3() && matches!(self.object2(), Avm2Value::Null) {
             let video_constr = context.avm2.classes().video;
             let mut activation = Avm2Activation::from_nothing(context);
             let size = self.0.size.get();
             match Avm2StageObject::for_display_object_childless_with_args(
                 &mut activation,
-                (*self).into(),
+                self.into(),
                 video_constr,
                 &[size.0.into(), size.1.into()],
             ) {
@@ -480,7 +480,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         }
     }
 
-    fn id(&self) -> CharacterId {
+    fn id(self) -> CharacterId {
         match self.0.source.get() {
             VideoSource::Swf(swf_source) => swf_source.streamdef.id,
             VideoSource::NetStream { .. } => 0,
@@ -488,7 +488,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         }
     }
 
-    fn self_bounds(&self) -> Rectangle<Twips> {
+    fn self_bounds(self) -> Rectangle<Twips> {
         let (size_x, size_y) = self.0.size.get();
         Rectangle {
             x_min: Twips::ZERO,
@@ -498,7 +498,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         }
     }
 
-    fn render(&self, context: &mut RenderContext) {
+    fn render(self, context: &mut RenderContext) {
         if !context.is_offscreen && !self.world_bounds().intersects(&context.stage.view_bounds()) {
             // Off-screen; culled
             return;
@@ -557,15 +557,15 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         context.transform_stack.pop();
     }
 
-    fn set_object2(&self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
         self.set_object(context, to.into());
     }
 
-    fn movie(&self) -> Arc<SwfMovie> {
+    fn movie(self) -> Arc<SwfMovie> {
         self.0.movie.clone()
     }
 
-    fn object(&self) -> Avm1Value<'gc> {
+    fn object(self) -> Avm1Value<'gc> {
         self.0
             .object
             .get()
@@ -574,7 +574,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
             .unwrap_or(Avm1Value::Undefined)
     }
 
-    fn object2(&self) -> Avm2Value<'gc> {
+    fn object2(self) -> Avm2Value<'gc> {
         self.0
             .object
             .get()


### PR DESCRIPTION
Display objects are already a pointer, no need to take a pointer to a pointer.