### PR TITLE
Updated PKGBUILD file to support Arm64

### DIFF
--- a/desktop/packages/linux/aur/ruffle-nightly-bin/PKGBUILD
+++ b/desktop/packages/linux/aur/ruffle-nightly-bin/PKGBUILD
@@ -3,14 +3,16 @@ pkgname=ruffle-nightly-bin
 pkgver=@VERSION@
 pkgrel=1
 pkgdesc="A Flash Player emulator written in Rust"
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url="https://ruffle.rs/"
 license=('Apache' 'MIT')
 depends=(zlib libxcb alsa-lib)
 provides=(ruffle)
 conflicts=(ruffle)
-source=("https://github.com/ruffle-rs/ruffle/releases/download/nightly-${pkgver//./-}/ruffle-nightly-${pkgver//./_}-linux-x86_64.tar.gz")
-sha512sums=(@SHA512SUM_x86_64@)
+source_x86_64=("https://github.com/ruffle-rs/ruffle/releases/download/nightly-${pkgver//./-}/ruffle-nightly-${pkgver//./_}-linux-x86_64.tar.gz")
+source_aarch64=("https://github.com/ruffle-rs/ruffle/releases/download/nightly-${pkgver//./-}/ruffle-nightly-${pkgver//./_}-linux-aarch64.tar.gz")
+sha512sums_x86_64=(@SHA512SUM_x86_64@)
+sha512sums_aarch64=(@SHA512SUM_aarch64@)
 
 package() {
 	cd "$srcdir/"


### PR DESCRIPTION
With this change the AUR package will now support ARM64

* Fixes https://github.com/ruffle-rs/ruffle/issues/21273