### PR TITLE
avm2: Fix comparison of positive and negative zeros in `Math.max`/`min`

### DIFF
--- a/core/src/avm2/globals/math.rs
+++ b/core/src/avm2/globals/math.rs
@@ -90,7 +90,7 @@ pub fn max<'gc>(
         let val = arg.coerce_to_number(activation)?;
         if val.is_nan() {
             return Ok(f64::NAN.into());
-        } else if val > cur_max {
+        } else if val.total_cmp(&cur_max).is_gt() {
             cur_max = val;
         };
     }
@@ -107,7 +107,7 @@ pub fn min<'gc>(
         let val = arg.coerce_to_number(activation)?;
         if val.is_nan() {
             return Ok(f64::NAN.into());
-        } else if val < cur_min {
+        } else if val.total_cmp(&cur_min).is_lt() {
             cur_min = val;
         }
     }

--- a/tests/tests/swfs/from_avmplus/as3/Math/e15_8_2_11_rest/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Math/e15_8_2_11_rest/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/as3/Math/e15_8_2_12_rest/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Math/e15_8_2_12_rest/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/regress/bug_551587/test.toml
+++ b/tests/tests/swfs/from_avmplus/regress/bug_551587/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Flash Player treats the negative zero as smaller than the positive zero. The default partial comparison in Rust assumes that they are equal.

This patch uses the total comparison that makes sure we're ordering them properly.

See https://bugzilla.mozilla.org/show_bug.cgi?id=551587