### PR TITLE
ci: Add test coverage

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -13,6 +13,9 @@ concurrency:
 env:
   FEATURES: lzma,jpegxr
   TEST_OPTS: --workspace --locked --no-fail-fast -j 4
+  LLVM_COV_OPTS: --branch --profile ci ${TEST_OPTS} --features ${FEATURES},imgtests
+
+  LINUX_DEPENDENCIES: libasound2-dev mesa-vulkan-drivers libudev-dev
 
   # This is to counteract the disabling by rust-cache.
   # See: https://github.com/Swatinem/rust-cache/issues/43
@@ -77,7 +80,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt install -y libasound2-dev mesa-vulkan-drivers libudev-dev
+          sudo apt install -y ${{ env.LINUX_DEPENDENCIES }}
 
       - name: Enable image tests
         if: runner.os != 'macOS'
@@ -135,7 +138,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt install -y libasound2-dev mesa-vulkan-drivers libudev-dev
+          sudo apt install -y ${{ env.LINUX_DEPENDENCIES }}
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -152,6 +155,49 @@ jobs:
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings
+
+  coverage:
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
+    name: Coverage Report
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        # We need nightly for coverage due to:
+        #  1. wayland-backend requiring that,
+        #  2. branch coverage being unstable.
+        #
+        # Ad 1.
+        #   See <https://github.com/Smithay/wayland-rs/commit/05d8307ea647053b949357eb8588dfdab394f4fe>
+        # Ad 2.
+        #   See <https://github.com/taiki-e/cargo-llvm-cov/issues/8>
+        #   See <https://github.com/rust-lang/rust/issues/79649>
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools
+
+      - name: Install llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install -y ${{ env.LINUX_DEPENDENCIES }}
+
+      - name: Run llvm-cov for SWF tests
+        working-directory: tests
+        run: cargo llvm-cov --html ${{ env.LLVM_COV_OPTS }}
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvm-cov
+          path: target/llvm-cov
 
   dependencies:
     needs: changes


### PR DESCRIPTION
Coverage Report computes coverage of SWF tests after each PR.

This can be used to assess how well the newly added code is covered.

I've tried using `tarpaulin` and `llvm-cov`. The output of `llvm-cov` was a lot more accurate and it took around the same time to run. Running `llvm-cov` with `nextest` caused tests to execute over 4 times slower compared to `test`. Still, coverage runs faster than tests on Windows, which remains the longest executing job for a PR.

Things to do in the future:

* add coverage for all tests; this was impossible with `tarpaulin` (due to errors), but should be possible with `llvm-cov`; it's still worth keeping SWF-tests-only coverage, as it informs us about what code is tested in terms of compatibility with FP,
* ignore known failures as they don't contribute towards coverage.