### PR TITLE
avm2: Return object if function constructor returns object

### DIFF
--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -127,9 +127,15 @@ impl<'gc> FunctionObject<'gc> {
             object_class.instance_vtable(),
         );
 
-        self.call(activation, instance.into(), arguments)?;
+        let result = self.call(activation, instance.into(), arguments)?;
 
-        Ok(instance)
+        // If the constructor returns an object, use that instead of the created instance
+        // TODO: avmplus returns null here if the constructor returns null
+        if let Value::Object(obj) = result {
+            Ok(obj)
+        } else {
+            Ok(instance)
+        }
     }
 
     pub fn prototype(&self) -> Option<Object<'gc>> {

--- a/tests/tests/swfs/from_avmplus/as3/Expressions/e11_2_2_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Expressions/e11_2_2_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/ExecutionContexts/e10_1_6/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/ExecutionContexts/e10_1_6/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
This is the test case this fixes:

```js
function TestFunction() {
    return arguments;
}

Assert.expectEq(
      "(new TestFunction(0,1,2,3,4,5)).length",
      6,
      (new TestFunction(0,1,2,3,4,5)).length
 );
```

The fix corresponds to 9) from here:
https://262.ecma-international.org/5.1/#sec-13.2.2