### PR TITLE
ci: Switch Mac GHA runners to macos-15

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -100,13 +100,13 @@ jobs:
 
           # Mac does two Rust builds to make a universal binary
           - build_name: macos-x86_64
-            os: macos-14
+            os: macos-15
             target: x86_64-apple-darwin
             MACOSX_DEPLOYMENT_TARGET: 10.7
             DESKTOP_FEATURES: sandbox,jpegxr
 
           - build_name: macos-aarch64
-            os: macos-14
+            os: macos-15
             target: aarch64-apple-darwin
             MACOSX_DEPLOYMENT_TARGET: 11.0
             DESKTOP_FEATURES: sandbox,jpegxr
@@ -225,7 +225,7 @@ jobs:
   build-mac-universal-binary:
     name: Build macOS universal binary
     needs: [create-nightly-release, build, build-browser-extensions]
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       PACKAGE_FILE: ${{ needs.create-nightly-release.outputs.package_prefix }}-macos-universal.tar.gz
     steps:

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         rust_version: [stable]
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]
         include:
           - rust_version: nightly
             os: ubuntu-24.04
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         rust_version: [stable]
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]
         include:
           - rust_version: nightly
             os: ubuntu-24.04


### PR DESCRIPTION
Not entirely unlike https://github.com/ruffle-rs/ruffle/pull/21202.
See: https://github.com/actions/runner-images/issues/12520