### PR TITLE
desktop: Add Thai font to egui

### DIFF
--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -578,6 +578,7 @@ fn load_system_fonts(
         4,
         vec![
             Family::Name("Noto Sans Hebrew"), // Open font
+            Family::Name("Tahoma"),           // Windows
         ],
     ));
 
@@ -586,6 +587,16 @@ fn load_system_fonts(
         5,
         vec![
             Family::Name("Noto Sans Arabic"), // Open font
+            Family::Name("Tahoma"),           // Windows
+        ],
+    ));
+
+    // Thai
+    queries.push((
+        6,
+        vec![
+            Family::Name("Noto Sans Thai"), // Open font
+            Family::Name("Tahoma"),         // Windows
         ],
     ));
 


### PR DESCRIPTION
Ruffle now supports Thai too, this is required for Thai to be displayed properly.