### PR TITLE
avm2: Do not reference trivially copyable objects

### DIFF
--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -121,7 +121,7 @@ impl<'gc> Domain<'gc> {
     }
 
     #[cfg(feature = "egui")]
-    pub fn children(&self, mc: &Mutation<'gc>) -> Vec<Domain<'gc>> {
+    pub fn children(self, mc: &Mutation<'gc>) -> Vec<Domain<'gc>> {
         // Take this opportunity to clean up dead children.
         let mut output = Vec::new();
         self.cell_mut(mc).children.retain(|child| {
@@ -327,7 +327,7 @@ impl<'gc> Domain<'gc> {
         res
     }
 
-    pub fn get_defined_names(&self) -> Vec<QName<'gc>> {
+    pub fn get_defined_names(self) -> Vec<QName<'gc>> {
         self.cell()
             .defs
             .iter()
@@ -349,7 +349,7 @@ impl<'gc> Domain<'gc> {
     /// Export a class into the current application domain.
     ///
     /// This does nothing if the definition already exists in this domain or a parent.
-    pub fn export_class(&self, export_name: QName<'gc>, class: Class<'gc>, mc: &Mutation<'gc>) {
+    pub fn export_class(self, export_name: QName<'gc>, class: Class<'gc>, mc: &Mutation<'gc>) {
         if self.has_class(export_name) {
             return;
         }
@@ -371,7 +371,7 @@ impl<'gc> Domain<'gc> {
         std::ptr::eq(domain_memory_ptr, default_domain_memory_ptr)
     }
 
-    pub fn domain_memory(&self) -> ByteArrayObject<'gc> {
+    pub fn domain_memory(self) -> ByteArrayObject<'gc> {
         self.0
             .domain_memory
             .get()

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -295,7 +295,7 @@ fn describe_internal_body<'gc>(
                     activation.gc(),
                 );
 
-                let params = write_params(&method.method, activation);
+                let params = write_params(method.method, activation);
                 method_obj.set_dynamic_property(
                     istr!("parameters"),
                     params.into(),
@@ -416,7 +416,7 @@ fn describe_internal_body<'gc>(
     if let Some(constructor) = constructor.filter(|c| {
         !c.signature().is_empty() && flags.contains(DescribeTypeFlags::INCLUDE_CONSTRUCTOR)
     }) {
-        let params = write_params(&constructor, activation);
+        let params = write_params(constructor, activation);
         traits.set_dynamic_property(istr!("constructor"), params.into(), activation.gc());
     } else {
         // This is needed to override the normal 'constructor' property
@@ -452,7 +452,7 @@ fn display_name<'gc>(
 }
 
 fn write_params<'gc>(
-    method: &Method<'gc>,
+    method: Method<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> ArrayObject<'gc> {
     let params = ArrayObject::empty(activation);

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -305,7 +305,7 @@ pub fn replace<'gc>(
     {
         // Replacement is either a function or treatable as string.
         if let Some(f) = replacement.as_object().and_then(|o| o.as_function_object()) {
-            return Ok(RegExp::replace_fn(regexp, activation, this, &f)?.into());
+            return Ok(RegExp::replace_fn(regexp, activation, this, f)?.into());
         } else {
             let replacement = replacement.coerce_to_string(activation)?;
             return Ok(RegExp::replace_string(regexp, activation, this, replacement)?.into());

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -738,7 +738,7 @@ pub fn contains<'gc>(
     let value = args.get_value(0);
 
     if let Some(other) = value.as_object().and_then(|obj| obj.as_xml_object()) {
-        let result = xml.node().equals(&other.node());
+        let result = xml.node().equals(other.node());
         return Ok(result.into());
     }
     Ok(false.into())

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -233,16 +233,16 @@ impl<'gc> Method<'gc> {
     }
 
     /// Get the underlying ABC file.
-    pub fn abc(&self) -> Rc<AbcFile> {
+    pub fn abc(self) -> Rc<AbcFile> {
         self.0.txunit.abc()
     }
 
     /// Get the underlying translation unit this method was defined in.
-    pub fn translation_unit(&self) -> TranslationUnit<'gc> {
+    pub fn translation_unit(self) -> TranslationUnit<'gc> {
         self.0.txunit
     }
 
-    pub fn abc_method_index(&self) -> u32 {
+    pub fn abc_method_index(self) -> u32 {
         self.0.abc_method
     }
 
@@ -252,7 +252,7 @@ impl<'gc> Method<'gc> {
     }
 
     /// Get a reference to the SwfMovie this method came from.
-    pub fn owner_movie(&self) -> Arc<SwfMovie> {
+    pub fn owner_movie(self) -> Arc<SwfMovie> {
         self.0.txunit.movie()
     }
 
@@ -296,7 +296,7 @@ impl<'gc> Method<'gc> {
         &self.0.resolved_info.get().unwrap().param_config
     }
 
-    pub fn resolved_return_type(&self) -> Option<Class<'gc>> {
+    pub fn resolved_return_type(self) -> Option<Class<'gc>> {
         self.0.resolved_info.get().unwrap().return_type
     }
 
@@ -351,14 +351,14 @@ impl<'gc> Method<'gc> {
     /// Determine if a given method is variadic.
     ///
     /// Variadic methods shove excess parameters into a final register.
-    pub fn is_variadic(&self) -> bool {
+    pub fn is_variadic(self) -> bool {
         self.method()
             .flags
             .intersects(AbcMethodFlags::NEED_ARGUMENTS | AbcMethodFlags::NEED_REST)
     }
 
     /// Check if this method needs `arguments`.
-    pub fn needs_arguments_object(&self) -> bool {
+    pub fn needs_arguments_object(self) -> bool {
         self.method().flags.contains(AbcMethodFlags::NEED_ARGUMENTS)
     }
 
@@ -366,7 +366,7 @@ impl<'gc> Method<'gc> {
         &self.0.method_kind
     }
 
-    pub fn return_type(&self) -> Option<Gc<'gc, Multiname<'gc>>> {
+    pub fn return_type(self) -> Option<Gc<'gc, Multiname<'gc>>> {
         self.0.return_type
     }
 
@@ -392,7 +392,7 @@ impl<'gc> Method<'gc> {
     ///
     ///  * The method was declared as a free-standing function
     ///  * The function's parameters have no declared types or default values
-    pub fn is_unchecked(&self) -> bool {
+    pub fn is_unchecked(self) -> bool {
         self.0.is_unchecked
     }
 }

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -245,27 +245,27 @@ impl<'gc> Namespace<'gc> {
         )))
     }
 
-    pub fn is_public(&self) -> bool {
+    pub fn is_public(self) -> bool {
         matches!(self.0.as_deref(), Some(NamespaceData::Namespace(name, _)) if name.as_wstr().is_empty())
     }
 
-    pub fn is_public_ignoring_ns(&self) -> bool {
+    pub fn is_public_ignoring_ns(self) -> bool {
         matches!(self.0.as_deref(), Some(NamespaceData::Namespace(_, _)))
     }
 
-    pub fn is_any(&self) -> bool {
+    pub fn is_any(self) -> bool {
         self.0.is_none()
     }
 
-    pub fn is_private(&self) -> bool {
+    pub fn is_private(self) -> bool {
         matches!(self.0.as_deref(), Some(NamespaceData::Private(_)))
     }
 
-    pub fn is_namespace(&self) -> bool {
+    pub fn is_namespace(self) -> bool {
         matches!(self.0.as_deref(), Some(NamespaceData::Namespace(_, _)))
     }
 
-    pub fn as_uri_opt(&self) -> Option<AvmString<'gc>> {
+    pub fn as_uri_opt(self) -> Option<AvmString<'gc>> {
         self.0.map(|data| match *data {
             NamespaceData::Namespace(a, _) => a.into(),
             NamespaceData::PackageInternal(a) => a.into(),
@@ -279,7 +279,7 @@ impl<'gc> Namespace<'gc> {
     /// Get the string value of this namespace, ignoring its type.
     ///
     /// TODO: Is this *actually* the namespace URI?
-    pub fn as_uri(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
+    pub fn as_uri(self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         self.as_uri_opt().unwrap_or_else(|| context.empty())
     }
 
@@ -289,7 +289,7 @@ impl<'gc> Namespace<'gc> {
     ///
     /// Namespace does not implement `PartialEq`, so that each caller is required
     /// to explicitly choose either `exact_version_match` or `matches_ns`.
-    pub fn exact_version_match(&self, other: Self) -> bool {
+    pub fn exact_version_match(self, other: Self) -> bool {
         if self.0.map(Gc::as_ptr) == other.0.map(Gc::as_ptr) {
             true
         } else if self.is_private() || other.is_private() {
@@ -304,7 +304,7 @@ impl<'gc> Namespace<'gc> {
     /// seen by the other). This is used to implement `PropertyMap`, where we want to
     /// a definition with `ApiVersion::SWF_16` to be visible when queried from
     /// a SWF with `ApiVersion::SWF_16` or any higher version.
-    pub fn matches_ns(&self, other: Self) -> bool {
+    pub fn matches_ns(self, other: Self) -> bool {
         if self.exact_version_match(other) {
             return true;
         }
@@ -321,7 +321,7 @@ impl<'gc> Namespace<'gc> {
             _ => false,
         }
     }
-    pub fn matches_api_version(&self, match_version: ApiVersion) -> bool {
+    pub fn matches_api_version(self, match_version: ApiVersion) -> bool {
         match self.0.as_deref() {
             Some(NamespaceData::Namespace(_, version)) => version <= &match_version,
             _ => true,

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -742,7 +742,7 @@ impl<'gc> ClassObject<'gc> {
             .map(|c| c.0)
     }
 
-    pub fn name(&self) -> QName<'gc> {
+    pub fn name(self) -> QName<'gc> {
         self.inner_class_definition().name()
     }
 }

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -392,7 +392,7 @@ impl<'gc> Context3DObject<'gc> {
         });
     }
 
-    pub(crate) fn set_color_mask(&self, red: bool, green: bool, blue: bool, alpha: bool) {
+    pub(crate) fn set_color_mask(self, red: bool, green: bool, blue: bool, alpha: bool) {
         self.with_context_3d(|ctx| {
             ctx.process_command(Context3DCommand::SetColorMask {
                 red,
@@ -403,7 +403,7 @@ impl<'gc> Context3DObject<'gc> {
         });
     }
 
-    pub(crate) fn set_depth_test(&self, depth_mask: bool, pass_compare_mode: Context3DCompareMode) {
+    pub(crate) fn set_depth_test(self, depth_mask: bool, pass_compare_mode: Context3DCompareMode) {
         self.with_context_3d(|ctx| {
             ctx.process_command(Context3DCommand::SetDepthTest {
                 depth_mask,
@@ -452,7 +452,7 @@ impl<'gc> Context3DObject<'gc> {
         });
     }
 
-    pub(crate) fn set_scissor_rectangle(&self, rect: Option<Rectangle<Twips>>) {
+    pub(crate) fn set_scissor_rectangle(self, rect: Option<Rectangle<Twips>>) {
         self.with_context_3d(|ctx| {
             ctx.process_command(Context3DCommand::SetScissorRectangle { rect })
         });

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -58,7 +58,7 @@ pub struct ErrorObjectData<'gc> {
 }
 
 impl<'gc> ErrorObject<'gc> {
-    pub fn display(&self) -> WString {
+    pub fn display(self) -> WString {
         let name = match self.base().get_slot(error_slots::NAME) {
             Value::String(string) => string.as_wstr(),
             Value::Null => WStr::from_units(b"null"),
@@ -81,7 +81,7 @@ impl<'gc> ErrorObject<'gc> {
         output
     }
 
-    pub fn display_full(&self) -> WString {
+    pub fn display_full(self) -> WString {
         let mut output = WString::new();
         output.push_str(&self.display());
         self.call_stack().display(&mut output);

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -352,7 +352,7 @@ impl<'gc> EventObject<'gc> {
         )
     }
 
-    pub fn event(&self) -> Ref<'gc, Event<'gc>> {
+    pub fn event(self) -> Ref<'gc, Event<'gc>> {
         Gc::as_ref(self.0).event.borrow()
     }
 

--- a/core/src/avm2/object/file_reference_object.rs
+++ b/core/src/avm2/object/file_reference_object.rs
@@ -40,7 +40,7 @@ impl<'gc> TObject<'gc> for FileReferenceObject<'gc> {
 }
 
 impl FileReferenceObject<'_> {
-    pub fn init_from_dialog_result(&self, result: Box<dyn FileDialogResult>) -> FileReference {
+    pub fn init_from_dialog_result(self, result: Box<dyn FileDialogResult>) -> FileReference {
         self.0
             .reference
             .replace(FileReference::FileDialogResult(result))
@@ -50,11 +50,11 @@ impl FileReferenceObject<'_> {
         self.0.reference.borrow()
     }
 
-    pub fn set_loaded(&self, value: bool) {
+    pub fn set_loaded(self, value: bool) {
         self.0.loaded.set(value)
     }
 
-    pub fn loaded(&self) -> bool {
+    pub fn loaded(self) -> bool {
         self.0.loaded.get()
     }
 }

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -138,7 +138,7 @@ impl<'gc> FunctionObject<'gc> {
         }
     }
 
-    pub fn prototype(&self) -> Option<Object<'gc>> {
+    pub fn prototype(self) -> Option<Object<'gc>> {
         self.0.prototype.get()
     }
 

--- a/core/src/avm2/object/index_buffer_3d_object.rs
+++ b/core/src/avm2/object/index_buffer_3d_object.rs
@@ -38,11 +38,11 @@ impl<'gc> IndexBuffer3DObject<'gc> {
         .into()
     }
 
-    pub fn count(&self) -> usize {
+    pub fn count(self) -> usize {
         self.0.count.get()
     }
 
-    pub fn set_count(&self, val: usize) {
+    pub fn set_count(self, val: usize) {
         self.0.count.set(val);
     }
 
@@ -50,7 +50,7 @@ impl<'gc> IndexBuffer3DObject<'gc> {
         RefMut::map(self.0.handle.borrow_mut(), |h| h.as_mut())
     }
 
-    pub fn context3d(&self) -> Context3DObject<'gc> {
+    pub fn context3d(self) -> Context3DObject<'gc> {
         self.0.context3d
     }
 }

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -154,22 +154,22 @@ impl<'gc> LoaderInfoObject<'gc> {
         Ok(object)
     }
 
-    pub fn loader(&self) -> Option<Object<'gc>> {
+    pub fn loader(self) -> Option<Object<'gc>> {
         self.0.loader
     }
 
-    pub fn shared_events(&self) -> Object<'gc> {
+    pub fn shared_events(self) -> Object<'gc> {
         self.0.shared_events
     }
 
-    pub fn uncaught_error_events(&self) -> Object<'gc> {
+    pub fn uncaught_error_events(self) -> Object<'gc> {
         self.0.uncaught_error_events
     }
 
     /// Gets the `ContentType`, 'hiding' it by returning `ContentType::Unknown`
     /// if we haven't yet fired the 'init' event. The real ContentType first becomes
     /// visible to ActionScript in the 'init' event.
-    pub fn content_type_hide_before_init(&self) -> ContentType {
+    pub fn content_type_hide_before_init(self) -> ContentType {
         if self.0.init_event_fired.get() {
             self.0.content_type.get()
         } else {
@@ -177,19 +177,19 @@ impl<'gc> LoaderInfoObject<'gc> {
         }
     }
 
-    pub fn set_errored(&self, val: bool) {
+    pub fn set_errored(self, val: bool) {
         self.0.errored.set(val);
     }
 
-    pub fn errored(&self) -> bool {
+    pub fn errored(self) -> bool {
         self.0.errored.get()
     }
 
-    pub fn init_event_fired(&self) -> bool {
+    pub fn init_event_fired(self) -> bool {
         self.0.init_event_fired.get()
     }
 
-    pub fn reset_init_and_complete_events(&self) {
+    pub fn reset_init_and_complete_events(self) {
         self.0.init_event_fired.set(false);
         self.0.complete_event_fired.set(false);
     }
@@ -198,7 +198,7 @@ impl<'gc> LoaderInfoObject<'gc> {
     /// Returns `true` if both events have been fired (either as a result of
     /// this call, or due to a previous call).
     pub fn fire_init_and_complete_events(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         status: u16,
         redirected: bool,
@@ -210,7 +210,7 @@ impl<'gc> LoaderInfoObject<'gc> {
             // TODO - 'init' should be fired earlier during the download.
             // Right now, we fire it when downloading is fully completed.
             let init_evt = EventObject::bare_default_event(context, "init");
-            Avm2::dispatch_event(context, init_evt, (*self).into());
+            Avm2::dispatch_event(context, init_evt, self.into());
         }
 
         if !self.0.complete_event_fired.get() {
@@ -232,12 +232,12 @@ impl<'gc> LoaderInfoObject<'gc> {
                     let http_status_evt =
                         EventObject::http_status_event(&mut activation, status, redirected);
 
-                    Avm2::dispatch_event(context, http_status_evt, (*self).into());
+                    Avm2::dispatch_event(context, http_status_evt, self.into());
                 }
 
                 self.0.complete_event_fired.set(true);
                 let complete_evt = EventObject::bare_default_event(context, "complete");
-                Avm2::dispatch_event(context, complete_evt, (*self).into());
+                Avm2::dispatch_event(context, complete_evt, self.into());
                 return true;
             }
             return false;
@@ -246,18 +246,18 @@ impl<'gc> LoaderInfoObject<'gc> {
     }
 
     /// Unwrap this object's loader stream
-    pub fn loader_stream(&self) -> Ref<'gc, LoaderStream<'gc>> {
+    pub fn loader_stream(self) -> Ref<'gc, LoaderStream<'gc>> {
         Gc::as_ref(self.0).loaded_stream.borrow()
     }
 
-    pub fn expose_content(&self) -> bool {
+    pub fn expose_content(self) -> bool {
         self.0.expose_content.get()
     }
 
     /// Makes the 'content' visible to ActionScript.
     /// This is used by certain special loaders (the stage and root movie),
     /// which expose the loaded content before the 'init' event is fired.
-    pub fn set_expose_content(&self) {
+    pub fn set_expose_content(self) {
         self.0.expose_content.set(true);
     }
 
@@ -265,11 +265,11 @@ impl<'gc> LoaderInfoObject<'gc> {
         *unlock!(Gc::write(mc, self.0), LoaderInfoObjectData, loaded_stream).borrow_mut() = stream;
     }
 
-    pub fn set_content_type(&self, content_type: ContentType) {
+    pub fn set_content_type(self, content_type: ContentType) {
         self.0.content_type.set(content_type);
     }
 
-    pub fn unload(&self, activation: &mut Activation<'_, 'gc>) {
+    pub fn unload(self, activation: &mut Activation<'_, 'gc>) {
         // Reset properties
         let movie = &activation.context.root_swf;
         let empty_swf = Arc::new(SwfMovie::empty(movie.version(), Some(movie.url().into())));

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -66,11 +66,11 @@ pub struct LocalConnectionObjectData<'gc> {
 }
 
 impl<'gc> LocalConnectionObject<'gc> {
-    pub fn is_connected(&self) -> bool {
+    pub fn is_connected(self) -> bool {
         self.0.connection_handle.borrow().is_some()
     }
 
-    pub fn client(&self) -> Object<'gc> {
+    pub fn client(self) -> Object<'gc> {
         self.0.client.get().expect("Client must be initialized")
     }
 
@@ -78,14 +78,14 @@ impl<'gc> LocalConnectionObject<'gc> {
         unlock!(Gc::write(mc, self.0), LocalConnectionObjectData, client).set(Some(client));
     }
 
-    pub fn connect(&self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) -> bool {
+    pub fn connect(self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) -> bool {
         if self.is_connected() {
             return false;
         }
 
         let connection_handle = activation.context.local_connections.connect(
             &LocalConnections::get_domain(activation.context.root_swf.url()),
-            (activation.domain(), *self),
+            (activation.domain(), self),
             &name,
         );
         let result = connection_handle.is_some();
@@ -95,13 +95,13 @@ impl<'gc> LocalConnectionObject<'gc> {
         result
     }
 
-    pub fn disconnect(&self, activation: &mut Activation<'_, 'gc>) {
+    pub fn disconnect(self, activation: &mut Activation<'_, 'gc>) {
         if let Some(conn_handle) = self.0.connection_handle.borrow_mut().take() {
             activation.context.local_connections.close(conn_handle);
         }
     }
 
-    pub fn send_status(&self, context: &mut UpdateContext<'gc>, status: AvmString<'gc>) {
+    pub fn send_status(self, context: &mut UpdateContext<'gc>, status: AvmString<'gc>) {
         let mut activation = Activation::from_nothing(context);
 
         let status_event_cls = activation.avm2().classes().statusevent;
@@ -118,11 +118,11 @@ impl<'gc> LocalConnectionObject<'gc> {
             ],
         );
 
-        Avm2::dispatch_event(activation.context, event, (*self).into());
+        Avm2::dispatch_event(activation.context, event, self.into());
     }
 
     pub fn run_method(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         domain: Domain<'gc>,
         method_name: AvmString<'gc>,
@@ -158,7 +158,7 @@ impl<'gc> LocalConnectionObject<'gc> {
                         ],
                     );
 
-                    Avm2::dispatch_event(activation.context, event, (*self).into());
+                    Avm2::dispatch_event(activation.context, event, self.into());
                 }
                 _ => {
                     tracing::error!("Unhandled error dispatching AVM2 LocalConnection method call to '{method_name}': {e}");

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -85,7 +85,7 @@ impl<'gc> NamespaceObject<'gc> {
         self.0.namespace
     }
 
-    pub fn prefix(&self) -> Option<AvmString<'gc>> {
+    pub fn prefix(self) -> Option<AvmString<'gc>> {
         self.0.prefix
     }
 }

--- a/core/src/avm2/object/net_connection_object.rs
+++ b/core/src/avm2/object/net_connection_object.rs
@@ -52,11 +52,11 @@ impl<'gc> TObject<'gc> for NetConnectionObject<'gc> {
 }
 
 impl NetConnectionObject<'_> {
-    pub fn handle(&self) -> Option<NetConnectionHandle> {
+    pub fn handle(self) -> Option<NetConnectionHandle> {
         self.0.handle.get()
     }
 
-    pub fn set_handle(&self, handle: Option<NetConnectionHandle>) -> Option<NetConnectionHandle> {
+    pub fn set_handle(self, handle: Option<NetConnectionHandle>) -> Option<NetConnectionHandle> {
         self.0.handle.replace(handle)
     }
 }

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -42,7 +42,7 @@ impl<'gc> Program3DObject<'gc> {
         &self.0.shader_module_handle
     }
 
-    pub fn context3d(&self) -> Context3DObject<'gc> {
+    pub fn context3d(self) -> Context3DObject<'gc> {
         self.0.context3d
     }
 }

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -87,7 +87,7 @@ impl<'gc> QNameObject<'gc> {
         write_name.set_local_name(local);
     }
 
-    pub fn local_name(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
+    pub fn local_name(self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         let name = self.name();
 
         name.local_name().unwrap_or_else(|| istr!(context, "*"))
@@ -99,7 +99,7 @@ impl<'gc> QNameObject<'gc> {
         write_name.set_is_qname(is_qname);
     }
 
-    pub fn uri(&self, context: &mut StringContext<'gc>) -> Option<AvmString<'gc>> {
+    pub fn uri(self, context: &mut StringContext<'gc>) -> Option<AvmString<'gc>> {
         let name = self.0.name.borrow();
 
         if name.is_any_namespace() {
@@ -114,7 +114,7 @@ impl<'gc> QNameObject<'gc> {
         }
     }
 
-    pub fn is_any_namespace(&self) -> bool {
+    pub fn is_any_namespace(self) -> bool {
         self.0.name.borrow().is_any_namespace()
     }
 

--- a/core/src/avm2/object/responder_object.rs
+++ b/core/src/avm2/object/responder_object.rs
@@ -43,11 +43,11 @@ impl<'gc> TObject<'gc> for ResponderObject<'gc> {
 }
 
 impl<'gc> ResponderObject<'gc> {
-    pub fn result(&self) -> Option<FunctionObject<'gc>> {
+    pub fn result(self) -> Option<FunctionObject<'gc>> {
         self.0.result.get()
     }
 
-    pub fn status(&self) -> Option<FunctionObject<'gc>> {
+    pub fn status(self) -> Option<FunctionObject<'gc>> {
         self.0.status.get()
     }
 
@@ -63,7 +63,7 @@ impl<'gc> ResponderObject<'gc> {
     }
 
     pub fn send_callback(
-        &self,
+        self,
         context: &mut UpdateContext<'gc>,
         callback: ResponderCallback,
         message: &AMFValue,
@@ -77,11 +77,7 @@ impl<'gc> ResponderObject<'gc> {
             let mut activation = Activation::from_nothing(context);
             let value = crate::avm2::amf::deserialize_value(&mut activation, message)?;
             let args = &[value];
-            function.call(
-                &mut activation,
-                (*self).into(),
-                FunctionArgs::from_slice(args),
-            )?;
+            function.call(&mut activation, self.into(), FunctionArgs::from_slice(args))?;
         }
 
         Ok(())

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -188,7 +188,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
     }
 
     pub fn get_property_local(
-        &self,
+        self,
         multiname: &Multiname<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
@@ -220,7 +220,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
     }
 
     pub fn set_property_local(
-        &self,
+        self,
         multiname: &Multiname<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
@@ -252,7 +252,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
     }
 
     pub fn init_property_local(
-        &self,
+        self,
         multiname: &Multiname<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
@@ -260,7 +260,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
         self.set_property_local(multiname, value, activation)
     }
 
-    pub fn delete_property_local(&self, mc: &Mutation<'gc>, multiname: &Multiname<'gc>) -> bool {
+    pub fn delete_property_local(self, mc: &Mutation<'gc>, multiname: &Multiname<'gc>) -> bool {
         // TODO: FP behaves differently here in interpreter mode vs JIT mode
         if !multiname.valid_dynamic_name() {
             return false;
@@ -276,7 +276,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
     }
 
     #[inline(always)]
-    pub fn get_slot(&self, id: u32) -> Value<'gc> {
+    pub fn get_slot(self, id: u32) -> Value<'gc> {
         self.0
             .slots
             .get(id as usize)
@@ -286,7 +286,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
     }
 
     /// Set a slot by its index.
-    pub fn set_slot(&self, id: u32, value: Value<'gc>, mc: &Mutation<'gc>) {
+    pub fn set_slot(self, id: u32, value: Value<'gc>, mc: &Mutation<'gc>) {
         let slot = self
             .0
             .slots
@@ -300,11 +300,11 @@ impl<'gc> ScriptObjectWrapper<'gc> {
     }
 
     /// Retrieve a bound method from the method table.
-    pub fn get_bound_method(&self, id: u32) -> Option<FunctionObject<'gc>> {
+    pub fn get_bound_method(self, id: u32) -> Option<FunctionObject<'gc>> {
         self.bound_methods().get(id as usize).and_then(|v| *v)
     }
 
-    pub fn has_own_dynamic_property(&self, name: &Multiname<'gc>) -> bool {
+    pub fn has_own_dynamic_property(self, name: &Multiname<'gc>) -> bool {
         if name.valid_dynamic_name() {
             if let Some(name) = name.local_name() {
                 let key = maybe_int_property(name);
@@ -314,11 +314,11 @@ impl<'gc> ScriptObjectWrapper<'gc> {
         false
     }
 
-    pub fn has_own_property(&self, name: &Multiname<'gc>) -> bool {
+    pub fn has_own_property(self, name: &Multiname<'gc>) -> bool {
         self.vtable().has_trait(name) || self.has_own_dynamic_property(name)
     }
 
-    pub fn proto(&self) -> Option<Object<'gc>> {
+    pub fn proto(self) -> Option<Object<'gc>> {
         self.0.proto.get()
     }
 
@@ -326,14 +326,14 @@ impl<'gc> ScriptObjectWrapper<'gc> {
         unlock!(Gc::write(mc, self.0), ScriptObjectData, proto).set(Some(proto));
     }
 
-    pub fn get_next_enumerant(&self, last_index: u32) -> u32 {
+    pub fn get_next_enumerant(self, last_index: u32) -> u32 {
         self.values()
             .next(last_index as usize)
             .map(|val| val as u32)
             .unwrap_or(0)
     }
 
-    pub fn get_enumerant_name(&self, index: u32) -> Option<Value<'gc>> {
+    pub fn get_enumerant_name(self, index: u32) -> Option<Value<'gc>> {
         self.values().key_at(index as usize).map(|key| match key {
             DynamicKey::String(name) => Value::String(*name),
             DynamicKey::Object(obj) => Value::Object(*obj),
@@ -341,7 +341,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
         })
     }
 
-    pub fn property_is_enumerable(&self, name: AvmString<'gc>) -> bool {
+    pub fn property_is_enumerable(self, name: AvmString<'gc>) -> bool {
         let key = maybe_int_property(name);
         self.values()
             .as_hashmap()
@@ -350,7 +350,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
     }
 
     pub fn set_local_property_is_enumerable(
-        &self,
+        self,
         mc: &Mutation<'gc>,
         name: AvmString<'gc>,
         is_enumerable: bool,
@@ -363,7 +363,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
 
     /// Install a method into the object.
     pub fn install_bound_method(
-        &self,
+        self,
         mc: &Mutation<'gc>,
         disp_id: u32,
         function: FunctionObject<'gc>,
@@ -378,16 +378,16 @@ impl<'gc> ScriptObjectWrapper<'gc> {
     }
 
     /// Get the `Class` for this object.
-    pub fn instance_class(&self) -> Class<'gc> {
+    pub fn instance_class(self) -> Class<'gc> {
         self.0.instance_class
     }
 
     /// Get the vtable for this object, if it has one.
-    pub fn vtable(&self) -> VTable<'gc> {
+    pub fn vtable(self) -> VTable<'gc> {
         self.0.vtable.get()
     }
 
-    pub fn is_sealed(&self) -> bool {
+    pub fn is_sealed(self) -> bool {
         self.instance_class().is_sealed()
     }
 
@@ -401,7 +401,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
         unlock!(Gc::write(mc, self.0), ScriptObjectData, vtable).set(vtable);
     }
 
-    pub fn class_name(&self) -> QName<'gc> {
+    pub fn class_name(self) -> QName<'gc> {
         self.instance_class().name()
     }
 }

--- a/core/src/avm2/object/shader_data_object.rs
+++ b/core/src/avm2/object/shader_data_object.rs
@@ -42,13 +42,13 @@ impl fmt::Debug for ShaderDataObject<'_> {
 }
 
 impl ShaderDataObject<'_> {
-    pub fn pixel_bender_shader(&self) -> Option<PixelBenderShaderHandle> {
+    pub fn pixel_bender_shader(self) -> Option<PixelBenderShaderHandle> {
         let shader = &self.0.shader;
         let guard = scopeguard::guard(shader.take(), |stolen| shader.set(stolen));
         guard.clone()
     }
 
-    pub fn set_pixel_bender_shader(&self, shader: PixelBenderShaderHandle) {
+    pub fn set_pixel_bender_shader(self, shader: PixelBenderShaderHandle) {
         self.0.shader.set(Some(shader));
     }
 }

--- a/core/src/avm2/object/shared_object_object.rs
+++ b/core/src/avm2/object/shared_object_object.rs
@@ -49,7 +49,7 @@ impl<'gc> SharedObjectObject<'gc> {
         ))
     }
 
-    pub fn data(&self) -> Object<'gc> {
+    pub fn data(self) -> Object<'gc> {
         self.0.data.get()
     }
 

--- a/core/src/avm2/object/socket_object.rs
+++ b/core/src/avm2/object/socket_object.rs
@@ -48,37 +48,37 @@ impl<'gc> TObject<'gc> for SocketObject<'gc> {
 }
 
 impl<'gc> SocketObject<'gc> {
-    pub fn endian(&self) -> Endian {
+    pub fn endian(self) -> Endian {
         self.0.endian.get()
     }
 
-    pub fn set_endian(&self, endian: Endian) {
+    pub fn set_endian(self, endian: Endian) {
         self.0.endian.set(endian)
     }
 
-    pub fn object_encoding(&self) -> ObjectEncoding {
+    pub fn object_encoding(self) -> ObjectEncoding {
         self.0.object_encoding.get()
     }
 
-    pub fn set_object_encoding(&self, object_encoding: ObjectEncoding) {
+    pub fn set_object_encoding(self, object_encoding: ObjectEncoding) {
         self.0.object_encoding.set(object_encoding)
     }
 
-    pub fn timeout(&self) -> u32 {
+    pub fn timeout(self) -> u32 {
         self.0.timeout.get()
     }
 
-    pub fn set_timeout(&self, timeout: u32) {
+    pub fn set_timeout(self, timeout: u32) {
         // NOTE: When a timeout of smaller than 250 milliseconds is provided,
         //       we clamp it to 250 milliseconds.
         self.0.timeout.set(std::cmp::max(250, timeout));
     }
 
-    pub fn handle(&self) -> Option<SocketHandle> {
+    pub fn handle(self) -> Option<SocketHandle> {
         self.0.handle.get()
     }
 
-    pub fn set_handle(&self, handle: SocketHandle) -> Option<SocketHandle> {
+    pub fn set_handle(self, handle: SocketHandle) -> Option<SocketHandle> {
         self.0.handle.replace(Some(handle))
     }
 
@@ -90,7 +90,7 @@ impl<'gc> SocketObject<'gc> {
         self.0.write_buffer.borrow_mut()
     }
 
-    pub fn read_bytes(&self, amnt: usize) -> Result<Vec<u8>, ByteArrayError> {
+    pub fn read_bytes(self, amnt: usize) -> Result<Vec<u8>, ByteArrayError> {
         let mut buf = self.read_buffer();
 
         if amnt > buf.len() {
@@ -103,22 +103,22 @@ impl<'gc> SocketObject<'gc> {
         Ok(bytes.collect())
     }
 
-    pub fn write_bytes(&self, bytes: &[u8]) {
+    pub fn write_bytes(self, bytes: &[u8]) {
         self.0.write_buffer.borrow_mut().extend_from_slice(bytes)
     }
 
-    pub fn read_boolean(&self) -> Result<bool, ByteArrayError> {
+    pub fn read_boolean(self) -> Result<bool, ByteArrayError> {
         Ok(self.read_bytes(1)? != [0])
     }
 
-    pub fn write_boolean(&self, val: bool) {
+    pub fn write_boolean(self, val: bool) {
         self.write_bytes(&[val as u8; 1])
     }
 
     /// Same as `read_bytes`, but:
     /// - cuts the result at the first null byte to recreate a bug in FP
     /// - strips off an optional UTF8 BOM at the beginning
-    pub fn read_utf_bytes(&self, amnt: usize) -> Result<Vec<u8>, ByteArrayError> {
+    pub fn read_utf_bytes(self, amnt: usize) -> Result<Vec<u8>, ByteArrayError> {
         let mut bytes = &*self.read_bytes(amnt)?;
         if let Some(without_bom) = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]) {
             bytes = without_bom;
@@ -129,7 +129,7 @@ impl<'gc> SocketObject<'gc> {
         Ok(bytes.to_vec())
     }
 
-    pub fn read_utf(&self) -> Result<Vec<u8>, ByteArrayError> {
+    pub fn read_utf(self) -> Result<Vec<u8>, ByteArrayError> {
         let len = self.read_unsigned_short()?;
         let val = self.read_utf_bytes(len.into())?;
         Ok(val)
@@ -137,7 +137,7 @@ impl<'gc> SocketObject<'gc> {
 
     // Writes a UTF String into the buffer, with its length as a prefix
     pub fn write_utf(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         utf_string: &str,
     ) -> Result<(), Error<'gc>> {

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -73,11 +73,11 @@ impl<'gc> TextFormatObject<'gc> {
         Ok(this)
     }
 
-    pub fn text_format(&self) -> Ref<'gc, TextFormat> {
+    pub fn text_format(self) -> Ref<'gc, TextFormat> {
         Gc::as_ref(self.0).text_format.borrow()
     }
 
-    pub fn text_format_mut(&self) -> RefMut<'gc, TextFormat> {
+    pub fn text_format_mut(self) -> RefMut<'gc, TextFormat> {
         Gc::as_ref(self.0).text_format.borrow_mut()
     }
 }

--- a/core/src/avm2/object/texture_object.rs
+++ b/core/src/avm2/object/texture_object.rs
@@ -38,15 +38,15 @@ impl<'gc> TextureObject<'gc> {
         .into()
     }
 
-    pub fn original_format(&self) -> Context3DTextureFormat {
+    pub fn original_format(self) -> Context3DTextureFormat {
         self.0.original_format
     }
 
-    pub fn handle(&self) -> Rc<dyn Texture> {
+    pub fn handle(self) -> Rc<dyn Texture> {
         self.0.handle.clone()
     }
 
-    pub fn context3d(&self) -> Context3DObject<'gc> {
+    pub fn context3d(self) -> Context3DObject<'gc> {
         self.0.context3d
     }
 }

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -39,15 +39,15 @@ impl<'gc> VertexBuffer3DObject<'gc> {
         .into()
     }
 
-    pub fn handle(&self) -> Rc<dyn VertexBuffer> {
+    pub fn handle(self) -> Rc<dyn VertexBuffer> {
         self.0.handle.clone()
     }
 
-    pub fn context3d(&self) -> Context3DObject<'gc> {
+    pub fn context3d(self) -> Context3DObject<'gc> {
         self.0.context3d
     }
 
-    pub fn data32_per_vertex(&self) -> u8 {
+    pub fn data32_per_vertex(self) -> u8 {
         self.0.data32_per_vertex
     }
 }

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -87,16 +87,16 @@ impl<'gc> XmlListObject<'gc> {
         ))
     }
 
-    pub fn set_dirty_flag(&self) {
+    pub fn set_dirty_flag(self) {
         self.0.target_dirty.set(true);
     }
 
-    pub fn length(&self) -> usize {
+    pub fn length(self) -> usize {
         self.0.children.borrow().len()
     }
 
     pub fn xml_object_child(
-        &self,
+        self,
         index: usize,
         activation: &mut Activation<'_, 'gc>,
     ) -> Option<XmlObject<'gc>> {
@@ -108,7 +108,7 @@ impl<'gc> XmlListObject<'gc> {
         }
     }
 
-    pub fn node_child(&self, index: usize) -> Option<E4XNode<'gc>> {
+    pub fn node_child(self, index: usize) -> Option<E4XNode<'gc>> {
         self.0.children.borrow().get(index).map(|x| x.node())
     }
 
@@ -120,19 +120,19 @@ impl<'gc> XmlListObject<'gc> {
         unlock!(Gc::write(mc, self.0), XmlListObjectData, children).borrow_mut()
     }
 
-    pub fn set_children(&self, mc: &Mutation<'gc>, children: Vec<E4XOrXml<'gc>>) {
+    pub fn set_children(self, mc: &Mutation<'gc>, children: Vec<E4XOrXml<'gc>>) {
         *unlock!(Gc::write(mc, self.0), XmlListObjectData, children).borrow_mut() = children;
     }
 
-    fn target_object(&self) -> Option<XmlOrXmlListObject<'gc>> {
+    fn target_object(self) -> Option<XmlOrXmlListObject<'gc>> {
         self.0.target_object.get()
     }
 
-    fn target_property(&self) -> Option<Multiname<'gc>> {
+    fn target_property(self) -> Option<Multiname<'gc>> {
         self.0.target_property.borrow().clone()
     }
 
-    pub fn deep_copy(&self, activation: &mut Activation<'_, 'gc>) -> XmlListObject<'gc> {
+    pub fn deep_copy(self, activation: &mut Activation<'_, 'gc>) -> XmlListObject<'gc> {
         self.reevaluate_target_object(activation);
 
         let children = self
@@ -148,7 +148,7 @@ impl<'gc> XmlListObject<'gc> {
         )
     }
 
-    pub fn as_xml_string(&self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
+    pub fn as_xml_string(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
         let children = self.children();
         let mut out = WString::new();
         for (i, child) in children.iter().enumerate() {
@@ -161,7 +161,7 @@ impl<'gc> XmlListObject<'gc> {
     }
 
     // Based on https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/XMLListObject.cpp#L621
-    pub fn reevaluate_target_object(&self, activation: &mut Activation<'_, 'gc>) {
+    pub fn reevaluate_target_object(self, activation: &mut Activation<'_, 'gc>) {
         if self.0.target_dirty.get() && !self.0.children.borrow().is_empty() {
             let last_node = self
                 .0
@@ -216,7 +216,7 @@ impl<'gc> XmlListObject<'gc> {
     }
 
     // ECMA-357 9.2.1.6 [[Append]] (V)
-    pub fn append(&self, value: Value<'gc>, mc: &Mutation<'gc>) {
+    pub fn append(self, value: Value<'gc>, mc: &Mutation<'gc>) {
         let mut children = self.children_mut(mc);
 
         // 3. If Type(V) is XMLList,
@@ -242,12 +242,12 @@ impl<'gc> XmlListObject<'gc> {
 
     // ECMA-357 9.2.1.10 [[ResolveValue]] ( )
     pub fn resolve_value(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Option<XmlOrXmlListObject<'gc>>, Error<'gc>> {
         // 1. If x.[[Length]] > 0, return x
         if self.length() > 0 {
-            Ok(Some(XmlOrXmlListObject::XmlList(*self)))
+            Ok(Some(XmlOrXmlListObject::XmlList(self)))
         // 2. Else
         } else {
             self.reevaluate_target_object(activation);
@@ -309,7 +309,7 @@ impl<'gc> XmlListObject<'gc> {
     }
 
     pub fn equals(
-        &self,
+        self,
         other: &Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<bool, Error<'gc>> {

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -1083,9 +1083,9 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                         let removed_node = removed.node();
                         if let Some(parent) = removed_node.parent() {
                             if removed_node.is_attribute() {
-                                parent.remove_attribute(activation.gc(), &removed_node);
+                                parent.remove_attribute(activation.gc(), removed_node);
                             } else {
-                                parent.remove_child(activation.gc(), &removed_node);
+                                parent.remove_child(activation.gc(), removed_node);
                             }
                         }
                     }

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -121,7 +121,7 @@ impl<'gc> XmlObject<'gc> {
 
     // 13.4.4.6 XML.prototype.child ( propertyName )
     pub fn child(
-        &self,
+        self,
         name: &Multiname<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> XmlListObject<'gc> {
@@ -155,7 +155,7 @@ impl<'gc> XmlObject<'gc> {
     }
 
     pub fn elements(
-        &self,
+        self,
         name: &Multiname<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> XmlListObject<'gc> {
@@ -172,7 +172,7 @@ impl<'gc> XmlObject<'gc> {
         let list = XmlListObject::new_with_children(
             activation,
             children,
-            Some(XmlOrXmlListObject::Xml(*self)),
+            Some(XmlOrXmlListObject::Xml(self)),
             // NOTE: Spec says to set target property here, but avmplus doesn't, so we do the same.
             None,
         );
@@ -185,7 +185,7 @@ impl<'gc> XmlObject<'gc> {
         list
     }
 
-    pub fn length(&self) -> Option<usize> {
+    pub fn length(self) -> Option<usize> {
         self.node().length()
     }
 
@@ -193,12 +193,12 @@ impl<'gc> XmlObject<'gc> {
         unlock!(Gc::write(mc, self.0), XmlObjectData, node).set(node);
     }
 
-    pub fn local_name(&self) -> Option<AvmString<'gc>> {
+    pub fn local_name(self) -> Option<AvmString<'gc>> {
         self.0.node.get().local_name()
     }
 
     pub fn namespace_object(
-        &self,
+        self,
         activation: &mut Activation<'_, 'gc>,
         in_scope_ns: &[E4XNamespace<'gc>],
     ) -> Result<NamespaceObject<'gc>, Error<'gc>> {
@@ -207,26 +207,26 @@ impl<'gc> XmlObject<'gc> {
             .as_namespace_object(activation)
     }
 
-    pub fn matches_name(&self, multiname: &Multiname<'gc>) -> bool {
+    pub fn matches_name(self, multiname: &Multiname<'gc>) -> bool {
         self.0.node.get().matches_name(multiname)
     }
 
-    pub fn node(&self) -> E4XNode<'gc> {
+    pub fn node(self) -> E4XNode<'gc> {
         self.0.node.get()
     }
 
-    pub fn deep_copy(&self, activation: &mut Activation<'_, 'gc>) -> XmlObject<'gc> {
+    pub fn deep_copy(self, activation: &mut Activation<'_, 'gc>) -> XmlObject<'gc> {
         let node = self.node();
         XmlObject::new(node.deep_copy(activation.gc()), activation)
     }
 
-    pub fn as_xml_string(&self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
+    pub fn as_xml_string(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
         let node = self.node();
         node.xml_to_xml_string(activation)
     }
 
     pub fn equals(
-        &self,
+        self,
         other: &Value<'gc>,
         _activation: &mut Activation<'_, 'gc>,
     ) -> Result<bool, Error<'gc>> {
@@ -238,7 +238,7 @@ impl<'gc> XmlObject<'gc> {
         };
 
         // It seems like an XML object should always be equal to itself
-        if Object::ptr_eq(*self, other) {
+        if Object::ptr_eq(self, other) {
             return Ok(true);
         }
 
@@ -249,7 +249,7 @@ impl<'gc> XmlObject<'gc> {
     // Implements "The Abstract Equality Comparison Algorithm" as defined
     // in ECMA-357 when one side is an XML type (object).
     pub fn abstract_eq(
-        &self,
+        self,
         other: &Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<bool, Error<'gc>> {

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -243,7 +243,7 @@ impl<'gc> XmlObject<'gc> {
         }
 
         let node = other.node();
-        Ok(self.node().equals(&node))
+        Ok(self.node().equals(node))
     }
 
     // Implements "The Abstract Equality Comparison Algorithm" as defined

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -228,7 +228,7 @@ impl<'gc> RegExp<'gc> {
         regexp: RegExpObject<'gc>,
         activation: &mut Activation<'_, 'gc>,
         text: AvmString<'gc>,
-        f: &FunctionObject<'gc>,
+        f: FunctionObject<'gc>,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         Self::replace_with_fn(regexp, activation, &text, |activation, txt, m| {
             let args = std::iter::once(Some(&m.range))

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -233,7 +233,7 @@ impl<'gc> TranslationUnit<'gc> {
     }
 
     /// Gets a script in the ABC file by index.
-    pub fn get_script(&self, index: usize) -> Option<Script<'gc>> {
+    pub fn get_script(self, index: usize) -> Option<Script<'gc>> {
         self.0.scripts.get(index).and_then(|s| s.get()).copied()
     }
 

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -154,7 +154,7 @@ struct FunctionInfo {
 }
 
 impl FunctionInfo {
-    pub fn from_method(method: &Method, stubbed: bool) -> Self {
+    pub fn from_method(method: Method, stubbed: bool) -> Self {
         Self {
             returns: method
                 .return_type()
@@ -388,7 +388,7 @@ impl Definition {
                     output
                         .get_or_insert_default()
                         .function
-                        .insert(trait_name, FunctionInfo::from_method(method, stubbed));
+                        .insert(trait_name, FunctionInfo::from_method(*method, stubbed));
                 }
                 TraitKind::Getter { method, .. } => {
                     let stubbed = stubs.has_getter(&trait_name);

--- a/core/src/avm2/stack.rs
+++ b/core/src/avm2/stack.rs
@@ -72,7 +72,7 @@ impl<'gc> Stack<'gc> {
         StackFrame::for_data(subslice)
     }
 
-    pub fn dispose_stack_frame(&self, stack_frame: StackFrame<'_, 'gc>) {
+    pub fn dispose_stack_frame(self, stack_frame: StackFrame<'_, 'gc>) {
         self.0
             .stack_pointer
             .set(self.0.stack_pointer.get() - stack_frame.data.len());


### PR DESCRIPTION
It's more efficient and simpler to just copy trivially copyable objects instead of referencing them.

This PR covers AVM2's part.