### PR TITLE
chore: Make `TDisplayObject::object2` return `Option<StageObject>`

### DIFF
--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -4,7 +4,6 @@ use crate::avm2::activation::Activation;
 use crate::avm2::function::FunctionArgs;
 use crate::avm2::globals::slots::flash_events_event_dispatcher as slots;
 use crate::avm2::object::{EventObject, FunctionObject, Object, TObject as _};
-use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
@@ -343,8 +342,8 @@ impl Hash for EventHandler<'_> {
 pub fn parent_of(target: Object<'_>) -> Option<Object<'_>> {
     if let Some(dobj) = target.as_display_object() {
         if let Some(dparent) = dobj.parent() {
-            if let Value::Object(parent) = dparent.object2() {
-                return Some(parent);
+            if let Some(parent) = dparent.object2() {
+                return Some(parent.into());
             }
         }
     }
@@ -439,8 +438,8 @@ pub fn dispatch_event<'gc>(
     // the parent DisplayObject hierarchy, only adding ancestors that have objects constructed.
     let mut parent = target.as_display_object().and_then(|dobj| dobj.parent());
     while let Some(parent_dobj) = parent {
-        if let Value::Object(parent_obj) = parent_dobj.object2() {
-            ancestor_list.push(parent_obj);
+        if let Some(parent_obj) = parent_dobj.object2() {
+            ancestor_list.push(parent_obj.into());
         }
         parent = parent_dobj.parent();
     }

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -590,7 +590,7 @@ pub fn get_parent<'gc>(
     if let Some(dobj) = this.as_display_object() {
         return Ok(dobj
             .avm2_parent()
-            .map(|parent| parent.object2())
+            .map(|parent| parent.object2_or_null())
             .unwrap_or(Value::Null));
     }
 
@@ -608,7 +608,7 @@ pub fn get_root<'gc>(
     if let Some(dobj) = this.as_display_object() {
         return Ok(dobj
             .avm2_root()
-            .map(|root| root.object2())
+            .map(|root| root.object2_or_null())
             .unwrap_or(Value::Null));
     }
 
@@ -626,7 +626,7 @@ pub fn get_stage<'gc>(
     if let Some(dobj) = this.as_display_object() {
         return Ok(dobj
             .avm2_stage(activation.context)
-            .map(|stage| stage.object2())
+            .map(|stage| stage.object2_or_null())
             .unwrap_or(Value::Null));
     }
 
@@ -1088,7 +1088,12 @@ pub fn get_mask<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(this) = this.as_display_object() {
-        return Ok(this.masker().map_or(Value::Null, |m| m.object2()));
+        let masker = this
+            .masker()
+            .map(|m| m.object2_or_null())
+            .unwrap_or(Value::Null);
+
+        return Ok(masker);
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/display/loader_info.rs
+++ b/core/src/avm2/globals/flash/display/loader_info.rs
@@ -145,7 +145,7 @@ pub fn get_content<'gc>(
     let loader_stream = loader_info.loader_stream();
     match &*loader_stream {
         LoaderStream::Swf(_, root) | LoaderStream::NotYetLoaded(_, Some(root), _) => {
-            Ok(root.object2())
+            Ok(root.object2_or_null())
         }
         _ => Ok(Value::Null),
     }

--- a/core/src/avm2/globals/flash/display/simple_button.rs
+++ b/core/src/avm2/globals/flash/display/simple_button.rs
@@ -120,7 +120,7 @@ pub fn get_down_state<'gc>(
     {
         return Ok(btn
             .get_state_child(ButtonState::DOWN)
-            .map(|state| state.object2())
+            .map(|state| state.object2_or_null())
             .unwrap_or(Value::Null));
     }
 
@@ -163,7 +163,7 @@ pub fn get_over_state<'gc>(
     {
         return Ok(btn
             .get_state_child(ButtonState::OVER)
-            .map(|state| state.object2())
+            .map(|state| state.object2_or_null())
             .unwrap_or(Value::Null));
     }
 
@@ -206,7 +206,7 @@ pub fn get_hit_test_state<'gc>(
     {
         return Ok(btn
             .get_state_child(ButtonState::HIT_TEST)
-            .map(|state| state.object2())
+            .map(|state| state.object2_or_null())
             .unwrap_or(Value::Null));
     }
 
@@ -249,7 +249,7 @@ pub fn get_up_state<'gc>(
     {
         return Ok(btn
             .get_state_child(ButtonState::UP)
-            .map(|state| state.object2())
+            .map(|state| state.object2_or_null())
             .unwrap_or(Value::Null));
     }
 

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -71,7 +71,7 @@ pub fn get_drop_target<'gc>(
         .and_then(|o| o.as_movie_clip())
         .and_then(|o| o.drop_target())
     {
-        return Ok(mc.object2());
+        return Ok(mc.object2_or_null());
     }
 
     Ok(Value::Null)
@@ -296,7 +296,7 @@ pub fn get_hit_area<'gc>(
         .and_then(|o| o.as_movie_clip())
         .and_then(|o| o.hit_area())
     {
-        return Ok(mc.object2());
+        return Ok(mc.object2_or_null());
     }
 
     Ok(Value::Null)

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -183,8 +183,7 @@ pub fn get_focus<'gc>(
         .focus_tracker
         .get()
         .map(|o| o.as_displayobject())
-        .and_then(|focus_dobj| focus_dobj.object2().as_object())
-        .map(|o| o.into())
+        .map(|focus_dobj| focus_dobj.object2_or_null())
         .unwrap_or(Value::Null))
 }
 

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -137,7 +137,7 @@ impl<'gc> EventObject<'gc> {
                 local.y.to_pixels().into(),
                 // relatedObject
                 related_object
-                    .map(|o| o.as_displayobject().object2())
+                    .map(|o| o.as_displayobject().object2_or_null())
                     .unwrap_or(Value::Null),
                 // ctrlKey
                 activation
@@ -302,7 +302,7 @@ impl<'gc> EventObject<'gc> {
                 true.into(),
                 cancelable.into(),
                 related_object
-                    .map(|o| o.as_displayobject().object2())
+                    .map(|o| o.as_displayobject().object2_or_null())
                     .unwrap_or(Value::Null),
                 shift_key.into(),
                 key_code.into(),

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -1478,11 +1478,12 @@ impl DisplayObjectWindow {
                     ui.end_row();
                 }
 
-                if let crate::avm2::Value::Object(object) = object.object2() {
+                if let Some(object) = object.object2() {
                     ui.label("AVM2 Object");
                     if ui.button(format!("{:p}", object.as_ptr())).clicked() {
                         messages.push(Message::TrackAVM2Object(AVM2ObjectHandle::new(
-                            context, object,
+                            context,
+                            object.into(),
                         )));
                     }
                     ui.end_row();

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -1,4 +1,5 @@
 use crate::avm1::{Activation, ActivationIdentifier, NativeObject, Object, Value};
+use crate::avm2::StageObject as Avm2StageObject;
 use crate::backend::audio::AudioManager;
 use crate::backend::ui::MouseCursor;
 use crate::context::{ActionType, RenderContext, UpdateContext};
@@ -351,6 +352,11 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
             .get()
             .map(Value::from)
             .unwrap_or(Value::Undefined)
+    }
+
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        // AVM1 buttons don't have an associated AVM2 object
+        None
     }
 
     fn allow_as_mask(self) -> bool {

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -4,7 +4,7 @@ use super::interactive::Avm2MousePick;
 use crate::avm1::Object as Avm1Object;
 use crate::avm2::{
     Activation as Avm2Activation, ClassObject as Avm2ClassObject, FunctionArgs as Avm2FunctionArgs,
-    StageObject as Avm2StageObject, Value as Avm2Value,
+    StageObject as Avm2StageObject,
 };
 use crate::backend::audio::AudioManager;
 use crate::backend::ui::MouseCursor;
@@ -650,12 +650,8 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
         false
     }
 
-    fn object2(self) -> Avm2Value<'gc> {
-        self.0
-            .object
-            .get()
-            .map(Avm2Value::from)
-            .unwrap_or(Avm2Value::Null)
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        self.0.object.get()
     }
 
     fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2StageObject<'gc>) {

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -4,7 +4,7 @@ use crate::avm1;
 use crate::avm2::{
     Activation as Avm2Activation, BitmapDataObject as Avm2BitmapDataObject,
     ClassObject as Avm2ClassObject, FunctionArgs as Avm2FunctionArgs,
-    StageObject as Avm2StageObject, Value as Avm2Value,
+    StageObject as Avm2StageObject,
 };
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::context::{RenderContext, UpdateContext};
@@ -383,12 +383,8 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         );
     }
 
-    fn object2(self) -> Avm2Value<'gc> {
-        self.0
-            .avm2_object
-            .get()
-            .map(|o| o.into())
-            .unwrap_or(Avm2Value::Null)
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        self.0.avm2_object.get()
     }
 
     fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2StageObject<'gc>) {

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -30,9 +30,9 @@ pub fn dispatch_removed_from_stage_event<'gc>(
     child: DisplayObject<'gc>,
     context: &mut UpdateContext<'gc>,
 ) {
-    if let Avm2Value::Object(object) = child.object2() {
+    if let Some(object) = child.object2() {
         let removed_evt = Avm2EventObject::bare_default_event(context, "removedFromStage");
-        Avm2::dispatch_event(context, removed_evt, object);
+        Avm2::dispatch_event(context, removed_evt, object.into());
     }
 
     if let Some(child_container) = child.as_container() {
@@ -45,9 +45,9 @@ pub fn dispatch_removed_from_stage_event<'gc>(
 /// Dispatch the `removed` event on a child and log any errors encountered
 /// whilst doing so.
 pub fn dispatch_removed_event<'gc>(child: DisplayObject<'gc>, context: &mut UpdateContext<'gc>) {
-    if let Avm2Value::Object(object) = child.object2() {
+    if let Some(object) = child.object2() {
         let removed_evt = Avm2EventObject::bare_event(context, "removed", true, false);
-        Avm2::dispatch_event(context, removed_evt, object);
+        Avm2::dispatch_event(context, removed_evt, object.into());
 
         if child.is_on_stage(context) {
             dispatch_removed_from_stage_event(child, context)
@@ -60,9 +60,9 @@ pub fn dispatch_added_to_stage_event_only<'gc>(
     child: DisplayObject<'gc>,
     context: &mut UpdateContext<'gc>,
 ) {
-    if let Avm2Value::Object(object) = child.object2() {
+    if let Some(object) = child.object2() {
         let added_evt = Avm2EventObject::bare_default_event(context, "addedToStage");
-        Avm2::dispatch_event(context, added_evt, object);
+        Avm2::dispatch_event(context, added_evt, object.into());
     }
 }
 
@@ -89,9 +89,9 @@ pub fn dispatch_added_to_stage_event<'gc>(
 /// Dispatch an `added` event to one object, and log any errors encountered
 /// whilst doing so.
 pub fn dispatch_added_event_only<'gc>(child: DisplayObject<'gc>, context: &mut UpdateContext<'gc>) {
-    if let Avm2Value::Object(object) = child.object2() {
+    if let Some(object) = child.object2() {
         let added_evt = Avm2EventObject::bare_event(context, "added", true, false);
-        Avm2::dispatch_event(context, added_evt, object);
+        Avm2::dispatch_event(context, added_evt, object.into());
     }
 }
 
@@ -379,7 +379,7 @@ pub trait TDisplayObjectContainer<'gc>:
         if removed_from_render_list {
             if !self.raw_container().is_action_script_3() {
                 child.avm1_unload(context);
-            } else if !matches!(child.object2(), Avm2Value::Null) {
+            } else if child.object2().is_some() {
                 //TODO: This is an awful, *awful* hack to deal with the fact
                 //that unloaded AVM1 clips see their parents, while AVM2 clips
                 //don't.
@@ -461,7 +461,7 @@ pub trait TDisplayObjectContainer<'gc>:
 
             if !self.raw_container().is_action_script_3() {
                 removed.avm1_unload(context);
-            } else if !matches!(removed.object2(), Avm2Value::Null) {
+            } else if removed.object2().is_some() {
                 removed.set_parent(context, None);
             }
 
@@ -752,7 +752,7 @@ impl<'gc> ChildContainer<'gc> {
                 );
                 if child.has_explicit_name() {
                     if let Some(name) = child.name() {
-                        if let Avm2Value::Object(parent_obj) = parent.object2() {
+                        if let Some(parent_obj) = parent.object2() {
                             let parent_obj = Avm2Value::from(parent_obj);
 
                             let mut activation = Avm2Activation::from_nothing(context);

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -144,7 +144,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 
     fn construct_frame(self, context: &mut UpdateContext<'gc>) {
-        if self.movie().is_action_script_3() && matches!(self.object2(), Avm2Value::Null) {
+        if self.movie().is_action_script_3() && self.object2().is_none() {
             let class_object = self
                 .0
                 .class
@@ -241,12 +241,8 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         self.0.shared.get().movie.clone()
     }
 
-    fn object2(self) -> Avm2Value<'gc> {
-        self.0
-            .avm2_object
-            .get()
-            .map(Avm2Value::from)
-            .unwrap_or(Avm2Value::Null)
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        self.0.avm2_object.get()
     }
 
     fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2StageObject<'gc>) {

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -287,8 +287,8 @@ pub trait TInteractiveObject<'gc>:
             }
         }
 
-        let target = if let Avm2Value::Object(target) = self.as_displayobject().object2() {
-            target
+        let target = if let Some(target) = self.as_displayobject().object2() {
+            target.into()
         } else {
             return ClipEventResult::NotHandled;
         };
@@ -435,9 +435,12 @@ pub trait TInteractiveObject<'gc>:
                         MouseButton::Left,
                     );
 
-                    if let Avm2Value::Object(avm2_target) = tgt.object2() {
-                        handled = Avm2::dispatch_event(activation.context, avm2_event, avm2_target)
-                            || handled;
+                    if let Some(avm2_target) = tgt.object2() {
+                        handled = Avm2::dispatch_event(
+                            activation.context,
+                            avm2_event,
+                            avm2_target.into(),
+                        ) || handled;
                     }
 
                     rollout_target = tgt.parent();
@@ -471,9 +474,12 @@ pub trait TInteractiveObject<'gc>:
                         MouseButton::Left,
                     );
 
-                    if let Avm2Value::Object(avm2_target) = tgt.object2() {
-                        handled = Avm2::dispatch_event(activation.context, avm2_event, avm2_target)
-                            || handled;
+                    if let Some(avm2_target) = tgt.object2() {
+                        handled = Avm2::dispatch_event(
+                            activation.context,
+                            avm2_event,
+                            avm2_target.into(),
+                        ) || handled;
                     }
 
                     rollover_target = tgt.parent();
@@ -640,11 +646,11 @@ pub trait TInteractiveObject<'gc>:
             };
 
             Avm1::run_stack_frame_for_method(self_do, object, method_name, &[other], context);
-        } else if let Avm2Value::Object(object) = self_do.object2() {
+        } else if let Some(object) = self_do.object2() {
             let mut activation = Avm2Activation::from_nothing(context);
             let event_name = if focused { "focusIn" } else { "focusOut" };
             let event = EventObject::focus_event(&mut activation, event_name, false, other, 0);
-            Avm2::dispatch_event(activation.context, event, object);
+            Avm2::dispatch_event(activation.context, event, object.into());
         }
     }
 

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -86,12 +86,8 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
         Default::default()
     }
 
-    fn object2(self) -> Avm2Value<'gc> {
-        self.0
-            .avm2_object
-            .get()
-            .map(Avm2Value::from)
-            .unwrap_or(Avm2Value::Null)
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        self.0.avm2_object.get()
     }
 
     fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2StageObject<'gc>) {

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -93,12 +93,8 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         self.invalidate_cached_bitmap();
     }
 
-    fn object2(self) -> Avm2Value<'gc> {
-        self.0
-            .object
-            .get()
-            .map(Avm2Value::from)
-            .unwrap_or(Avm2Value::Null)
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        self.0.object.get()
     }
 
     fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2StageObject<'gc>) {
@@ -108,7 +104,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
 
     /// Construct objects placed on this frame.
     fn construct_frame(self, context: &mut UpdateContext<'gc>) {
-        if self.movie().is_action_script_3() && matches!(self.object2(), Avm2Value::Null) {
+        if self.movie().is_action_script_3() && self.object2().is_none() {
             let class = context.avm2.classes().morphshape;
             let object = Avm2StageObject::for_display_object(context.gc(), self.into(), class);
             // We don't need to call the initializer method, as AVM2 can't link

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -7,7 +7,7 @@ use crate::avm2::script::Script;
 use crate::avm2::Activation as Avm2Activation;
 use crate::avm2::{
     Avm2, ClassObject as Avm2ClassObject, FunctionArgs as Avm2FunctionArgs, LoaderInfoObject,
-    Object as Avm2Object, QName as Avm2QName, StageObject as Avm2StageObject, Value as Avm2Value,
+    Object as Avm2Object, QName as Avm2QName, StageObject as Avm2StageObject,
 };
 use crate::backend::audio::{AudioManager, SoundInstanceHandle};
 use crate::backend::navigator::Request;
@@ -2338,7 +2338,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                 // The supercall constructor for display objects is responsible
                 // for triggering construct_frame on frame 1.
                 for child in self.iter_render_list() {
-                    if running_construct_frame && child.object2().as_object().is_none() {
+                    if running_construct_frame && child.object2().is_none() {
                         continue;
                     }
                     child.construct_frame(context);
@@ -2467,12 +2467,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             .unwrap_or(Avm1Value::Undefined)
     }
 
-    fn object2(self) -> Avm2Value<'gc> {
-        self.0
-            .object2
-            .get()
-            .map(Avm2Value::from)
-            .unwrap_or(Avm2Value::Null)
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        self.0.object2.get()
     }
 
     fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2StageObject<'gc>) {

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -4,7 +4,7 @@ use crate::avm1::Object as Avm1Object;
 use crate::avm2::object::Stage3DObject;
 use crate::avm2::{
     Activation as Avm2Activation, Avm2, EventObject as Avm2EventObject, LoaderInfoObject,
-    Object as Avm2Object, StageObject as Avm2StageObject, Value as Avm2Value,
+    Object as Avm2Object, StageObject as Avm2StageObject,
 };
 use crate::backend::ui::MouseCursor;
 use crate::config::Letterbox;
@@ -699,9 +699,9 @@ impl<'gc> Stage<'gc> {
                     context,
                 );
             }
-        } else if let Avm2Value::Object(stage) = self.object2() {
+        } else if let Some(stage) = self.object2() {
             let resized_event = Avm2EventObject::bare_default_event(context, "resize");
-            Avm2::dispatch_event(context, resized_event, stage);
+            Avm2::dispatch_event(context, resized_event, stage.into());
         }
     }
 
@@ -729,7 +729,7 @@ impl<'gc> Stage<'gc> {
                     context,
                 );
             }
-        } else if let Avm2Value::Object(stage) = self.object2() {
+        } else if let Some(stage) = self.object2() {
             let mut activation = Avm2Activation::from_nothing(context);
 
             let full_screen_event_cls = activation.avm2().classes().fullscreenevent;
@@ -746,7 +746,7 @@ impl<'gc> Stage<'gc> {
                 ],
             );
 
-            Avm2::dispatch_event(context, full_screen_event, stage);
+            Avm2::dispatch_event(context, full_screen_event, stage.into());
         }
     }
 
@@ -863,12 +863,8 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         }
     }
 
-    fn object2(self) -> Avm2Value<'gc> {
-        self.0
-            .avm2_object
-            .get()
-            .expect("Attempted to access Stage::object2 before initialization")
-            .into()
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        self.0.avm2_object.get()
     }
 
     fn set_perspective_projection(self, mut perspective_projection: Option<PerspectiveProjection>) {

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -273,12 +273,8 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         }
     }
 
-    fn object2(self) -> Avm2Value<'gc> {
-        self.0
-            .avm2_object
-            .get()
-            .map(|o| o.into())
-            .unwrap_or(Avm2Value::Null)
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        self.0.avm2_object.get()
     }
 
     fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2StageObject<'gc>) {

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -1,7 +1,7 @@
 //! Video player display object
 
 use crate::avm1::{NativeObject as Avm1NativeObject, Object as Avm1Object, Value as Avm1Value};
-use crate::avm2::{StageObject as Avm2StageObject, Value as Avm2Value};
+use crate::avm2::StageObject as Avm2StageObject;
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{Avm1TextFieldBinding, DisplayObjectBase};
 use crate::prelude::*;
@@ -439,7 +439,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
     }
 
     fn construct_frame(self, context: &mut UpdateContext<'gc>) {
-        if self.movie().is_action_script_3() && matches!(self.object2(), Avm2Value::Null) {
+        if self.movie().is_action_script_3() && self.object2().is_none() {
             let video_constr = context.avm2.classes().video;
             let object =
                 Avm2StageObject::for_display_object(context.gc(), self.into(), video_constr);
@@ -531,10 +531,6 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         context.transform_stack.pop();
     }
 
-    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2StageObject<'gc>) {
-        self.set_object(context, to.into());
-    }
-
     fn movie(self) -> Arc<SwfMovie> {
         self.0.movie.clone()
     }
@@ -548,13 +544,12 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
             .unwrap_or(Avm1Value::Undefined)
     }
 
-    fn object2(self) -> Avm2Value<'gc> {
-        self.0
-            .object
-            .get()
-            .and_then(|o| o.as_avm2_object())
-            .map(Avm2Value::from)
-            .unwrap_or(Avm2Value::Null)
+    fn object2(self) -> Option<Avm2StageObject<'gc>> {
+        self.0.object.get().and_then(|o| o.as_avm2_object())
+    }
+
+    fn set_object2(self, context: &mut UpdateContext<'gc>, to: Avm2StageObject<'gc>) {
+        self.set_object(context, to.into());
     }
 
     fn avm1_text_field_bindings(&self) -> Option<Ref<'_, [Avm1TextFieldBinding<'gc>]>> {

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -7,7 +7,6 @@ pub use crate::display_object::{
 };
 use crate::display_object::{EditText, InteractiveObject, TInteractiveObject};
 use crate::events::{ClipEvent, KeyCode};
-use crate::prelude::Avm2Value;
 use crate::Player;
 use either::Either;
 use gc_arena::barrier::unlock;
@@ -250,7 +249,7 @@ impl<'gc> FocusTracker<'gc> {
             .map(|int| int.as_displayobject())
             .unwrap_or_else(|| context.stage.as_displayobject())
             .object2();
-        let Avm2Value::Object(target) = target else {
+        let Some(target) = target else {
             return false;
         };
 
@@ -258,7 +257,7 @@ impl<'gc> FocusTracker<'gc> {
         let key_code = key_code.map(|k| k.value()).unwrap_or_default();
         let event =
             EventObject::focus_event(&mut activation, event_type, true, related_object, key_code);
-        Avm2::dispatch_event(activation.context, event, target);
+        Avm2::dispatch_event(activation.context, event, target.into());
 
         let canceled = event.event().is_cancelled();
         canceled

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -657,7 +657,7 @@ impl Player {
                 };
 
                 crate::avm1::make_context_menu_state(menu_object, display_obj, &mut activation)
-            } else if let Some(Avm2Value::Object(hit_obj)) = display_obj.map(|obj| obj.object2()) {
+            } else if let Some(hit_obj) = display_obj.and_then(|obj| obj.object2()) {
                 let mut activation = Avm2Activation::from_nothing(context);
 
                 let menu_object = display_obj
@@ -740,8 +740,8 @@ impl Player {
                                         menu_item_select_string.into(),
                                         false.into(),
                                         false.into(),
-                                        display_obj.object2(),
-                                        display_obj.object2(),
+                                        display_obj.object2_or_null(),
+                                        display_obj.object2_or_null(),
                                     ],
                                 );
 
@@ -1195,10 +1195,9 @@ impl Player {
                 if target_object.movie().is_action_script_3() {
                     let target = target_object
                         .object2()
-                        .as_object()
-                        .expect("DisplayObject is not an object!");
+                        .expect("DisplayObject was not constructed!");
 
-                    Avm2::dispatch_event(activation.context, keyboard_event, target);
+                    Avm2::dispatch_event(activation.context, keyboard_event, target.into());
                 }
             }
 


### PR DESCRIPTION
This also adds a method `TDisplayObject::object2_or_null` to reduce boilerplate

See #19522