### PR TITLE
core: Fix memory leak when unloading child SWFs

### DIFF
--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -298,7 +298,7 @@ impl Default for DispatchList<'_> {
 /// A single instance of an event handler.
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-struct EventHandler<'gc> {
+pub struct EventHandler<'gc> {
     /// The event handler to call.
     handler: Object<'gc>,
 

--- a/core/src/avm2/globals/flash/display/shader_job.rs
+++ b/core/src/avm2/globals/flash/display/shader_job.rs
@@ -255,11 +255,8 @@ pub fn start<'gc>(
             let mut target_bitmap_data = target_bitmap.borrow_mut(activation.gc());
             let width = target_bitmap_data.width();
             let height = target_bitmap_data.height();
-            target_bitmap_data.set_gpu_dirty(
-                activation.gc(),
-                sync_handle,
-                PixelRegion::for_whole_size(width, height),
-            );
+            target_bitmap_data
+                .set_gpu_dirty(sync_handle, PixelRegion::for_whole_size(width, height));
         }
         PixelBenderOutput::Bytes(pixels) => {
             if let Some(mut bytearray) = target.as_bytearray_mut() {

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -6,7 +6,6 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::character::Character;
-use crate::tag_utils::SwfSlice;
 use crate::utils::HasPrefixField;
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak};
@@ -25,9 +24,7 @@ pub fn byte_array_allocator<'gc>(
     {
         if let Some(lib) = activation.context.library.library_for_movie(movie) {
             if let Some(Character::BinaryData(binary_data)) = lib.character_by_id(id) {
-                Some(ByteArrayStorage::from_vec(
-                    SwfSlice::as_ref(&binary_data).to_vec(),
-                ))
+                binary_data.with_data(|data| ByteArrayStorage::from_vec(data.to_vec()))
             } else {
                 None
             }

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -63,7 +63,7 @@ pub fn fill_rect<'gc>(
             write.set_pixel32_row_raw(rect.x_min, rect.x_max, y, color);
         }
     }
-    write.set_cpu_dirty(mc, rect);
+    write.set_cpu_dirty(rect);
 }
 
 pub fn set_pixel32<'gc>(
@@ -85,7 +85,7 @@ pub fn set_pixel32<'gc>(
         y,
         Color::from(color).to_premultiplied_alpha(transparency),
     );
-    write.set_cpu_dirty(mc, PixelRegion::for_pixel(x, y));
+    write.set_cpu_dirty(PixelRegion::for_pixel(x, y));
 }
 
 pub fn get_pixel32(target: BitmapData, renderer: &mut dyn RenderBackend, x: u32, y: u32) -> u32 {
@@ -117,7 +117,7 @@ pub fn set_pixel<'gc>(
     } else {
         write.set_pixel32_raw(x, y, color.with_alpha(0xFF));
     }
-    write.set_cpu_dirty(mc, PixelRegion::for_pixel(x, y));
+    write.set_cpu_dirty(PixelRegion::for_pixel(x, y));
 }
 
 pub fn get_pixel(target: BitmapData, renderer: &mut dyn RenderBackend, x: u32, y: u32) -> u32 {
@@ -175,7 +175,7 @@ pub fn flood_fill<'gc>(
             }
         }
     }
-    write.set_cpu_dirty(mc, dirty_region);
+    write.set_cpu_dirty(dirty_region);
 }
 
 pub fn noise<'gc>(
@@ -241,7 +241,7 @@ pub fn noise<'gc>(
         }
     }
     let region = PixelRegion::for_whole_size(write.width(), write.height());
-    write.set_cpu_dirty(mc, region)
+    write.set_cpu_dirty(region)
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -358,7 +358,7 @@ pub fn perlin_noise<'gc>(
         }
     }
     let region = PixelRegion::for_whole_size(write.width(), write.height());
-    write.set_cpu_dirty(mc, region)
+    write.set_cpu_dirty(region)
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -457,7 +457,7 @@ pub fn copy_channel<'gc>(
         }
     }
 
-    write.set_cpu_dirty(mc, dest_region);
+    write.set_cpu_dirty(dest_region);
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -511,10 +511,10 @@ pub fn color_transform<'gc>(
             )
         }
     }
-    write.set_cpu_dirty(
-        mc,
-        PixelRegion::encompassing_pixels((x_min, y_min), (x_max - 1, y_max - 1)),
-    );
+    write.set_cpu_dirty(PixelRegion::encompassing_pixels(
+        (x_min, y_min),
+        (x_max - 1, y_max - 1),
+    ));
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -612,7 +612,7 @@ pub fn threshold<'gc>(
     }
 
     if let Some(dirty_area) = dirty_area {
-        write.set_cpu_dirty(mc, dirty_area);
+        write.set_cpu_dirty(dirty_area);
     }
 
     modified_count
@@ -669,7 +669,7 @@ pub fn scroll<'gc>(
     }
 
     let region = PixelRegion::for_whole_size(write.width(), write.height());
-    write.set_cpu_dirty(mc, region)
+    write.set_cpu_dirty(region)
 }
 
 pub fn palette_map<'gc>(
@@ -734,7 +734,7 @@ pub fn palette_map<'gc>(
         }
     }
 
-    write.set_cpu_dirty(mc, dest_region);
+    write.set_cpu_dirty(dest_region);
 }
 
 /// Compare two BitmapData objects.
@@ -1020,7 +1020,7 @@ pub fn merge<'gc>(
         }
     }
 
-    write.set_cpu_dirty(mc, dest_region);
+    write.set_cpu_dirty(dest_region);
 }
 
 pub fn copy_pixels<'gc>(
@@ -1197,7 +1197,7 @@ pub fn copy_pixels_with_alpha_source<'gc>(
         ((dest_min_x + src_width), (dest_min_y + src_height)),
     );
     dirty_region.clamp(write.width(), write.height());
-    write.set_cpu_dirty(context.gc(), dirty_region);
+    write.set_cpu_dirty(dirty_region);
 }
 
 pub fn apply_filter<'gc>(
@@ -1262,7 +1262,7 @@ pub fn apply_filter<'gc>(
     );
     let region = PixelRegion::for_whole_size(write.width(), write.height());
     match sync_handle {
-        Some(sync_handle) => write.set_gpu_dirty(context.gc(), sync_handle, region),
+        Some(sync_handle) => write.set_gpu_dirty(sync_handle, region),
         None => {
             tracing::warn!("BitmapData.apply_filter: Renderer not yet implemented")
         }
@@ -1304,7 +1304,7 @@ fn copy_on_cpu<'gc>(
             }
         }
 
-        write.set_cpu_dirty(context, dest_region);
+        write.set_cpu_dirty(dest_region);
     } else {
         let dest = dest.sync(renderer);
         let mut dest_write = dest.borrow_mut(context);
@@ -1361,7 +1361,7 @@ fn copy_on_cpu<'gc>(
             }
         }
 
-        dest_write.set_cpu_dirty(context, dest_region);
+        dest_write.set_cpu_dirty(dest_region);
     }
 }
 
@@ -1393,7 +1393,7 @@ fn blend_and_transform<'gc>(
             }
         }
 
-        write.set_cpu_dirty(context.gc(), dest_region);
+        write.set_cpu_dirty(dest_region);
     } else {
         let dest = dest.sync(context.renderer);
         let mut dest_write = dest.borrow_mut(context.gc());
@@ -1416,7 +1416,7 @@ fn blend_and_transform<'gc>(
             }
         }
 
-        dest_write.set_cpu_dirty(context.gc(), dest_region);
+        dest_write.set_cpu_dirty(dest_region);
     }
 }
 
@@ -1605,7 +1605,7 @@ pub fn draw<'gc>(
 
     match image {
         Some(sync_handle) => {
-            write.set_gpu_dirty(context.gc(), sync_handle, dirty_region);
+            write.set_gpu_dirty(sync_handle, dirty_region);
             Ok(())
         }
         None => Err(BitmapDataDrawError::Unimplemented),
@@ -1660,7 +1660,7 @@ pub fn set_vector<'gc>(
     let mut bitmap_data = bitmap_data.borrow_mut(activation.gc());
     let transparency = bitmap_data.transparency();
     let mut iter = vector.iter();
-    bitmap_data.set_cpu_dirty(activation.gc(), region);
+    bitmap_data.set_cpu_dirty(region);
     for y in region.y_min..region.y_max {
         for x in region.x_min..region.x_max {
             let color = iter
@@ -1740,7 +1740,7 @@ pub fn set_pixels_from_byte_array<'gc>(
             }
         }
 
-        write.set_cpu_dirty(mc, region)
+        write.set_cpu_dirty(region)
     }
 
     Ok(())
@@ -1961,7 +1961,7 @@ pub fn pixel_dissolve<'gc>(
         );
     }
 
-    write.set_cpu_dirty(mc, dest_region);
+    write.set_cpu_dirty(dest_region);
 
     raw_perm_index as i32
 }

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -77,7 +77,7 @@ impl<'gc> Avm1Button<'gc> {
             Avm1ButtonData {
                 base: Default::default(),
                 cell: RefLock::new(Avm1ButtonDataMut {
-                    container: ChildContainer::new(&source_movie.movie),
+                    container: ChildContainer::new(&source_movie.movie.upgrade().unwrap().clone()),
                     hit_area: BTreeMap::new(),
                     hit_bounds: Default::default(),
                     text_field_bindings: Vec::new(),
@@ -85,7 +85,7 @@ impl<'gc> Avm1Button<'gc> {
                 shared: Gc::new(
                     mc,
                     ButtonShared {
-                        swf: source_movie.movie.clone(),
+                        swf: source_movie.movie.upgrade().unwrap().clone(),
                         id: button.id,
                         actions,
                         cell: RefCell::new(ButtonSharedMut {
@@ -198,7 +198,7 @@ impl<'gc> Avm1Button<'gc> {
             let removed_child = self.replace_at_depth(context, child, depth.into());
             dispatch_added_event(self.into(), child, false, context);
             if let Some(removed_child) = removed_child {
-                dispatch_removed_event(removed_child, context);
+                dispatch_removed_event(self.into(), removed_child, context);
             }
         }
 

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -111,7 +111,7 @@ impl<'gc> Avm2Button<'gc> {
                 shared: Gc::new(
                     context.gc(),
                     ButtonShared {
-                        swf: source_movie.movie.clone(),
+                        swf: source_movie.movie.upgrade().unwrap().clone(),
                         id: button.id,
                         cell: RefCell::new(ButtonSharedMut {
                             records: button.records.clone(),
@@ -360,7 +360,7 @@ impl<'gc> Avm2Button<'gc> {
             }
 
             if let Some(old_state_child) = old_state_child {
-                dispatch_removed_event(old_state_child, context);
+                dispatch_removed_event(self.into(), old_state_child, context);
             }
 
             if let Some(child) = child {

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -8,7 +8,7 @@ use crate::avm2::{
 };
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::context::{RenderContext, UpdateContext};
-use crate::display_object::{DisplayObjectBase, DisplayObjectPtr, DisplayObjectWeak};
+use crate::display_object::{DisplayObjectBase, DisplayObjectPtr};
 use crate::prelude::*;
 use crate::tag_utils::SwfMovie;
 use crate::utils::HasPrefixField;
@@ -167,7 +167,7 @@ impl<'gc> Bitmap<'gc> {
             },
         ));
 
-        bitmap_data.add_display_object(mc, DisplayObjectWeak::Bitmap(bitmap.downgrade()));
+        bitmap_data.add_display_object(mc, DisplayObject::Bitmap(bitmap));
 
         bitmap
     }
@@ -230,12 +230,12 @@ impl<'gc> Bitmap<'gc> {
     /// This also forces the `BitmapData` to be sent to the rendering backend,
     /// if that has not already been done.
     pub fn set_bitmap_data(self, context: &mut UpdateContext<'gc>, bitmap_data: BitmapData<'gc>) {
-        let weak_self = DisplayObjectWeak::Bitmap(self.downgrade());
+        let bitmap = DisplayObject::Bitmap(self);
 
         self.0
             .bitmap_data
             .get()
-            .remove_display_object(context.gc(), weak_self);
+            .remove_display_object(context.gc(), bitmap);
 
         // Refresh our cached values, even if we're writing the same BitmapData
         // that we currently have stored. This will update them to '0' if the
@@ -249,7 +249,7 @@ impl<'gc> Bitmap<'gc> {
         )
         .set(bitmap_data);
 
-        bitmap_data.add_display_object(context.gc(), weak_self);
+        bitmap_data.add_display_object(context.gc(), bitmap);
     }
 
     pub fn avm2_bitmapdata_class(self) -> Option<Avm2ClassObject<'gc>> {


### PR DESCRIPTION
This probably fixes all the games that also depend on other SWFs. Currently only tested on binary data.