### PR TITLE
debug_ui: Add layout debug information on EditTexts

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1541,6 +1541,10 @@ impl<'gc> EditText<'gc> {
         self.0.text_spans.borrow()
     }
 
+    pub fn layout(&self) -> Ref<'_, Layout<'gc>> {
+        self.0.layout.borrow()
+    }
+
     pub fn render_settings(self) -> TextRenderSettings {
         self.0.render_settings.get()
     }

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -1315,6 +1315,14 @@ impl<'gc> FontSet<'gc> {
             },
         ))
     }
+
+    pub fn main_font(&self) -> Font<'gc> {
+        self.0.main_font
+    }
+
+    pub fn fallback_fonts(&self) -> &[Font<'gc>] {
+        &self.0.fallback_fonts
+    }
 }
 
 impl<'gc> FontLike<'gc> for FontSet<'gc> {

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -1378,6 +1378,10 @@ impl<'gc> LayoutBox<'gc> {
         }
     }
 
+    pub fn text_range(&self) -> Range<usize> {
+        self.start()..self.end()
+    }
+
     /// Return x-axis char bounds of the given char relative to the whole layout.
     pub fn char_x_bounds(&self, position: usize) -> Option<(Twips, Twips)> {
         let relative_position = position.checked_sub(self.start())?;


### PR DESCRIPTION
Makes it easier to debug device text issues such as https://github.com/ruffle-rs/ruffle/issues/21301.

<img height="300" src="https://github.com/user-attachments/assets/1c4980eb-cf8d-4c2c-aba6-ab1a9ead7aaa" />
