### PR TITLE
ci: Switch Windows GHA runners to windows-2025

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -112,14 +112,14 @@ jobs:
             DESKTOP_FEATURES: sandbox,jpegxr
 
           - build_name: windows-x86_32
-            os: windows-latest
+            os: windows-2025
             target: i686-pc-windows-msvc
             RUSTFLAGS: -Ctarget-feature=+crt-static
             DESKTOP_FEATURES: jpegxr
             MSI_ARCH: x86
 
           - build_name: windows-x86_64
-            os: windows-latest
+            os: windows-2025
             target: x86_64-pc-windows-msvc
             RUSTFLAGS: -Ctarget-feature=+crt-static
             DESKTOP_FEATURES: jpegxr

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         rust_version: [stable]
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-14]
         include:
           - rust_version: nightly
             os: ubuntu-24.04
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         rust_version: [stable]
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-14]
         include:
           - rust_version: nightly
             os: ubuntu-24.04

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         node_version: ["22", "24"]
-        os: [ubuntu-24.04, windows-latest]
+        os: [ubuntu-24.04, windows-2025]
 
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
       - name: Install wasm-opt
         # It runs for a long time, and the build is already slow on Windows,
         # where it doesn't have much benefit anyway - most tests are run on Ubuntu.
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2025'
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
@@ -198,7 +198,7 @@ jobs:
     strategy:
       matrix:
         node_version: ["22", "24"]
-        os: [ubuntu-24.04, windows-latest]
+        os: [ubuntu-24.04, windows-2025]
 
     steps:
       - name: No-op


### PR DESCRIPTION
This is more just to see whether anything will fail a month from now...

See: https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/#windows-latest-image-label-migration