### PR TITLE
avm2: Make Date.prototype an instance of Date

### DIFF
--- a/core/src/avm2/globals/Date.as
+++ b/core/src/avm2/globals/Date.as
@@ -4,6 +4,10 @@ package {
     public dynamic class Date {
         public static const length:int = 7;
 
+        private static native function initCustomPrototype();
+
+        initCustomPrototype();
+
         prototype.valueOf = function():* {
             var d:Date = this;
             return d.AS3::valueOf();

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -189,6 +189,21 @@ fn get_arguments_array<'gc>(args: &[Value<'gc>]) -> Vec<Value<'gc>> {
         .collect()
 }
 
+pub fn init_custom_prototype<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this.as_object().unwrap();
+    let this = this.as_class_object().unwrap();
+
+    let prototype_date_object = DateObject::for_prototype(activation, this);
+
+    this.link_prototype(activation, prototype_date_object);
+
+    Ok(Value::Undefined)
+}
+
 /// Implements `Date`'s instance constructor.
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -61,6 +61,29 @@ impl<'gc> DateObject<'gc> {
         Ok(instance)
     }
 
+    pub fn for_prototype(
+        activation: &mut Activation<'_, 'gc>,
+        date_class: ClassObject<'gc>,
+    ) -> Object<'gc> {
+        let object_class = activation.avm2().classes().object;
+        let base = ScriptObjectData::custom_new(
+            date_class.inner_class_definition(),
+            Some(object_class.prototype()),
+            date_class.instance_vtable(),
+        );
+
+        let instance: Object<'gc> = DateObject(Gc::new(
+            activation.gc(),
+            DateObjectData {
+                base,
+                date_time: Cell::new(None),
+            },
+        ))
+        .into();
+
+        instance
+    }
+
     pub fn date_time(self) -> Option<DateTime<Utc>> {
         self.0.date_time.get()
     }

--- a/tests/tests/swfs/from_avmplus/ecma3/Exceptions/date_001_rt/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Exceptions/date_001_rt/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Exceptions/date_002_rt/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Exceptions/date_002_rt/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Exceptions/date_003_rt/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Exceptions/date_003_rt/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Exceptions/date_004_rt/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Exceptions/date_004_rt/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Replaces https://github.com/ruffle-rs/ruffle/pull/21030 .

Hopefully same approach could be also used to implement the same behavior for other classes doing this: `Function, MethodClosure, Error, Array, RegExp`. (note: `MethodClosure` is absent in Ruffle)