### PR TITLE
ci: Ignore known failures when running coverage

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -190,6 +190,8 @@ jobs:
 
       - name: Run llvm-cov for SWF tests
         working-directory: tests
+        env:
+          RUFFLE_TEST_OPTS: --ignore-known-failures
         run: cargo llvm-cov --html ${{ env.LLVM_COV_OPTS }}
 
       - name: Upload report

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5522,6 +5522,7 @@ name = "tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "env_logger",
  "futures",
  "image",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -36,6 +36,7 @@ futures = { workspace = true }
 env_logger = "0.11.8"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+clap = { workspace = true }
 
 [[test]]
 name = "tests"

--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -132,8 +132,16 @@ impl Test {
             .collect()
     }
 
-    pub fn should_run(&self, check_renderer: bool, environment: &impl Environment) -> bool {
+    pub fn should_run(
+        &self,
+        ignore_known_failures: bool,
+        check_renderer: bool,
+        environment: &impl Environment,
+    ) -> bool {
         if self.options.ignore {
+            return false;
+        }
+        if ignore_known_failures && self.options.known_failure {
             return false;
         }
         self.options.required_features.can_run()


### PR DESCRIPTION
Known failures do not contribute to coverage, because we do not verify their output, instead we only check if they start passing.

This PR adds the `RUFFLE_TEST_OPTS` variable, which can contain Ruffle tests specific options separate from `cargo test` (specifically `--ignore-known-failures`). In the future it can also contain e.g. test filtering capabilities (slow/fast tests).