### PR TITLE
core: Allow loading fonts into memory lazily

### DIFF
--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -1,5 +1,8 @@
 pub use crate::loader::Error as DialogLoaderError;
-use crate::{backend::navigator::OwnedFuture, font::FontQuery};
+use crate::{
+    backend::navigator::OwnedFuture,
+    font::{FontQuery, FontSource},
+};
 use chrono::{DateTime, Utc};
 use fluent_templates::loader::langid;
 pub use fluent_templates::LanguageIdentifier;
@@ -18,7 +21,7 @@ pub enum FontDefinition<'a> {
         name: String,
         is_bold: bool,
         is_italic: bool,
-        data: Vec<u8>,
+        source: FontSource,
         index: u32,
     },
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod stub;
 
 pub use context_menu::ContextMenuItem;
 pub use events::PlayerEvent;
-pub use font::{DefaultFont, FontQuery};
+pub use font::{DefaultFont, FontQuery, FontSource};
 pub use indexmap;
 pub use loader::LoadBehavior;
 pub use player::{Player, PlayerBuilder, PlayerMode, PlayerRuntime, StaticCallstack};

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -2,7 +2,6 @@ use crate::avm1::{PropertyMap as Avm1PropertyMap, PropertyMap};
 use crate::avm2::{Class as Avm2Class, Domain as Avm2Domain};
 use crate::backend::audio::SoundHandle;
 use crate::character::Character;
-use std::borrow::Cow;
 
 use crate::display_object::{Bitmap, Graphic, MorphShape, Text};
 use crate::font::{Font, FontDescriptor, FontQuery, FontType};
@@ -691,17 +690,13 @@ impl<'gc> Library<'gc> {
                 name,
                 is_bold,
                 is_italic,
-                data,
+                source,
                 index,
             } => {
                 let descriptor = FontDescriptor::from_parts(&name, is_bold, is_italic);
-                if let Ok(font) = Font::from_font_file(
-                    gc_context,
-                    descriptor,
-                    Cow::Owned(data),
-                    index,
-                    FontType::Device,
-                ) {
+                if let Ok(font) =
+                    Font::from_font_file(gc_context, descriptor, source, index, FontType::Device)
+                {
                     let name = font.descriptor().name().to_owned();
                     info!("Loaded new device font \"{name}\" (bold: {is_bold}, italic: {is_italic}) from file");
                     self.device_fonts.register(font);

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2945,6 +2945,7 @@ impl PlayerBuilder {
 
         #[cfg(feature = "default_font")]
         {
+            use crate::font::FontSource;
             use flate2::read::DeflateDecoder;
             use std::io::Read;
 
@@ -2958,7 +2959,7 @@ impl PlayerBuilder {
                 name: "Noto Sans".into(),
                 is_bold: false,
                 is_italic: false,
-                data,
+                source: FontSource::from_bytes(data),
                 index: 0,
             });
 

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -5,6 +5,7 @@ use swf::{CharacterId, Fixed8, HeaderExt, Rectangle, TagCode, Twips};
 use thiserror::Error;
 use url::Url;
 
+use crate::font::FontError;
 use crate::sandbox::SandboxType;
 
 #[derive(Error, Debug)]
@@ -16,7 +17,7 @@ pub enum Error {
     InvalidBitmap(#[from] ruffle_render::error::Error),
 
     #[error("Couldn't register font: {0}")]
-    InvalidFont(#[from] ttf_parser::FaceParsingError),
+    InvalidFont(#[from] FontError),
 
     #[error("Attempted to set symbol classes on movie without any")]
     NoSymbolClasses,

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -14,7 +14,7 @@ use ruffle_core::backend::ui::{
     DialogLoaderError, DialogResultFuture, FileDialogResult, FileFilter, FontDefinition,
     FullscreenError, LanguageIdentifier, MouseCursor, UiBackend,
 };
-use ruffle_core::FontQuery;
+use ruffle_core::{FontQuery, FontSource};
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -403,12 +403,12 @@ fn load_font_from_file(
     is_bold: bool,
     is_italic: bool,
 ) -> Result<FontDefinition<'static>> {
-    match std::fs::read(path) {
-        Ok(data) => Ok(FontDefinition::FontFile {
+    match std::fs::File::open(path) {
+        Ok(file) => Ok(FontDefinition::FontFile {
             name,
             is_bold,
             is_italic,
-            data,
+            source: FontSource::from_file(file),
             index,
         }),
         Err(e) => Err(anyhow!("Couldn't read font file at {path:?}: {e}")),
@@ -429,7 +429,7 @@ fn load_fontdb_font(name: String, face: &FaceInfo) -> Result<FontDefinition<'sta
                 name,
                 is_bold,
                 is_italic,
-                data: bin.as_ref().as_ref().to_vec(),
+                source: FontSource::from_bytes(bin.as_ref().as_ref().to_vec()),
                 index: face.index,
             })
         }

--- a/tests/framework/src/backends/ui.rs
+++ b/tests/framework/src/backends/ui.rs
@@ -5,7 +5,7 @@ use ruffle_core::{
         DialogLoaderError, DialogResultFuture, FileDialogResult, FileFilter, FontDefinition,
         FullscreenError, LanguageIdentifier, MouseCursor, UiBackend, US_ENGLISH,
     },
-    FontQuery,
+    FontQuery, FontSource,
 };
 use url::Url;
 
@@ -146,7 +146,7 @@ impl UiBackend for TestUiBackend {
                 name: name.to_owned(),
                 is_bold,
                 is_italic,
-                data: font.bytes.clone(),
+                source: FontSource::from_bytes(font.bytes.clone()),
                 index: 0,
             });
             break;

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -11,10 +11,10 @@ use ruffle_core::backend::ui::FontDefinition;
 use ruffle_core::compatibility_rules::CompatibilityRules;
 use ruffle_core::config::{Letterbox, NetworkingAccessMode};
 use ruffle_core::events::{GamepadButton, KeyCode};
-use ruffle_core::ttf_parser;
 use ruffle_core::{
     swf, Color, DefaultFont, Player, PlayerBuilder, PlayerRuntime, StageAlign, StageScaleMode,
 };
+use ruffle_core::{ttf_parser, FontSource};
 use ruffle_render::backend::RenderBackend;
 use ruffle_render::quality::StageQuality;
 use ruffle_video_external::backend::ExternalVideoBackend;
@@ -418,7 +418,7 @@ impl RuffleInstanceBuilder {
                                             name: name.to_string(),
                                             is_bold: font.is_bold,
                                             is_italic: font.is_italic,
-                                            data: data.to_vec(),
+                                            source: FontSource::from_bytes(data.to_vec()),
                                             index: 0,
                                         })
                                     } else {
@@ -470,7 +470,7 @@ impl RuffleInstanceBuilder {
             name: name.to_string(),
             is_bold: face.is_bold(),
             is_italic: face.is_italic(),
-            data: bytes,
+            source: FontSource::from_bytes(bytes),
             index,
         });
     }


### PR DESCRIPTION
This patch improves memory footprint by preventing fonts from being loaded eagerly into memory. Instead, it's possible to pass a file reference to a font, which will be used to load data from the font file when needed. This mechanism is used on desktop.

This patch also introduces a preloading mechanism, that makes sure we read from the font file once per a text fragment, and not for each glyph.