### PR TITLE
desktop: Prefer non-sRGB surface formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,7 +1322,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "ecolor"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#78a8de2e8f8d6da82680af4701cfa6e61cfe389c"
+source = "git+https://github.com/emilk/egui.git?branch=main#f46926aaf1ea7ab5a3756c678a1d647b9e549bd6"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1331,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#78a8de2e8f8d6da82680af4701cfa6e61cfe389c"
+source = "git+https://github.com/emilk/egui.git?branch=main#f46926aaf1ea7ab5a3756c678a1d647b9e549bd6"
 dependencies = [
  "ahash",
  "bitflags 2.9.4",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#78a8de2e8f8d6da82680af4701cfa6e61cfe389c"
+source = "git+https://github.com/emilk/egui.git?branch=main#f46926aaf1ea7ab5a3756c678a1d647b9e549bd6"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#78a8de2e8f8d6da82680af4701cfa6e61cfe389c"
+source = "git+https://github.com/emilk/egui.git?branch=main#f46926aaf1ea7ab5a3756c678a1d647b9e549bd6"
 dependencies = [
  "ahash",
  "arboard",
@@ -1384,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#78a8de2e8f8d6da82680af4701cfa6e61cfe389c"
+source = "git+https://github.com/emilk/egui.git?branch=main#f46926aaf1ea7ab5a3756c678a1d647b9e549bd6"
 dependencies = [
  "ahash",
  "egui",
@@ -1403,7 +1403,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "emath"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#78a8de2e8f8d6da82680af4701cfa6e61cfe389c"
+source = "git+https://github.com/emilk/egui.git?branch=main#f46926aaf1ea7ab5a3756c678a1d647b9e549bd6"
 dependencies = [
  "bytemuck",
 ]
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#78a8de2e8f8d6da82680af4701cfa6e61cfe389c"
+source = "git+https://github.com/emilk/egui.git?branch=main#f46926aaf1ea7ab5a3756c678a1d647b9e549bd6"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#78a8de2e8f8d6da82680af4701cfa6e61cfe389c"
+source = "git+https://github.com/emilk/egui.git?branch=main#f46926aaf1ea7ab5a3756c678a1d647b9e549bd6"
 
 [[package]]
 name = "equivalent"

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -310,11 +310,11 @@ fn show_value_type_combo_box<'gc>(
             // so just disable the selectable labels to prevent setting to these types.
             ui.add_enabled(
                 false,
-                egui::SelectableLabel::new(matches!(value, Value::Object(_)), "Object"),
+                egui::Button::selectable(matches!(value, Value::Object(_)), "Object"),
             );
             ui.add_enabled(
                 false,
-                egui::SelectableLabel::new(matches!(value, Value::MovieClip(_)), "MovieClip"),
+                egui::Button::selectable(matches!(value, Value::MovieClip(_)), "MovieClip"),
             );
         });
     new

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -75,12 +75,23 @@ impl GuiController {
             adapter_info.name,
             adapter_info.device_type
         );
-        let surface_format = surface
-            .get_capabilities(&adapter)
-            .formats
-            .first()
-            .cloned()
-            .expect("At least one format should be supported");
+        let preferred_formats = [
+            // by egui
+            wgpu::TextureFormat::Rgba8Unorm,
+            wgpu::TextureFormat::Bgra8Unorm,
+        ];
+        let supported_formats = surface.get_capabilities(&adapter).formats;
+        let surface_format = preferred_formats
+            .iter()
+            .find(|format| supported_formats.contains(format))
+            .copied()
+            .unwrap_or_else(|| {
+                supported_formats
+                    .first()
+                    .copied()
+                    .expect("At least one format should be supported")
+            });
+        tracing::info!("Using surface format {:?}", surface_format);
         let size = window.inner_size();
         surface.configure(
             &device,


### PR DESCRIPTION
This is ~~a half measure~~ to unblock https://github.com/ruffle-rs/ruffle/pull/20898 (following https://github.com/emilk/egui/pull/7311) - the colors are probably still not right if only sRGB formats are supported.