### PR TITLE
avm1: Defer movie loading to start of next frame

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1604,7 +1604,7 @@ fn load_movie<'gc>(
         None,
         crate::loader::MovieLoaderVMData::Avm1 { broadcaster: None },
     );
-    activation.context.navigator.spawn_future(future);
+    activation.context.avm1.deferred_loads.push(future);
 
     Ok(Value::Undefined)
 }
@@ -1625,7 +1625,7 @@ fn load_variables<'gc>(
         target,
         request,
     );
-    activation.context.navigator.spawn_future(future);
+    activation.context.avm1.deferred_loads.push(future);
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -64,7 +64,7 @@ fn load_clip<'gc>(
                         broadcaster: Some(this),
                     },
                 );
-                activation.context.navigator.spawn_future(future);
+                activation.context.avm1.deferred_loads.push(future);
 
                 return Ok(true.into());
             }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -503,7 +503,7 @@ pub struct ActionQueue<'gc> {
 
 impl<'gc> ActionQueue<'gc> {
     const DEFAULT_CAPACITY: usize = 32;
-    const NUM_PRIORITIES: usize = 3;
+    const NUM_PRIORITIES: usize = 5;
 
     /// Crates a new `ActionQueue` with an empty queue.
     pub fn new() -> Self {
@@ -652,6 +652,18 @@ pub enum ActionType<'gc> {
         args: Vec<Avm1Value<'gc>>,
     },
 
+    OnLoad {
+        object: Avm1Object<'gc>,
+        name: AvmString<'gc>,
+        args: Vec<Avm1Value<'gc>>,
+    },
+
+    OnLoadInit {
+        object: Avm1Object<'gc>,
+        name: AvmString<'gc>,
+        args: Vec<Avm1Value<'gc>>,
+    },
+
     /// A system listener method.
     NotifyListeners {
         listener: AvmString<'gc>,
@@ -663,9 +675,11 @@ pub enum ActionType<'gc> {
 impl ActionType<'_> {
     fn priority(&self) -> usize {
         match self {
-            ActionType::Initialize { .. } => 2,
-            ActionType::Construct { .. } => 1,
-            _ => 0,
+            ActionType::Initialize { .. } => 4,
+            ActionType::Construct { .. } => 3,
+            ActionType::OnLoadInit { .. } => 1,
+            ActionType::OnLoad { .. } => 0,
+            _ => 2,
         }
     }
 }
@@ -691,6 +705,18 @@ impl fmt::Debug for ActionType<'_> {
                 .finish(),
             ActionType::Method { object, name, args } => f
                 .debug_struct("ActionType::Method")
+                .field("object", object)
+                .field("name", name)
+                .field("args", args)
+                .finish(),
+            ActionType::OnLoad { object, name, args } => f
+                .debug_struct("ActionType::OnLoad")
+                .field("object", object)
+                .field("name", name)
+                .field("args", args)
+                .finish(),
+            ActionType::OnLoadInit { object, name, args } => f
+                .debug_struct("ActionType::OnLoadInit")
                 .field("object", object)
                 .field("name", name)
                 .field("args", args)

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2698,15 +2698,27 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
                 // (e.g., clip.onEnterFrame = foo).
                 if self.should_fire_event_handlers(context, event) {
                     if let Some(name) = event.method_name(&context.strings) {
-                        context.action_queue.queue_action(
-                            self.into(),
-                            ActionType::Method {
-                                object,
-                                name,
-                                args: vec![],
-                            },
-                            event == ClipEvent::Unload,
-                        );
+                        if let ClipEvent::Load = event {
+                            context.action_queue.queue_action(
+                                self.into(),
+                                ActionType::OnLoad {
+                                    object,
+                                    name,
+                                    args: vec![],
+                                },
+                                event == ClipEvent::Unload,
+                            );
+                        } else {
+                            context.action_queue.queue_action(
+                                self.into(),
+                                ActionType::Method {
+                                    object,
+                                    name,
+                                    args: vec![],
+                                },
+                                event == ClipEvent::Unload,
+                            );
+                        }
                     }
                 }
             }

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -2703,7 +2703,7 @@ impl<'gc> Loader<'gc> {
                 {
                     queue.queue_action(
                         clip,
-                        ActionType::Method {
+                        ActionType::OnLoadInit {
                             object: broadcaster,
                             name: istr!(strings, "broadcastMessage"),
                             args: vec![istr!(strings, "onLoadInit").into(), clip.object()],

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2146,6 +2146,14 @@ impl Player {
                     Avm1::run_stack_frame_for_method(action.clip, object, name, &args, context);
                 }
 
+                ActionType::OnLoad { object, name, args } => {
+                    Avm1::run_stack_frame_for_method(action.clip, object, name, &args, context);
+                }
+
+                ActionType::OnLoadInit { object, name, args } => {
+                    Avm1::run_stack_frame_for_method(action.clip, object, name, &args, context);
+                }
+
                 // Event handler method call (e.g. onEnterFrame).
                 ActionType::NotifyListeners {
                     listener,

--- a/tests/tests/swfs/avm1/focusrect_property_swf5/test.toml
+++ b/tests/tests/swfs/avm1/focusrect_property_swf5/test.toml
@@ -1,1 +1,1 @@
-num_ticks = 2
+num_ticks = 3

--- a/tests/tests/swfs/avm1/focusrect_property_swf6/test.toml
+++ b/tests/tests/swfs/avm1/focusrect_property_swf6/test.toml
@@ -1,1 +1,1 @@
-num_ticks = 2
+num_ticks = 3

--- a/tests/tests/swfs/avm1/focusrect_property_swf7/test.toml
+++ b/tests/tests/swfs/avm1/focusrect_property_swf7/test.toml
@@ -1,1 +1,1 @@
-num_ticks = 2
+num_ticks = 3

--- a/tests/tests/swfs/avm1/from_shumway/moviecliploader/test.toml
+++ b/tests/tests/swfs/avm1/from_shumway/moviecliploader/test.toml
@@ -1,4 +1,3 @@
 # Test adapted from Shumway at https://github.com/mozilla/shumway/tree/master/test/swfs/avm1/moviecliploader
 
-num_frames = 3
-known_failure = true # https://github.com/ruffle-rs/ruffle/issues/12273
+num_frames = 4

--- a/tests/tests/swfs/avm1/loadmovie_fail/test.toml
+++ b/tests/tests/swfs/avm1/loadmovie_fail/test.toml
@@ -1,1 +1,1 @@
-num_frames = 1
+num_frames = 2

--- a/tests/tests/swfs/avm1/loadmovie_method/test.toml
+++ b/tests/tests/swfs/avm1/loadmovie_method/test.toml
@@ -1,1 +1,1 @@
-num_frames = 2
+num_frames = 3

--- a/tests/tests/swfs/avm1/loadmovie_var_persistence/test.toml
+++ b/tests/tests/swfs/avm1/loadmovie_var_persistence/test.toml
@@ -1,1 +1,1 @@
-num_ticks = 6
+num_ticks = 7

--- a/tests/tests/swfs/avm1/lock_root/test.toml
+++ b/tests/tests/swfs/avm1/lock_root/test.toml
@@ -1,1 +1,1 @@
-num_frames = 2
+num_frames = 3

--- a/tests/tests/swfs/avm1/mcl_loadclip_properties/test.toml
+++ b/tests/tests/swfs/avm1/mcl_loadclip_properties/test.toml
@@ -1,1 +1,1 @@
-num_ticks = 2
+num_ticks = 3

--- a/tests/tests/swfs/avm1/mcl_loadclip_replace_root/test.toml
+++ b/tests/tests/swfs/avm1/mcl_loadclip_replace_root/test.toml
@@ -1,1 +1,1 @@
-num_ticks = 2
+num_ticks = 3

--- a/tests/tests/swfs/avm1/moviecliploader_flashvars/test.toml
+++ b/tests/tests/swfs/avm1/moviecliploader_flashvars/test.toml
@@ -1,1 +1,1 @@
-num_ticks = 2
+num_ticks = 3

--- a/tests/tests/swfs/avm1/register_class/test.toml
+++ b/tests/tests/swfs/avm1/register_class/test.toml
@@ -1,1 +1,1 @@
-num_frames = 3
+num_frames = 6

--- a/tests/tests/swfs/avm1/register_class_swf6/test.toml
+++ b/tests/tests/swfs/avm1/register_class_swf6/test.toml
@@ -1,1 +1,1 @@
-num_frames = 3
+num_frames = 6

--- a/tests/tests/swfs/avm1/root_onload/test.toml
+++ b/tests/tests/swfs/avm1/root_onload/test.toml
@@ -1,2 +1,1 @@
 num_frames = 1
-known_failure = true

--- a/tests/tests/swfs/avm1/sandbox_type_remote/test.toml
+++ b/tests/tests/swfs/avm1/sandbox_type_remote/test.toml
@@ -1,1 +1,1 @@
-num_ticks = 3
+num_ticks = 400

--- a/tests/tests/swfs/avm1/string_paths_eval2/test.toml
+++ b/tests/tests/swfs/avm1/string_paths_eval2/test.toml
@@ -1,1 +1,1 @@
-num_frames = 5
+num_frames = 6


### PR DESCRIPTION
This fixes Final Fortress, root.onLoad and from_shumway/moviecliploader. This doesn't pass tests though, I would need assistance with this.