### PR TITLE
core/render: avoid copying pixels on bitmap CPU -> GPU syncs

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -47,7 +47,7 @@ lzma-rs = {version = "0.3.0", optional = true }
 dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.4", default-features = false, optional = true }
 enumset = "1.1.7"
-bytemuck = { workspace = true }
+bytemuck = { workspace = true, features = ["derive"] }
 clap = { workspace = true, optional=true }
 realfft = "3.5.0"
 hashbrown = { version = "0.14.5", features = ["raw"] }

--- a/core/src/avm2/globals/flash/display3D/textures/texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/texture.rs
@@ -47,7 +47,7 @@ pub fn do_copy<'gc>(
                 .chunks_exact(4)
                 .map(|chunk| {
                     // The ByteArray is in BGRA format. FIXME - should this be premultiplied?
-                    Color::argb(chunk[3], chunk[2], chunk[1], chunk[0])
+                    Color::rgba(chunk[2], chunk[1], chunk[0], chunk[3])
                 })
                 .collect();
 

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -369,7 +369,8 @@ impl<'gc> Context3DObject<'gc> {
 
         self.with_context_3d(|ctx| {
             ctx.process_command(Context3DCommand::CopyBitmapToTexture {
-                source: source.pixels_rgba(),
+                // TODO: it'd be nice to avoid copying the pixels here.
+                source: source.pixels_rgba().to_owned(),
                 source_width: source.width(),
                 source_height: source.height(),
                 dest,

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -59,7 +59,7 @@ pub enum BitmapDataDrawError {
 
 impl Color {
     #[must_use]
-    pub fn argb(a: u8, r: u8, g: u8, b: u8) -> Self {
+    pub fn rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
         Self { r, g, b, a }
     }
 
@@ -100,7 +100,7 @@ impl Color {
         let g = ((self.green() as u32 * a + 127) / 255) as u8;
         let b = ((self.blue() as u32 * a + 127) / 255) as u8;
 
-        Self::argb(old_alpha, r, g, b)
+        Self::rgba(r, g, b, old_alpha)
     }
 
     #[must_use]
@@ -143,12 +143,12 @@ impl Color {
         let g = unmultiply(self.green());
         let b = unmultiply(self.blue());
 
-        Self::argb(self.alpha(), r, g, b)
+        Self::rgba(r, g, b, self.alpha())
     }
 
     #[must_use]
     pub fn with_alpha(&self, alpha: u8) -> Self {
-        Self::argb(alpha, self.red(), self.green(), self.blue())
+        Self::rgba(self.red(), self.green(), self.blue(), alpha)
     }
 
     /// # Arguments
@@ -163,7 +163,7 @@ impl Color {
         let g = source.green() + ((self.green() as u16 * (255 - sa as u16)) / 255) as u8;
         let b = source.blue() + ((self.blue() as u16 * (255 - sa as u16)) / 255) as u8;
         let a = source.alpha() + ((self.alpha() as u16 * (255 - sa as u16)) / 255) as u8;
-        Self::argb(a, r, g, b)
+        Self::rgba(r, g, b, a)
     }
 
     fn slice_as_rgba(slice: &[Self]) -> &[u8] {
@@ -191,7 +191,7 @@ impl From<u32> for Color {
 
 impl From<swf::Color> for Color {
     fn from(c: swf::Color) -> Self {
-        Self::argb(c.a, c.r, c.g, c.b)
+        Self::rgba(c.r, c.g, c.b, c.a)
     }
 }
 
@@ -837,7 +837,7 @@ fn copy_pixels_to_bitmapdata(
                 255
             };
 
-            let nc = Color::argb(a, r, g, b);
+            let nc = Color::rgba(r, g, b, a);
 
             // Ignore the original color entirely - the blending (including alpha)
             // was done by the renderer when it wrote over the previous texture contents.

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -218,7 +218,7 @@ pub fn noise<'gc>(
                     255
                 };
 
-                Color::argb(alpha, gray, gray, gray)
+                Color::rgba(gray, gray, gray, alpha)
             } else {
                 let r = if channel_options.contains(ChannelOptions::RED) {
                     rng.random_range(low..high)
@@ -244,7 +244,7 @@ pub fn noise<'gc>(
                     255
                 };
 
-                Color::argb(a, r, g, b)
+                Color::rgba(r, g, b, a)
             };
 
             write.set_pixel32_raw(x, y, pixel_color);
@@ -364,7 +364,7 @@ pub fn perlin_noise<'gc>(
                 color[3] = 255;
             }
 
-            write.set_pixel32_raw(x, y, Color::argb(color[3], color[0], color[1], color[2]));
+            write.set_pixel32_raw(x, y, Color::rgba(color[0], color[1], color[2], color[3]));
         }
     }
     let region = PixelRegion::for_whole_size(write.width(), write.height());
@@ -773,19 +773,19 @@ pub fn compare<'gc>(
             let bitmap_pixel = bitmap_pixel.to_un_multiplied_alpha();
             let other_pixel = other_pixel.to_un_multiplied_alpha();
             if bitmap_pixel == other_pixel {
-                Color::argb(0, 0, 0, 0)
+                Color::rgba(0, 0, 0, 0)
             } else if bitmap_pixel.with_alpha(0) != other_pixel.with_alpha(0) {
                 different = true;
-                Color::argb(
-                    0xff,
+                Color::rgba(
                     bitmap_pixel.red().wrapping_sub(other_pixel.red()),
                     bitmap_pixel.green().wrapping_sub(other_pixel.green()),
                     bitmap_pixel.blue().wrapping_sub(other_pixel.blue()),
+                    0xff,
                 )
             } else {
                 different = true;
                 let alpha = bitmap_pixel.alpha().wrapping_sub(other_pixel.alpha());
-                Color::argb(alpha, alpha, alpha, alpha)
+                Color::rgba(alpha, alpha, alpha, alpha)
             }
         })
         .collect();
@@ -1021,7 +1021,7 @@ pub fn merge<'gc>(
                 + dest_color.alpha() as u16 * (256 - alpha_mult))
                 / 256;
 
-            let mix_color = Color::argb(alpha as u8, red as u8, green as u8, blue as u8);
+            let mix_color = Color::rgba(red as u8, green as u8, blue as u8, alpha as u8);
 
             write.set_pixel32_raw(
                 dest_x,
@@ -1186,7 +1186,7 @@ pub fn copy_pixels_with_alpha_source<'gc>(
             let r = (source_color.red() as f64 / a).round() as u8;
             let g = (source_color.green() as f64 / a).round() as u8;
             let b = (source_color.blue() as f64 / a).round() as u8;
-            let intermediate_color = Color::argb(source_color.alpha(), r, g, b)
+            let intermediate_color = Color::rgba(r, g, b, source_color.alpha())
                 .with_alpha(final_alpha)
                 .to_premultiplied_alpha(true);
 

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -109,7 +109,7 @@ impl CompressedBitmap {
             },
         }
     }
-    pub fn decode(&self) -> Result<RenderBitmap, RenderError> {
+    pub fn decode(&self) -> Result<RenderBitmap<'static>, RenderError> {
         match self {
             CompressedBitmap::Jpeg {
                 data,

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -147,7 +147,7 @@ impl Avm2ObjectWindow {
                                 encoder.set_depth(png::BitDepth::Eight);
                                 if let Err(e) = encoder.write_header().and_then(|mut w| {
                                     w.write_image_data(
-                                        &bmd.sync(activation.context.renderer).read().pixels_rgba(),
+                                        bmd.sync(activation.context.renderer).read().pixels_rgba(),
                                     )
                                 }) {
                                     tracing::error!("Couldn't create png: {e}");

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -787,7 +787,7 @@ impl DisplayObjectWindow {
                 let texture = egui_texture.get_or_insert_with(|| {
                     let image = egui::ColorImage::from_rgba_premultiplied(
                         [bitmap_data.width() as usize, bitmap_data.height() as usize],
-                        &bitmap_data.pixels_rgba(),
+                        bitmap_data.pixels_rgba(),
                     );
                     ui.ctx().load_texture(
                         format!("bitmap-{:?}", object.as_ptr()),

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -198,7 +198,7 @@ impl BitmapData {
         })
     }
 
-    fn update_pixels(&self, bitmap: Bitmap) -> Result<(), JsValue> {
+    fn update_pixels(&self, bitmap: Bitmap<'_>) -> Result<(), JsValue> {
         let bitmap = bitmap.to_rgba();
         let image_data =
             ImageData::new_with_u8_clamped_array(Clamped(bitmap.data()), bitmap.width())
@@ -530,7 +530,7 @@ impl RenderBackend for WebCanvasRenderBackend {
         commands.execute(self);
     }
 
-    fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, Error> {
+    fn register_bitmap(&mut self, bitmap: Bitmap<'_>) -> Result<BitmapHandle, Error> {
         let bitmap_data = BitmapData::with_bitmap(bitmap).map_err(Error::JavascriptError)?;
         Ok(BitmapHandle(Arc::new(bitmap_data)))
     }
@@ -538,7 +538,7 @@ impl RenderBackend for WebCanvasRenderBackend {
     fn update_texture(
         &mut self,
         handle: &BitmapHandle,
-        bitmap: Bitmap,
+        bitmap: Bitmap<'_>,
         _region: PixelRegion,
     ) -> Result<(), Error> {
         let data = as_bitmap_data(handle);

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -77,11 +77,11 @@ pub trait RenderBackend: Any {
 
     fn create_empty_texture(&mut self, width: u32, height: u32) -> Result<BitmapHandle, Error>;
 
-    fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, Error>;
+    fn register_bitmap(&mut self, bitmap: Bitmap<'_>) -> Result<BitmapHandle, Error>;
     fn update_texture(
         &mut self,
         handle: &BitmapHandle,
-        bitmap: Bitmap,
+        bitmap: Bitmap<'_>,
         region: PixelRegion,
     ) -> Result<(), Error>;
 

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -78,14 +78,14 @@ impl RenderBackend for NullRenderer {
         _cache_entries: Vec<BitmapCacheEntry>,
     ) {
     }
-    fn register_bitmap(&mut self, _bitmap: Bitmap) -> Result<BitmapHandle, Error> {
+    fn register_bitmap(&mut self, _bitmap: Bitmap<'_>) -> Result<BitmapHandle, Error> {
         Ok(BitmapHandle(Arc::new(NullBitmapHandle)))
     }
 
     fn update_texture(
         &mut self,
         _handle: &BitmapHandle,
-        _bitmap: Bitmap,
+        _bitmap: Bitmap<'_>,
         _region: PixelRegion,
     ) -> Result<(), Error> {
         Ok(())

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -1,5 +1,6 @@
 use h263_rs_yuv::bt601::yuv420_to_rgba;
 use std::any::Any;
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -91,16 +92,24 @@ impl PixelSnapping {
 
 /// Decoded bitmap data from an SWF tag.
 #[derive(Clone, Debug)]
-pub struct Bitmap {
+pub struct Bitmap<'a> {
     width: u32,
     height: u32,
     format: BitmapFormat,
-    data: Vec<u8>,
+    data: Cow<'a, [u8]>,
 }
 
-impl Bitmap {
+impl<'a> Bitmap<'a> {
     /// Ensures that `data` is the correct size for the given `width` and `height`.
-    pub fn new(width: u32, height: u32, format: BitmapFormat, mut data: Vec<u8>) -> Self {
+    #[inline]
+    pub fn new<D>(width: u32, height: u32, format: BitmapFormat, data: D) -> Self
+    where
+        D: Into<Cow<'a, [u8]>>,
+    {
+        Self::new_impl(width, height, format, data.into())
+    }
+
+    fn new_impl(width: u32, height: u32, format: BitmapFormat, mut data: Cow<'a, [u8]>) -> Self {
         // If the size is incorrect, either we screwed up or the decoder screwed up.
         let expected_len = format.length_for_size(width as usize, height as usize);
         if data.len() != expected_len {
@@ -109,9 +118,21 @@ impl Bitmap {
                 expected_len,
                 data.len(),
             );
-            // Truncate or zero pad to the expected size.
-            data.resize(expected_len, 0);
+
+            // Truncate or zero-pad to the expected size.
+            if let Cow::Borrowed(slice) = &data {
+                // Allocate the owned buffer ourselves instead of using `Cow::to_mut`, to avoid
+                // a reallocation if the buffer needs to be padded.
+                let mut vec = Vec::with_capacity(expected_len);
+                vec.extend_from_slice(&slice[..expected_len]);
+                data = Cow::Owned(vec);
+            }
+            match &mut data {
+                Cow::Owned(data) => data.resize(expected_len, 0),
+                Cow::Borrowed(_) => unreachable!(),
+            }
         }
+
         Self {
             width,
             height,
@@ -165,7 +186,7 @@ impl Bitmap {
                 let u = &self.data[luma_len..luma_len + chroma_len];
                 let v = &self.data[luma_len + chroma_len..luma_len + 2 * chroma_len];
 
-                self.data = yuv420_to_rgba(y, u, v, self.width as usize);
+                self.data = Cow::Owned(yuv420_to_rgba(y, u, v, self.width as usize));
             }
             BitmapFormat::Yuva420p => {
                 let luma_len = (self.width * self.height) as usize;
@@ -224,11 +245,6 @@ impl Bitmap {
     #[inline]
     pub fn data(&self) -> &[u8] {
         &self.data
-    }
-
-    #[inline]
-    pub fn data_mut(&mut self) -> &mut [u8] {
-        &mut self.data
     }
 
     pub fn as_colors(&self) -> impl Iterator<Item = u32> + '_ {

--- a/render/src/utils.rs
+++ b/render/src/utils.rs
@@ -30,7 +30,10 @@ pub fn determine_jpeg_tag_format(data: &[u8]) -> JpegTagFormat {
 
 /// Decodes bitmap data from a DefineBitsJPEG2/3 tag.
 /// The data is returned with pre-multiplied alpha.
-pub fn decode_define_bits_jpeg(data: &[u8], alpha_data: Option<&[u8]>) -> Result<Bitmap, Error> {
+pub fn decode_define_bits_jpeg(
+    data: &[u8],
+    alpha_data: Option<&[u8]>,
+) -> Result<Bitmap<'static>, Error> {
     let format = determine_jpeg_tag_format(data);
     if format != JpegTagFormat::Jpeg && alpha_data.is_some() {
         // Only DefineBitsJPEG3 with true JPEG data should have separate alpha data.
@@ -179,7 +182,7 @@ fn decode_jpeg_dimensions(jpeg_data: &[u8]) -> Result<(u16, u16), Error> {
 
 /// Decodes a JPEG with optional alpha data.
 /// The decoded bitmap will have pre-multiplied alpha.
-fn decode_jpeg(jpeg_data: &[u8], alpha_data: Option<&[u8]>) -> Result<Bitmap, Error> {
+fn decode_jpeg(jpeg_data: &[u8], alpha_data: Option<&[u8]>) -> Result<Bitmap<'static>, Error> {
     let jpeg_data = remove_invalid_jpeg_data(jpeg_data);
 
     let mut decoder = jpeg_decoder::Decoder::new(&jpeg_data[..]);
@@ -218,7 +221,7 @@ fn decode_jpeg(jpeg_data: &[u8], alpha_data: Option<&[u8]>) -> Result<Bitmap, Er
         let alpha_data = decompress_zlib(alpha_data)?;
 
         if alpha_data.len() == decoded_data.len() / 3 {
-            let rgba = decoded_data
+            let rgba: Vec<_> = decoded_data
                 .chunks_exact(3)
                 .zip(alpha_data)
                 .flat_map(|(rgb, a)| {
@@ -257,7 +260,9 @@ fn decode_jpeg(jpeg_data: &[u8], alpha_data: Option<&[u8]>) -> Result<Bitmap, Er
 /// Decodes the bitmap data in DefineBitsLossless tag into RGBA.
 /// DefineBitsLossless is Zlib encoded pixel data (similar to PNG), possibly
 /// palletized.
-pub fn decode_define_bits_lossless(swf_tag: &swf::DefineBitsLossless) -> Result<Bitmap, Error> {
+pub fn decode_define_bits_lossless(
+    swf_tag: &swf::DefineBitsLossless,
+) -> Result<Bitmap<'static>, Error> {
     // Decompress the image data (DEFLATE compression).
     let mut decoded_data = decompress_zlib(&swf_tag.data)?;
 
@@ -370,7 +375,7 @@ fn decode_png_dimensions(data: &[u8]) -> Result<(u16, u16), Error> {
 /// Decodes the bitmap data in DefineBitsLossless tag into RGBA.
 /// DefineBitsLossless is Zlib encoded pixel data (similar to PNG), possibly
 /// palletized.
-fn decode_png(data: &[u8]) -> Result<Bitmap, Error> {
+fn decode_png(data: &[u8]) -> Result<Bitmap<'static>, Error> {
     use png::{ColorType, Transformations};
 
     let mut decoder = png::Decoder::new(data);
@@ -443,7 +448,7 @@ fn decode_gif_dimensions(data: &[u8]) -> Result<(u16, u16), Error> {
 /// Decodes the bitmap data in DefineBitsLossless tag into RGBA.
 /// DefineBitsLossless is Zlib encoded pixel data (similar to PNG), possibly
 /// palletized.
-fn decode_gif(data: &[u8]) -> Result<Bitmap, Error> {
+fn decode_gif(data: &[u8]) -> Result<Bitmap<'static>, Error> {
     let mut decode_options = gif::DecodeOptions::new();
     decode_options.set_color_output(gif::ColorOutput::RGBA);
     let mut reader = decode_options.read_info(data)?;

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1071,7 +1071,7 @@ impl RenderBackend for WebGlRenderBackend {
         self.end_frame();
     }
 
-    fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, BitmapError> {
+    fn register_bitmap(&mut self, bitmap: Bitmap<'_>) -> Result<BitmapHandle, BitmapError> {
         let (format, bitmap) = match bitmap.format() {
             BitmapFormat::Rgb | BitmapFormat::Yuv420p => (Gl::RGB, bitmap.to_rgb()),
             BitmapFormat::Rgba | BitmapFormat::Yuva420p => (Gl::RGBA, bitmap.to_rgba()),
@@ -1118,7 +1118,7 @@ impl RenderBackend for WebGlRenderBackend {
     fn update_texture(
         &mut self,
         handle: &BitmapHandle,
-        bitmap: Bitmap,
+        bitmap: Bitmap<'_>,
         _region: PixelRegion,
     ) -> Result<(), BitmapError> {
         let texture = &as_registry_data(handle).texture;

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -609,7 +609,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
     }
 
     #[instrument(level = "debug", skip_all)]
-    fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, BitmapError> {
+    fn register_bitmap(&mut self, bitmap: Bitmap<'_>) -> Result<BitmapHandle, BitmapError> {
         let mut bitmap = bitmap.to_rgba();
 
         self.clamp_bitmap(&mut bitmap);
@@ -668,7 +668,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
     fn update_texture(
         &mut self,
         handle: &BitmapHandle,
-        bitmap: Bitmap,
+        bitmap: Bitmap<'_>,
         mut region: PixelRegion,
     ) -> Result<(), BitmapError> {
         let texture = as_texture(handle);

--- a/video/src/frame.rs
+++ b/video/src/frame.rs
@@ -22,7 +22,7 @@ impl<'a> EncodedFrame<'a> {
 }
 
 /// A decoded frame of video. It can be in whichever format the decoder chooses.
-pub type DecodedFrame = Bitmap;
+pub type DecodedFrame = Bitmap<'static>;
 
 /// What dependencies a given video frame has on any previous frames.
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
This is done by making `render::Bitmap` capable of holding borrowed pixel data, and by changing `core::bitmap::Color`'s internal representation to be compatible with what the render backend expects.

Slightly pessimizes `setPixel` & friends, as they now need to convert the ActionScript color representation (BGRA) into RGBA; this could be fixed by switching renderers to use BGRA internally, but I'm not sure how much work this represents or if it is even possible.