### PR TITLE
avm2: store a `Domain` instead of a `TranslationUnit` in `TraitKind/PropertyClass`

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -926,7 +926,8 @@ impl<'gc> Class<'gc> {
         let mut i_class = ClassData::empty(variable_name);
         i_class.attributes = Cell::new(ClassAttributes::FINAL | ClassAttributes::SEALED);
         // TODO make the slot typed
-        let traits: Box<[_]> = Box::new([Trait::from_const(variable_name, None, None)]);
+        let domain = activation.avm2().playerglobals_domain;
+        let traits: Box<[_]> = Box::new([Trait::from_const(variable_name, None, None, domain)]);
         i_class.traits = OnceLock::from(traits);
         let i_class = Class(Gc::new(activation.gc(), i_class));
         i_class.init_vtable(activation.context)?;

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -2,6 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
+use crate::avm2::domain::Domain;
 use crate::avm2::metadata::Metadata;
 use crate::avm2::method::Method;
 use crate::avm2::script::TranslationUnit;
@@ -76,7 +77,7 @@ pub enum TraitKind<'gc> {
         slot_id: u32,
         type_name: Option<Gc<'gc, Multiname<'gc>>>,
         default_value: Value<'gc>,
-        unit: Option<TranslationUnit<'gc>>,
+        domain: Domain<'gc>,
     },
 
     /// A method on an object that can be called.
@@ -98,7 +99,7 @@ pub enum TraitKind<'gc> {
         slot_id: u32,
         type_name: Option<Gc<'gc, Multiname<'gc>>>,
         default_value: Value<'gc>,
-        unit: Option<TranslationUnit<'gc>>,
+        domain: Domain<'gc>,
     },
 }
 
@@ -107,6 +108,7 @@ impl<'gc> Trait<'gc> {
         name: QName<'gc>,
         type_name: Option<Gc<'gc, Multiname<'gc>>>,
         default_value: Option<Value<'gc>>,
+        domain: Domain<'gc>,
     ) -> Self {
         Trait {
             name,
@@ -115,7 +117,7 @@ impl<'gc> Trait<'gc> {
                 slot_id: 0,
                 default_value: default_value.unwrap_or_else(|| default_value_for_type(type_name)),
                 type_name,
-                unit: None,
+                domain,
             },
             metadata: None,
         }
@@ -144,7 +146,7 @@ impl<'gc> Trait<'gc> {
                         slot_id: *slot_id,
                         type_name,
                         default_value,
-                        unit: Some(unit),
+                        domain: unit.domain(),
                     },
                     metadata: Metadata::from_abc_index(activation, unit, &abc_trait.metadata)?,
                 }
@@ -200,7 +202,7 @@ impl<'gc> Trait<'gc> {
                         slot_id: *slot_id,
                         type_name,
                         default_value,
-                        unit: Some(unit),
+                        domain: unit.domain(),
                     },
                     metadata: Metadata::from_abc_index(activation, unit, &abc_trait.metadata)?,
                 }

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -441,16 +441,16 @@ impl<'gc> VTable<'gc> {
 
                     let (new_prop, new_class) = match trait_data.kind() {
                         TraitKind::Slot {
-                            type_name, unit, ..
+                            type_name, domain, ..
                         } => (
                             Property::new_slot(new_slot_id),
-                            PropertyClass::name(*type_name, *unit),
+                            PropertyClass::name(*type_name, *domain),
                         ),
                         TraitKind::Const {
-                            type_name, unit, ..
+                            type_name, domain, ..
                         } => (
                             Property::new_const_slot(new_slot_id),
-                            PropertyClass::name(*type_name, *unit),
+                            PropertyClass::name(*type_name, *domain),
                         ),
                         TraitKind::Class { class, .. } => (
                             Property::new_const_slot(new_slot_id),


### PR DESCRIPTION
A small cleanup/refactor, which removes an unneeded `Option`.