### PR TITLE
avm2: Defer nextFrame calls from frame scripts for FP9 compatibility

### DIFF
--- a/tests/tests/swfs/timeline/events/fp9/test.toml
+++ b/tests/tests/swfs/timeline/events/fp9/test.toml
@@ -1,4 +1,3 @@
 # Test adapted from Shumway at https://github.com/mozilla/shumway/tree/master/test/swfs/timeline/events
 
 num_frames = 4
-known_failure = true # https://github.com/ruffle-rs/ruffle/issues/12141


### PR DESCRIPTION
This makes the timeline/events/fp9 test pass.