### PR TITLE
web: Allow data-ruffle-optout for any element to opt-out that section

### DIFF
--- a/web/packages/core/src/internal/player/ruffle-embed-element.ts
+++ b/web/packages/core/src/internal/player/ruffle-embed-element.ts
@@ -1,4 +1,8 @@
-import { copyElement, RufflePlayerElement } from "./ruffle-player-element";
+import {
+    copyElement,
+    hasOptOut,
+    RufflePlayerElement,
+} from "./ruffle-player-element";
 import {
     getPolyfillOptions,
     isFallbackElement,
@@ -117,6 +121,11 @@ export class RuffleEmbedElement extends RufflePlayerElement {
 
         // Don't polyfill if the element is inside a specific node.
         if (isFallbackElement(elem)) {
+            return false;
+        }
+
+        // Don't polyfill if the element or its ancestor has data-ruffle-optout.
+        if (hasOptOut(elem)) {
             return false;
         }
 

--- a/web/packages/core/src/internal/player/ruffle-object-element.ts
+++ b/web/packages/core/src/internal/player/ruffle-object-element.ts
@@ -1,4 +1,8 @@
-import { copyElement, RufflePlayerElement } from "./ruffle-player-element";
+import {
+    copyElement,
+    hasOptOut,
+    RufflePlayerElement,
+} from "./ruffle-player-element";
 import {
     getPolyfillOptions,
     isFallbackElement,
@@ -174,6 +178,11 @@ export class RuffleObjectElement extends RufflePlayerElement {
     static isInterdictable(elem: Element): boolean {
         // Don't polyfill if the element is inside a specific node.
         if (isFallbackElement(elem)) {
+            return false;
+        }
+
+        // Don't polyfill if the element or its ancestor has data-ruffle-optout.
+        if (hasOptOut(elem)) {
             return false;
         }
 

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -213,3 +213,23 @@ export function copyElement(element: Element, destination: Element): void {
         }
     }
 }
+
+/**
+ * Checks whether a given element is inside an "opt-out" zone for Ruffle.
+ *
+ * @param element The element to check.
+ * @returns true if the element or its ancestor has data-ruffle-optout and not set to ignore opt-out, else false.
+ */
+export function hasOptOut(element: Element): boolean {
+    // We could try to pass the config specific to this element all the way
+    // but only the extension can set ignoreOptout and when it does
+    // it gets added to the global RufflePlayer config, so this is simpler.
+    const globalConfig = window.RufflePlayer?.config ?? {};
+    if ("ignoreOptout" in globalConfig && globalConfig["ignoreOptout"]) {
+        return false;
+    }
+    if (element.closest("[data-ruffle-optout]")) {
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
The purpose is so if a single page has some content that works with Ruffle and some that does not you can add this directly to the embeds that don't work, or even to some parent div of all the embeds that don't work with Ruffle. It still can be ignored with the "Play Flash content even on sites that disallow Ruffle" toggle.

Before this, you could only opt-out of Ruffle page-wide with data-ruffle-optout on the https://developer.mozilla.org/en-US/docs/Web/API/Document/documentElement of the page or iframe.

Requested on Discord.