### PR TITLE
avm2: Set functions as their own constructors

### DIFF
--- a/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_6_1_3/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_6_1_3/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_6_2_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_6_2_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/e15_3_1_1_1_rt/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/e15_3_1_1_1_rt/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/e15_3_2_1_1_rt/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/e15_3_2_1_1_rt/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/e15_3_5_2_rt/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/e15_3_5_2_rt/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Functions should apparently be set as their own constructors, at least according to the tests.
<img width="1991" height="38" alt="image" src="https://github.com/user-attachments/assets/a3101198-3bc6-4c26-877b-5b138e9d5015" />
