### PR TITLE
chore: Update package index before installing tools in l10n GHA workflows

### DIFF
--- a/.github/workflows/download_translations.yml
+++ b/.github/workflows/download_translations.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y itstool gettext appstream
 
       - name: Generate desktop & metainfo sources

--- a/.github/workflows/upload_texts.yml
+++ b/.github/workflows/upload_texts.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y itstool gettext appstream
 
       - name: Generate desktop & metainfo sources


### PR DESCRIPTION
To avoid these situations:
 - https://github.com/ruffle-rs/ruffle/actions/runs/17138673876/job/48620893530
 - https://github.com/ruffle-rs/ruffle/actions/runs/17138737889/job/48621278812