### PR TITLE
exporter: Add Support for Full Auto-Export, End-on-Last-Frame Logic, and Prevent --force-play Looping

### DIFF
--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -186,16 +186,10 @@ fn take_screenshot(
 fn force_root_clip_play(player: &Arc<Mutex<Player>>) {
     let mut player_guard = player.lock().unwrap();
 
-    // Check and resume if suspended
-    if !player_guard.is_playing() {
-        player_guard.set_is_playing(true);
-    }
-
-    // Also resume the root MovieClip if stopped
     player_guard.mutate_with_update_context(|ctx| {
         if let Some(root_clip) = ctx.stage.root_clip() {
             if let Some(movie_clip) = root_clip.as_movie_clip() {
-                if !movie_clip.playing() {
+                if !movie_clip.playing() && movie_clip.current_frame() < movie_clip.total_frames() {
                     movie_clip.play();
                 }
             }

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -191,9 +191,7 @@ fn is_root_movie_clip_at_end(player: &Arc<Mutex<Player>>) -> bool {
         ctx.stage
             .root_clip()
             .and_then(|root_clip| root_clip.as_movie_clip())
-            .map_or(false, |movie_clip| {
-                movie_clip.current_frame() == movie_clip.total_frames()
-            })
+            .is_some_and(|movie_clip| movie_clip.current_frame() == movie_clip.total_frames())
     })
 }
 
@@ -298,7 +296,7 @@ fn capture_single_swf(descriptors: Arc<Descriptors>, opt: &Opt) -> Result<()> {
         let digits = frames.len().to_string().len();
         for (frame, image) in frames.iter().enumerate() {
             let mut path: PathBuf = (&output).into();
-            path.push(format!("{:0width$}.png", frame, width = digits));
+            path.push(format!("{frame:0digits$}.png"));
             image.save(&path)?;
         }
     }
@@ -393,7 +391,7 @@ fn capture_multiple_swfs(descriptors: Arc<Descriptors>, opt: &Opt) -> Result<()>
                 let digits = frames.len().to_string().len();
                 for (frame, image) in frames.iter().enumerate() {
                     let mut destination = parent.clone();
-                    destination.push(format!("{:0width$}.png", frame, width = digits));
+                    destination.push(format!("{frame:0digits$}.png"));
                     image.save(&destination)?;
                 }
             }


### PR DESCRIPTION
Let me know if you'd like any of these features to be placed behind new CLI arguments. I'm happy to update the PR accordingly.

Changes for the Exporter Tool:
- Support `--frames 0` to export all frames. #20930
- Add a check to exit the frame render loop once the root movie clip reaches its final frame. #20929
- Improve the `--force-play` feature to avoid restarting the timeline if it's already on the last frame. #20927
- Zero-pad filenames when exporting multiple frames to a directory, ensuring proper sort order and compatibility with external tools. #20928
