### PR TITLE
demo: Check if SWF sample type is undefined, not null

### DIFF
--- a/web/packages/demo/src/navbar/samples.tsx
+++ b/web/packages/demo/src/navbar/samples.tsx
@@ -21,7 +21,7 @@ export interface DemoSwf {
     author?: string;
     authorLink?: string;
     config?: Config.BaseLoadOptions;
-    type: SampleCategory | null;
+    type?: SampleCategory;
 }
 
 interface SampleSelectionProperties {
@@ -87,7 +87,7 @@ export function SampleSelection({
             >
                 {availableSamples.map((sample, i) => (
                     <Fragment key={i}>
-                        {sample.type === null && (
+                        {sample.type === undefined && (
                             <option value={i}>{sample.title}</option>
                         )}
                     </Fragment>


### PR DESCRIPTION
We don't define a type for the Ruffle logo SWF in swfs.json. That means its type is undefined, not null.

This fixes the Ruffle Logo entry not appearing in the Sample SWF dropdown (regressed by #20448)