### PR TITLE
avm2: remove `GcCell` in `VTable`

### DIFF
--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -189,10 +189,11 @@ pub fn recursive_serialize<'gc>(
     if let Some(static_properties) = static_properties {
         let vtable = obj.vtable();
         // TODO: respect versioning
-        let mut props = vtable.public_properties();
         // Flash appears to use vtable iteration order, but we sort ours
         // to make our test output consistent.
-        props.sort_by_key(|(name, _)| name.to_utf8_lossy().to_string());
+        let mut props = vtable.public_properties().collect::<Vec<_>>();
+        props.sort_by_key(|(name, _)| *name);
+
         for (name, prop) in props {
             if let Property::Method { .. } = prop {
                 continue;

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -137,14 +137,15 @@ pub struct ClassData<'gc> {
     /// Must be called each time a new class instance is constructed.
     instance_init: Option<Method<'gc>>,
 
-    /// Traits for a given class.
+    /// Traits (and vtable) for a given class.
     ///
     /// These are accessed as normal instance properties; they should not be
     /// present on prototypes, but instead should shadow any prototype
     /// properties that would match.
     traits: OnceLock<Box<[Trait<'gc>]>>,
 
-    vtable: VTable<'gc>,
+    /// The class' vtable.
+    vtable: OnceLock<VTable<'gc>>,
 
     /// The customization point for `Class(args...)` without `new`
     /// If None, a simple coercion is done.
@@ -204,7 +205,7 @@ impl core::fmt::Debug for Class<'_> {
 
 impl<'gc> ClassData<'gc> {
     /// Create an unlinked & unloaded class.
-    fn empty(mc: &Mutation<'gc>, name: QName<'gc>) -> Self {
+    fn empty(name: QName<'gc>) -> Self {
         Self {
             name: Lock::new(name),
             param: Lock::new(None),
@@ -216,7 +217,7 @@ impl<'gc> ClassData<'gc> {
             instance_allocator: Allocator(scriptobject_allocator),
             instance_init: None,
             traits: OnceLock::new(),
-            vtable: VTable::empty(mc),
+            vtable: OnceLock::new(),
             call_handler: None,
             custom_constructor: None,
             linked_class: Lock::new(ClassLink::Unlinked),
@@ -240,7 +241,7 @@ impl<'gc> Class<'gc> {
         traits: Box<[Trait<'gc>]>,
         mc: &Mutation<'gc>,
     ) -> Self {
-        let mut class = ClassData::empty(mc, name);
+        let mut class = ClassData::empty(name);
         class.super_class = super_class;
         class.traits = OnceLock::from(traits);
         Class(Gc::new(mc, class))
@@ -291,7 +292,7 @@ impl<'gc> Class<'gc> {
         local_name_buf.push_char('$');
         let c_name = QName::new(name.namespace(), AvmString::new(mc, local_name_buf));
 
-        let mut i_class = ClassData::empty(mc, name);
+        let mut i_class = ClassData::empty(name);
         i_class.param = Lock::new(Some(Some(param)));
         i_class.super_class = Some(object_vector_i_class);
         i_class.instance_allocator = object_vector_i_class.instance_allocator();
@@ -300,7 +301,7 @@ impl<'gc> Class<'gc> {
         i_class.traits = OnceLock::from(Box::default());
         let i_class = Class(Gc::new(mc, i_class));
 
-        let mut c_class = ClassData::empty(mc, c_name);
+        let mut c_class = ClassData::empty(c_name);
         c_class.super_class = Some(context.avm2.class_defs().class);
         c_class.attributes = Cell::new(ClassAttributes::FINAL);
         c_class.instance_init = object_vector_c_class.instance_init();
@@ -462,7 +463,7 @@ impl<'gc> Class<'gc> {
             .or_else(|| super_class.map(|c| c.instance_allocator()))
             .unwrap_or(Allocator(scriptobject_allocator));
 
-        let mut class = ClassData::empty(activation.gc(), name);
+        let mut class = ClassData::empty(name);
         class.super_class = super_class;
         class.attributes = Cell::new(attributes);
         class.protected_namespace = protected_namespace;
@@ -513,7 +514,7 @@ impl<'gc> Class<'gc> {
             AvmString::new(activation.gc(), local_name_buf),
         );
 
-        let mut class = ClassData::empty(activation.gc(), c_name);
+        let mut class = ClassData::empty(c_name);
         class.super_class = Some(class_class);
         class.attributes = Cell::new(ClassAttributes::FINAL);
         class.protected_namespace = protected_namespace;
@@ -826,7 +827,7 @@ impl<'gc> Class<'gc> {
             );
         }
 
-        self.0.vtable.init_vtable(
+        let vtable = VTable::new(
             self,
             None,
             None,
@@ -834,12 +835,14 @@ impl<'gc> Class<'gc> {
             context.gc(),
         );
 
+        let _ = unlock!(Gc::write(context.gc(), self.0), ClassData, vtable).set(vtable);
+
         self.link_interfaces(context)?;
 
         Ok(())
     }
 
-    pub fn link_interfaces(self, context: &mut UpdateContext<'gc>) -> Result<(), Error<'gc>> {
+    fn link_interfaces(self, context: &mut UpdateContext<'gc>) -> Result<(), Error<'gc>> {
         let mut interfaces = Vec::with_capacity(self.direct_interfaces().len());
 
         let mut dedup = HashSet::new();
@@ -874,7 +877,7 @@ impl<'gc> Class<'gc> {
             for interface_trait in interface.traits() {
                 if !interface_trait.name().namespace().is_public() {
                     let public_name = QName::new(ns, interface_trait.name().local_name());
-                    self.0.vtable.copy_property_for_interface(
+                    self.vtable().copy_property_for_interface(
                         context.gc(),
                         public_name,
                         interface_trait.name(),
@@ -922,7 +925,7 @@ impl<'gc> Class<'gc> {
 
         let name = QName::new(activation.avm2().namespaces.public_all(), name);
 
-        let mut i_class = ClassData::empty(activation.gc(), name);
+        let mut i_class = ClassData::empty(name);
         i_class.attributes = Cell::new(ClassAttributes::FINAL | ClassAttributes::SEALED);
         i_class.traits = OnceLock::from(traits);
         let i_class = Class(Gc::new(activation.gc(), i_class));
@@ -938,7 +941,7 @@ impl<'gc> Class<'gc> {
         variable_name: QName<'gc>,
     ) -> Result<Class<'gc>, Error<'gc>> {
         // Yes, the name of the class is the variable's name
-        let mut i_class = ClassData::empty(activation.gc(), variable_name);
+        let mut i_class = ClassData::empty(variable_name);
         i_class.attributes = Cell::new(ClassAttributes::FINAL | ClassAttributes::SEALED);
         // TODO make the slot typed
         let traits: Box<[_]> = Box::new([Trait::from_const(variable_name, None, None)]);
@@ -982,7 +985,7 @@ impl<'gc> Class<'gc> {
     }
 
     pub fn vtable(self) -> VTable<'gc> {
-        self.0.vtable
+        *self.0.vtable.get().expect("VTable not yet initialized!")
     }
 
     pub fn dollar_removed_name(self, mc: &Mutation<'gc>) -> QName<'gc> {

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -211,7 +211,7 @@ fn describe_internal_body<'gc>(
                     _ => unreachable!(),
                 };
 
-                let trait_metadata = vtable.get_metadata_for_slot(slot_id);
+                let trait_metadata = vtable.get_metadata_for_slot(*slot_id);
 
                 let variable = ScriptObject::new_object(activation);
                 variable.set_string_property_local(istr!("name"), prop_name.into(), activation)?;
@@ -232,7 +232,7 @@ fn describe_internal_body<'gc>(
                 if flags.contains(DescribeTypeFlags::INCLUDE_METADATA) {
                     let metadata_object = ArrayObject::empty(activation);
                     if let Some(metadata) = trait_metadata {
-                        write_metadata(metadata_object, &metadata, activation)?;
+                        write_metadata(metadata_object, metadata, activation)?;
                     }
                     variable.set_string_property_local(
                         istr!("metadata"),
@@ -273,7 +273,7 @@ fn describe_internal_body<'gc>(
 
                 let declared_by_name = declared_by.dollar_removed_name(mc).to_qualified_name(mc);
 
-                let trait_metadata = vtable.get_metadata_for_disp(disp_id);
+                let trait_metadata = vtable.get_metadata_for_disp(*disp_id);
 
                 let method_obj = ScriptObject::new_object(activation);
 
@@ -311,7 +311,7 @@ fn describe_internal_body<'gc>(
                 if flags.contains(DescribeTypeFlags::INCLUDE_METADATA) {
                     let metadata_object = ArrayObject::empty(activation);
                     if let Some(metadata) = trait_metadata {
-                        write_metadata(metadata_object, &metadata, activation)?;
+                        write_metadata(metadata_object, metadata, activation)?;
                     }
                     method_obj.set_string_property_local(
                         istr!("metadata"),
@@ -391,14 +391,14 @@ fn describe_internal_body<'gc>(
                 let metadata_object = ArrayObject::empty(activation);
 
                 if let Some(get_disp_id) = get {
-                    if let Some(metadata) = vtable.get_metadata_for_disp(get_disp_id) {
-                        write_metadata(metadata_object, &metadata, activation)?;
+                    if let Some(metadata) = vtable.get_metadata_for_disp(*get_disp_id) {
+                        write_metadata(metadata_object, metadata, activation)?;
                     }
                 }
 
                 if let Some(set_disp_id) = set {
-                    if let Some(metadata) = vtable.get_metadata_for_disp(set_disp_id) {
-                        write_metadata(metadata_object, &metadata, activation)?;
+                    if let Some(metadata) = vtable.get_metadata_for_disp(*set_disp_id) {
+                        write_metadata(metadata_object, metadata, activation)?;
                     }
                 }
 

--- a/core/src/avm2/globals/null.rs
+++ b/core/src/avm2/globals/null.rs
@@ -13,7 +13,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     );
     class.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
     // The void class has no interfaces, so this can't fail.
-    class.link_interfaces(activation.context).unwrap();
+    class.init_vtable(activation.context).unwrap();
 
     class
 }

--- a/core/src/avm2/globals/void.rs
+++ b/core/src/avm2/globals/void.rs
@@ -13,7 +13,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     );
     class.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
     // The null class has no interfaces, so this can't fail.
-    class.link_interfaces(activation.context).unwrap();
+    class.init_vtable(activation.context).unwrap();
 
     class
 }

--- a/core/src/avm2/optimizer/optimize.rs
+++ b/core/src/avm2/optimizer/optimize.rs
@@ -6,7 +6,7 @@ use crate::avm2::optimizer::blocks::assemble_blocks;
 use crate::avm2::optimizer::peephole;
 use crate::avm2::property::Property;
 use crate::avm2::verify::Exception;
-use crate::avm2::vtable::{ClassBoundMethod, VTable};
+use crate::avm2::vtable::VTable;
 use crate::avm2::{Activation, Class, Error};
 
 use gc_arena::Gc;
@@ -1432,10 +1432,8 @@ fn abstract_interpret_ops<'gc>(
                             Some(Property::Virtual {
                                 set: Some(disp_id), ..
                             }) => {
-                                let full_method = vtable
-                                    .get_full_method(disp_id)
-                                    .expect("Method should exist");
-                                let ClassBoundMethod { method, .. } = full_method;
+                                let method =
+                                    vtable.get_method(disp_id).expect("Method should exist");
 
                                 let mut result_op = Op::CallMethod {
                                     num_args: 1,
@@ -1487,10 +1485,7 @@ fn abstract_interpret_ops<'gc>(
                         Some(Property::Virtual {
                             set: Some(disp_id), ..
                         }) => {
-                            let full_method = vtable
-                                .get_full_method(disp_id)
-                                .expect("Method should exist");
-                            let ClassBoundMethod { method, .. } = full_method;
+                            let method = vtable.get_method(disp_id).expect("Method should exist");
 
                             let mut result_op = Op::CallMethod {
                                 num_args: 1,
@@ -1975,10 +1970,7 @@ fn optimize_get_property<'gc>(
             Some(Property::Virtual {
                 get: Some(disp_id), ..
             }) => {
-                let full_method = vtable
-                    .get_full_method(disp_id)
-                    .expect("Method should exist");
-                let ClassBoundMethod { method, .. } = full_method;
+                let method = vtable.get_method(disp_id).expect("Method should exist");
 
                 let mut result_op = Op::CallMethod {
                     num_args: 0,
@@ -2027,10 +2019,7 @@ fn optimize_call_property<'gc>(
     if let Some(vtable) = stack_value.vtable() {
         match vtable.get_trait(&multiname) {
             Some(Property::Method { disp_id }) => {
-                let full_method = vtable
-                    .get_full_method(disp_id)
-                    .expect("Method should exist");
-                let ClassBoundMethod { method, .. } = full_method;
+                let method = vtable.get_method(disp_id).expect("Method should exist");
 
                 let mut result_op = Op::CallMethod {
                     num_args,

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -475,8 +475,7 @@ impl<'gc> Script<'gc> {
         let scope = ScopeChain::new(domain);
         let object_class = activation.avm2().classes().object;
 
-        let global_obj_vtable = VTable::empty(mc);
-        global_obj_vtable.init_vtable(
+        let global_obj_vtable = VTable::new(
             global_class,
             Some(object_class),
             Some(scope),

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -7,7 +7,7 @@ use crate::avm2::function::{exec, FunctionArgs};
 use crate::avm2::object::{NamespaceObject, Object, TObject};
 use crate::avm2::property::Property;
 use crate::avm2::script::TranslationUnit;
-use crate::avm2::vtable::{ClassBoundMethod, VTable};
+use crate::avm2::vtable::VTable;
 use crate::avm2::{Error, Multiname, Namespace};
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use crate::string::{AvmAtom, AvmString, WStr};
@@ -1235,19 +1235,12 @@ impl<'gc> Value<'gc> {
 
         // Execute immediately if this method doesn't require binding
         if !full_method.method.needs_arguments_object() {
-            let ClassBoundMethod {
-                class,
-                super_class_obj,
-                scope,
-                method,
-            } = full_method;
-
             return exec(
-                method,
-                scope.expect("Scope should exist here"),
+                full_method.method,
+                full_method.scope(),
                 *self,
-                super_class_obj,
-                Some(class),
+                full_method.super_class_obj,
+                Some(full_method.class),
                 arguments,
                 activation,
                 *self, // Callee deliberately invalid.

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -56,8 +56,14 @@ impl PartialEq for VTable<'_> {
 pub struct ClassBoundMethod<'gc> {
     pub class: Class<'gc>,
     pub super_class_obj: Option<ClassObject<'gc>>,
-    pub scope: Option<ScopeChain<'gc>>,
+    scope: Option<ScopeChain<'gc>>,
     pub method: Method<'gc>,
+}
+
+impl<'gc> ClassBoundMethod<'gc> {
+    pub fn scope(&self) -> ScopeChain<'gc> {
+        self.scope.expect("Scope should exists here")
+    }
 }
 
 impl<'gc> VTable<'gc> {

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -549,15 +549,11 @@ impl<'gc> VTable<'gc> {
         )
     }
 
-    pub fn public_properties(self) -> Vec<(AvmString<'gc>, Property)> {
-        let mut props = Vec::new();
-
-        for (name, ns, prop) in self.resolved_traits().iter() {
-            if ns.is_public() {
-                props.push((name, *prop));
-            }
-        }
-        props
+    pub fn public_properties(self) -> impl Iterator<Item = (AvmString<'gc>, Property)> {
+        self.resolved_traits()
+            .iter()
+            .filter(|(_, ns, _)| ns.is_public())
+            .map(|(name, _, prop)| (name, *prop))
     }
 }
 

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -171,12 +171,12 @@ impl<'gc> VTable<'gc> {
         Ref::map(self.0.read(), |v| &v.default_slots)
     }
 
-    pub fn slot_classes(&self) -> Ref<'_, Vec<PropertyClass<'gc>>> {
-        Ref::map(self.0.read(), |v| &v.slot_classes)
+    pub fn slot_class(self, slot_id: u32) -> Option<PropertyClass<'gc>> {
+        self.0.read().slot_classes.get(slot_id as usize).copied()
     }
 
-    pub fn set_slot_class(&self, mc: &Mutation<'gc>, index: usize, value: PropertyClass<'gc>) {
-        self.0.write(mc).slot_classes[index] = value;
+    pub fn set_slot_class(self, mc: &Mutation<'gc>, slot_id: u32, value: PropertyClass<'gc>) {
+        self.0.write(mc).slot_classes[slot_id as usize] = value;
     }
 
     pub fn replace_scopes_with(&self, mc: &Mutation<'gc>, new_scope: ScopeChain<'gc>) {

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -302,13 +302,12 @@ impl Avm2ObjectWindow {
         activation: &mut Activation<'_, 'gc>,
         ui: &mut Ui,
     ) {
-        let mut entries = Vec::<(String, Namespace<'gc>, Property)>::new();
-        // We can't access things whilst we iterate the vtable, so clone and sort it all here
-        let vtable = object.vtable();
-
-        for (name, ns, prop) in vtable.resolved_traits().iter() {
-            entries.push((name.to_string(), ns, *prop));
-        }
+        let mut entries: Vec<(Cow<'gc, str>, Namespace<'gc>, Property)> = object
+            .vtable()
+            .resolved_traits()
+            .iter()
+            .map(|(name, ns, prop)| (name.as_wstr().to_utf8_lossy(), ns, *prop))
+            .collect();
         entries.sort_by(|a, b| a.0.cmp(&b.0));
 
         ui.horizontal(|ui| {

--- a/tests/tests/swfs/avm2/weird_superinterface_properties/test.toml
+++ b/tests/tests/swfs/avm2/weird_superinterface_properties/test.toml
@@ -1,4 +1,4 @@
 num_frames = 1
 # FIXME - match Flash's verification behavior, and fix interface property copying
-# See `ClassObject::link_interfaces` for more details
+# See `VTable::copy_interface_properties` for more details
 known_failure = true


### PR DESCRIPTION
To avoid having to put (almost) every `VTable` field behind a `OnceLock`, this also changes the `Class/ClassObject` vtable initialization logic to fully replace the vtable object instead of mutating it in place.