### PR TITLE
WIP: core: Support a PlaceObject by AS3 class name instead of character ID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ panic = "unwind"
 
 [profile.release]
 panic = "abort"
+#incremental = true
 
 [profile.dev.package.h263-rs]
 opt-level = 3

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -1929,15 +1929,21 @@ impl<'a> Reader<'a> {
             None
         };
 
-        let action = match (flags.contains(PlaceFlag::MOVE), has_character_id) {
-            (true, false) => PlaceObjectAction::Modify,
-            (false, true) => {
+        let action = match (flags.contains(PlaceFlag::MOVE), has_character_id, has_class_name) {
+            (true, false, false) => PlaceObjectAction::Modify,
+            (false, true, false) => {
                 let id = self.read_u16()?;
                 PlaceObjectAction::Place(id)
             }
-            (true, true) => {
+            (false, false, true) => {
+                PlaceObjectAction::Place(65530)
+            }
+            (true, true, false) => {
                 let id = self.read_u16()?;
                 PlaceObjectAction::Replace(id)
+            }
+            (true, false, true) => {
+                PlaceObjectAction::Replace(65530)
             }
             _ => return Err(Error::invalid_data("Invalid PlaceObject type")),
         };


### PR DESCRIPTION
This fixes issues with "Invalid PlaceObject type" in name, but only tested on #14745 .

TODO:

- instead of `context.avm2.stage_domain()`, it should (I assume, need to check to be sure) use the domain from library of the swf this tag belongs to,
- - also, currently our SymbolClass registry can return a symbol from a different movie. Our SymbolClass registry being global is probably wrong, but it also sounds possible for a child SWF to register a Sprite subclass to parent's domain. Could check if FP supports this and make sure it works here too. One way would be to replace the "get the id from symbolclass" implementation by just `let as3_stage_object = class.construct(activation, &[]);`. and then get the DO from the AS3 object. (this can also be left unimplemented with just a stub log for the future :P )
- - PS just realized, it may be possible that this feature doesn't require SymbolClass at all, as in you just write `class MySprite extends Sprite {}` and the PlaceObject "just works"; if that's confirmed to be the case, the implementation will definitely need to be swapped out for `class.construct()`.
- check if there are more places than `instantiate_child` where we should respect the PlaceObject class name, then move the code outside of `instantiate_child` to some common function? (For example, currently this doesn't support `PlaceObjectAction::Replace` in `fn place_object`)
- write some nicer way to communicate "this is a `PlaceObjectAction::Place`, but there's no id", my current solution is a hack (the magic number 65530). In fact, IMO it's kinda weird that `instantiate_child` takes a PlaceObject and the id (which comes from this PlaceObject) as a separate argument - maybe this could be refactored as a whole?

If someone wants to pick this up, just let me know, I'm not sure when I'd be able to continue this myself.