### PR TITLE
avm2: Fix `decodeURI` failing on invalid UTF-16 sequences

### DIFF
--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -272,6 +272,18 @@ pub fn make_error_1033<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
     }
 }
 
+pub fn make_error_1052<'gc>(activation: &mut Activation<'_, 'gc>, func_name: &str) -> Error<'gc> {
+    let err = uri_error(
+        activation,
+        &format!("Error #1052: Invalid URI passed to {func_name} function."),
+        1052,
+    );
+    match err {
+        Ok(err) => Error::avm_error(err),
+        Err(err) => err,
+    }
+}
+
 pub fn make_error_1053<'gc>(
     activation: &mut Activation<'_, 'gc>,
     trait_name: AvmString<'gc>,

--- a/tests/tests/swfs/from_avmplus/regress/bug_538107/test.toml
+++ b/tests/tests/swfs/from_avmplus/regress/bug_538107/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Functions `decodeURI` and `decodeURIComponent` should not fail on invalid UTF-16 sequences.

See https://bugzilla.mozilla.org/show_bug.cgi?id=538107