### PR TITLE
tests: Fix from_shumway/avm1/hitarea

### DIFF
--- a/tests/tests/swfs/from_shumway/avm1/hitarea/input.json
+++ b/tests/tests/swfs/from_shumway/avm1/hitarea/input.json
@@ -1,6 +1,11 @@
 [
-  {
-    "type": "MouseMove",
-    "pos": [250.0, 300.0]
-  }
+  { "type": "MouseMove", "pos": [0.0, 0.0] },
+  { "type": "MouseMove", "pos": [100.0, 100.0] },
+  { "type": "Wait" },
+  { "type": "Wait" },
+  { "type": "Wait" },
+  { "type": "Wait" },
+  { "type": "Wait" },
+  { "type": "MouseMove", "pos": [0.0, 0.0] },
+  { "type": "MouseMove", "pos": [100.0, 100.0] }
 ]

--- a/tests/tests/swfs/from_shumway/avm1/hitarea/test.toml
+++ b/tests/tests/swfs/from_shumway/avm1/hitarea/test.toml
@@ -1,3 +1,5 @@
 # Test adapted from Shumway at https://github.com/mozilla/shumway/tree/master/test/swfs/avm1/hitarea
 
 num_frames = 7
+
+known_failure = true


### PR DESCRIPTION
The input.json of this test was wrong, it rolled cursor over a wrong area, which caused the test to pass despite Ruffle not handling hitArea properly.