### PR TITLE
chore: Mark `avm2/stage3d_errors_atf` test as flaky

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,6 +4,7 @@
 filter = """
 test(pixelbender) or \
 test(avm2/graphics_round_rects) or \
+test(avm2/stage3d_errors_atf) or \
 test(avm1/netstream_play_flv) or \
 test(avm1/netstream_play_flv_screen)"""
 retries = 4


### PR DESCRIPTION
The test is flaky:
* https://github.com/ruffle-rs/ruffle/actions/runs/17018310796/job/48243817289
* https://github.com/ruffle-rs/ruffle/actions/runs/17109193806/job/48526039895