### PR TITLE
core: properly free memory in `BitmapData::dispose`

### DIFF
--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -608,7 +608,7 @@ impl<'gc> BitmapData<'gc> {
     pub fn dispose(&mut self) {
         self.width = 0;
         self.height = 0;
-        self.pixels.clear();
+        self.pixels = Vec::new(); // free the CPU pixel buffer
         self.bitmap_handle = None;
         // There's no longer a handle to update
         self.dirty_state = DirtyState::Clean;


### PR DESCRIPTION
`Vec::clear` doesn't actually free the backing memory, so replace with an empty vec instead.