### PR TITLE
refactor: Do not reference trivially copyable objects

### DIFF
--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -463,7 +463,7 @@ pub fn make_error_1089<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 #[cold]
 pub fn make_error_1098<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    prefix: &AvmString<'gc>,
+    prefix: AvmString<'gc>,
 ) -> Error<'gc> {
     let err = type_error(
         activation,

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -64,7 +64,7 @@ pub fn namespace_constructor<'gc>(
             };
             // The only allowed prefix if the uri is empty is the literal empty string
             if namespace_uri.is_empty() && !resulting_prefix.is_some_and(|s| s.is_empty()) {
-                return Err(make_error_1098(activation, &prefix_str));
+                return Err(make_error_1098(activation, prefix_str));
             }
             if !prefix_str.is_empty() && !is_xml_name(prefix_str) {
                 resulting_prefix = None;

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -18,7 +18,7 @@ fn is_false(b: &bool) -> bool {
     !(*b)
 }
 
-fn escape_string(string: &AvmString) -> String {
+fn escape_string(string: AvmString) -> String {
     let mut output = "".to_string();
     output.push('\"');
 
@@ -46,7 +46,7 @@ fn escape_string(string: &AvmString) -> String {
 }
 
 fn format_value(value: &Value) -> Option<String> {
-    match value {
+    match *value {
         Value::Undefined => None,
         Value::Null => Some("null".to_string()),
         Value::Bool(value) => Some(value.to_string()),
@@ -302,12 +302,7 @@ impl Definition {
                 }
             };
             if &name != b"constructor" {
-                Self::add_prototype_value(
-                    &name,
-                    value.value,
-                    &mut definition.prototype,
-                    activation,
-                );
+                Self::add_prototype_value(name, value.value, &mut definition.prototype, activation);
             }
         }
 
@@ -328,7 +323,7 @@ impl Definition {
     }
 
     fn add_prototype_value<'gc>(
-        name: &AvmString<'gc>,
+        name: AvmString<'gc>,
         value: Value<'gc>,
         output: &mut Option<TraitList>,
         activation: &mut Activation<'_, 'gc>,

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -102,7 +102,7 @@ impl Avm1ObjectWindow {
                     let value = object.get(key, activation);
 
                     ui.label(key.to_string());
-                    if let Some(new) = self.show_avm1_value(ui, activation, &key, value, messages) {
+                    if let Some(new) = self.show_avm1_value(ui, activation, key, value, messages) {
                         if let Err(e) = object.set(key, new, activation) {
                             tracing::error!("Failed to set key {key}: {e}");
                         }
@@ -119,7 +119,7 @@ impl Avm1ObjectWindow {
         &mut self,
         ui: &mut Ui,
         activation: &mut Activation<'_, 'gc>,
-        key: &AvmString,
+        key: AvmString,
         value: Result<Value<'gc>, Error<'gc>>,
         messages: &mut Vec<Message>,
     ) -> Option<Value<'gc>> {
@@ -180,7 +180,7 @@ impl Avm1ObjectWindow {
         None
     }
 
-    fn num_edit_ui(&mut self, ui: &mut Ui, key: &AvmString, num: f64) -> Option<f64> {
+    fn num_edit_ui(&mut self, ui: &mut Ui, key: AvmString, num: f64) -> Option<f64> {
         let mut new_val = None;
         if self
             .edited_key
@@ -226,12 +226,7 @@ impl Avm1ObjectWindow {
         new_val
     }
 
-    fn string_edit_ui(
-        &mut self,
-        ui: &mut Ui,
-        key: &AvmString,
-        string: AvmString,
-    ) -> Option<String> {
+    fn string_edit_ui(&mut self, ui: &mut Ui, key: AvmString, string: AvmString) -> Option<String> {
         let mut new_val = None;
         ui.horizontal(|ui| {
             if self

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -828,7 +828,7 @@ impl<'gc> EditText<'gc> {
     /// `DisplayObject`.
     pub fn text_transform(self, color: Color, baseline_adjustment: Twips) -> Transform {
         let mut transform: Transform = Default::default();
-        transform.color_transform.set_mult_color(&color);
+        transform.color_transform.set_mult_color(color);
 
         // TODO MIKE: This feels incorrect here but is necessary for correct vertical position;
         // the glyphs are rendered relative to the baseline. This should be taken into account either

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -3517,8 +3517,8 @@ impl EditTextRestrict {
             && !self.intervals_contain(character, &self.disallowed)
     }
 
-    fn intervals_contain(&self, character: char, intervals: &Vec<(char, char)>) -> bool {
-        for interval in intervals {
+    fn intervals_contain(&self, character: char, intervals: &[(char, char)]) -> bool {
+        for &interval in intervals {
             if self.interval_contains(character, interval) {
                 return true;
             }
@@ -3527,7 +3527,7 @@ impl EditTextRestrict {
     }
 
     #[inline]
-    fn interval_contains(&self, character: char, interval: &(char, char)) -> bool {
+    fn interval_contains(&self, character: char, interval: (char, char)) -> bool {
         character >= interval.0 && character <= interval.1
     }
 

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -384,7 +384,7 @@ impl MorphShapeShared {
 // These interpolate between two SWF shape structures.
 // a + b should = 1.0
 
-fn lerp_color(start: &Color, end: &Color, a: f32, b: f32) -> Color {
+fn lerp_color(start: Color, end: Color, a: f32, b: f32) -> Color {
     // f32 -> u8 cast is defined to saturate for out of bounds values,
     // so we don't have to worry about clamping.
     Color {
@@ -411,7 +411,7 @@ fn lerp_fill(start: &swf::FillStyle, end: &swf::FillStyle, a: f32, b: f32) -> sw
     match (start, end) {
         // Color-to-color
         (FillStyle::Color(start), FillStyle::Color(end)) => {
-            FillStyle::Color(lerp_color(start, end, a, b))
+            FillStyle::Color(lerp_color(*start, *end, a, b))
         }
 
         // Bitmap-to-bitmap
@@ -592,7 +592,7 @@ fn lerp_gradient(start: &swf::Gradient, end: &swf::Gradient, a: f32, b: f32) -> 
         .zip(end.records.iter())
         .map(|(start, end)| swf::GradientRecord {
             ratio: (f32::from(start.ratio) * a + f32::from(end.ratio) * b) as u8,
-            color: lerp_color(&start.color, &end.color, a, b),
+            color: lerp_color(start.color, end.color, a, b),
         })
         .collect();
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3757,18 +3757,18 @@ impl<'gc, 'a> MovieClipShared<'gc> {
     fn register_export(
         context: &mut UpdateContext<'gc>,
         id: CharacterId,
-        name: &AvmString<'gc>,
+        name: AvmString<'gc>,
         movie: Arc<SwfMovie>,
     ) {
         let mc = context.gc();
         let library = context.library.library_for_movie_mut(movie);
-        library.register_export(id, *name);
+        library.register_export(id, name);
 
         // TODO: do other types of Character need to know their exported name?
         if let Some(character) = library.character_by_id(id) {
             if let Character::MovieClip(clip) = character {
                 let data = Gc::write(mc, clip.0.shared.get());
-                unlock!(data, MovieClipShared, exported_name).set(Some(*name));
+                unlock!(data, MovieClipShared, exported_name).set(Some(name));
             } else {
                 // This is fairly common, don't log anything here
             }
@@ -3797,7 +3797,7 @@ impl<'gc, 'a> MovieClipShared<'gc> {
                 .library(context)
                 .and_then(|l| l.character_by_id(export.id))
             {
-                Self::register_export(context, export.id, &name, self.movie());
+                Self::register_export(context, export.id, name, self.movie());
                 tracing::debug!("register_export asset: {} (ID: {})", name, export.id);
 
                 if let Some(parent) = importer_movie {
@@ -3806,7 +3806,7 @@ impl<'gc, 'a> MovieClipShared<'gc> {
                     if let Some(id) = parent_library.character_id_by_import_name(name) {
                         parent_library.register_character(id, character);
 
-                        Self::register_export(context, id, &name, parent.clone());
+                        Self::register_export(context, id, name, parent.clone());
                         tracing::debug!(
                             "Registering parent asset: {} (Parent ID: {})(ID: {})",
                             name,

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -162,7 +162,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
                 let scale = (height.get() as f32) / font.scale();
                 transform.matrix.a = scale;
                 transform.matrix.d = scale;
-                transform.color_transform.set_mult_color(&color);
+                transform.color_transform.set_mult_color(color);
                 for c in &block.glyphs {
                     if let Some(glyph) = font.get_glyph(c.index as usize) {
                         if let Some(glyph_shape_handle) = glyph.shape_handle(context.renderer) {

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -206,7 +206,7 @@ impl<'gc> FocusTracker<'gc> {
         self.update_virtual_keyboard(context);
     }
 
-    fn update_virtual_keyboard(&self, context: &mut UpdateContext<'gc>) {
+    fn update_virtual_keyboard(self, context: &mut UpdateContext<'gc>) {
         if let Some(text_field) = self.get_as_edit_text() {
             if text_field.is_editable() {
                 context.ui.open_virtual_keyboard();
@@ -221,7 +221,7 @@ impl<'gc> FocusTracker<'gc> {
     /// Update selection on the newly focused text field.
     ///
     /// This applies even if the focused element hasn't changed.
-    fn update_edittext_selection(&self) {
+    fn update_edittext_selection(self) {
         // Only key and programmatic focus change should trigger this, because
         // when focusing a text field with a mouse, a caret should be placed.
         // Note that this may suggest we should reorder operations on the text field:
@@ -336,7 +336,7 @@ impl<'gc> FocusTracker<'gc> {
         self.0.highlight.replace(self.calculate_highlight(context));
     }
 
-    fn calculate_highlight(&self, context: &mut UpdateContext<'gc>) -> Highlight {
+    fn calculate_highlight(self, context: &mut UpdateContext<'gc>) -> Highlight {
         let Some(focus) = self.get() else {
             return Highlight::Inactive;
         };

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -615,7 +615,7 @@ impl<'gc> Font<'gc> {
 
     /// Returns whether this font contains glyph shapes.
     /// If not, this font should be rendered as a device font.
-    pub fn has_glyphs(&self) -> bool {
+    pub fn has_glyphs(self) -> bool {
         !matches!(self.0.glyphs, GlyphSource::Empty)
     }
 
@@ -632,7 +632,7 @@ impl<'gc> Font<'gc> {
     }
 
     /// Determine if this font contains all the glyphs within a given string.
-    pub fn has_glyphs_for_str(&self, target_str: &WStr) -> bool {
+    pub fn has_glyphs_for_str(self, target_str: &WStr) -> bool {
         for character in target_str.chars() {
             let c = character.unwrap_or(char::REPLACEMENT_CHARACTER);
             if self.get_glyph_for_char(c).is_none() {
@@ -647,7 +647,7 @@ impl<'gc> Font<'gc> {
         &self.0.descriptor
     }
 
-    pub fn has_layout(&self) -> bool {
+    pub fn has_layout(self) -> bool {
         self.0.has_layout
     }
 }
@@ -1316,7 +1316,7 @@ impl<'gc> FontSet<'gc> {
         ))
     }
 
-    pub fn main_font(&self) -> Font<'gc> {
+    pub fn main_font(self) -> Font<'gc> {
         self.0.main_font
     }
 

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -1485,8 +1485,8 @@ enum HtmlTag {
 }
 
 impl HtmlTag {
-    fn closeable(&self) -> bool {
-        self != &Self::Br && self != &Self::Sbr
+    fn closeable(self) -> bool {
+        self != Self::Br && self != Self::Sbr
     }
 }
 

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -211,7 +211,7 @@ impl MainWindow {
                     ElementState::Pressed => {
                         self.player.handle_event(PlayerEvent::KeyDown { key });
                         if let Some(control_code) =
-                            winit_to_ruffle_text_control(&event, &self.modifiers)
+                            winit_to_ruffle_text_control(&event, self.modifiers)
                         {
                             self.player
                                 .handle_event(PlayerEvent::TextControl { code: control_code });

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -317,7 +317,7 @@ pub enum GameModePreference {
 }
 
 impl GameModePreference {
-    pub fn as_str(&self) -> Option<&'static str> {
+    pub fn as_str(self) -> Option<&'static str> {
         match self {
             GameModePreference::Default => None,
             GameModePreference::On => Some("on"),
@@ -347,7 +347,7 @@ pub enum OpenUrlMode {
 }
 
 impl OpenUrlMode {
-    pub fn as_str(&self) -> Option<&'static str> {
+    pub fn as_str(self) -> Option<&'static str> {
         match self {
             OpenUrlMode::Confirm => None,
             OpenUrlMode::Allow => Some("allow"),

--- a/desktop/src/gui/theme.rs
+++ b/desktop/src/gui/theme.rs
@@ -182,7 +182,7 @@ pub enum ThemePreference {
 }
 
 impl ThemePreference {
-    pub fn as_str(&self) -> Option<&'static str> {
+    pub fn as_str(self) -> Option<&'static str> {
         match self {
             ThemePreference::System => None,
             ThemePreference::Light => Some("light"),

--- a/desktop/src/log.rs
+++ b/desktop/src/log.rs
@@ -22,7 +22,7 @@ impl FromStr for FilenamePattern {
 }
 
 impl FilenamePattern {
-    pub fn create_path(&self, directory: &Path) -> PathBuf {
+    pub fn create_path(self, directory: &Path) -> PathBuf {
         match self {
             FilenamePattern::SingleFile => directory.join("ruffle.log"),
             FilenamePattern::WithTimestamp => {
@@ -31,7 +31,7 @@ impl FilenamePattern {
         }
     }
 
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             FilenamePattern::SingleFile => "single_file",
             FilenamePattern::WithTimestamp => "with_timestamp",

--- a/desktop/src/preferences/storage.rs
+++ b/desktop/src/preferences/storage.rs
@@ -23,7 +23,7 @@ impl FromStr for StorageBackend {
 }
 
 impl StorageBackend {
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             StorageBackend::Disk => "disk",
             StorageBackend::Memory => "memory",
@@ -31,7 +31,7 @@ impl StorageBackend {
     }
 
     pub fn create_backend(
-        &self,
+        self,
         opt: &LaunchOptions,
     ) -> Box<dyn ruffle_core::backend::storage::StorageBackend> {
         match self {

--- a/desktop/src/util.rs
+++ b/desktop/src/util.rs
@@ -18,7 +18,7 @@ use winit::window::Window;
 /// Returns `None` if there is no match.
 pub fn winit_to_ruffle_text_control(
     event: &KeyEvent,
-    modifiers: &Modifiers,
+    modifiers: Modifiers,
 ) -> Option<TextControlCode> {
     let shift = modifiers.state().shift_key();
     let ctrl_cmd = modifiers.state().control_key()

--- a/render/src/utils.rs
+++ b/render/src/utils.rs
@@ -330,10 +330,10 @@ pub fn decode_define_bits_lossless(
             for _ in 0..swf_tag.height {
                 for _ in 0..swf_tag.width {
                     let entry = decoded_data[i] as usize;
-                    let color = palette.get(entry).unwrap_or(if has_alpha {
-                        &Color::TRANSPARENT
+                    let color = palette.get(entry).copied().unwrap_or(if has_alpha {
+                        Color::TRANSPARENT
                     } else {
-                        &Color::BLACK
+                        Color::BLACK
                     });
                     out_data.extend([color.r, color.g, color.b, color.a]);
                     i += 1;

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -1378,10 +1378,10 @@ impl<'a> EditText<'a> {
     }
 
     #[inline]
-    pub fn color(&self) -> Option<&Color> {
+    pub fn color(&self) -> Option<Color> {
         self.flags
             .contains(EditTextFlag::HAS_TEXT_COLOR)
-            .then_some(&self.color)
+            .then_some(self.color)
     }
 
     #[inline]

--- a/swf/src/types/color_transform.rs
+++ b/swf/src/types/color_transform.rs
@@ -58,7 +58,7 @@ impl ColorTransform {
     }
 
     /// Sets the multiplicate component of this color transform.
-    pub fn set_mult_color(&mut self, color: &Color) {
+    pub fn set_mult_color(&mut self, color: Color) {
         self.r_multiply = Fixed8::from_f32(f32::from(color.r) / 255.0);
         self.g_multiply = Fixed8::from_f32(f32::from(color.g) / 255.0);
         self.b_multiply = Fixed8::from_f32(f32::from(color.b) / 255.0);


### PR DESCRIPTION
This PR covers the rest of cases where we referenced trivially copyable objects.