### PR TITLE
tests: Disable default font feature by default

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2495,6 +2495,8 @@ pub struct PlayerBuilder {
     #[cfg(feature = "known_stubs")]
     stub_report_output: Option<std::path::PathBuf>,
     avm2_optimizer_enabled: bool,
+    #[cfg(feature = "default_font")]
+    default_font: bool,
 }
 
 impl PlayerBuilder {
@@ -2549,6 +2551,8 @@ impl PlayerBuilder {
             #[cfg(feature = "known_stubs")]
             stub_report_output: None,
             avm2_optimizer_enabled: true,
+            #[cfg(feature = "default_font")]
+            default_font: true,
         }
     }
 
@@ -2770,6 +2774,12 @@ impl PlayerBuilder {
         self
     }
 
+    #[cfg(feature = "default_font")]
+    pub fn with_default_font(mut self, value: bool) -> Self {
+        self.default_font = value;
+        self
+    }
+
     fn create_gc_root<'gc>(
         gc_context: &'gc Mutation<'gc>,
         player_version: u8,
@@ -2944,7 +2954,7 @@ impl PlayerBuilder {
         let mut player_lock = player.lock().unwrap();
 
         #[cfg(feature = "default_font")]
-        {
+        if self.default_font {
             use crate::font::FontFileData;
             use flate2::read::DeflateDecoder;
             use std::io::Read;

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -156,6 +156,7 @@ pub struct PlayerOptions {
     with_video: bool,
     runtime: PlayerRuntime,
     mode: Option<PlayerMode>,
+    with_default_font: bool,
 }
 
 impl PlayerOptions {
@@ -181,7 +182,8 @@ impl PlayerOptions {
         player_builder = player_builder
             .with_player_runtime(self.runtime)
             // Assume flashplayerdebugger is used in tests
-            .with_player_mode(self.mode.unwrap_or(PlayerMode::Debug));
+            .with_player_mode(self.mode.unwrap_or(PlayerMode::Debug))
+            .with_default_font(self.with_default_font);
 
         if self.with_video {
             #[cfg(feature = "ruffle_video_external")]

--- a/tests/tests/swfs/avm1/device_font_spacing/test.toml
+++ b/tests/tests/swfs/avm1/device_font_spacing/test.toml
@@ -1,1 +1,5 @@
 num_frames = 1
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm1/edittext_drag_select/test.toml
+++ b/tests/tests/swfs/avm1/edittext_drag_select/test.toml
@@ -1,1 +1,5 @@
 num_ticks = 1
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm1/edittext_hscroll/test.toml
+++ b/tests/tests/swfs/avm1/edittext_hscroll/test.toml
@@ -2,3 +2,7 @@ num_frames = 1
 
 [approximations]
 epsilon = 2.0
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm1/from_shumway/text_bind/test.toml
+++ b/tests/tests/swfs/avm1/from_shumway/text_bind/test.toml
@@ -7,3 +7,5 @@ tolerance = 0
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm1/gettextextent/test.toml
+++ b/tests/tests/swfs/avm1/gettextextent/test.toml
@@ -3,3 +3,7 @@ num_frames = 1
 [approximations]
 # TODO: Flash Player breaks single words that are longer than the line, but we don't.
 epsilon = 30.0
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/away3d_advanced_shallow_water_demo/test.toml
+++ b/tests/tests/swfs/avm2/away3d_advanced_shallow_water_demo/test.toml
@@ -6,3 +6,5 @@ max_outliers = 400
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/bitmapdata_applyfilter_blur/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_applyfilter_blur/test.toml
@@ -5,3 +5,5 @@ tolerance = 12
 
 [player_options]
 with_renderer = { sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/bitmapdata_applyfilter_colormatrix/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_applyfilter_colormatrix/test.toml
@@ -5,3 +5,5 @@ tolerance = 2
 
 [player_options]
 with_renderer = { sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/bitmapdata_draw/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_draw/test.toml
@@ -5,3 +5,5 @@ tolerance = 0
 
 [player_options]
 with_renderer = { optional = true, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/bitmapdata_drawwithquality/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_drawwithquality/test.toml
@@ -5,3 +5,5 @@ tolerance = 8
 
 [player_options]
 with_renderer = { sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/edittext_always_show_selection/test.toml
+++ b/tests/tests/swfs/avm2/edittext_always_show_selection/test.toml
@@ -5,3 +5,5 @@ trigger = 1
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/edittext_at_point_methods_basic/test.toml
+++ b/tests/tests/swfs/avm2/edittext_at_point_methods_basic/test.toml
@@ -1,1 +1,5 @@
 num_ticks = 1
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/edittext_get_line_index_of_char/test.toml
+++ b/tests/tests/swfs/avm2/edittext_get_line_index_of_char/test.toml
@@ -1,1 +1,5 @@
 num_ticks = 1
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/edittext_getcharboundaries_missing_embedded_font/test.toml
+++ b/tests/tests/swfs/avm2/edittext_getcharboundaries_missing_embedded_font/test.toml
@@ -2,3 +2,6 @@ num_ticks = 1
 
 # Currently Ruffle falls back to device font on missing embedded font.
 known_failure = true
+
+[player_options]
+with_default_font = true

--- a/tests/tests/swfs/avm2/edittext_line_methods/test.toml
+++ b/tests/tests/swfs/avm2/edittext_line_methods/test.toml
@@ -1,1 +1,5 @@
 num_ticks = 1
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/edittext_mouse_selection/test.toml
+++ b/tests/tests/swfs/avm2/edittext_mouse_selection/test.toml
@@ -1,1 +1,5 @@
 num_ticks = 1
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/edittext_scrollh/test.toml
+++ b/tests/tests/swfs/avm2/edittext_scrollh/test.toml
@@ -1,1 +1,5 @@
 num_ticks = 1
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/mouse_wheel_events/test.toml
+++ b/tests/tests/swfs/avm2/mouse_wheel_events/test.toml
@@ -1,1 +1,5 @@
 num_ticks = 1
+
+[player_options]
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/stage3d_bitmap/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_bitmap/test.toml
@@ -7,3 +7,5 @@ tolerance = 4
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/stage3d_fractal/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_fractal/test.toml
@@ -7,3 +7,5 @@ max_outliers = 25
 [player_options]
 max_execution_duration = { secs = 1000, nanos = 0 }
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/avm2/stage3d_texture/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_texture/test.toml
@@ -10,3 +10,5 @@ max_outliers = 117
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/fonts/embed_matching/no_font_found/test.toml
+++ b/tests/tests/swfs/fonts/embed_matching/no_font_found/test.toml
@@ -8,3 +8,4 @@ tolerance = 0
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+with_default_font = true

--- a/tests/tests/swfs/visual/cache_as_bitmap/edittext_scroll/test.toml
+++ b/tests/tests/swfs/visual/cache_as_bitmap/edittext_scroll/test.toml
@@ -10,3 +10,5 @@ max_outliers = 5
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/cache_as_bitmap/edittext_selection/test.toml
+++ b/tests/tests/swfs/visual/cache_as_bitmap/edittext_selection/test.toml
@@ -14,3 +14,5 @@ max_outliers = 5
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/cache_as_bitmap/text/test.toml
+++ b/tests/tests/swfs/visual/cache_as_bitmap/text/test.toml
@@ -5,3 +5,5 @@ tolerance = 0
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/filters/bevel/test.toml
+++ b/tests/tests/swfs/visual/filters/bevel/test.toml
@@ -5,3 +5,5 @@ tolerance = 3
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/filters/bevel_full/test.toml
+++ b/tests/tests/swfs/visual/filters/bevel_full/test.toml
@@ -5,3 +5,5 @@ tolerance = 4
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/filters/bevel_inner/test.toml
+++ b/tests/tests/swfs/visual/filters/bevel_inner/test.toml
@@ -5,3 +5,5 @@ tolerance = 4
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/filters/bevel_outer/test.toml
+++ b/tests/tests/swfs/visual/filters/bevel_outer/test.toml
@@ -5,3 +5,5 @@ tolerance = 3
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/filters/drop_shadow/test.toml
+++ b/tests/tests/swfs/visual/filters/drop_shadow/test.toml
@@ -5,3 +5,5 @@ tolerance = 2
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/filters/glow/test.toml
+++ b/tests/tests/swfs/visual/filters/glow/test.toml
@@ -5,3 +5,5 @@ tolerance = 2
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/filters/glow_with_alpha_strength/test.toml
+++ b/tests/tests/swfs/visual/filters/glow_with_alpha_strength/test.toml
@@ -5,3 +5,5 @@ tolerance = 4
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/filters/glow_without_composite_source/test.toml
+++ b/tests/tests/swfs/visual/filters/glow_without_composite_source/test.toml
@@ -8,3 +8,5 @@ tolerance = 3
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/fonts/font_lookup_as3/test.toml
+++ b/tests/tests/swfs/visual/fonts/font_lookup_as3/test.toml
@@ -5,3 +5,5 @@ tolerance = 1
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true

--- a/tests/tests/swfs/visual/text/String_path_variable_button/test.toml
+++ b/tests/tests/swfs/visual/text/String_path_variable_button/test.toml
@@ -6,3 +6,5 @@ max_outliers = 12
 
 [player_options]
 with_renderer = { optional = false, sample_count = 1 }
+# TODO Fix this test. It shouldn't depend on the default font.
+with_default_font = true


### PR DESCRIPTION
Having default font enabled makes it easier to write a bad test, because it's a Ruffle-specific behavior that Flash doesn't have.  It means that every test that uses the default font (i.e. changes output with default font enabled) is probably not based on FP's output, but on Ruffle's output.

This PR adds a property `with_defaut_font`, which, when set, will load the default font and the test will work as before.  It also marks all tests that rely on this behavior.  Almost all of them should be fixed.

See also https://github.com/ruffle-rs/ruffle/pull/21374