### PR TITLE
ci: Update metainfo automatically in release commits

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -63,6 +63,11 @@ jobs:
           shopt -s globstar
           sed -i -e '$a\' **/package.json
 
+      - name: Update metainfo
+        if: steps.activity.outputs.is_active == 'true'
+        run: |
+          $RELEASE_SCRIPT metainfo
+
       - name: Create release commit
         if: steps.activity.outputs.is_active == 'true'
         id: commit

--- a/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml.in
+++ b/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <component type="desktop-application">
     <id>rs.ruffle.Ruffle</id>
     <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
Metainfo contains information about releases.  By updating it automatically on each release commit, we can make sure all downstreams have valid metainfo with proper releases.

It's a follow-up to https://github.com/ruffle-rs/ruffle/pull/20860

It hasn't been end-to-end tested, but the code has been adapted from stable releases branch (and it worked there), and the worst case scenario is a failed nightly release. The Python script works properly.