### PR TITLE
avm2: Correct error text in LocalConnectionObject::run_method

### DIFF
--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -141,10 +141,19 @@ impl<'gc> LocalConnectionObject<'gc> {
                 Some(error) => {
                     let event_name = istr!("asyncError");
                     let async_error_event_cls = activation.avm2().classes().asyncerrorevent;
+
+                    let text = AvmString::new_utf8(activation.gc(), format!("Error #2095: flash.net.LocalConnection was unable to invoke callback {method_name}."));
+
                     let event = EventObject::from_class_and_args(
                         &mut activation,
                         async_error_event_cls,
-                        &[event_name.into(), false.into(), false.into(), error, error],
+                        &[
+                            event_name.into(),
+                            false.into(),
+                            false.into(),
+                            text.into(),
+                            error,
+                        ],
                     );
 
                     Avm2::dispatch_event(activation.context, event, (*self).into());

--- a/tests/tests/swfs/from_shumway/localconnection/test.toml
+++ b/tests/tests/swfs/from_shumway/localconnection/test.toml
@@ -1,5 +1,4 @@
 num_ticks = 3
-known_failure = true
 
 [image_comparisons.output]
 tolerance = 5


### PR DESCRIPTION
This is probably not quite correct, but with a proper error constructor, there's an extra 'Error: ' in the error text, failing the test. Hopefully someone knows the proper way to do this