### PR TITLE
core: Upgrade quick_xml and improve error handling when parsing xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,13 +4078,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.7.3"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546b279bf0638ee811d9e47de2ca5b66575a543035d79fdf83959dd2f5c3b4c3"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml 0.37.5",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -4261,18 +4261,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -4578,7 +4569,7 @@ dependencies = [
  "fnv",
  "gc-arena",
  "hashbrown 0.16.1",
- "quick-xml 0.38.4",
+ "quick-xml",
  "regress",
  "ruffle_macros",
  "ruffle_wstr",
@@ -4630,7 +4621,7 @@ dependencies = [
  "num-traits",
  "percent-encoding",
  "png",
- "quick-xml 0.38.4",
+ "quick-xml",
  "rand",
  "realfft",
  "regress",
@@ -5701,7 +5692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6524,9 +6515,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.11"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.12.1",
  "rustix 1.1.4",
@@ -6547,9 +6538,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.11"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
  "rustix 1.1.4",
  "wayland-client",
@@ -6558,9 +6549,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.9"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.12.1",
  "wayland-backend",
@@ -6570,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07a14257c077ab3279987c4f8bb987851bf57081b93710381daea94f2c2c032"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
  "bitflags 2.12.1",
  "wayland-backend",
@@ -6583,9 +6574,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
  "bitflags 2.12.1",
  "wayland-backend",
@@ -6596,12 +6587,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.7"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.37.5",
+ "quick-xml",
  "quote",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,7 +4084,7 @@ checksum = "546b279bf0638ee811d9e47de2ca5b66575a543035d79fdf83959dd2f5c3b4c3"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml",
+ "quick-xml 0.37.5",
  "serde",
  "time",
 ]
@@ -4264,6 +4264,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
@@ -4569,7 +4578,7 @@ dependencies = [
  "fnv",
  "gc-arena",
  "hashbrown 0.16.1",
- "quick-xml",
+ "quick-xml 0.38.4",
  "regress",
  "ruffle_macros",
  "ruffle_wstr",
@@ -4621,7 +4630,7 @@ dependencies = [
  "num-traits",
  "percent-encoding",
  "png",
- "quick-xml",
+ "quick-xml 0.38.4",
  "rand",
  "realfft",
  "regress",
@@ -5692,7 +5701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6592,7 +6601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.37.5",
  "quote",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ num-traits = "0.2.19"
 serde = "1.0.228"
 thiserror = "2.0.18"
 url = "2.5.8"
-quick-xml = "0.38.4"
+quick-xml = "0.39.4"
 regress = { git = "https://github.com/ruffle-rs/regras3", rev = "6d48179d6bd448f2cc66b76352c9f048dde968d1" }
 # Make sure to match wasm-bindgen-cli version to this everywhere.
 wasm-bindgen = "=0.2.120"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ num-traits = "0.2.19"
 serde = "1.0.228"
 thiserror = "2.0.18"
 url = "2.5.8"
-quick-xml = "0.37.5"
+quick-xml = "0.38.4"
 regress = { git = "https://github.com/ruffle-rs/regras3", rev = "6d48179d6bd448f2cc66b76352c9f048dde968d1" }
 # Make sure to match wasm-bindgen-cli version to this everywhere.
 wasm-bindgen = "=0.2.120"

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -141,37 +141,61 @@ impl<'gc> Xml<'gc> {
     ) -> Result<(), quick_xml::Error> {
         let data_utf8 = data.to_utf8_lossy();
         let mut parser = Reader::from_str(&data_utf8);
+        // Flash is lenient with lone `&` in text content.
+        parser.config_mut().allow_dangling_amp = true;
+
         let mut open_tags = vec![self.root()];
+        let mut text_buf: Vec<u8> = Vec::new();
 
         self.0.status.set(XmlStatus::NoError);
 
         loop {
-            let event = parser.read_event().map_err(|error| {
-                self.0.status.set(match error {
-                    quick_xml::Error::Syntax(_)
-                    | quick_xml::Error::InvalidAttr(AttrError::ExpectedEq(_))
-                    | quick_xml::Error::InvalidAttr(AttrError::Duplicated(_, _)) => {
-                        XmlStatus::ElementMalformed
+            let event = match parser.read_event() {
+                Ok(event) => event,
+                Err(error) => {
+                    // Flash keeps nodes parsed so far on a parse error. Flush
+                    // any buffered text (quick-xml emits entities as separate
+                    // events; the last run may still be in the buffer) before
+                    // bailing so it is not lost.
+                    if !text_buf.is_empty() {
+                        Self::handle_text_cdata(&text_buf, ignore_white, &open_tags, activation);
+                        text_buf.clear();
                     }
-                    quick_xml::Error::IllFormed(
-                        IllFormedError::MismatchedEndTag { .. }
-                        | IllFormedError::UnmatchedEndTag { .. },
-                    ) => XmlStatus::MismatchedEnd,
-                    quick_xml::Error::IllFormed(IllFormedError::MissingDeclVersion(_)) => {
-                        XmlStatus::DeclNotTerminated
-                    }
-                    quick_xml::Error::InvalidAttr(AttrError::UnquotedValue(_)) => {
-                        XmlStatus::AttributeNotTerminated
-                    }
-                    _ => XmlStatus::OutOfMemory,
-                    // Not accounted for:
-                    // quick_xml::Error::UnexpectedToken(_)
-                    // quick_xml::Error::UnexpectedBang
-                    // quick_xml::Error::TextNotFound
-                    // quick_xml::Error::EscapeError(_)
-                });
-                error
-            })?;
+                    self.0.status.set(match error {
+                        quick_xml::Error::Syntax(_)
+                        | quick_xml::Error::InvalidAttr(AttrError::ExpectedEq(_))
+                        | quick_xml::Error::InvalidAttr(AttrError::Duplicated(_, _)) => {
+                            XmlStatus::ElementMalformed
+                        }
+                        quick_xml::Error::IllFormed(
+                            IllFormedError::MismatchedEndTag { .. }
+                            | IllFormedError::UnmatchedEndTag { .. },
+                        ) => XmlStatus::MismatchedEnd,
+                        quick_xml::Error::IllFormed(IllFormedError::MissingDeclVersion(_)) => {
+                            XmlStatus::DeclNotTerminated
+                        }
+                        quick_xml::Error::InvalidAttr(AttrError::UnquotedValue(_)) => {
+                            XmlStatus::AttributeNotTerminated
+                        }
+                        _ => XmlStatus::OutOfMemory,
+                        // Not accounted for:
+                        // quick_xml::Error::UnexpectedToken(_)
+                        // quick_xml::Error::UnexpectedBang
+                        // quick_xml::Error::TextNotFound
+                        // quick_xml::Error::EscapeError(_)
+                    });
+                    return Err(error);
+                }
+            };
+
+            // Flush any buffered text before handling non-text events.
+            // CData stays a separate child, so flush before it too.
+            let needs_flush = !matches!(event, Event::Text(_) | Event::GeneralRef(_));
+
+            if needs_flush && !text_buf.is_empty() {
+                Self::handle_text_cdata(&text_buf, ignore_white, &open_tags, activation);
+                text_buf.clear();
+            }
 
             match event {
                 Event::Start(bs) => {
@@ -192,14 +216,20 @@ impl<'gc> Xml<'gc> {
                 Event::End(_) => {
                     open_tags.pop();
                 }
-                Event::Text(bt) => {
-                    Self::handle_text_cdata(
-                        avm1_unescape(&bt)
+                Event::Text(ref bt) => {
+                    text_buf.extend_from_slice(
+                        avm1_unescape(bt)
                             .map_err(|e| quick_xml::Error::Encoding(EncodingError::Utf8(e)))?
                             .as_bytes(),
-                        ignore_white,
-                        &open_tags,
-                        activation,
+                    );
+                }
+                Event::GeneralRef(ref br) => {
+                    let entity = crate::xml_util::reconstruct_entity_ref(br);
+
+                    text_buf.extend_from_slice(
+                        avm1_unescape(&entity)
+                            .map_err(|e| quick_xml::Error::Encoding(EncodingError::Utf8(e)))?
+                            .as_bytes(),
                     );
                 }
                 Event::CData(bt) => {

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -786,9 +786,16 @@ impl<'gc> E4XNode<'gc> {
 
         let data_utf8 = string.to_utf8_lossy();
         let mut parser = NsReader::from_str(&data_utf8);
+        // Flash is lenient with lone `&` in text content.
+        parser.config_mut().allow_dangling_amp = true;
+
         let mut open_tags: Vec<E4XNode<'gc>> = vec![];
 
         let mut top_level = vec![];
+        // Since quick-xml 0.38, character data adjacent to entity references is
+        // split into separate `Text` and `GeneralRef` events. Buffer them so a
+        // single text node is emitted, matching the pre-0.38 tree shape.
+        let mut pending_text: Vec<u8> = Vec::new();
 
         // This can't be a closure that captures these variables, because we need to modify them
         // outside of this body.
@@ -888,8 +895,23 @@ impl<'gc> E4XNode<'gc> {
                 _ => return Err(make_xml_error(activation, XmlErrorCode::ElementMalformed)),
             };
 
-            match &event {
-                Event::Start(bs) => {
+            // Flush buffered text before handling non-text events.
+            if !matches!(event, Event::Text(_) | Event::GeneralRef(_)) && !pending_text.is_empty() {
+                let text = avm2_unescape(&pending_text)
+                    .map_err(|_| make_xml_error(activation, XmlErrorCode::ElementMalformed))?;
+                handle_text_cdata(
+                    text.as_bytes(),
+                    ignore_white,
+                    &mut open_tags,
+                    &mut top_level,
+                    true,
+                    activation,
+                );
+                pending_text.clear();
+            }
+
+            match event {
+                Event::Start(ref bs) => {
                     let child = E4XNode::from_start_event(activation, &parser, bs)?;
 
                     if let Some(current_tag) = open_tags.last_mut() {
@@ -897,7 +919,7 @@ impl<'gc> E4XNode<'gc> {
                     }
                     open_tags.push(child);
                 }
-                Event::Empty(bs) => {
+                Event::Empty(ref bs) => {
                     let node = E4XNode::from_start_event(activation, &parser, bs)?;
                     push_childless_node(node, &mut open_tags, &mut top_level, activation);
                 }
@@ -907,21 +929,15 @@ impl<'gc> E4XNode<'gc> {
                         top_level.push(node);
                     }
                 }
-                Event::Text(bt) => {
-                    handle_text_cdata(
-                        avm2_unescape(bt)
-                            .map_err(|_| {
-                                make_xml_error(activation, XmlErrorCode::ElementMalformed)
-                            })?
-                            .as_bytes(),
-                        ignore_white,
-                        &mut open_tags,
-                        &mut top_level,
-                        true,
-                        activation,
-                    );
+                Event::Text(ref bt) => {
+                    pending_text.extend_from_slice(bt);
                 }
-                Event::CData(bt) => {
+                Event::GeneralRef(ref br) => {
+                    pending_text.push(b'&');
+                    pending_text.extend_from_slice(br);
+                    pending_text.push(b';');
+                }
+                Event::CData(ref bt) => {
                     // This is already unescaped
                     handle_text_cdata(
                         bt,
@@ -933,7 +949,7 @@ impl<'gc> E4XNode<'gc> {
                     );
                 }
 
-                Event::Comment(bt) => {
+                Event::Comment(ref bt) => {
                     if ignore_comments {
                         continue;
                     }
@@ -955,7 +971,7 @@ impl<'gc> E4XNode<'gc> {
 
                     push_childless_node(node, &mut open_tags, &mut top_level, activation);
                 }
-                Event::PI(bt) => {
+                Event::PI(ref bt) => {
                     if ignore_processing_instructions {
                         continue;
                     }

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -878,9 +878,10 @@ impl<'gc> E4XNode<'gc> {
                 }
                 Err(XmlError::Syntax(syntax_error)) => {
                     let code = match syntax_error {
-                        XmlSyntaxError::UnclosedPIOrXmlDecl => {
+                        XmlSyntaxError::UnclosedPI => {
                             XmlErrorCode::UnterminatedProcessingInstruction
                         }
+                        XmlSyntaxError::UnclosedXmlDecl => XmlErrorCode::UnterminatedXmlDecl,
                         XmlSyntaxError::UnclosedComment => XmlErrorCode::UnterminatedComment,
                         XmlSyntaxError::UnclosedDoctype => XmlErrorCode::UnterminatedDoctype,
                         XmlSyntaxError::UnclosedCData => XmlErrorCode::UnterminatedCData,
@@ -1052,7 +1053,7 @@ impl<'gc> E4XNode<'gc> {
                 .map_err(|_| make_xml_error(activation, XmlErrorCode::ElementMalformed))?;
             let value = AvmString::new_utf8(activation.gc(), value_str);
 
-            let (ns, local_name) = parser.resolve_attribute(attribute.key);
+            let (ns, local_name) = parser.resolver().resolve_attribute(attribute.key);
 
             let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
             let name = activation.strings().intern_wstr(local_name).into();
@@ -1101,7 +1102,7 @@ impl<'gc> E4XNode<'gc> {
             attribute_nodes.push(attribute);
         }
 
-        let (ns, local_name) = parser.resolve_element(bs.name());
+        let (ns, local_name) = parser.resolver().resolve_element(bs.name());
 
         let local_name = ruffle_wstr::from_utf8_bytes(local_name.into_inner());
         let name = activation.strings().intern_wstr(local_name).into();

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -199,7 +199,6 @@ pub enum XmlErrorCode {
     /// Error #1091: XML parser failure: Unterminated CDATA section.
     UnterminatedCData = 1091,
     /// Error #1092: XML parser failure: Unterminated XML declaration.
-    #[allow(unused)]
     UnterminatedXmlDecl = 1092,
     /// Error #1093: XML parser failure: Unterminated DOCTYPE declaration.
     UnterminatedDoctype = 1093,

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -713,12 +713,22 @@ impl FormatSpans {
 
         // Helper function to decode a byte sequence returned by quick_xml into a WString.
         // TODO: use Cow<'_, WStr>?
-        let decode_to_wstr = |raw: &[u8]| -> WString {
+        let decode_to_wstr = |raw: Cow<'_, [u8]>| -> WString {
             if is_raw_latin1 {
-                WString::from_buf(raw.to_vec())
+                WString::from_buf(raw.into_owned())
             } else {
-                let utf8 = std::str::from_utf8(raw).expect("raw should be valid utf8");
-                WString::from_utf8(utf8)
+                match raw {
+                    Cow::Borrowed(borrowed) => {
+                        let str = std::str::from_utf8(borrowed).expect("raw should be valid utf8");
+
+                        WString::from_utf8(str)
+                    }
+                    Cow::Owned(owned) => {
+                        let string = String::from_utf8(owned).expect("raw should be valid utf8");
+
+                        WString::from_utf8_owned(string)
+                    }
+                }
             }
         };
 
@@ -785,7 +795,7 @@ impl FormatSpans {
                                 .key
                                 .into_inner()
                                 .eq_ignore_ascii_case(name)
-                                .then(|| decode_to_wstr(&attribute.value))
+                                .then(|| decode_to_wstr(Cow::Borrowed(&attribute.value)))
                         })
                     };
                     let mut format = format_stack.last().unwrap().clone();
@@ -997,8 +1007,22 @@ impl FormatSpans {
                     opened_buffer.extend(tag_name);
                     format_stack.push(format);
                 }
+                Ok(Event::GeneralRef(ref br)) => {
+                    let raw = crate::xml_util::reconstruct_entity_ref(br);
+
+                    let e = decode_to_wstr(Cow::Owned(raw));
+                    let e = process_html_entity(&e).unwrap_or(e);
+                    let format = format_stack.last().unwrap().clone();
+
+                    if let Some(TextDisplay::None) = format.display {
+                        continue;
+                    }
+
+                    text.push_str(&e);
+                    spans.push(TextSpan::with_length_and_format(e.len(), &format));
+                }
                 Ok(Event::Text(e)) if !e.is_empty() => 'text: {
-                    let e = decode_to_wstr(&e.into_inner());
+                    let e = decode_to_wstr(e.into_inner());
                     let e = process_html_entity(&e).unwrap_or(e);
                     let format = format_stack.last().unwrap().clone();
                     if let Some(TextDisplay::None) = format.display {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,6 +48,7 @@ mod tessellation_cache;
 pub mod timer;
 mod types;
 mod vminterface;
+mod xml_util;
 
 pub mod backend;
 pub mod compatibility_rules;

--- a/core/src/xml_util.rs
+++ b/core/src/xml_util.rs
@@ -1,0 +1,8 @@
+use quick_xml::events::BytesRef;
+
+pub fn reconstruct_entity_ref(br: &BytesRef<'_>) -> Vec<u8> {
+    std::iter::once(b'&')
+        .chain(br.iter().copied())
+        .chain(std::iter::once(b';'))
+        .collect()
+}

--- a/tests/tests/swfs/from_avmplus/as3/RuntimeErrors/Error1092XmlUnterminatedXmlDecl/output.ruffle.txt
+++ b/tests/tests/swfs/from_avmplus/as3/RuntimeErrors/Error1092XmlUnterminatedXmlDecl/output.ruffle.txt
@@ -1,1 +1,0 @@
-Runtime Error FAILED! expected: TypeError: Error #1092 got: TypeError: Error #1097

--- a/tests/tests/swfs/from_avmplus/as3/RuntimeErrors/Error1092XmlUnterminatedXmlDecl/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/RuntimeErrors/Error1092XmlUnterminatedXmlDecl/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/e4x/XML/bug_564468/output.ruffle.txt
+++ b/tests/tests/swfs/from_avmplus/e4x/XML/bug_564468/output.ruffle.txt
@@ -1,5 +1,5 @@
 Asserting for TypeError PASSED!
-lowercase xml FAILED! expected: Error #1092 got: Error #1097
+lowercase xml PASSED!
 Asserting for TypeError PASSED!
 uppercase xml FAILED! expected: Error #1092 got: Error #1097
 Asserting for TypeError PASSED!

--- a/tests/tests/swfs/from_avmplus/e4x/XML/misc_errors/output.ruffle.txt
+++ b/tests/tests/swfs/from_avmplus/e4x/XML/misc_errors/output.ruffle.txt
@@ -25,7 +25,7 @@ wrong case end tag PASSED!
 Asserting for TypeError PASSED!
 missing attribute value PASSED!
 Asserting for TypeError PASSED!
-unterminated XML decl FAILED! expected: Error #1092 got: Error #1097
+unterminated XML decl PASSED!
 Asserting for TypeError PASSED!
 XML must start and end with same entity PASSED!
 Asserting for TypeError PASSED!


### PR DESCRIPTION
EDIT: This PR was repurposed to upgrade quick-xml to version 38 and adjust the code to the breaking changes. 

After https://github.com/tafia/quick-xml/issues/926 and https://github.com/tafia/quick-xml/issues/927 are implemented and after https://github.com/tafia/quick-xml/pull/924 is included in a new release, some more tests can be made to pass.

The breaking change that was introduced is that Event::GeneralRef was added, forcing us to rewrite both avm1 and avm2 logic, because text and references are now provided as separate events, but we have to merge them into one node. 

