### PR TITLE
chore: Mark all Pixel Bender tests as flaky

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,16 +1,8 @@
 # TODO: Figure out why these specific tests are flaky on CI, fix them, then delete this file.
+# Note: All Pixel Bender tests are flaky :( probably some unsoundness in naga, lavapipe?
 [[profile.ci.overrides]]
 filter = """
-test(avm2/pixelbender_shaderdata) or \
-test(avm2/pixelbender_conditional) or \
-test(avm2/pixelbender_conversions) or \
-test(avm2/pixelbender_div) or \
-test(avm2/pixelbender_eof) or \
-test(avm2/pixelbender_rsqrt) or \
-test(avm2/pixelbender_outputs) or \
-test(avm2/pixelbender_padding_bytes) or \
-test(avm2/pixelbender_parameters) or \
-test(avm2/pixelbender_parameters_bool) or \
+test(pixelbender) or \
 test(avm2/graphics_round_rects) or \
 test(avm1/netstream_play_flv_screen)"""
 retries = 4


### PR DESCRIPTION
Unfortunately, it seems that all Pixel Bender tests are flaky :/

According to the documentation, this should mark all tests that have `pixelbender` in their name as flaky.