### PR TITLE
core: Finish porting `MovieClip` away from `GcCell`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -729,7 +729,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         if let Some((clip, frame)) = call_frame {
             if frame <= u16::MAX as u32 {
-                for action in clip.actions_on_frame(self.context, frame as u16) {
+                for action in clip.actions_on_frame(frame as u16) {
                     let _ = self.run_child_frame_for_action("[Frame Call]", clip.into(), action)?;
                 }
             }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -987,7 +987,7 @@ pub fn clone_sprite<'gc>(
     new_clip.set_matrix(context.gc(), *movie_clip.base().matrix());
     new_clip.set_color_transform(context.gc(), *movie_clip.base().color_transform());
 
-    new_clip.set_clip_event_handlers(context.gc(), movie_clip.clip_actions().to_vec());
+    new_clip.set_clip_event_handlers((&*movie_clip.clip_actions()).into());
 
     if let Some(drawing) = movie_clip.drawing().as_deref().cloned() {
         *new_clip.drawing_mut(context.gc()) = drawing;

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -987,7 +987,7 @@ pub fn clone_sprite<'gc>(
     new_clip.set_matrix(context.gc(), *movie_clip.base().matrix());
     new_clip.set_color_transform(context.gc(), *movie_clip.base().color_transform());
 
-    new_clip.set_clip_event_handlers((&*movie_clip.clip_actions()).into());
+    new_clip.init_clip_event_handlers(movie_clip.clip_actions().into());
 
     if let Some(drawing) = movie_clip.drawing().as_deref().cloned() {
         *new_clip.drawing_mut(context.gc()) = drawing;

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -309,7 +309,7 @@ pub fn set_hit_area<'gc>(
         let object = args
             .try_get_object(activation, 0)
             .and_then(|hit_area| hit_area.as_display_object());
-        mc.set_hit_area(activation.context, object);
+        mc.set_hit_area(activation.gc(), object);
     }
 
     Ok(Value::Undefined)

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -40,8 +40,8 @@ use crate::vminterface::{AvmObject, Instantiator};
 use bitflags::bitflags;
 use core::fmt;
 use gc_arena::barrier::unlock;
-use gc_arena::lock::Lock;
-use gc_arena::{Collect, Gc, GcCell, GcWeakCell, Mutation};
+use gc_arena::lock::{Lock, RefLock};
+use gc_arena::{Collect, Gc, GcCell, GcWeak, Mutation};
 use ruffle_macros::istr;
 use ruffle_render::perspective_projection::PerspectiveProjection;
 use smallvec::SmallVec;
@@ -122,19 +122,19 @@ enum NextFrame {
 /// The unloaded state can only be reached in AVM1 through the unloadMovie function.
 #[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
-pub struct MovieClip<'gc>(GcCell<'gc, MovieClipData<'gc>>);
+pub struct MovieClip<'gc>(Gc<'gc, MovieClipData<'gc>>);
 
 impl fmt::Debug for MovieClip<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MovieClip")
-            .field("ptr", &self.0.as_ptr())
+            .field("ptr", &Gc::as_ptr(self.0))
             .finish()
     }
 }
 
 #[derive(Clone, Debug, Collect, Copy)]
 #[collect(no_drop)]
-pub struct MovieClipWeak<'gc>(GcWeakCell<'gc, MovieClipData<'gc>>);
+pub struct MovieClipWeak<'gc>(GcWeak<'gc, MovieClipData<'gc>>);
 
 impl<'gc> MovieClipWeak<'gc> {
     pub fn upgrade(self, mc: &Mutation<'gc>) -> Option<MovieClip<'gc>> {
@@ -149,30 +149,30 @@ impl<'gc> MovieClipWeak<'gc> {
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct MovieClipData<'gc> {
-    base: InteractiveObjectBase<'gc>,
-    shared: Gc<'gc, MovieClipShared<'gc>>,
+    base: RefLock<InteractiveObjectBase<'gc>>,
+    shared: Lock<Gc<'gc, MovieClipShared<'gc>>>,
     tag_stream_pos: Cell<u64>,
     current_frame: Cell<FrameNumber>,
     #[collect(require_static)]
     audio_stream: Cell<Option<SoundInstanceHandle>>,
-    container: ChildContainer<'gc>,
-    object: Option<AvmObject<'gc>>,
+    container: RefLock<ChildContainer<'gc>>,
+    object: Lock<Option<AvmObject<'gc>>>,
     #[collect(require_static)]
-    clip_event_handlers: Vec<ClipEventHandler>,
+    clip_event_handlers: RefCell<Box<[ClipEventHandler]>>,
     #[collect(require_static)]
     clip_event_flags: Cell<ClipEventFlag>,
-    frame_scripts: Vec<Option<Avm2Object<'gc>>>,
+    frame_scripts: RefLock<Vec<Option<Avm2Object<'gc>>>>,
     flags: Cell<MovieClipFlags>,
     /// This is lazily allocated on demand, to make `MovieClipData` smaller in the common case.
     #[collect(require_static)]
-    drawing: Option<Box<Drawing>>,
+    drawing: RefCell<Option<Box<Drawing>>>,
     avm2_enabled: Cell<bool>,
 
     /// Show a hand cursor when the clip is in button mode.
     avm2_use_hand_cursor: Cell<bool>,
 
     /// A DisplayObject (doesn't need to be visible) to use for hit tests instead of this clip.
-    hit_area: Option<DisplayObject<'gc>>,
+    hit_area: Lock<Option<DisplayObject<'gc>>>,
 
     /// Force enable button mode, which causes all mouse-related events to
     /// trigger on this clip rather than any input-eligible children.
@@ -181,19 +181,19 @@ pub struct MovieClipData<'gc> {
     queued_script_frame: Cell<FrameNumber>,
     has_pending_script: Cell<bool>,
     queued_goto_frame: Cell<Option<FrameNumber>>,
-    drop_target: Option<DisplayObject<'gc>>,
+    drop_target: Lock<Option<DisplayObject<'gc>>>,
 
     /// List of tags queued up for the current frame.
     #[collect(require_static)]
     queued_tags: RefCell<HashMap<Depth, QueuedTagList>>,
 
     /// Attached audio (AVM1)
-    attached_audio: Option<NetStream<'gc>>,
+    attached_audio: Lock<Option<NetStream<'gc>>>,
 
     // If this movie was loaded from ImportAssets(2), this will be the parent movie.
     importer_movie: Option<Arc<SwfMovie>>,
 
-    avm1_text_field_bindings: Vec<Avm1TextFieldBinding<'gc>>,
+    avm1_text_field_bindings: RefLock<Vec<Avm1TextFieldBinding<'gc>>>,
 }
 
 impl<'gc> MovieClipData<'gc> {
@@ -201,17 +201,17 @@ impl<'gc> MovieClipData<'gc> {
         let movie = shared.movie();
         Self {
             base: Default::default(),
-            shared: Gc::new(mc, shared),
+            shared: Lock::new(Gc::new(mc, shared)),
             tag_stream_pos: Cell::new(0),
             current_frame: Cell::new(0),
             audio_stream: Cell::new(None),
-            container: ChildContainer::new(&movie),
-            object: None,
-            clip_event_handlers: Vec::new(),
+            container: RefLock::new(ChildContainer::new(&movie)),
+            object: Lock::new(None),
+            clip_event_handlers: Default::default(),
             clip_event_flags: Cell::new(ClipEventFlag::empty()),
-            frame_scripts: Vec::new(),
+            frame_scripts: RefLock::new(Vec::new()),
             flags: Cell::new(MovieClipFlags::empty()),
-            drawing: None,
+            drawing: RefCell::new(None),
             avm2_enabled: Cell::new(true),
             avm2_use_hand_cursor: Cell::new(true),
             button_mode: Cell::new(false),
@@ -219,29 +219,29 @@ impl<'gc> MovieClipData<'gc> {
             queued_script_frame: Cell::new(0),
             has_pending_script: Cell::new(false),
             queued_goto_frame: Cell::new(None),
-            drop_target: None,
-            hit_area: None,
-            queued_tags: RefCell::new(HashMap::new()),
-            attached_audio: None,
+            drop_target: Lock::new(None),
+            hit_area: Lock::new(None),
+            queued_tags: Default::default(),
+            attached_audio: Lock::new(None),
             importer_movie: None,
-            avm1_text_field_bindings: Vec::new(),
+            avm1_text_field_bindings: Default::default(),
         }
     }
 
     #[inline(always)]
-    fn shared_cell(&self) -> Ref<'_, MovieClipSharedMut> {
-        self.shared.cell.borrow()
+    fn shared_cell(&self) -> Ref<'gc, MovieClipSharedMut> {
+        Gc::as_ref(self.shared.get()).cell.borrow()
     }
 }
 
 impl<'gc> MovieClip<'gc> {
     pub fn downgrade(self) -> MovieClipWeak<'gc> {
-        MovieClipWeak(GcCell::downgrade(self.0))
+        MovieClipWeak(Gc::downgrade(self.0))
     }
 
     pub fn new(movie: Arc<SwfMovie>, mc: &Mutation<'gc>) -> Self {
         let shared = MovieClipShared::empty(movie);
-        MovieClip(GcCell::new(mc, MovieClipData::new(shared, mc)))
+        MovieClip(Gc::new(mc, MovieClipData::new(shared, mc)))
     }
 
     pub fn new_with_avm2(
@@ -253,8 +253,8 @@ impl<'gc> MovieClip<'gc> {
         let mut shared = MovieClipShared::empty(movie);
         *shared.avm2_class.get_mut() = Some(class);
         let mut data = MovieClipData::new(shared, mc);
-        data.object = Some(this.into());
-        MovieClip(GcCell::new(mc, data))
+        data.object = Some(this.into()).into();
+        MovieClip(Gc::new(mc, data))
     }
 
     /// Constructs a non-root movie
@@ -267,7 +267,7 @@ impl<'gc> MovieClip<'gc> {
         let shared = MovieClipShared::with_data(id, swf, num_frames, None);
         let data = MovieClipData::new(shared, mc);
         data.flags.set(MovieClipFlags::PLAYING);
-        MovieClip(GcCell::new(mc, data))
+        MovieClip(Gc::new(mc, data))
     }
 
     pub fn new_import_assets(
@@ -282,7 +282,7 @@ impl<'gc> MovieClip<'gc> {
         let mut data = MovieClipData::new(shared, context.gc());
         data.flags.set(MovieClipFlags::PLAYING);
         data.importer_movie = Some(parent);
-        MovieClip(GcCell::new(context.gc(), data))
+        MovieClip(Gc::new(context.gc(), data))
     }
 
     /// Construct a movie clip that represents the root movie
@@ -313,9 +313,9 @@ impl<'gc> MovieClip<'gc> {
         );
         let data = MovieClipData::new(shared, activation.gc());
         data.flags.set(MovieClipFlags::PLAYING);
-        data.base.base.set_is_root(true);
+        data.base.borrow().base.set_is_root(true);
 
-        let mc = MovieClip(GcCell::new(activation.gc(), data));
+        let mc = MovieClip(Gc::new(activation.gc(), data));
         if let Some((_, loader_info)) = loader_info {
             loader_info.set_loader_stream(LoaderStream::Swf(movie, mc.into()), activation.gc());
         }
@@ -337,17 +337,23 @@ impl<'gc> MovieClip<'gc> {
         is_root: bool,
         loader_info: Option<LoaderInfoObject<'gc>>,
     ) {
-        let mut mc = self.0.write(context.gc());
-        let movie = movie.unwrap_or_else(|| Arc::new(SwfMovie::empty(mc.movie().version(), None)));
+        let write = Gc::write(context.gc(), self.0);
+        let movie =
+            movie.unwrap_or_else(|| Arc::new(SwfMovie::empty(write.movie().version(), None)));
         let total_frames = movie.num_frames();
         assert_eq!(
-            mc.shared.loader_info, None,
+            write.shared.get().loader_info,
+            None,
             "Called replace_movie on a clip with LoaderInfo set"
         );
 
-        mc.base.base.reset_for_movie_load();
-        mc.container = ChildContainer::new(&movie);
-        mc.shared = Gc::new(
+        {
+            let base = write.base.borrow();
+            base.base.reset_for_movie_load();
+            base.base.set_is_root(is_root);
+        }
+        unlock!(write, MovieClipData, container).replace(ChildContainer::new(&movie));
+        unlock!(write, MovieClipData, shared).set(Gc::new(
             context.gc(),
             MovieClipShared::with_data(
                 0,
@@ -355,23 +361,21 @@ impl<'gc> MovieClip<'gc> {
                 total_frames,
                 loader_info.map(|l| l.into()),
             ),
-        );
-        mc.tag_stream_pos.set(0);
-        mc.flags.set(MovieClipFlags::PLAYING);
-        mc.base.base.set_is_root(is_root);
-        mc.current_frame.set(0);
-        mc.audio_stream.set(None);
-        drop(mc);
+        ));
+        write.tag_stream_pos.set(0);
+        write.flags.set(MovieClipFlags::PLAYING);
+        write.current_frame.set(0);
+        write.audio_stream.take();
     }
 
     pub fn set_initialized(self) {
-        self.0.read().set_initialized(true);
+        self.0.set_initialized(true);
     }
 
     /// Tries to fire events from our `LoaderInfo` object if we're ready - returns
     /// `true` if both `init` and `complete` have been fired
     pub fn try_fire_loaderinfo_events(self, context: &mut UpdateContext<'gc>) -> bool {
-        if self.0.read().initialized() {
+        if self.0.initialized() {
             if let Some(loader_info) = self
                 .loader_info()
                 .as_ref()
@@ -400,7 +404,7 @@ impl<'gc> MovieClip<'gc> {
         context: &mut UpdateContext<'gc>,
         chunk_limit: &mut ExecutionLimit,
     ) -> bool {
-        let shared = Gc::as_ref(self.0.read().shared);
+        let shared = Gc::as_ref(self.0.shared.get());
         let (swf, progress) = (&shared.swf, &shared.preload_progress);
 
         if progress.next_preload_chunk.get() >= swf.len() as u64 {
@@ -467,7 +471,7 @@ impl<'gc> MovieClip<'gc> {
                 TagCode::DoInitAction => self.do_init_action(context, reader, tag_len),
                 TagCode::DefineSceneAndFrameLabelData => shared.scene_and_frame_labels(reader),
                 TagCode::ExportAssets => {
-                    shared.export_assets(context, reader, self.0.read().importer_movie.as_ref())
+                    shared.export_assets(context, reader, self.0.importer_movie.as_ref())
                 }
                 TagCode::FrameLabel => shared.frame_label(reader),
                 TagCode::JpegTables => shared.jpeg_tables(context, reader),
@@ -503,7 +507,7 @@ impl<'gc> MovieClip<'gc> {
         };
         let is_finished = end_tag_found || result.is_err() || !result.unwrap_or_default();
 
-        if let Some(importer_movie) = self.0.read().importer_movie.clone() {
+        if let Some(importer_movie) = self.0.importer_movie.clone() {
             shared.import_exports_of_importer(context, importer_movie);
         }
 
@@ -544,8 +548,8 @@ impl<'gc> MovieClip<'gc> {
 
         let slice = self
             .0
-            .read()
             .shared
+            .get()
             .swf
             .resize_to_reader(reader, tag_len - num_read);
 
@@ -628,27 +632,23 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn playing(self) -> bool {
-        self.0.read().playing()
+        self.0.playing()
     }
 
     pub fn programmatically_played(self) -> bool {
-        self.0.read().programmatically_played()
+        self.0.programmatically_played()
     }
 
     pub fn drop_target(self) -> Option<DisplayObject<'gc>> {
-        self.0.read().drop_target
+        self.0.drop_target.get()
     }
 
-    pub fn set_drop_target(
-        self,
-        gc_context: &Mutation<'gc>,
-        drop_target: Option<DisplayObject<'gc>>,
-    ) {
-        self.0.write(gc_context).drop_target = drop_target;
+    pub fn set_drop_target(self, mc: &Mutation<'gc>, drop_target: Option<DisplayObject<'gc>>) {
+        unlock!(Gc::write(mc, self.0), MovieClipData, drop_target).set(drop_target);
     }
 
     pub fn set_programmatically_played(self) {
-        self.0.read().set_programmatically_played()
+        self.0.set_programmatically_played()
     }
 
     pub fn next_frame(self, context: &mut UpdateContext<'gc>) {
@@ -658,7 +658,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn play(self) {
-        self.0.read().play()
+        self.0.play()
     }
 
     pub fn prev_frame(self, context: &mut UpdateContext<'gc>) {
@@ -668,18 +668,18 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn initialized(self) -> bool {
-        self.0.read().initialized()
+        self.0.initialized()
     }
 
     pub fn stop(self, context: &mut UpdateContext<'gc>) {
-        self.0.read().stop(context)
+        self.0.stop(context)
     }
 
     /// Does this clip have a unload handler
     pub fn has_unload_handler(&self) -> bool {
         self.0
-            .read()
             .clip_event_handlers
+            .borrow()
             .iter()
             .any(|handler| handler.events.contains(ClipEventFlag::UNLOAD))
     }
@@ -709,30 +709,29 @@ impl<'gc> MovieClip<'gc> {
         if frame != self.current_frame() {
             if self
                 .0
-                .read()
                 .contains_flag(MovieClipFlags::EXECUTING_AVM2_FRAME_SCRIPT)
             {
                 // AVM2 does not allow a clip to see while it is executing a frame script.
                 // The goto is instead queued and run once the frame script is completed.
-                self.0.read().queued_goto_frame.set(Some(frame));
+                self.0.queued_goto_frame.set(Some(frame));
             } else {
                 self.run_goto(context, frame, false);
             }
         } else if self.movie().is_action_script_3() {
             // Despite not running, the goto still overwrites the currently enqueued frame.
-            self.0.read().queued_goto_frame.set(None);
+            self.0.queued_goto_frame.set(None);
             // Pretend we actually did a goto, but don't do anything.
             run_inner_goto_frame(context, &[], self);
         }
     }
 
     pub fn current_frame(self) -> FrameNumber {
-        self.0.read().current_frame()
+        self.0.current_frame()
     }
 
     /// Return the current scene.
     pub fn current_scene(self) -> Option<Scene> {
-        let current_frame = self.0.read().current_frame();
+        let current_frame = self.0.current_frame();
 
         self.filter_scenes(
             |best,
@@ -792,7 +791,7 @@ impl<'gc> MovieClip<'gc> {
 
     /// Return the next scene.
     pub fn next_scene(self) -> Option<Scene> {
-        let current_frame = self.0.read().current_frame();
+        let current_frame = self.0.current_frame();
 
         self.filter_scenes(
             |best,
@@ -820,7 +819,7 @@ impl<'gc> MovieClip<'gc> {
     ///
     /// Scenes will be sorted in playback order.
     pub fn scenes(self) -> Vec<Scene> {
-        let mut out: Vec<_> = self.0.read().shared_cell().scene_labels.clone();
+        let mut out: Vec<_> = self.0.shared_cell().scene_labels.clone();
         out.sort_unstable_by(|Scene { start: a, .. }, Scene { start: b, .. }| a.cmp(b));
         out
     }
@@ -831,9 +830,7 @@ impl<'gc> MovieClip<'gc> {
     where
         F: FnMut(Option<&Scene>, &Scene) -> bool,
     {
-        let read = self.0.read();
-        let read = read.shared_cell();
-
+        let read = self.0.shared_cell();
         let mut best: Option<&Scene> = None;
         for scene in read.scene_labels.iter() {
             if cond(best, scene) {
@@ -846,9 +843,8 @@ impl<'gc> MovieClip<'gc> {
 
     /// Yield the current frame label as a tuple of string and frame number.
     pub fn current_label(self) -> Option<(WString, FrameNumber)> {
-        let read = self.0.read();
-        let current_frame = read.current_frame();
-        let read = read.shared_cell();
+        let read = self.0.shared_cell();
+        let current_frame = self.0.current_frame();
 
         let mut best: Option<(&WString, FrameNumber)> = None;
         for (frame, label) in read.frame_labels.iter() {
@@ -872,9 +868,8 @@ impl<'gc> MovieClip<'gc> {
         from: FrameNumber,
         to: FrameNumber,
     ) -> Vec<(WString, FrameNumber)> {
-        let read = self.0.read();
-
-        let mut values: Vec<(WString, FrameNumber)> = read
+        let mut values: Vec<(WString, FrameNumber)> = self
+            .0
             .shared_cell()
             .frame_labels
             .iter()
@@ -888,13 +883,13 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn total_frames(self) -> FrameNumber {
-        self.0.read().total_frames()
+        self.0.total_frames()
     }
 
     pub fn has_frame_script(self, frame: FrameNumber) -> bool {
         self.0
-            .read()
             .frame_scripts
+            .borrow()
             .get(frame as usize)
             .map(|v| v.is_some())
             .unwrap_or_default()
@@ -904,8 +899,8 @@ impl<'gc> MovieClip<'gc> {
     /// in the _framesloaded / framesLoaded property being the given number - 1).
     pub fn set_cur_preload_frame(self, cur_preload_frame: u16) {
         self.0
-            .read()
             .shared
+            .get()
             .preload_progress
             .cur_preload_frame
             .set(cur_preload_frame);
@@ -913,11 +908,11 @@ impl<'gc> MovieClip<'gc> {
 
     /// This sets the current frame of this MovieClip to a given number.
     pub fn set_current_frame(self, current_frame: FrameNumber) {
-        self.0.read().current_frame.set(current_frame);
+        self.0.current_frame.set(current_frame);
     }
 
     pub fn frames_loaded(self) -> i32 {
-        self.0.read().frames_loaded()
+        self.0.frames_loaded()
     }
 
     pub fn total_bytes(self) -> i32 {
@@ -931,8 +926,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn loaded_bytes(self) -> u32 {
-        let read = self.0.read();
-        let progress = &read.shared.preload_progress;
+        let progress = &Gc::as_ref(self.0.shared.get()).preload_progress;
         if progress.next_preload_chunk.get() == u64::MAX {
             // u64::MAX is a sentinel for load complete
             return max(self.total_bytes(), 0) as u32;
@@ -976,11 +970,11 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn avm2_class(self) -> Option<Avm2ClassObject<'gc>> {
-        self.0.read().shared.avm2_class.get()
+        self.0.shared.get().avm2_class.get()
     }
 
     pub fn set_avm2_class(self, mc: &Mutation<'gc>, constr: Option<Avm2ClassObject<'gc>>) {
-        let data = Gc::write(mc, self.0.read().shared);
+        let data = Gc::write(mc, self.0.shared.get());
         unlock!(data, MovieClipShared, avm2_class).set(constr);
     }
 
@@ -993,26 +987,19 @@ impl<'gc> MovieClip<'gc> {
         // They are case sensitive in AVM2.
         if self.movie().is_action_script_3() {
             self.0
-                .read()
                 .shared_cell()
                 .frame_labels_map
                 .get(frame_label)
                 .copied()
         } else {
             let label = frame_label.to_ascii_lowercase();
-            self.0
-                .read()
-                .shared_cell()
-                .frame_labels_map
-                .get(&label)
-                .copied()
+            self.0.shared_cell().frame_labels_map.get(&label).copied()
         }
     }
 
     pub fn scene_label_to_number(self, scene_label: &WStr) -> Option<FrameNumber> {
         // Never used in AVM1, so always be case sensitive.
         self.0
-            .read()
             .shared_cell()
             .scene_labels_map
             .get(&WString::from(scene_label))
@@ -1041,7 +1028,7 @@ impl<'gc> MovieClip<'gc> {
             for Scene {
                 start: new_scene_start,
                 ..
-            } in self.0.read().shared_cell().scene_labels.iter()
+            } in self.0.shared_cell().scene_labels.iter()
             {
                 if *new_scene_start < end && *new_scene_start > scene {
                     end = *new_scene_start;
@@ -1056,28 +1043,24 @@ impl<'gc> MovieClip<'gc> {
 
     /// Gets the clip events for this MovieClip.
     pub fn clip_actions(&self) -> Ref<'_, [ClipEventHandler]> {
-        Ref::map(self.0.read(), |mc| mc.clip_event_handlers())
+        Ref::map(self.0.clip_event_handlers.borrow(), |r| &**r)
     }
 
     /// Sets the clip actions (a.k.a. clip events) for this MovieClip.
     /// Clip actions are created in the Flash IDE by using the `onEnterFrame`
     /// tag on a MovieClip instance.
-    pub fn set_clip_event_handlers(
-        self,
-        gc_context: &Mutation<'gc>,
-        event_handlers: Vec<ClipEventHandler>,
-    ) {
-        let mut mc = self.0.write(gc_context);
-        mc.set_clip_event_handlers(event_handlers);
+    pub fn set_clip_event_handlers(self, event_handlers: Box<[ClipEventHandler]>) {
+        let mut all_event_flags = ClipEventFlag::empty();
+        for handler in &event_handlers {
+            all_event_flags |= handler.events;
+        }
+        self.0.clip_event_flags.set(all_event_flags);
+        self.0.clip_event_handlers.replace(event_handlers);
     }
 
     /// Returns an iterator of AVM1 `DoAction` blocks on the given frame number.
     /// Used by the AVM `Call` action.
-    pub fn actions_on_frame(
-        self,
-        _context: &mut UpdateContext<'gc>,
-        frame: FrameNumber,
-    ) -> impl DoubleEndedIterator<Item = SwfSlice> {
+    pub fn actions_on_frame(self, frame: FrameNumber) -> impl DoubleEndedIterator<Item = SwfSlice> {
         use swf::read::Reader;
 
         let mut actions: SmallVec<[SwfSlice; 2]> = SmallVec::new();
@@ -1085,8 +1068,8 @@ impl<'gc> MovieClip<'gc> {
         // Iterate through this clip's tags, counting frames until we reach the target frame.
         if frame > 0 && frame <= self.total_frames() {
             let mut cur_frame = 1;
-            let clip = self.0.read();
-            let mut reader = clip.shared.swf.read_from(0);
+            let shared = self.0.shared.get();
+            let mut reader = shared.swf.read_from(0);
             while cur_frame <= frame && !reader.get_ref().is_empty() {
                 let tag_callback = |reader: &mut Reader<'_>, tag_code, tag_len| {
                     match tag_code {
@@ -1096,7 +1079,7 @@ impl<'gc> MovieClip<'gc> {
                         }
                         TagCode::DoAction if cur_frame == frame => {
                             // On the target frame, add any DoAction tags to the array.
-                            let slice = clip.shared.swf.resize_to_reader(reader, tag_len);
+                            let slice = shared.swf.resize_to_reader(reader, tag_len);
                             if !slice.is_empty() {
                                 actions.push(slice);
                             }
@@ -1131,30 +1114,27 @@ impl<'gc> MovieClip<'gc> {
         run_sounds: bool,
         is_action_script_3: bool,
     ) {
+        let shared = Gc::as_ref(self.0.shared.get());
+
         let next_frame = self.determine_next_frame();
         match next_frame {
             NextFrame::Next => {
-                let read = self.0.read();
-                if (read.current_frame.get() + 1)
-                    >= read.shared.preload_progress.cur_preload_frame.get()
-                {
+                if (self.0.current_frame() + 1) >= shared.preload_progress.cur_preload_frame.get() {
                     return;
                 }
 
                 // AS3 removals need to happen before frame advance (see below)
                 if !is_action_script_3 {
-                    read.increment_current_frame();
+                    self.0.increment_current_frame();
                 }
             }
             NextFrame::First => return self.run_goto(context, 1, true),
             NextFrame::Same => self.stop(context),
         }
 
-        let mc = self.0.read();
-        let tag_stream_start = mc.shared.swf.as_ref().as_ptr() as u64;
-        let data = mc.shared.swf.clone();
-        let mut reader = data.read_from(mc.tag_stream_pos.get());
-        drop(mc);
+        let tag_stream_start = shared.swf.as_ref().as_ptr() as u64;
+        let data = shared.swf.clone();
+        let mut reader = data.read_from(self.0.tag_stream_pos.get());
 
         let tag_callback = |reader: &mut SwfStream<'_>, tag_code, tag_len| {
             match tag_code {
@@ -1205,7 +1185,7 @@ impl<'gc> MovieClip<'gc> {
             Ok(ControlFlow::Continue)
         };
         let _ = tag_utils::decode_tags(&mut reader, tag_callback);
-        if let Err(e) = self.run_abc_and_symbol_tags(context, self.0.read().current_frame.get()) {
+        if let Err(e) = self.run_abc_and_symbol_tags(context, self.0.current_frame()) {
             tracing::error!("Error running abc/symbol in frame: {e:?}");
         }
 
@@ -1229,28 +1209,28 @@ impl<'gc> MovieClip<'gc> {
 
         // It is now safe to update the tag position and frame number.
         // TODO: Determine if explicit gotos override these or not.
-        let read = self.0.read();
 
-        read.tag_stream_pos
+        self.0
+            .tag_stream_pos
             .set(reader.get_ref().as_ptr() as u64 - tag_stream_start);
 
         // Check if our audio track has finished playing.
-        if let Some(audio_stream) = read.audio_stream.get() {
+        if let Some(audio_stream) = self.0.audio_stream.get() {
             if !context.is_sound_playing(audio_stream) {
-                read.audio_stream.set(None);
+                self.0.audio_stream.take();
             }
         }
 
         if matches!(next_frame, NextFrame::Next) && is_action_script_3 {
-            read.increment_current_frame();
+            self.0.increment_current_frame();
         }
 
-        read.queued_script_frame.set(read.current_frame.get());
-        if read.last_queued_script_frame.get() != Some(read.current_frame.get()) {
+        self.0.queued_script_frame.set(self.0.current_frame.get());
+        if self.0.last_queued_script_frame.get() != Some(self.0.current_frame.get()) {
             // We explicitly clear this variable since AS3 may later GOTO back
             // to the already-ran frame. Since the frame number *has* changed
             // in the meantime, it should absolutely run again.
-            read.last_queued_script_frame.set(None);
+            self.0.last_queued_script_frame.set(None);
         }
     }
 
@@ -1298,7 +1278,6 @@ impl<'gc> MovieClip<'gc> {
                     {
                         // Convert from `swf::ClipAction` to Ruffle's `ClipEventHandler`.
                         clip.set_clip_event_handlers(
-                            context.gc(),
                             clip_actions
                                 .iter()
                                 .cloned()
@@ -1337,17 +1316,16 @@ impl<'gc> MovieClip<'gc> {
 
     #[cfg(feature = "timeline_debug")]
     fn assert_expected_tag_start(self) {
-        let read = self.0.read();
-
         assert_eq!(
-            Some(read.tag_stream_pos.get()),
-            read.shared_cell()
+            Some(self.0.tag_stream_pos.get()),
+            self.0
+                .shared_cell()
                 .tag_frame_boundaries
-                .get(&read.current_frame.get())
+                .get(&self.0.current_frame())
                 .map(|(_start, end)| *end), // Yes, this is correct, at least for AVM1.
             "[{:?}] Gotos must start from the correct tag position for frame {}",
-            read.base.base.name,
-            read.current_frame.get()
+            self.base().name,
+            self.0.current_frame()
         );
     }
 
@@ -1356,11 +1334,11 @@ impl<'gc> MovieClip<'gc> {
 
     #[cfg(feature = "timeline_debug")]
     fn assert_expected_tag_end(self, hit_target_frame: bool) {
-        let read = self.0.read();
-        let tag_frame_end = read
+        let tag_frame_end = self
+            .0
             .shared_cell()
             .tag_frame_boundaries
-            .get(&read.current_frame.get())
+            .get(&self.0.current_frame.get())
             .map(|(_start, end)| *end);
 
         // Gotos that do *not* hit their target frame will not update their tag
@@ -1369,21 +1347,18 @@ impl<'gc> MovieClip<'gc> {
         // observable to user code as any further timeline interaction would
         // trigger a rewind, so we ignore it here for now.
         if hit_target_frame {
-            let read = self.0.read();
-
             assert_eq!(
-                Some(read.tag_stream_pos.get()),
+                Some(self.0.tag_stream_pos.get()),
                 tag_frame_end,
                 "[{:?}] Gotos must end at the correct tag position for frame {}",
-                read.base.base.name,
-                read.current_frame.get()
+                self.base().name,
+                self.0.current_frame()
             );
         } else {
             // Of course, the target frame desync absolutely will break our
             // other asserts, so fix them up here.
-            drop(read);
             if let Some(end) = tag_frame_end {
-                self.0.read().tag_stream_pos.set(end);
+                self.0.tag_stream_pos.set(end);
             }
         }
     }
@@ -1425,14 +1400,14 @@ impl<'gc> MovieClip<'gc> {
         // TODO: Move this to UpdateContext to avoid allocations.
         let mut goto_commands: Vec<GotoPlaceObject<'_>> = vec![];
 
-        self.0.read().stop_audio_stream(context);
+        self.0.stop_audio_stream(context);
 
         let is_rewind = if frame <= self.current_frame() {
             // Because we can only step forward, we have to start at frame 1
             // when rewinding. We don't actually remove children yet because
             // otherwise AS3 can observe byproducts of the rewinding process.
-            self.0.read().tag_stream_pos.set(0);
-            self.0.read().current_frame.set(0);
+            self.0.tag_stream_pos.set(0);
+            self.0.current_frame.set(0);
 
             true
         } else {
@@ -1444,30 +1419,28 @@ impl<'gc> MovieClip<'gc> {
         // Explicit gotos in the middle of an AS3 loop cancel the loop's queued
         // tags. The rest of the goto machinery can handle the side effects of
         // a half-executed loop.
-        let read = self.0.read();
-        if read.loop_queued() {
-            read.queued_tags.replace(HashMap::new());
+        if self.0.loop_queued() {
+            self.0.queued_tags.take();
         }
 
         if is_implicit {
-            read.set_loop_queued();
+            self.0.set_loop_queued();
         }
 
         // Step through the intermediate frames, and aggregate the deltas of each frame.
-        let tag_stream_start = read.shared.swf.as_ref().as_ptr() as u64;
-        let mut frame_pos = read.tag_stream_pos.get();
-        let data = read.shared.swf.clone();
+        let data = self.0.shared.get().swf.clone();
+        let tag_stream_start = data.as_ref().as_ptr() as u64;
+        let mut frame_pos = self.0.tag_stream_pos.get();
         let mut index = 0;
 
         // Sanity; let's make sure we don't seek way too far.
-        let clamped_frame = frame.min(max(read.frames_loaded(), 0) as FrameNumber);
-        drop(read);
+        let clamped_frame = frame.min(max(self.0.frames_loaded(), 0) as FrameNumber);
 
         let mut removed_frame_scripts: Vec<DisplayObject<'gc>> = vec![];
 
         let mut reader = data.read_from(frame_pos);
         while self.current_frame() < clamped_frame && !reader.get_ref().is_empty() {
-            self.0.read().increment_current_frame();
+            self.0.increment_current_frame();
             frame_pos = reader.get_ref().as_ptr() as u64 - tag_stream_start;
 
             let tag_callback = |reader: &mut _, tag_code, _tag_len| {
@@ -1490,8 +1463,13 @@ impl<'gc> MovieClip<'gc> {
                 match action {
                     Action::Place(version) => {
                         index += 1;
-                        let mc = self.0.read();
-                        mc.goto_place_object(reader, version, &mut goto_commands, is_rewind, index)
+                        self.0.goto_place_object(
+                            reader,
+                            version,
+                            &mut goto_commands,
+                            is_rewind,
+                            index,
+                        )
                     }
                     Action::Remove(version) => self.goto_remove_object(
                         reader,
@@ -1511,7 +1489,7 @@ impl<'gc> MovieClip<'gc> {
                 tracing::error!("Error running abc/symbols in goto: {e:?}");
             }
         }
-        let hit_target_frame = self.0.read().current_frame.get() == frame;
+        let hit_target_frame = self.0.current_frame() == frame;
 
         if is_rewind {
             // Remove all display objects that were created after the
@@ -1549,12 +1527,11 @@ impl<'gc> MovieClip<'gc> {
                 //
                 // TODO: We can only queue *new* object placement, existing
                 // objects still get updated too early.
-                let read = self.0.read();
                 let new_tag = QueuedTag {
                     tag_type: QueuedTagAction::Place(params.version),
                     tag_start: params.tag_start,
                 };
-                let mut queued_tags = read.queued_tags.borrow_mut();
+                let mut queued_tags = self.0.queued_tags.borrow_mut();
                 let bucket = queued_tags
                     .entry(params.place_object.depth as Depth)
                     .or_insert_with(|| QueuedTagList::None);
@@ -1617,8 +1594,8 @@ impl<'gc> MovieClip<'gc> {
         // Note that this only happens if the frame exists and is loaded;
         // e.g. gotoAndStop(9999) displays the final frame, but actions don't run!
         if hit_target_frame {
-            self.0.read().decrement_current_frame();
-            self.0.read().tag_stream_pos.set(frame_pos);
+            self.0.decrement_current_frame();
+            self.0.tag_stream_pos.set(frame_pos);
             // If we changed frames, then trigger any sounds in our target frame.
             // However, if we executed a 'no-op goto' (start and end frames are the same),
             // then do *not* run sounds. Some SWFS (e.g. 'This is the only level too')
@@ -1630,7 +1607,7 @@ impl<'gc> MovieClip<'gc> {
                 self.movie().is_action_script_3(),
             );
         } else {
-            self.0.read().current_frame.set(clamped_frame);
+            self.0.current_frame.set(clamped_frame);
         }
 
         // Finally, run frames for children that are placed on this frame.
@@ -1660,8 +1637,8 @@ impl<'gc> MovieClip<'gc> {
         run_frame: bool,
     ) {
         //TODO: This will break horribly when AVM2 starts touching the display list
-        if self.0.read().object.is_none() {
-            let avm1_constructor = self.0.read().get_registered_avm1_constructor(context);
+        if self.0.object.get().is_none() {
+            let avm1_constructor = self.0.get_registered_avm1_constructor(context);
 
             // If we are running within the AVM, this must be an immediate action.
             // If we are not, then this must be queued to be ran first-thing
@@ -1681,7 +1658,8 @@ impl<'gc> MovieClip<'gc> {
                         Some(prototype),
                         Avm1NativeObject::MovieClip(self),
                     );
-                    self.0.write(activation.gc()).object = Some(object.into());
+                    let write = Gc::write(activation.gc(), self.0);
+                    unlock!(write, MovieClipData, object).set(Some(object.into()));
 
                     if run_frame {
                         self.run_frame_avm1(activation.context);
@@ -1711,7 +1689,8 @@ impl<'gc> MovieClip<'gc> {
                 Some(context.avm1.prototypes().movie_clip),
                 Avm1NativeObject::MovieClip(self),
             );
-            self.0.write(context.gc()).object = Some(object.into());
+            let write = Gc::write(context.gc(), self.0);
+            unlock!(write, MovieClipData, object).set(Some(object.into()));
 
             if run_frame {
                 self.run_frame_avm1(context);
@@ -1733,7 +1712,7 @@ impl<'gc> MovieClip<'gc> {
 
             let mut events = Vec::new();
 
-            for event_handler in self.0.read().clip_event_handlers().iter() {
+            for event_handler in self.0.clip_event_handlers.borrow().iter() {
                 if event_handler.events.contains(ClipEventFlag::INITIALIZE) {
                     context.action_queue.queue_action(
                         self.into(),
@@ -1779,7 +1758,7 @@ impl<'gc> MovieClip<'gc> {
         context: &mut UpdateContext<'gc>,
         display_object: DisplayObject<'gc>,
     ) {
-        let class_object = self.0.read().shared.avm2_class.get();
+        let class_object = self.0.shared.get().avm2_class.get();
         let class_object = class_object.unwrap_or_else(|| context.avm2.classes().movieclip);
 
         let mut constr_thing = || {
@@ -1806,7 +1785,7 @@ impl<'gc> MovieClip<'gc> {
     /// intended to be called from `post_instantiate`.
     #[inline(never)]
     fn construct_as_avm2_object(self, context: &mut UpdateContext<'gc>) {
-        let class_object = self.0.read().shared.avm2_class.get();
+        let class_object = self.0.shared.get().avm2_class.get();
         let class_object = class_object.unwrap_or_else(|| context.avm2.classes().movieclip);
 
         if let Avm2Value::Object(object) = self.object2() {
@@ -1837,9 +1816,9 @@ impl<'gc> MovieClip<'gc> {
         callable: Option<Avm2Object<'gc>>,
         context: &mut UpdateContext<'gc>,
     ) {
-        let mut write = self.0.write(context.gc());
-        let current_frame = write.current_frame.get();
-        let frame_scripts = &mut write.frame_scripts;
+        let write = Gc::write(context.gc(), self.0);
+        let current_frame = write.current_frame();
+        let mut frame_scripts = unlock!(write, MovieClipData, frame_scripts).borrow_mut();
 
         let index = frame_id as usize;
         if let Some(callable) = callable {
@@ -1893,7 +1872,7 @@ impl<'gc> MovieClip<'gc> {
             //
             // We also have to reset the frame number as this emits AS3 events.
             let to_frame = self.current_frame();
-            self.0.read().current_frame.set(from_frame);
+            self.0.current_frame.set(from_frame);
 
             let child = self.child_by_depth(depth);
             if let Some(child) = child {
@@ -1906,7 +1885,7 @@ impl<'gc> MovieClip<'gc> {
                 removed_frame_scripts.push(child);
             }
 
-            self.0.read().current_frame.set(to_frame);
+            self.0.current_frame.set(to_frame);
         }
         Ok(())
     }
@@ -1920,11 +1899,11 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn avm2_enabled(self) -> bool {
-        self.0.read().avm2_enabled.get()
+        self.0.avm2_enabled.get()
     }
 
     pub fn set_avm2_enabled(self, enabled: bool) {
-        self.0.read().avm2_enabled.set(enabled);
+        self.0.avm2_enabled.set(enabled);
     }
 
     fn use_hand_cursor(self, context: &mut UpdateContext<'gc>) -> bool {
@@ -1936,55 +1915,49 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn avm2_use_hand_cursor(self) -> bool {
-        self.0.read().avm2_use_hand_cursor.get()
+        self.0.avm2_use_hand_cursor.get()
     }
 
     pub fn set_avm2_use_hand_cursor(self, use_hand_cursor: bool) {
-        self.0.read().avm2_use_hand_cursor.set(use_hand_cursor);
+        self.0.avm2_use_hand_cursor.set(use_hand_cursor);
     }
 
     pub fn hit_area(self) -> Option<DisplayObject<'gc>> {
-        self.0.read().hit_area
+        self.0.hit_area.get()
     }
 
-    pub fn set_hit_area(
-        self,
-        context: &mut UpdateContext<'gc>,
-        hit_area: Option<DisplayObject<'gc>>,
-    ) {
-        self.0.write(context.gc()).hit_area = hit_area;
+    pub fn set_hit_area(self, mc: &Mutation<'gc>, hit_area: Option<DisplayObject<'gc>>) {
+        unlock!(Gc::write(mc, self.0), MovieClipData, hit_area).set(hit_area);
     }
 
     pub fn tag_stream_len(&self) -> usize {
-        self.0.read().tag_stream_len()
+        self.0.tag_stream_len()
     }
 
     pub fn forced_button_mode(self) -> bool {
-        self.0.read().button_mode.get()
+        self.0.button_mode.get()
     }
 
     pub fn set_forced_button_mode(self, button_mode: bool) {
-        self.0.read().button_mode.set(button_mode);
+        self.0.button_mode.set(button_mode);
     }
 
     pub fn drawing_mut(&self, gc_context: &Mutation<'gc>) -> RefMut<'_, Drawing> {
         // We're about to change graphics, so invalidate on the next frame
         self.invalidate_cached_bitmap(gc_context);
-        RefMut::map(self.0.write(gc_context), |this| {
-            &mut **this.drawing.get_or_insert_with(Default::default)
+        RefMut::map(self.0.drawing.borrow_mut(), |drawing| {
+            &mut **drawing.get_or_insert_with(Default::default)
         })
     }
 
     pub fn drawing(&self) -> Option<Ref<'_, Drawing>> {
-        let read = Ref::map(self.0.read(), |s| &s.drawing);
-        Ref::filter_map(read, Option::as_deref).ok()
+        Ref::filter_map(self.0.drawing.borrow(), |d| d.as_deref()).ok()
     }
 
     pub fn is_button_mode(&self, context: &mut UpdateContext<'gc>) -> bool {
         if self.forced_button_mode()
             || self
                 .0
-                .read()
                 .clip_event_flags
                 .get()
                 .intersects(ClipEvent::BUTTON_EVENT_FLAGS)
@@ -2021,8 +1994,7 @@ impl<'gc> MovieClip<'gc> {
     ) -> Vec<(Depth, QueuedTag)> {
         use std::collections::hash_map::Entry;
 
-        let read = self.0.read();
-        let mut queued_tags = read.queued_tags.borrow_mut();
+        let mut queued_tags = self.0.queued_tags.borrow_mut();
         let mut unqueued: Vec<_> = queued_tags
             .iter_mut()
             .filter_map(|(d, q)| filter(q).map(|q| (*d, q)))
@@ -2125,54 +2097,60 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn attach_audio(self, context: &mut UpdateContext<'gc>, netstream: Option<NetStream<'gc>>) {
-        let mut write = self.0.write(context.gc());
-        if netstream != write.attached_audio {
-            if let Some(old_netstream) = write.attached_audio {
+        let old_netstream = self.0.attached_audio.get();
+        if netstream != old_netstream {
+            if let Some(old_netstream) = old_netstream {
                 old_netstream.was_detached(context);
             }
 
-            write.attached_audio = netstream;
-
             if let Some(netstream) = netstream {
+                let write = Gc::write(context.gc(), self.0);
+                unlock!(write, MovieClipData, attached_audio).set(Some(netstream));
                 netstream.was_attached(context, self);
+            } else {
+                self.0.attached_audio.take();
             }
         }
     }
 
     pub fn run_frame_script_cleanup(context: &mut UpdateContext<'gc>) {
         while let Some(clip) = context.frame_script_cleanup_queue.pop_front() {
-            clip.0.read().has_pending_script.set(true);
-            clip.0.read().last_queued_script_frame.set(None);
+            clip.0.has_pending_script.set(true);
+            clip.0.last_queued_script_frame.set(None);
             clip.run_local_frame_scripts(context);
         }
     }
 
     fn run_local_frame_scripts(self, context: &mut UpdateContext<'gc>) {
-        let mut read: Ref<'_, MovieClipData<'gc>> = self.0.read();
-        let avm2_object = read.object.and_then(|o| o.as_avm2_object());
+        let avm2_object = self.0.object.get().and_then(|o| o.as_avm2_object());
 
         if let Some(avm2_object) = avm2_object {
-            if read.has_pending_script.get() {
-                let frame_id = read.queued_script_frame.get();
+            if self.0.has_pending_script.get() {
+                let frame_id = self.0.queued_script_frame.get();
                 // If we are already executing frame scripts, then we shouldn't
                 // run frame scripts recursively. This is because AVM2 can run
                 // gotos, which will both queue and run frame scripts for the
                 // whole movie again. If a goto is attempting to queue frame
                 // scripts on us AGAIN, we should allow the current stack to
                 // wind down before handling that.
-                if !read.contains_flag(MovieClipFlags::EXECUTING_AVM2_FRAME_SCRIPT) {
-                    let is_fresh_frame =
-                        read.last_queued_script_frame.get() != Some(read.queued_script_frame.get());
+                if !self
+                    .0
+                    .contains_flag(MovieClipFlags::EXECUTING_AVM2_FRAME_SCRIPT)
+                {
+                    let is_fresh_frame = self.0.last_queued_script_frame.get() != Some(frame_id);
 
                     if is_fresh_frame {
-                        if let Some(Some(callable)) =
-                            read.frame_scripts.get(frame_id as usize).cloned()
+                        if let Some(Some(callable)) = self
+                            .0
+                            .frame_scripts
+                            .borrow()
+                            .get(frame_id as usize)
+                            .cloned()
                         {
-                            read.last_queued_script_frame.set(Some(frame_id));
-                            read.has_pending_script.set(false);
-                            read.set_flag(MovieClipFlags::EXECUTING_AVM2_FRAME_SCRIPT, true);
-
-                            drop(read);
+                            self.0.last_queued_script_frame.set(Some(frame_id));
+                            self.0.has_pending_script.set(false);
+                            self.0
+                                .set_flag(MovieClipFlags::EXECUTING_AVM2_FRAME_SCRIPT, true);
 
                             let movie = self.movie();
                             let domain = context
@@ -2193,17 +2171,16 @@ impl<'gc> MovieClip<'gc> {
                                     e
                                 );
                             }
-                            read = self.0.read();
 
-                            read.set_flag(MovieClipFlags::EXECUTING_AVM2_FRAME_SCRIPT, false);
+                            self.0
+                                .set_flag(MovieClipFlags::EXECUTING_AVM2_FRAME_SCRIPT, false);
                         }
                     }
                 }
             }
         }
 
-        let goto_frame = read.queued_goto_frame.take();
-        drop(read);
+        let goto_frame = self.0.queued_goto_frame.take();
         if let Some(frame) = goto_frame {
             self.run_goto(context, frame, false);
         }
@@ -2212,27 +2189,28 @@ impl<'gc> MovieClip<'gc> {
 
 impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     fn base(&self) -> Ref<'_, DisplayObjectBase<'gc>> {
-        Ref::map(self.0.read(), |r| &r.base.base)
+        Ref::map(self.0.base.borrow(), |r| &r.base)
     }
 
     fn base_mut<'a>(&'a self, mc: &Mutation<'gc>) -> RefMut<'a, DisplayObjectBase<'gc>> {
-        RefMut::map(self.0.write(mc), |w| &mut w.base.base)
+        let base = unlock!(Gc::write(mc, self.0), MovieClipData, base);
+        RefMut::map(base.borrow_mut(), |r| &mut r.base)
     }
 
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(GcCell::new(gc_context, self.0.read().clone())).into()
+    fn instantiate(self, mc: &Mutation<'gc>) -> DisplayObject<'gc> {
+        Self(Gc::new(mc, (*self.0).clone())).into()
     }
 
     fn as_ptr(self) -> *const DisplayObjectPtr {
-        self.0.as_ptr() as *const DisplayObjectPtr
+        Gc::as_ptr(self.0) as *const DisplayObjectPtr
     }
 
     fn id(self) -> CharacterId {
-        self.0.read().id()
+        self.0.id()
     }
 
     fn movie(self) -> Arc<SwfMovie> {
-        self.0.read().movie()
+        self.0.movie()
     }
 
     fn enter_frame(self, context: &mut UpdateContext<'gc>) {
@@ -2270,7 +2248,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             // PlaceObject tags execute at this time.
             // Note that this is NOT when constructors run; that happens later
             // after tags have executed.
-            let data = self.0.read().shared.swf.clone();
+            let data = self.0.shared.get().swf.clone();
             let place_actions = self.unqueue_filtered(|q| q.unqueue_add());
 
             for (_, tag) in place_actions {
@@ -2294,7 +2272,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         if self.movie().is_action_script_3()
             && (self.frames_loaded() >= 1 || self.total_frames() == 0)
         {
-            let is_load_frame = !self.0.read().initialized();
+            let is_load_frame = !self.0.initialized();
             let needs_construction = if matches!(self.object2(), Avm2Value::Null) {
                 self.allocate_as_avm2_object(context, self.into());
                 true
@@ -2302,7 +2280,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                 false
             };
 
-            self.0.read().unset_loop_queued();
+            self.0.unset_loop_queued();
 
             if needs_construction {
                 self.construct_as_avm2_object(context);
@@ -2317,7 +2295,6 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             } else if !(is_load_frame && self.placed_by_script()) {
                 let running_construct_frame = self
                     .0
-                    .read()
                     .contains_flag(MovieClipFlags::RUNNING_CONSTRUCT_FRAME);
                 // The supercall constructor for display objects is responsible
                 // for triggering construct_frame on frame 1.
@@ -2332,21 +2309,22 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
         // Check for frame-scripts before starting the frame-script phase,
         // to differentiate the pre-existing scripts from those introduced during frame-script phase.
-        let read = self.0.read();
-        let has_pending_script = read
+        let has_pending_script = self
+            .0
             .frame_scripts
-            .get(read.current_frame.get() as usize)
+            .borrow()
+            .get(self.0.current_frame.get() as usize)
             .is_some();
-        read.has_pending_script.set(has_pending_script);
+        self.0.has_pending_script.set(has_pending_script);
     }
 
     fn run_frame_avm1(self, context: &mut UpdateContext<'gc>) {
         if !self.movie().is_action_script_3() {
             // Run my load/enterFrame clip event.
-            let is_load_frame = !self.0.read().contains_flag(MovieClipFlags::INITIALIZED);
+            let is_load_frame = !self.0.contains_flag(MovieClipFlags::INITIALIZED);
             if is_load_frame {
                 self.event_dispatch(context, ClipEvent::Load);
-                self.0.read().set_initialized(true);
+                self.0.set_initialized(true);
             } else {
                 self.event_dispatch(context, ClipEvent::EnterFrame);
             }
@@ -2463,17 +2441,11 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         instantiated_by: Instantiator,
         run_frame: bool,
     ) {
-        if self
-            .0
-            .read()
-            .contains_flag(MovieClipFlags::POST_INSTANTIATED)
-        {
+        if self.0.contains_flag(MovieClipFlags::POST_INSTANTIATED) {
             // Ensure that the same clip doesn't get post-instantiated twice.
             return;
         }
-        self.0
-            .read()
-            .set_flag(MovieClipFlags::POST_INSTANTIATED, true);
+        self.0.set_flag(MovieClipFlags::POST_INSTANTIATED, true);
 
         self.set_default_instance_name(context);
 
@@ -2486,8 +2458,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
     fn object(self) -> Avm1Value<'gc> {
         self.0
-            .read()
             .object
+            .get()
             .and_then(|o| o.as_avm1_object())
             .map(Avm1Value::from)
             .unwrap_or(Avm1Value::Undefined)
@@ -2495,15 +2467,16 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
     fn object2(self) -> Avm2Value<'gc> {
         self.0
-            .read()
             .object
+            .get()
             .and_then(|o| o.as_avm2_object())
             .map(Avm2Value::from)
             .unwrap_or(Avm2Value::Null)
     }
 
     fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2Object<'gc>) {
-        self.0.write(context.gc()).object = Some(to.into());
+        let write = Gc::write(context.gc(), self.0);
+        unlock!(write, MovieClipData, object).set(Some(to.into()));
         if self.parent().is_none() {
             context.avm2.add_orphan_obj(self.into());
         }
@@ -2559,7 +2532,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
         self.drop_focus(context);
 
-        self.0.read().stop_audio_stream(context);
+        self.0.stop_audio_stream(context);
 
         if self.is_root() {
             context
@@ -2576,25 +2549,26 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn avm1_text_field_bindings(&self) -> Option<Ref<'_, [Avm1TextFieldBinding<'gc>]>> {
-        let read = self.0.read();
-        read.object
-            .and_then(|o| o.as_avm1_object())
-            .map(|_| Ref::map(read, |r| &*r.avm1_text_field_bindings))
+        let obj = self.0.object.get().and_then(|o| o.as_avm1_object());
+        obj.map(|_| {
+            let bindings = self.0.avm1_text_field_bindings.borrow();
+            Ref::map(bindings, |b| &**b)
+        })
     }
 
     fn avm1_text_field_bindings_mut(
         &self,
         mc: &Mutation<'gc>,
     ) -> Option<RefMut<'_, Vec<Avm1TextFieldBinding<'gc>>>> {
-        let write = self.0.write(mc);
-        write
-            .object
-            .and_then(|o| o.as_avm1_object())
-            .map(|_| RefMut::map(write, |w| &mut w.avm1_text_field_bindings))
+        let obj = self.0.object.get().and_then(|o| o.as_avm1_object());
+        obj.map(|_| {
+            let write = Gc::write(mc, self.0);
+            unlock!(write, MovieClipData, avm1_text_field_bindings).borrow_mut()
+        })
     }
 
     fn loader_info(self) -> Option<Avm2Object<'gc>> {
-        self.0.read().shared.loader_info
+        self.0.shared.get().loader_info
     }
 
     fn allow_as_mask(self) -> bool {
@@ -2604,11 +2578,11 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
 impl<'gc> TDisplayObjectContainer<'gc> for MovieClip<'gc> {
     fn raw_container(&self) -> Ref<'_, ChildContainer<'gc>> {
-        Ref::map(self.0.read(), |this| &this.container)
+        self.0.container.borrow()
     }
 
-    fn raw_container_mut(&self, gc_context: &Mutation<'gc>) -> RefMut<'_, ChildContainer<'gc>> {
-        RefMut::map(self.0.write(gc_context), |this| &mut this.container)
+    fn raw_container_mut(&self, mc: &Mutation<'gc>) -> RefMut<'_, ChildContainer<'gc>> {
+        unlock!(Gc::write(mc, self.0), MovieClipData, container).borrow_mut()
     }
 
     fn is_tab_children_avm1(self, context: &mut UpdateContext<'gc>) -> bool {
@@ -2618,11 +2592,11 @@ impl<'gc> TDisplayObjectContainer<'gc> for MovieClip<'gc> {
 
 impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
     fn raw_interactive(&self) -> Ref<'_, InteractiveObjectBase<'gc>> {
-        Ref::map(self.0.read(), |r| &r.base)
+        self.0.base.borrow()
     }
 
     fn raw_interactive_mut(&self, mc: &Mutation<'gc>) -> RefMut<'_, InteractiveObjectBase<'gc>> {
-        RefMut::map(self.0.write(mc), |w| &mut w.base)
+        unlock!(Gc::write(mc, self.0), MovieClipData, base).borrow_mut()
     }
 
     fn as_displayobject(self) -> DisplayObject<'gc> {
@@ -2672,13 +2646,14 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
         }
 
         let mut handled = ClipEventResult::NotHandled;
-        let read = self.0.read();
-        if let Some(AvmObject::Avm1(object)) = read.object {
-            let swf_version = read.movie().version();
+        if let Some(AvmObject::Avm1(object)) = self.0.object.get() {
+            let swf_version = self.0.movie().version();
             if swf_version >= 5 {
                 if let Some(flag) = event.flag() {
-                    for event_handler in read
+                    for event_handler in self
+                        .0
                         .clip_event_handlers
+                        .borrow()
                         .iter()
                         .filter(|handler| handler.events.contains(flag))
                     {
@@ -3024,7 +2999,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
 
 impl<'gc> MovieClipData<'gc> {
     fn id(&self) -> CharacterId {
-        self.shared.id
+        self.shared.get().id
     }
 
     fn set_flag(&self, flag: MovieClipFlags, value: bool) {
@@ -3052,11 +3027,11 @@ impl<'gc> MovieClipData<'gc> {
     }
 
     fn total_frames(&self) -> FrameNumber {
-        self.shared.total_frames
+        self.shared.get().total_frames
     }
 
     fn frames_loaded(&self) -> i32 {
-        (self.shared.preload_progress.cur_preload_frame.get()) as i32 - 1
+        (self.shared.get().preload_progress.cur_preload_frame.get()) as i32 - 1
     }
 
     fn playing(&self) -> bool {
@@ -3100,7 +3075,7 @@ impl<'gc> MovieClipData<'gc> {
     }
 
     fn tag_stream_len(&self) -> usize {
-        self.shared.swf.end - self.shared.swf.start
+        self.shared.get().swf.end - self.shared.get().swf.start
     }
 
     /// Handles a PlaceObject tag when running a goto action.
@@ -3113,7 +3088,9 @@ impl<'gc> MovieClipData<'gc> {
         is_rewind: bool,
         index: usize,
     ) -> Result<(), Error> {
-        let tag_start = reader.get_ref().as_ptr() as u64 - self.shared.swf.as_ref().as_ptr() as u64;
+        let swf_ptr = self.shared.get().swf.as_ref().as_ptr();
+        let tag_ptr = reader.get_ref().as_ptr();
+        let tag_start = (tag_ptr.addr() - swf_ptr.addr()) as u64;
         let place_object = if version == 1 {
             reader.read_place_object()
         } else {
@@ -3137,19 +3114,6 @@ impl<'gc> MovieClipData<'gc> {
         }
 
         Ok(())
-    }
-
-    pub fn clip_event_handlers(&self) -> &[ClipEventHandler] {
-        &self.clip_event_handlers
-    }
-
-    pub fn set_clip_event_handlers(&mut self, event_handlers: Vec<ClipEventHandler>) {
-        let mut all_event_flags = ClipEventFlag::empty();
-        for handler in &event_handlers {
-            all_event_flags |= handler.events;
-        }
-        self.clip_event_flags.set(all_event_flags);
-        self.clip_event_handlers = event_handlers;
     }
 
     fn initialized(&self) -> bool {
@@ -3176,7 +3140,7 @@ impl<'gc> MovieClipData<'gc> {
         &self,
         context: &mut UpdateContext<'gc>,
     ) -> Option<Avm1Object<'gc>> {
-        let symbol_name = self.shared.exported_name.get();
+        let symbol_name = self.shared.get().exported_name.get();
         let symbol_name = symbol_name.as_ref()?;
         context
             .avm1
@@ -3184,7 +3148,7 @@ impl<'gc> MovieClipData<'gc> {
     }
 
     pub fn movie(&self) -> Arc<SwfMovie> {
-        self.shared.movie()
+        self.shared.get().movie()
     }
 }
 
@@ -3832,7 +3796,7 @@ impl<'gc, 'a> MovieClipShared<'gc> {
         // TODO: do other types of Character need to know their exported name?
         if let Some(character) = library.character_by_id(id) {
             if let Character::MovieClip(clip) = character {
-                let data = Gc::write(mc, clip.0.read().shared);
+                let data = Gc::write(mc, clip.0.shared.get());
                 unlock!(data, MovieClipShared, exported_name).set(Some(*name));
             } else {
                 // This is fairly common, don't log anything here
@@ -4067,7 +4031,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         }
 
         // Queue the actions.
-        let slice = self.0.read().shared.swf.resize_to_reader(reader, tag_len);
+        let slice = self.0.shared.get().swf.resize_to_reader(reader, tag_len);
         if !slice.is_empty() {
             context.action_queue.queue_action(
                 self.into(),
@@ -4096,7 +4060,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         context: &mut UpdateContext<'gc>,
         current_frame: FrameNumber,
     ) -> Result<(), Error> {
-        let Some(eager_tags) = self.0.read().shared.take_eager_tags(current_frame) else {
+        let Some(eager_tags) = self.0.shared.get().take_eager_tags(current_frame) else {
             return Ok(());
         };
 
@@ -4214,8 +4178,9 @@ impl<'gc, 'a> MovieClip<'gc> {
     }
 
     fn queue_place_object(self, reader: &mut SwfStream<'a>, version: u8) -> Result<(), Error> {
-        let read = self.0.read();
-        let tag_start = reader.get_ref().as_ptr() as u64 - read.shared.swf.as_ref().as_ptr() as u64;
+        let swf_ptr = self.0.shared.get().swf.as_ref().as_ptr();
+        let tag_ptr = reader.get_ref().as_ptr();
+        let tag_start = (tag_ptr.addr() - swf_ptr.addr()) as u64;
         let place_object = if version == 1 {
             reader.read_place_object()
         } else {
@@ -4226,7 +4191,7 @@ impl<'gc, 'a> MovieClip<'gc> {
             tag_type: QueuedTagAction::Place(version),
             tag_start,
         };
-        let mut queued_tags = read.queued_tags.borrow_mut();
+        let mut queued_tags = self.0.queued_tags.borrow_mut();
         let bucket = queued_tags
             .entry(place_object.depth as Depth)
             .or_insert_with(|| QueuedTagList::None);
@@ -4295,8 +4260,9 @@ impl<'gc, 'a> MovieClip<'gc> {
 
     #[inline]
     fn queue_remove_object(self, reader: &mut SwfStream<'a>, version: u8) -> Result<(), Error> {
-        let read = self.0.read();
-        let tag_start = reader.get_ref().as_ptr() as u64 - read.shared.swf.as_ref().as_ptr() as u64;
+        let swf_ptr = self.0.shared.get().swf.as_ref().as_ptr();
+        let tag_ptr = reader.get_ref().as_ptr();
+        let tag_start = (tag_ptr.addr() - swf_ptr.addr()) as u64;
         let remove_object = if version == 1 {
             reader.read_remove_object_1()
         } else {
@@ -4307,7 +4273,7 @@ impl<'gc, 'a> MovieClip<'gc> {
             tag_type: QueuedTagAction::Remove(version),
             tag_start,
         };
-        let mut queued_tags = read.queued_tags.borrow_mut();
+        let mut queued_tags = self.0.queued_tags.borrow_mut();
         let bucket = queued_tags
             .entry(remove_object.depth as Depth)
             .or_insert_with(|| QueuedTagList::None);
@@ -4340,23 +4306,22 @@ impl<'gc, 'a> MovieClip<'gc> {
         context: &mut UpdateContext<'gc>,
         _reader: &mut SwfStream<'a>,
     ) -> Result<(), Error> {
-        let mc = self.0.read();
-        let audio_stream = mc.playing().then(|| {
-            let stream_info = &mc.shared_cell().audio_stream_info;
-            if let (Some(stream_info), None) = (stream_info, mc.audio_stream.get()) {
-                let slice = mc
-                    .shared
-                    .swf
-                    .to_start_and_end(mc.tag_stream_pos.get() as usize, mc.tag_stream_len());
-                Some(context.start_stream(self, mc.current_frame(), slice, stream_info))
+        let audio_stream = self.0.playing().then(|| {
+            let read = self.0.shared_cell();
+            if let (Some(stream_info), None) = (&read.audio_stream_info, self.0.audio_stream.get())
+            {
+                let slice = self.0.shared.get().swf.to_start_and_end(
+                    self.0.tag_stream_pos.get() as usize,
+                    self.0.tag_stream_len(),
+                );
+                Some(context.start_stream(self, self.0.current_frame(), slice, stream_info))
             } else {
                 None
             }
         });
 
-        drop(mc);
         if let Some(stream) = audio_stream.flatten() {
-            self.0.read().audio_stream.set(stream);
+            self.0.audio_stream.set(stream);
         }
 
         Ok(())
@@ -4380,7 +4345,6 @@ impl<'gc, 'a> MovieClip<'gc> {
 
     pub fn set_constructing_frame(&self, val: bool) {
         self.0
-            .read()
             .set_flag(MovieClipFlags::RUNNING_CONSTRUCT_FRAME, val);
     }
 }


### PR DESCRIPTION
All display objects are now plain `Gc`s, which will allow future refactoring towards using `HasPrefixField` to handle the inheritance tree (as was done for AVM2 `Object`s)