### PR TITLE
avm2: Express Array.removeAt in terms of splice

### DIFF
--- a/tests/tests/swfs/from_avmplus/as3/Array/insertremove/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Array/insertremove/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
The insertremove test seems to indicate that removeAt needs the same resolve_array_hole logic that splice has.
Hence, I created splice_internal that splice, insertAt and removeAt are now expressed in terms of. 

Also, insertAt previously returned an array with the removed elements, which it seems it should not do (The function signature doesn't suggest it should and there are no tests for it). Now it just returns undefined. 

Splice_internal also collects directly into an ArrayStorage instead of an intermediate Vec as that seemed unnecessary.