### PR TITLE
desktop: Add Steamworks API as an optional ExternalInterface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,6 +4495,7 @@ dependencies = [
  "ruffle_render_wgpu",
  "ruffle_video_external",
  "ruffle_video_software",
+ "steamworks",
  "sys-locale",
  "thiserror 2.0.17",
  "tokio",
@@ -5236,6 +5237,24 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "steamworks"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa5de820b63330e5df107e9f1afde6205aeb74ab1488fc93ff5b9f256dd776d"
+dependencies = [
+ "bitflags 2.10.0",
+ "paste",
+ "steamworks-sys",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "steamworks-sys"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8ebb529945aa36439c2e94d613d38509da09677f2aa0c7f4b3a9cd9057d529"
 
 [[package]]
 name = "strength_reduce"

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -356,6 +356,8 @@ pub trait ExternalInterfaceProvider {
     fn on_callback_available(&self, name: &str);
 
     fn get_id(&self) -> Option<String>;
+
+    fn update(&self, _context: &mut UpdateContext<'_>) {}
 }
 
 pub struct NullExternalInterfaceProvider;
@@ -384,6 +386,10 @@ impl<'gc> ExternalInterface<'gc> {
 
     pub fn set_provider(&mut self, provider: Option<Box<dyn ExternalInterfaceProvider>>) {
         self.provider = provider.map(Rc::new);
+    }
+
+    pub fn get_provider(&self) -> Option<Rc<Box<dyn ExternalInterfaceProvider>>> {
+        self.provider.clone()
     }
 
     pub fn add_callback(&mut self, name: String, callback: Callback<'gc>) {

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -54,6 +54,8 @@ unicode-bidi = "0.3.18"
 fontconfig = { version = "0.10.0", optional = true, features = ["dlopen"]}
 memmap2.workspace = true
 
+steamworks = { version = "0.12.0", optional = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = "0.11.0"
 

--- a/desktop/sdk/README.md
+++ b/desktop/sdk/README.md
@@ -1,0 +1,49 @@
+Welcome to our ActionScript SDK used to extend ActionScript 3 with new native functionality when using the Ruffle desktop build.
+
+# Steamworks
+
+Currently this SDK includes support for the [Steamworks™ API](https://partner.steamgames.com/doc/api) [^1].
+Internally Ruffle uses the [steamworks](https://github.com/Noxime/steamworks-rs) Rust crate as wrapper around the API.
+See also their README, especially the section on "Help, I can't run my game!".
+To expose this functionality to AS3 code, the API is exposed as an `ExternalInterface`.
+Note: This means the ruffle option `--dummy-external-interface` is incompatible with using the steamworks API.
+
+## Building Ruffle
+
+When building ruffle you have to make sure to enable the `steamworks` feature, e.g. like this `cargo build --release --feature steamworks`.
+
+## Usage
+
+Include the SDK, e.g. with `mxmlc -compiler.source-path=/path/to/ruffle/desktop/sdk/`. The API is heavily inspired by [steamworks.js](https://github.com/ceifa/steamworks.js/).
+
+Code example:
+```
+package {
+    import ruffle.steamworks.Client;
+
+    public class Test {
+        function Test() {
+            var client: Client = new Client(/* appId */ 480); // Or new Client() when using steam_appid.txt
+
+            trace("appId: " + client.utils.getAppId());
+
+            trace("name: " + client.localPlayer.getName());
+            trace("level: " + client.localPlayer.getLevel());
+            trace("getIpCountry: " + client.localPlayer.getIpCountry());
+
+            client.addEventListener(Client.USER_STATS_RECEIVED, function(): void {
+                trace("Event: USER_STATS_RECEIVED");
+                trace("isActived('ACH_WIN_ONE_GAME'): " + client.achievement.isActivated('ACH_WIN_ONE_GAME'));
+
+                trace(client.achievement.names());
+            });
+
+            client.localPlayer.requestUserStats();
+        }
+    }
+}
+```
+
+[^1]: Steamworks is a trademark of the Valve Corporation.
+
+

--- a/desktop/sdk/ruffle/steamworks/Achievement.as
+++ b/desktop/sdk/ruffle/steamworks/Achievement.as
@@ -1,0 +1,23 @@
+package ruffle.steamworks {
+    import ruffle.steamworks.Client;
+
+    public class Achievement {
+        private var _client: Client;
+        public function Achievement(client: Client) {
+            _client = client;
+        }
+
+        public function activate(name: String): Boolean {
+            return _client.call("achievement.activate", name);
+        }
+        public function isActivated(name: String): Boolean {
+            return _client.call("achievement.isActivated", name);
+        }
+        public function clear(name: String): Boolean {
+            return _client.call("achievement.clear", name);
+        }
+        public function names(): Array {
+            return _client.call("achievement.names");
+        }
+    }
+}

--- a/desktop/sdk/ruffle/steamworks/Client.as
+++ b/desktop/sdk/ruffle/steamworks/Client.as
@@ -1,0 +1,55 @@
+package ruffle.steamworks {
+    import flash.events.Event;
+    import flash.events.EventDispatcher;
+    import flash.external.ExternalInterface;
+
+    import ruffle.steamworks.Achievement;
+    import ruffle.steamworks.LocalPlayer;
+    import ruffle.steamworks.Utils;
+
+    public class Client extends EventDispatcher {
+        public static var USER_STATS_RECEIVED: String = "userStatsReceived";
+
+        public function Client(appid: *) {
+            var error: * = appid ? call("client.init", appid)
+                                 : call("client.init");
+            if (error) {
+                throw new Error(error);
+            }
+
+            var self: Client = this;
+            ExternalInterface.addCallback("steamworks.callbacks.userStatsReceived", function (): void {
+                self.dispatchEvent(new Event(Client.USER_STATS_RECEIVED));
+            });
+        }
+
+        public function get achievement(): Achievement {
+            if (!_achievement) {
+                _achievement = new Achievement(this);
+            }
+            return _achievement;
+        }
+
+        public function get localPlayer(): LocalPlayer {
+            if (!_localPlayer) {
+                _localPlayer = new LocalPlayer(this);
+            }
+            return _localPlayer;
+        }
+
+        public function get utils(): Utils {
+            if (!_utils) {
+                _utils = new Utils(this);
+            }
+            return _utils;
+        }
+
+        internal function call(name: String, ...args: *): * {
+            return ExternalInterface.call.apply(null, ["steamworks." + name].concat(args));
+        }
+
+        private var _achievement: Achievement;
+        private var _localPlayer: LocalPlayer;
+        private var _utils: Utils;
+    }
+}

--- a/desktop/sdk/ruffle/steamworks/LocalPlayer.as
+++ b/desktop/sdk/ruffle/steamworks/LocalPlayer.as
@@ -1,0 +1,26 @@
+package ruffle.steamworks {
+    import ruffle.steamworks.Client;
+
+    public class LocalPlayer {
+        private var _client: Client;
+        public function LocalPlayer(client: Client) {
+            _client = client;
+        }
+
+        public function getSteamId(): String {
+            return _client.call("localplayer.getSteamId");
+        }
+        public function getName(): String {
+            return _client.call("localplayer.getName");
+        }
+        public function getLevel(): uint {
+            return _client.call("localplayer.getLevel");
+        }
+        public function getIpCountry(): String {
+            return _client.call("localplayer.getIpCountry");
+        }
+        public function requestUserStats(): void {
+            _client.call("localplayer.requestUserStats");
+        }
+    }
+}

--- a/desktop/sdk/ruffle/steamworks/Utils.as
+++ b/desktop/sdk/ruffle/steamworks/Utils.as
@@ -1,0 +1,17 @@
+package ruffle.steamworks {
+    import ruffle.steamworks.Client;
+
+    public class Utils {
+        private var _client: Client;
+        public function Utils(client: Client) {
+            _client = client;
+        }
+
+        public function getAppId(): uint {
+            return _client.call("utils.getAppId");
+        }
+        public function isSteamRunningOnSteamDeck(): Boolean {
+            return _client.call("utils.isSteamRunningOnSteamDeck");
+        }
+    }
+}

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -370,6 +370,13 @@ impl MainWindow {
             if dt > 0 {
                 self.time = new_time;
                 if let Some(mut player) = self.player.get() {
+                    #[cfg(feature = "steamworks")]
+                    player.mutate_with_update_context(|ctx| {
+                        if let Some(provider) = ctx.external_interface.get_provider() {
+                            provider.update(ctx);
+                        }
+                    });
+
                     player.tick(dt as f64 / 1_000_000.0);
                     self.next_frame_time = Some(new_time + player.time_til_next_frame());
                 } else {

--- a/desktop/src/backends.rs
+++ b/desktop/src/backends.rs
@@ -1,10 +1,14 @@
 mod external_interface;
 mod fscommand;
 mod navigator;
+#[cfg(feature = "steamworks")]
+mod steamworks_external_interface;
 mod ui;
 
 pub use external_interface::DesktopExternalInterfaceProvider;
 pub use fscommand::DesktopFSCommandProvider;
 pub use navigator::DesktopNavigatorInterface;
 pub use navigator::PathAllowList;
+#[cfg(feature = "steamworks")]
+pub use steamworks_external_interface::SteamWorksExternalInterfaceProvider;
 pub use ui::DesktopUiBackend;

--- a/desktop/src/backends/steamworks_external_interface.rs
+++ b/desktop/src/backends/steamworks_external_interface.rs
@@ -1,0 +1,153 @@
+use ruffle_core::context::UpdateContext;
+use ruffle_core::external::{ExternalInterfaceProvider, Value as ExternalValue};
+use std::cell::RefCell;
+use steamworks::{AppId, CallbackResult, Client};
+
+#[derive(Default)]
+pub struct SteamWorksExternalInterfaceProvider {
+    pub client: RefCell<Option<Client>>,
+}
+
+impl ExternalInterfaceProvider for SteamWorksExternalInterfaceProvider {
+    fn call_method(
+        &self,
+        _context: &mut UpdateContext<'_>,
+        name: &str,
+        args: &[ExternalValue],
+    ) -> ExternalValue {
+        let Some(ref client) = *self.client.borrow() else {
+            if name == "steamworks.client.init" {
+                let client = if let [ExternalValue::Number(id)] = args {
+                    Client::init_app(AppId(*id as u32))
+                } else {
+                    Client::init()
+                };
+
+                match client {
+                    Ok(client) => {
+                        self.client.replace(Some(client));
+                    }
+                    Err(err) => {
+                        tracing::warn!("Client::init failed: {err}");
+                        return ExternalValue::String(err.to_string());
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    "Steamworks client not initialized! Expected call to steamworks.client.init."
+                );
+            }
+
+            return ExternalValue::Undefined;
+        };
+
+        // API is heavily inspired by https://github.com/ceifa/steamworks.js/
+
+        match name {
+            "steamworks.utils.getAppId" => ExternalValue::Number(client.utils().app_id().0 as f64),
+            "steamworks.utils.isSteamRunningOnSteamDeck" => {
+                ExternalValue::Bool(client.utils().is_steam_running_on_steam_deck())
+            }
+
+            "steamworks.localplayer.getSteamId" => {
+                ExternalValue::String(client.user().steam_id().steamid32())
+            }
+            "steamworks.localplayer.getName" => ExternalValue::String(client.friends().name()),
+            "steamworks.localplayer.getLevel" => {
+                ExternalValue::Number(client.user().level() as f64)
+            }
+            "steamworks.localplayer.getIpCountry" => {
+                ExternalValue::String(client.utils().ip_country())
+            }
+            "steamworks.localplayer.requestUserStats" => {
+                client
+                    .user_stats()
+                    .request_user_stats(client.user().steam_id().raw());
+                ExternalValue::Undefined
+            }
+
+            "steamworks.achievement.activate" => {
+                let [ExternalValue::String(achievement)] = args else {
+                    tracing::warn!("steamworks.achievement.activate: Expected string argument");
+                    return ExternalValue::Undefined;
+                };
+
+                ExternalValue::Bool(
+                    client
+                        .user_stats()
+                        .achievement(achievement)
+                        .set()
+                        .and_then(|_| client.user_stats().store_stats())
+                        .is_ok(),
+                )
+            }
+            "steamworks.achievement.isActivated" => {
+                let [ExternalValue::String(achievement)] = args else {
+                    tracing::warn!("steamworks.achievement.isActivated: Expected string argument");
+                    return ExternalValue::Undefined;
+                };
+
+                ExternalValue::Bool(
+                    client
+                        .user_stats()
+                        .achievement(achievement)
+                        .get()
+                        .unwrap_or(false),
+                )
+            }
+            "steamworks.achievement.clear" => {
+                let [ExternalValue::String(achievement)] = args else {
+                    tracing::warn!("steamworks.achievement.clear: Expected string argument");
+                    return ExternalValue::Undefined;
+                };
+
+                ExternalValue::Bool(
+                    client
+                        .user_stats()
+                        .achievement(achievement)
+                        .set()
+                        .and_then(|_| client.user_stats().store_stats())
+                        .is_ok(),
+                )
+            }
+            "steamworks.achievement.names" => {
+                let names = client
+                    .user_stats()
+                    .get_achievement_names()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(ExternalValue::String)
+                    .collect();
+                ExternalValue::List(names)
+            }
+
+            _ => {
+                tracing::warn!(
+                    "Trying to call unknown SteamWorksExternalInterfaceProvider method: {name}"
+                );
+                ExternalValue::Undefined
+            }
+        }
+    }
+
+    fn on_callback_available(&self, _name: &str) {}
+
+    fn get_id(&self) -> Option<String> {
+        None
+    }
+
+    fn update(&self, context: &mut UpdateContext<'_>) {
+        if let Some(ref client) = *self.client.borrow() {
+            #[expect(clippy::single_match)]
+            client.process_callbacks(|result| match result {
+                CallbackResult::UserStatsReceived(_) => {
+                    let name = "steamworks.callbacks.userStatsReceived";
+                    if let Some(callback) = context.external_interface.get_callback(name) {
+                        let _ = callback.call(context, name, vec![]);
+                    }
+                }
+                _ => {}
+            });
+        }
+    }
+}

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "steamworks")]
+use crate::backends::SteamWorksExternalInterfaceProvider;
 use crate::backends::{
     DesktopExternalInterfaceProvider, DesktopFSCommandProvider, DesktopNavigatorInterface,
     DesktopUiBackend,
@@ -284,6 +286,13 @@ impl ActivePlayer {
             builder = builder.with_external_interface(Box::new(DesktopExternalInterfaceProvider {
                 spoof_url: opt.player.spoof_url.clone(),
             }));
+        } else {
+            #[cfg(feature = "steamworks")]
+            {
+                builder = builder.with_external_interface(Box::new(
+                    SteamWorksExternalInterfaceProvider::default(),
+                ));
+            }
         }
 
         if !opt.gamepad_button_mapping.is_empty() {


### PR DESCRIPTION
This is a new optional feature, which allows SWFs running inside Ruffle to use (a currently very limited) subset of the [Steamworks API](https://partner.steamgames.com/doc/sdk/api). To make this API easily usable from both AS3 and AS2, I decided to implement this as a "fake" ExternalInterface. The current API is heavily inspired by [steamworks.js](https://github.com/ceifa/steamworks.js/).

~~The biggest missing piece is of course callback support.~~

I am not sure which APIs to prioritize.

After compiling ruffle with `cargo build --features steamworks` and including the right directory you can use the API like this:

```actionscript
package {
    import flash.display.Sprite;
    import steamworks.Client;

    public class Test extends Sprite {
        function Test() {
            var client: Client = new Client(480)

            trace("appId: " + client.utils.getAppId());

            trace("name: " + client.localPlayer.getName());
            trace("level: " + client.localPlayer.getLevel());
            trace("getIpCountry: " + client.localPlayer.getIpCountry());

            client.addEventListener(Client.USER_STATS_RECEIVED, function(): void {
                trace("USER_STATS_RECEIVED");
                trace("isActived('ACH_WIN_ONE_GAME'): " + client.achievement.isActivated('ACH_WIN_ONE_GAME'));

                trace(client.achievement.names());
            });
            client.localPlayer.requestUserStats();
        }
    }
}