### PR TITLE
desktop: Switch from winapi to windows-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4544,7 +4544,7 @@ dependencies = [
  "vergen",
  "webbrowser",
  "wgpu",
- "winapi",
+ "windows-sys 0.59.0",
  "winit",
 ]
 

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -58,7 +58,7 @@ memmap2.workspace = true
 ashpd = "0.11.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["wincon"] }
+windows-sys = { version = "0.59.0", features = ["Win32_System_Console"] }
 
 [build-dependencies]
 embed-resource = "3"

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -63,7 +63,7 @@ fn init() {
     // silently if the parent has no console.
     #[cfg(windows)]
     unsafe {
-        use winapi::um::wincon::{AttachConsole, ATTACH_PARENT_PROCESS};
+        use windows_sys::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
         AttachConsole(ATTACH_PARENT_PROCESS);
     }
 
@@ -144,7 +144,7 @@ fn shutdown() {
     // Without explicitly detaching the console cmd won't redraw it's prompt.
     #[cfg(windows)]
     unsafe {
-        winapi::um::wincon::FreeConsole();
+        windows_sys::Win32::System::Console::FreeConsole();
     }
 }
 


### PR DESCRIPTION
We already depend on window-sys and it's more modern. We previously had a build issue with winapi in #21513.