### PR TITLE
core: Force correct alignment for `DisplayObjectBase`

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -192,6 +192,8 @@ impl BitmapCache {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
+// Ensure this always has the same alignment as its subclasses (needed for `Gc` casts).
+#[repr(align(8))]
 pub struct DisplayObjectBase<'gc> {
     cell: RefCell<DisplayObjectBaseMut>,
     parent: Lock<Option<DisplayObject<'gc>>>,


### PR DESCRIPTION
On certain architectures (e.g. 32-bits Android), `f64`s are only 4-aligned, so we need to increase the alignment of `DisplayObjectBase` to always match with its subclasses.