### PR TITLE
chore: Update required `webdriverio` version

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,9 +16,9 @@
             ],
             "devDependencies": {
                 "@eslint/js": "^9.31.0",
-                "@wdio/browserstack-service": "^9.18.0",
-                "@wdio/cli": "^9.18.0",
-                "@wdio/local-runner": "^9.18.0",
+                "@wdio/browserstack-service": "^9.18.1",
+                "@wdio/cli": "^9.18.1",
+                "@wdio/local-runner": "^9.18.1",
                 "@wdio/mocha-framework": "^9.18.0",
                 "@wdio/spec-reporter": "^9.18.0",
                 "@wdio/static-server-service": "^9.18.0",
@@ -43,7 +43,7 @@
                 "typedoc-plugin-mdn-links": "^5.0.4",
                 "typescript": "^5.8.3",
                 "typescript-eslint": "^8.37.0",
-                "webdriverio": "^9.2.2",
+                "webdriverio": "^9.18.1",
                 "webpack": "^5.100.2",
                 "webpack-cli": "^6.0.1",
                 "workspace-version": "^0.1.4"
@@ -3367,9 +3367,9 @@
             }
         },
         "node_modules/@wdio/browserstack-service": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/@wdio/browserstack-service/-/browserstack-service-9.18.0.tgz",
-            "integrity": "sha512-j92XBi8NwEBhmWEMT0u4+bMadlYhkdk7OxSvn8rKrRZlYemKKsTWEBl2suTFbiJqBa04Hobv9oBJD4c7O4as6g==",
+            "version": "9.18.1",
+            "resolved": "https://registry.npmjs.org/@wdio/browserstack-service/-/browserstack-service-9.18.1.tgz",
+            "integrity": "sha512-w3EJS/h/xgmxHAL0Xg5rrgHx+tmlWo+DbnE7ks2iRrYFmvjIWqunKtX+1I9iCViGNYIyHQ0Z92L0mUcQDmubUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3388,7 +3388,7 @@
                 "gitconfiglocal": "^2.1.0",
                 "undici": "^6.21.3",
                 "uuid": "^11.1.0",
-                "webdriverio": "9.18.0",
+                "webdriverio": "9.18.1",
                 "winston-transport": "^4.5.0",
                 "yauzl": "^3.0.0"
             },
@@ -3400,9 +3400,9 @@
             }
         },
         "node_modules/@wdio/cli": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.18.0.tgz",
-            "integrity": "sha512-gdIEqDdAHwrPlS+2v7eEYIjWsu2sCmwLZG3USXMKoCX8x9hsUhTl7FPqzgyMySt6gh0b68vWaMhCsPqqbhu/Kg==",
+            "version": "9.18.1",
+            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.18.1.tgz",
+            "integrity": "sha512-f/Akoj7bTjAG3fdZRXgQsRPO0SZFzl8U1z/U5b1MNBt/zCFhh/vUg8SbOGDWXMp1UdR3p3zQQdlrk9SxWT3NDg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3424,7 +3424,7 @@
                 "lodash.union": "^4.6.0",
                 "read-pkg-up": "^10.0.0",
                 "tsx": "^4.7.2",
-                "webdriverio": "9.18.0",
+                "webdriverio": "9.18.1",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -3490,16 +3490,16 @@
             }
         },
         "node_modules/@wdio/local-runner": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.18.0.tgz",
-            "integrity": "sha512-7myEUBkmeOOCyRfJsMbgT6UrXdFFErmrgJo4V4lkv0gUHyf/ngXMFaLy1K6uzU+D909Y0JfRl1CsllILu+Nr9A==",
+            "version": "9.18.1",
+            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.18.1.tgz",
+            "integrity": "sha512-AdsbI9PXNqHmEpWnmbtaRLHIEIbRReFA0L1kefVxbUrNcCRNcP8OBwpHQjUzJvOv9g99U0JltdtGwsXxZKhn2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.1.0",
                 "@wdio/logger": "9.18.0",
                 "@wdio/repl": "9.16.2",
-                "@wdio/runner": "9.18.0",
+                "@wdio/runner": "9.18.1",
                 "@wdio/types": "9.16.2",
                 "exit-hook": "^4.0.0",
                 "expect-webdriverio": "^5.3.4",
@@ -3906,9 +3906,9 @@
             "license": "MIT"
         },
         "node_modules/@wdio/runner": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.18.0.tgz",
-            "integrity": "sha512-u83BqOAL1H9buYHyUieGKZ+HMXtwnCXEi/XUErBjJGzz4ezE8pd9pPC7Y4Haccqog/PzK15CHr21/mj+fMoABw==",
+            "version": "9.18.1",
+            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.18.1.tgz",
+            "integrity": "sha512-B0S8o873Nv/AUDyxb4dL6YpvbD7xm+GYWUhDiSAug2TE40AGd0c+UmaTHZbq9cXGTUdA4SaP3eQiG5yMWJxiRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3921,7 +3921,7 @@
                 "@wdio/utils": "9.18.0",
                 "deepmerge-ts": "^7.0.3",
                 "webdriver": "9.18.0",
-                "webdriverio": "9.18.0"
+                "webdriverio": "9.18.1"
             },
             "engines": {
                 "node": ">=18.20.0"
@@ -16035,9 +16035,9 @@
             "license": "MIT"
         },
         "node_modules/webdriverio": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.18.0.tgz",
-            "integrity": "sha512-R4+8+wC/fJJP7Y+Ztj8GkMWU/yc66PM0m1zD7v6m3GbgDtxyI1ZjblRNGWYf+doWPmSODBCoNXxtb+b3IgZGEg==",
+            "version": "9.18.1",
+            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.18.1.tgz",
+            "integrity": "sha512-b9aVtmi5+BUkae+SfJlajjKcVWqhMP+HdxpW2B3MlAtvYG2MRpwXkR34yvRIh5IYVMnR5tyUi5knDlJUGOPHPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,9 +13,9 @@
     ],
     "devDependencies": {
         "@eslint/js": "^9.31.0",
-        "@wdio/browserstack-service": "^9.18.0",
-        "@wdio/cli": "^9.18.0",
-        "@wdio/local-runner": "^9.18.0",
+        "@wdio/browserstack-service": "^9.18.1",
+        "@wdio/cli": "^9.18.1",
+        "@wdio/local-runner": "^9.18.1",
         "@wdio/mocha-framework": "^9.18.0",
         "@wdio/spec-reporter": "^9.18.0",
         "@wdio/static-server-service": "^9.18.0",
@@ -40,7 +40,7 @@
         "typedoc-plugin-mdn-links": "^5.0.4",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.37.0",
-        "webdriverio": "^9.2.2",
+        "webdriverio": "^9.18.1",
         "webpack": "^5.100.2",
         "webpack-cli": "^6.0.1",
         "workspace-version": "^0.1.4"


### PR DESCRIPTION
Dependabot left this behind for some reason...

Fixes https://github.com/ruffle-rs/ruffle/issues/20948.