### PR TITLE
avm1: Move the global execution linked list from `DisplayObjectBase` to `MovieClip`

### DIFF
--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -6,8 +6,8 @@ use crate::avm1::property_map::PropertyMap;
 use crate::avm1::scope::Scope;
 use crate::avm1::{scope, Activation, ActivationIdentifier, Error, Object, Value};
 use crate::context::UpdateContext;
+use crate::display_object::{DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer};
 use crate::frame_lifecycle::FramePhase;
-use crate::prelude::*;
 use crate::string::{AvmString, StringContext};
 use crate::tag_utils::SwfSlice;
 use crate::{avm1, avm_debug};
@@ -58,7 +58,7 @@ pub struct Avm1<'gc> {
     has_mouse_listener: bool,
 
     /// The list of all movie clips in execution order.
-    clip_exec_list: Option<DisplayObject<'gc>>,
+    clip_exec_list: Option<MovieClip<'gc>>,
 
     /// The mappings between symbol names and constructors registered
     /// with `Object.registerClass()`.
@@ -472,7 +472,7 @@ impl<'gc> Avm1<'gc> {
         *context.frame_phase = FramePhase::Idle;
 
         // AVM1 execution order is determined by the global execution list, based on instantiation order.
-        let mut prev: Option<DisplayObject<'gc>> = None;
+        let mut prev: Option<MovieClip<'gc>> = None;
         let mut next = context.avm1.clip_exec_list;
         while let Some(clip) = next {
             next = clip.next_avm1_clip();
@@ -485,9 +485,7 @@ impl<'gc> Avm1<'gc> {
                 }
                 clip.set_next_avm1_clip(context.gc(), None);
             } else {
-                if let Some(clip) = clip.as_movie_clip() {
-                    clip.run_frame_avm1(context);
-                }
+                clip.run_frame_avm1(context);
                 prev = Some(clip);
             }
         }
@@ -504,7 +502,7 @@ impl<'gc> Avm1<'gc> {
     ///
     /// This should be called whenever a movie clip is created, and controls the order of
     /// execution for AVM1 movies.
-    pub fn add_to_exec_list(&mut self, gc_context: &Mutation<'gc>, clip: DisplayObject<'gc>) {
+    pub fn add_to_exec_list(&mut self, gc_context: &Mutation<'gc>, clip: MovieClip<'gc>) {
         // Adding while iterating is safe, as this does not modify any active nodes.
         if clip.next_avm1_clip().is_none() {
             clip.set_next_avm1_clip(gc_context, self.clip_exec_list);

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -485,7 +485,9 @@ impl<'gc> Avm1<'gc> {
                 }
                 clip.set_next_avm1_clip(context.gc(), None);
             } else {
-                clip.run_frame_avm1(context);
+                if let Some(clip) = clip.as_movie_clip() {
+                    clip.run_frame_avm1(context);
+                }
                 prev = Some(clip);
             }
         }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -209,11 +209,6 @@ pub struct DisplayObjectBase<'gc> {
     scale_y: Cell<Percent>,
     skew: Cell<f64>,
 
-    /// The next display object in order of execution.
-    ///
-    /// `None` in an AVM2 movie.
-    next_avm1_clip: Option<DisplayObject<'gc>>,
-
     /// The sound transform of sounds playing via this display object.
     #[collect(require_static)]
     sound_transform: SoundTransform,
@@ -274,7 +269,6 @@ impl Default for DisplayObjectBase<'_> {
             scale_x: Cell::new(Percent::from_unit(1.0)),
             scale_y: Cell::new(Percent::from_unit(1.0)),
             skew: Cell::new(0.0),
-            next_avm1_clip: None,
             masker: None,
             maskee: None,
             meta_data: None,
@@ -585,14 +579,6 @@ impl<'gc> DisplayObjectBase<'gc> {
     /// properly handles 'orphan' movie clips
     fn set_parent_ignoring_orphan_list(&mut self, parent: Option<DisplayObject<'gc>>) {
         self.parent = parent;
-    }
-
-    fn next_avm1_clip(&self) -> Option<DisplayObject<'gc>> {
-        self.next_avm1_clip
-    }
-
-    fn set_next_avm1_clip(&mut self, node: Option<DisplayObject<'gc>>) {
-        self.next_avm1_clip = node;
     }
 
     fn avm1_removed(&self) -> bool {
@@ -1698,14 +1684,6 @@ pub trait TDisplayObject<'gc>:
     /// seen in AVM2. Notably, it disallows access to non-container parents.
     fn avm2_parent(self) -> Option<DisplayObject<'gc>> {
         self.parent().filter(|p| p.as_container().is_some())
-    }
-
-    fn next_avm1_clip(self) -> Option<DisplayObject<'gc>> {
-        self.base().next_avm1_clip()
-    }
-
-    fn set_next_avm1_clip(self, gc_context: &Mutation<'gc>, node: Option<DisplayObject<'gc>>) {
-        self.base_mut(gc_context).set_next_avm1_clip(node);
     }
 
     fn masker(self) -> Option<DisplayObject<'gc>> {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -2101,9 +2101,6 @@ pub trait TDisplayObject<'gc>:
         }
     }
 
-    /// Execute all other timeline actions on this object.
-    fn run_frame_avm1(self, _context: &mut UpdateContext<'gc>) {}
-
     /// Emit a `frameConstructed` event on this DisplayObject and any children it
     /// may have.
     fn frame_constructed(self, context: &mut UpdateContext<'gc>) {
@@ -2357,14 +2354,12 @@ pub trait TDisplayObject<'gc>:
 
     fn post_instantiation(
         self,
-        context: &mut UpdateContext<'gc>,
+        _context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
-        run_frame: bool,
+        _run_frame: bool,
     ) {
-        if run_frame && !self.movie().is_action_script_3() {
-            self.run_frame_avm1(context);
-        }
+        // Noop.
     }
 
     /// Return the version of the SWF that created this movie clip.

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -280,10 +280,6 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
     ) {
         self.set_default_instance_name(context);
 
-        if !self.movie().is_action_script_3() {
-            context.avm1.add_to_exec_list(context.gc(), self.into());
-        }
-
         if self.0.object.get().is_none() {
             let object = Object::new_with_native(
                 &context.strings,

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -193,7 +193,9 @@ impl<'gc> Avm1Button<'gc> {
         for (child, depth) in children {
             // Initialize new child.
             child.post_instantiation(context, None, Instantiator::Movie, false);
-            child.run_frame_avm1(context);
+            if let Some(clip) = child.as_movie_clip() {
+                clip.run_frame_avm1(context);
+            }
             let removed_child = self.replace_at_depth(context, child, depth.into());
             dispatch_added_event(self.into(), child, false, context);
             if let Some(removed_child) = removed_child {
@@ -274,7 +276,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Object<'gc>>,
         _instantiated_by: Instantiator,
-        run_frame: bool,
+        _run_frame: bool,
     ) {
         self.set_default_instance_name(context);
 
@@ -290,10 +292,6 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
             );
             let obj = unlock!(Gc::write(context.gc(), self.0), Avm1ButtonData, object);
             obj.set(Some(object));
-
-            if run_frame {
-                self.run_frame_avm1(context);
-            }
         }
 
         if !self.0.initialized.get() {
@@ -335,10 +333,6 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
             }
             write.borrow_mut().hit_bounds = hit_bounds;
         }
-    }
-
-    fn run_frame_avm1(self, _context: &mut UpdateContext<'gc>) {
-        // Noop.
     }
 
     fn render_self(self, context: &mut RenderContext<'_, 'gc>) {

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -295,14 +295,8 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
                 self.run_frame_avm1(context);
             }
         }
-    }
 
-    fn run_frame_avm1(self, context: &mut UpdateContext<'gc>) {
-        let self_display_object = self.into();
-        let initialized = self.0.initialized.get();
-
-        // TODO: Move this to post_instantiation.
-        if !initialized {
+        if !self.0.initialized.get() {
             let mut new_children = Vec::new();
 
             self.set_state(context, ButtonState::Up);
@@ -317,7 +311,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
                     {
                         Some(child) => {
                             child.set_matrix(context.gc(), record.matrix.into());
-                            child.set_parent(context, Some(self_display_object));
+                            child.set_parent(context, Some(self.into()));
                             child.set_depth(record.depth.into());
                             new_children.push((child, record.depth.into()));
                         }
@@ -341,6 +335,10 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
             }
             write.borrow_mut().hit_bounds = hit_bounds;
         }
+    }
+
+    fn run_frame_avm1(self, _context: &mut UpdateContext<'gc>) {
+        // Noop.
     }
 
     fn render_self(self, context: &mut RenderContext<'_, 'gc>) {

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -335,7 +335,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         context: &mut UpdateContext<'gc>,
         _init_object: Option<avm1::Object<'gc>>,
         instantiated_by: Instantiator,
-        run_frame: bool,
+        _run_frame: bool,
     ) {
         if self.movie().is_action_script_3() {
             let mut activation = Avm2Activation::from_nothing(context);
@@ -376,10 +376,6 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
             self.on_construction_complete(context);
         } else {
             context.avm1.add_to_exec_list(context.gc(), self.into());
-
-            if run_frame {
-                self.run_frame_avm1(context);
-            }
         }
     }
 

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -374,8 +374,6 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
             }
 
             self.on_construction_complete(context);
-        } else {
-            context.avm1.add_to_exec_list(context.gc(), self.into());
         }
     }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2134,7 +2134,7 @@ impl<'gc> EditText<'gc> {
     }
 
     /// Construct the text field's AVM1 representation.
-    fn construct_as_avm1_object(self, context: &mut UpdateContext<'gc>, _run_frame: bool) {
+    fn construct_as_avm1_object(self, context: &mut UpdateContext<'gc>) {
         if self.0.object.get().is_none() {
             let object = Avm1Object::new_with_native(
                 &context.strings,
@@ -2545,13 +2545,12 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
-        run_frame: bool,
+        _run_frame: bool,
     ) {
         self.set_default_instance_name(context);
 
         if !self.movie().is_action_script_3() {
-            context.avm1.add_to_exec_list(context.gc(), self.into());
-            self.construct_as_avm1_object(context, run_frame);
+            self.construct_as_avm1_object(context);
         }
     }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2134,7 +2134,7 @@ impl<'gc> EditText<'gc> {
     }
 
     /// Construct the text field's AVM1 representation.
-    fn construct_as_avm1_object(self, context: &mut UpdateContext<'gc>, run_frame: bool) {
+    fn construct_as_avm1_object(self, context: &mut UpdateContext<'gc>, _run_frame: bool) {
         if self.0.object.get().is_none() {
             let object = Avm1Object::new_with_native(
                 &context.strings,
@@ -2155,10 +2155,6 @@ impl<'gc> EditText<'gc> {
 
             self.initialize_as_broadcaster(activation);
         });
-
-        if run_frame {
-            self.run_frame_avm1(context);
-        }
     }
 
     /// Construct the text field's AVM2 representation.
@@ -2534,10 +2530,6 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             self.construct_as_avm2_object(context, self.into());
             self.on_construction_complete(context);
         }
-    }
-
-    fn run_frame_avm1(self, _context: &mut UpdateContext) {
-        // Noop
     }
 
     fn as_edit_text(self) -> Option<EditText<'gc>> {

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -189,10 +189,6 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         self.invalidate_cached_bitmap(context.gc());
     }
 
-    fn run_frame_avm1(self, _context: &mut UpdateContext) {
-        // Noop
-    }
-
     fn render_self(self, context: &mut RenderContext) {
         if !context.is_offscreen && !self.world_bounds().intersects(&context.stage.view_bounds()) {
             // Off-screen; culled
@@ -240,16 +236,12 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
-        run_frame: bool,
+        _run_frame: bool,
     ) {
         if self.movie().is_action_script_3() {
             self.set_default_instance_name(context);
         } else {
             context.avm1.add_to_exec_list(context.gc(), self.into());
-
-            if run_frame {
-                self.run_frame_avm1(context);
-            }
         }
     }
 

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -240,8 +240,6 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     ) {
         if self.movie().is_action_script_3() {
             self.set_default_instance_name(context);
-        } else {
-            context.avm1.add_to_exec_list(context.gc(), self.into());
         }
     }
 

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -105,10 +105,6 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         self.invalidate_cached_bitmap(context.gc());
     }
 
-    fn run_frame_avm1(self, _context: &mut UpdateContext) {
-        // Noop
-    }
-
     fn object2(self) -> Avm2Value<'gc> {
         self.0
             .object

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -138,10 +138,6 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         self.invalidate_cached_bitmap(context.gc());
     }
 
-    fn run_frame_avm1(self, _context: &mut UpdateContext) {
-        // Noop
-    }
-
     fn render_self(self, context: &mut RenderContext) {
         let shared = self.0.shared.get();
         context.transform_stack.push(&Transform {

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -371,7 +371,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         context: &mut UpdateContext<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
-        run_frame: bool,
+        _run_frame: bool,
     ) {
         if !self.movie().is_action_script_3() {
             context.avm1.add_to_exec_list(context.gc(), self.into());
@@ -453,10 +453,6 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         }
 
         self.seek(context, starting_seek);
-
-        if !self.movie().is_action_script_3() && run_frame {
-            self.run_frame_avm1(context);
-        }
     }
 
     fn construct_frame(self, context: &mut UpdateContext<'gc>) {

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -373,10 +373,6 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         _instantiated_by: Instantiator,
         _run_frame: bool,
     ) {
-        if !self.movie().is_action_script_3() {
-            context.avm1.add_to_exec_list(context.gc(), self.into());
-        }
-
         let movie = self.0.movie.clone();
 
         let (stream, keyframes) = match self.0.source.get() {


### PR DESCRIPTION
Only AVM1 MovieClips can execute AVM1 framescripts, so there's no reason to put non-`MovieClip` display objects in the AVM1 exec list, and no reason to have it defined as part of `DisplayObjectBase`.