### PR TITLE
core: Make code more readable for PixelRegion (nit)

### DIFF
--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -371,15 +371,11 @@ impl PixelRegion {
     }
 
     pub fn for_region(x: u32, y: u32, width: u32, height: u32) -> Self {
-        let a = (x, y);
-        let b = (x.saturating_add(width), y.saturating_add(height));
-        let (min, max) = ((a.0.min(b.0), a.1.min(b.1)), (a.0.max(b.0), a.1.max(b.1)));
-
         Self {
-            x_min: min.0,
-            y_min: min.1,
-            x_max: max.0,
-            y_max: max.1,
+            x_min: x,
+            y_min: y,
+            x_max: x.saturating_add(width),
+            y_max: y.saturating_add(height),
         }
     }
 


### PR DESCRIPTION
Previous function
```rust
pub fn for_region(x: u32, y: u32, width: u32, height: u32) -> Self {
        let a = (x, y);
        let b = (x.saturating_add(width), y.saturating_add(height));
        let (min, max) = ((a.0.min(b.0), a.1.min(b.1)), (a.0.max(b.0), a.1.max(b.1)));

        Self {
            x_min: min.0,
            y_min: min.1,
            x_max: max.0,
            y_max: max.1,
        }
    }
```

Did make sure that x_max and y_max could not be less then x_min and y_min. But this is already ensured because saturating_add won't wrap around and the arguments to the function (width, height) will never be negative since they're unsigned.

This commit removes the extra checks while keeping the functionallity equal.