### PR TITLE
refactor: Fix the rest of references to trivially copyable objects

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -385,7 +385,7 @@ impl<'gc> MovieClip<'gc> {
         self.0.set_initialized(true);
     }
 
-    pub fn next_avm1_clip(&self) -> Option<MovieClip<'gc>> {
+    pub fn next_avm1_clip(self) -> Option<MovieClip<'gc>> {
         self.0.next_avm1_clip.get()
     }
 
@@ -716,7 +716,7 @@ impl<'gc> MovieClip<'gc> {
     }
 
     /// Does this clip have a unload handler
-    pub fn has_unload_handler(&self) -> bool {
+    pub fn has_unload_handler(self) -> bool {
         self.clip_actions()
             .iter()
             .any(|handler| handler.events.contains(ClipEventFlag::UNLOAD))
@@ -1987,7 +1987,7 @@ impl<'gc> MovieClip<'gc> {
         unlock!(Gc::write(mc, self.0), MovieClipData, hit_area).set(hit_area);
     }
 
-    pub fn tag_stream_len(&self) -> usize {
+    pub fn tag_stream_len(self) -> usize {
         self.0.tag_stream_len()
     }
 
@@ -2009,7 +2009,7 @@ impl<'gc> MovieClip<'gc> {
         self.0.drawing.get().map(|d| d.borrow())
     }
 
-    pub fn is_button_mode(&self, context: &mut UpdateContext<'gc>) -> bool {
+    pub fn is_button_mode(self, context: &mut UpdateContext<'gc>) -> bool {
         if self.forced_button_mode()
             || self
                 .0
@@ -2041,7 +2041,7 @@ impl<'gc> MovieClip<'gc> {
 
     /// Remove all tags matching the given filter off the internal tag queue.
     fn unqueue_filtered(
-        &self,
+        self,
         mut filter: impl FnMut(&mut QueuedTagList) -> Option<QueuedTag>,
     ) -> Vec<(Depth, QueuedTag)> {
         use std::collections::hash_map::Entry;
@@ -2075,7 +2075,7 @@ impl<'gc> MovieClip<'gc> {
     // calls with one frame delay? Does transform_to_unloaded_state need to get executed
     // after one frame if the target is a MovieClip? Test the behaviour and adapt the code
     // if necessary.
-    pub fn avm1_unload_movie(&self, context: &mut UpdateContext<'gc>) {
+    pub fn avm1_unload_movie(self, context: &mut UpdateContext<'gc>) {
         // TODO: In Flash player, the MovieClip properties change to the unloaded state
         // one frame after the unloadMovie command has been read, even if the MovieClip
         // is not a root MovieClip (see the movieclip_library_state_values test).
@@ -2087,7 +2087,7 @@ impl<'gc> MovieClip<'gc> {
         if self.is_root() {
             let unloader = Loader::MovieUnloader {
                 self_handle: None,
-                target_clip: DisplayObject::MovieClip(*self),
+                target_clip: DisplayObject::MovieClip(self),
             };
             let handle = context.load_manager.add_loader(unloader);
 
@@ -2132,7 +2132,7 @@ impl<'gc> MovieClip<'gc> {
     ///
     /// This happens if a MovieClip has been unloaded. The state is then changed one
     /// frame after the command to unload the MovieClip has been read.
-    fn transform_to_unloaded_state(&self, context: &mut UpdateContext<'gc>) {
+    fn transform_to_unloaded_state(self, context: &mut UpdateContext<'gc>) {
         let movie = if let Some(DisplayObject::MovieClip(parent_mc)) = self.parent() {
             let parent_movie = parent_mc.movie();
             let parent_version = parent_movie.version();
@@ -4329,7 +4329,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         Ok(())
     }
 
-    pub fn set_constructing_frame(&self, val: bool) {
+    pub fn set_constructing_frame(self, val: bool) {
         self.0
             .set_flag(MovieClipFlags::RUNNING_CONSTRUCT_FRAME, val);
     }

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -74,7 +74,7 @@ impl<'gc> Text<'gc> {
         self.invalidate_cached_bitmap();
     }
 
-    pub fn text(&self, context: &mut UpdateContext<'gc>) -> WString {
+    pub fn text(self, context: &mut UpdateContext<'gc>) -> WString {
         let mut ret = WString::new();
 
         for block in &self.0.shared.get().text_blocks {

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -206,7 +206,7 @@ impl<'gc> Video<'gc> {
     ///
     /// This function yields an error if this video player is not playing an
     /// embedded SWF video.
-    pub fn preload_swf_frame(&self, tag: VideoFrame) {
+    pub fn preload_swf_frame(self, tag: VideoFrame) {
         let movie = self.0.movie.clone();
 
         match self.0.source.get() {

--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -154,7 +154,7 @@ impl VertexAttributeFormat {
     }
 
     fn extend_to_float4(
-        &self,
+        self,
         base_expr: Handle<Expression>,
         builder: &mut NagaBuilder,
     ) -> Result<Handle<Expression>> {

--- a/render/pixel_bender/src/disassembly.rs
+++ b/render/pixel_bender/src/disassembly.rs
@@ -98,7 +98,7 @@ impl PixelBenderShaderDisassembly<'_> {
         if !reg.channels.is_empty() {
             write!(f, ".")?;
             for ch in &reg.channels {
-                f.write_str(self.channel_to_str(ch))?;
+                f.write_str(self.channel_to_str(*ch))?;
             }
         }
 
@@ -266,7 +266,7 @@ impl PixelBenderShaderDisassembly<'_> {
         }
     }
 
-    fn channel_to_str(&self, ch: &PixelBenderRegChannel) -> &'static str {
+    fn channel_to_str(&self, ch: PixelBenderRegChannel) -> &'static str {
         match ch {
             PixelBenderRegChannel::R => "r",
             PixelBenderRegChannel::G => "g",

--- a/swf/src/avm1/write.rs
+++ b/swf/src/avm1/write.rs
@@ -157,7 +157,7 @@ impl<W: Write> Writer<W> {
             Action::StartDrag => self.write_small_action(OpCode::StartDrag),
             Action::Stop => self.write_small_action(OpCode::Stop),
             Action::StopSounds => self.write_small_action(OpCode::StopSounds),
-            Action::StoreRegister(action) => self.write_store_register(action),
+            Action::StoreRegister(action) => self.write_store_register(*action),
             Action::StrictEquals => self.write_small_action(OpCode::StrictEquals),
             Action::StringAdd => self.write_small_action(OpCode::StringAdd),
             Action::StringEquals => self.write_small_action(OpCode::StringEquals),
@@ -382,7 +382,7 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn write_store_register(&mut self, action: &StoreRegister) -> Result<()> {
+    fn write_store_register(&mut self, action: StoreRegister) -> Result<()> {
         self.write_action_header(OpCode::StoreRegister, 1)?;
         self.write_u8(action.register)?;
         Ok(())


### PR DESCRIPTION
For realsies now, I missed some last time :(

It doesn't make sense to reference trivially copyable objects, so just remove references to them when not needed.