### PR TITLE
chore: Fix clippy warnings

### DIFF
--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -257,10 +257,7 @@ pub fn make_error_1026<'gc>(
 ) -> Error<'gc> {
     let err = verify_error(
         activation,
-        &format!(
-            "Error #1026: Slot {} exceeds slotCount={} of global.",
-            slot_id, slot_count
-        ),
+        &format!("Error #1026: Slot {slot_id} exceeds slotCount={slot_count} of global."),
         1026,
     );
     match err {


### PR DESCRIPTION
No idea why it's not reported in GitHub Actions.