### PR TITLE
web: Use title case for context menu entries

### DIFF
--- a/web/packages/core/texts/en-US/context_menu.ftl
+++ b/web/packages/core/texts/en-US/context_menu.ftl
@@ -1,12 +1,12 @@
 context-menu-download-swf = Download .swf
-context-menu-copy-debug-info = Copy debug info
+context-menu-copy-debug-info = Copy Debug Info
 context-menu-open-save-manager = Open Save Manager
 context-menu-about-ruffle =
     { $flavor ->
         [extension] About Ruffle Extension ({$version})
         *[other] About Ruffle ({$version})
     }
-context-menu-hide = Hide this menu
-context-menu-exit-fullscreen = Exit fullscreen
-context-menu-enter-fullscreen = Enter fullscreen
-context-menu-volume-controls = Volume controls
+context-menu-hide = Hide This Menu
+context-menu-exit-fullscreen = Exit Full Screen
+context-menu-enter-fullscreen = Enter Full Screen
+context-menu-volume-controls = Volume Controls


### PR DESCRIPTION
This fixes case in context menu entries. In English it should be title case.