### PR TITLE
chore: Mark avm1/netstream_play_flv as flaky

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,5 +4,6 @@
 filter = """
 test(pixelbender) or \
 test(avm2/graphics_round_rects) or \
+test(avm1/netstream_play_flv) or \
 test(avm1/netstream_play_flv_screen)"""
 retries = 4


### PR DESCRIPTION
It looks like avm1/netstream_play_flv is flaky too: https://github.com/ruffle-rs/ruffle/actions/runs/16299725240/job/46030922384