### PR TITLE
web: Improve asserting on traces in tests

### DIFF
--- a/web/packages/selfhosted/test/integration_tests/context_menu_escaping_body/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/context_menu_escaping_body/test.ts
@@ -1,4 +1,9 @@
-import { injectRuffleAndWait, openTest, playAndMonitor } from "../../utils.js";
+import {
+    assertNoMoreTraceOutput,
+    injectRuffleAndWait,
+    openTest,
+    playAndMonitor,
+} from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 
@@ -15,7 +20,7 @@ describe("Context Menu", () => {
         );
         await injectRuffleAndWait(browser);
         const player = await browser.$("<ruffle-object>");
-        await playAndMonitor(browser, player, "Loaded!\n");
+        await playAndMonitor(browser, player, ["Loaded!"]);
 
         // Dismiss hardware acceleration modal in Chrome
         await player.click();
@@ -44,7 +49,7 @@ describe("Context Menu", () => {
         );
         await injectRuffleAndWait(browser);
         const player = await browser.$("<ruffle-object>");
-        await playAndMonitor(browser, player, "Loaded!\n");
+        await playAndMonitor(browser, player, ["Loaded!"]);
 
         // Dismiss hardware acceleration modal in Chrome
         await player.click();
@@ -63,5 +68,10 @@ describe("Context Menu", () => {
 
         // Dismiss the menu
         await player.click({ x: -151, y: -151 });
+    });
+
+    it("no more traces", async function () {
+        const player = await browser.$("#objectElement");
+        assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/context_menu_position/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/context_menu_position/test.ts
@@ -1,4 +1,9 @@
-import { injectRuffleAndWait, openTest, playAndMonitor } from "../../utils.js";
+import {
+    assertNoMoreTraceOutput,
+    injectRuffleAndWait,
+    openTest,
+    playAndMonitor,
+} from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 
@@ -27,7 +32,7 @@ describe("Context Menu", () => {
         await openTest(browser, "integration_tests/context_menu_position");
         await injectRuffleAndWait(browser);
         const player = await browser.$("<ruffle-object>");
-        await playAndMonitor(browser, player, "Loaded!\n");
+        await playAndMonitor(browser, player, ["Loaded!"]);
 
         // Dismiss hardware acceleration modal in Chrome
         await player.click();
@@ -147,5 +152,10 @@ describe("Context Menu", () => {
 
         // Dismiss the menu
         await player.click({ x: -10, y: -10 });
+    });
+
+    it("no more traces", async function () {
+        const player = await browser.$("#objectElement");
+        assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/keyboard_input/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/keyboard_input/test.ts
@@ -1,5 +1,9 @@
-import { loadJsAPI, getTraceOutput } from "../../utils.js";
-import { use, expect } from "chai";
+import {
+    loadJsAPI,
+    expectTraceOutput,
+    assertNoMoreTraceOutput,
+} from "../../utils.js";
+import { use } from "chai";
 import chaiHtml from "chai-html";
 import { Key } from "webdriverio";
 
@@ -15,18 +19,16 @@ describe("Key up and down events work", () => {
         await player.click();
 
         await browser.keys("a");
-        const actualOutput = await getTraceOutput(browser, player);
-        expect(actualOutput).to.eql(
-            `onKeyDown
-event.charCode = 97
-event.keyCode = 65
-
-onKeyUp
-event.charCode = 97
-event.keyCode = 65
-
-`,
-        );
+        await expectTraceOutput(browser, player, [
+            "onKeyDown",
+            "event.charCode = 97",
+            "event.keyCode = 65",
+            "",
+            "onKeyUp",
+            "event.charCode = 97",
+            "event.keyCode = 65",
+            "",
+        ]);
     });
 
     it("enter key is recognised", async () => {
@@ -34,17 +36,20 @@ event.keyCode = 65
         await player.click();
 
         await browser.keys([Key.Enter]);
-        const actualOutput = await getTraceOutput(browser, player);
-        expect(actualOutput).to.eql(
-            `onKeyDown
-event.charCode = 13
-event.keyCode = 13
+        await expectTraceOutput(browser, player, [
+            "onKeyDown",
+            "event.charCode = 13",
+            "event.keyCode = 13",
+            "",
+            "onKeyUp",
+            "event.charCode = 13",
+            "event.keyCode = 13",
+            "",
+        ]);
+    });
 
-onKeyUp
-event.charCode = 13
-event.keyCode = 13
-
-`,
-        );
+    it("no more traces", async function () {
+        const player = await browser.$("<ruffle-object>");
+        assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/missing_default_fonts/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/missing_default_fonts/test.ts
@@ -9,6 +9,6 @@ describe("Missing Default Fonts", () => {
         await openTest(browser, "integration_tests/missing_default_fonts");
         await injectRuffleAndWait(browser);
         const player = await browser.$("<ruffle-object>");
-        await playAndMonitor(browser, player, "Loaded!\n");
+        await playAndMonitor(browser, player, ["Loaded!"]);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/mouse_wheel_avm2/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/mouse_wheel_avm2/test.ts
@@ -1,5 +1,6 @@
 import {
-    getTraceOutput,
+    assertNoMoreTraceOutput,
+    expectTraceOutput,
     hideHardwareAccelerationModal,
     injectRuffleAndWait,
     openTest,
@@ -77,7 +78,7 @@ interface TestParams {
             );
             await injectRuffleAndWait(browser);
             const player = await browser.$("<ruffle-object>");
-            await playAndMonitor(browser, player, "Loaded!\n");
+            await playAndMonitor(browser, player, ["Loaded!"]);
             await hideHardwareAccelerationModal(browser, player);
             // await new Promise(f => setTimeout(f, 10000000));
         });
@@ -85,12 +86,11 @@ interface TestParams {
         it("scroll the first clip", async () => {
             const player = await browser.$("#objectElement");
 
-            expect([
-                await scroll(browser, player, 100, 100, 1),
-                await getTraceOutput(browser, player),
-            ]).to.deep.equal([
+            expect(await scroll(browser, player, 100, 100, 1)).to.equal(
                 expectedScroll ?? false,
-                "Wheel consumed 1, vscroll: 1\n",
+            );
+            await expectTraceOutput(browser, player, [
+                "Wheel consumed 1, vscroll: 1",
             ]);
         });
 
@@ -121,12 +121,11 @@ interface TestParams {
         it("scroll the second clip", async () => {
             const player = await browser.$("#objectElement");
 
-            expect([
-                await scroll(browser, player, 500, 100, 1),
-                await getTraceOutput(browser, player),
-            ]).to.deep.equal([
+            expect(await scroll(browser, player, 500, 100, 1)).to.equal(
                 expectedScroll ?? false,
-                "Wheel consumed 2, vscroll: 2\n",
+            );
+            await expectTraceOutput(browser, player, [
+                "Wheel consumed 2, vscroll: 2",
             ]);
         });
 
@@ -136,6 +135,11 @@ interface TestParams {
             expect(await scroll(browser, player, 700, 100, 1)).to.equal(
                 expectedScroll ?? true,
             );
+        });
+
+        it("no more traces", async function () {
+            const player = await browser.$("#objectElement");
+            assertNoMoreTraceOutput(browser, player);
         });
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/programmatic_events/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/programmatic_events/test.ts
@@ -1,10 +1,11 @@
 import {
-    getTraceOutput,
+    assertNoMoreTraceOutput,
+    expectTraceOutput,
     injectRuffleAndWait,
     openTest,
     playAndMonitor,
 } from "../../utils.js";
-import { expect, use } from "chai";
+import { use } from "chai";
 import chaiHtml from "chai-html";
 
 use(chaiHtml);
@@ -30,7 +31,7 @@ describe("Programmatic Events", () => {
         await openTest(browser, "integration_tests/programmatic_events");
         await injectRuffleAndWait(browser);
         const player = await browser.$("<ruffle-object>");
-        await playAndMonitor(browser, player, "Loaded!\n");
+        await playAndMonitor(browser, player, ["Loaded!"]);
     });
 
     // See https://github.com/ruffle-rs/ruffle/issues/6952#issuecomment-1133990189
@@ -56,15 +57,14 @@ describe("Programmatic Events", () => {
             );
         }, player);
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "onKeyDown(0,39)\n",
-        );
+        await expectTraceOutput(browser, player, ["onKeyDown(0,39)"]);
 
         await browser.keys("x");
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "onKeyDown(120,88)\nonKeyUp(120,88)\n",
-        );
+        await expectTraceOutput(browser, player, [
+            "onKeyDown(120,88)",
+            "onKeyUp(120,88)",
+        ]);
     });
 
     // That has been possible since https://github.com/ruffle-rs/ruffle/pull/17158,
@@ -89,15 +89,14 @@ describe("Programmatic Events", () => {
             );
         }, player);
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "onKeyDown(0,39)\n",
-        );
+        await expectTraceOutput(browser, player, ["onKeyDown(0,39)"]);
 
         await browser.keys("x");
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "onKeyDown(120,88)\nonKeyUp(120,88)\n",
-        );
+        await expectTraceOutput(browser, player, [
+            "onKeyDown(120,88)",
+            "onKeyUp(120,88)",
+        ]);
     });
 
     // That's probably the most sane way of focusing Ruffle.
@@ -121,15 +120,14 @@ describe("Programmatic Events", () => {
             );
         }, player);
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "onKeyDown(0,39)\n",
-        );
+        await expectTraceOutput(browser, player, ["onKeyDown(0,39)"]);
 
         await browser.keys("x");
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "onKeyDown(120,88)\nonKeyUp(120,88)\n",
-        );
+        await expectTraceOutput(browser, player, [
+            "onKeyDown(120,88)",
+            "onKeyUp(120,88)",
+        ]);
     });
 
     it("scenario: example input overlay", async () => {
@@ -142,14 +140,18 @@ describe("Programmatic Events", () => {
 
         await overlay.click();
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "onKeyDown(0,39)\n",
-        );
+        await expectTraceOutput(browser, player, ["onKeyDown(0,39)"]);
 
         await browser.keys("x");
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "onKeyDown(120,88)\nonKeyUp(120,88)\n",
-        );
+        await expectTraceOutput(browser, player, [
+            "onKeyDown(120,88)",
+            "onKeyUp(120,88)",
+        ]);
+    });
+
+    it("no more traces", async function () {
+        const player = await browser.$("#objectElement");
+        assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/url_rewrite_rules/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/url_rewrite_rules/test.ts
@@ -1,5 +1,6 @@
 import {
-    getTraceOutput,
+    assertNoMoreTraceOutput,
+    expectTraceOutput,
     hideHardwareAccelerationModal,
     injectRuffleAndWait,
     openTest,
@@ -15,7 +16,7 @@ describe("URL Rewrite Rules", () => {
         await openTest(browser, "integration_tests/url_rewrite_rules");
         await injectRuffleAndWait(browser);
         const player = await browser.$("<ruffle-object>");
-        await playAndMonitor(browser, player, "Loaded test!\n");
+        await playAndMonitor(browser, player, ["Loaded test!"]);
         await hideHardwareAccelerationModal(browser, player);
     });
 
@@ -34,9 +35,10 @@ describe("URL Rewrite Rules", () => {
             );
         }, player);
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "Loaded other1!\nQP Value: example.com/other1\n",
-        );
+        await expectTraceOutput(browser, player, [
+            "Loaded other1!",
+            "QP Value: example.com/other1",
+        ]);
     });
 
     it("rewrites URL of other1 to an absolute one", async () => {
@@ -54,9 +56,10 @@ describe("URL Rewrite Rules", () => {
             );
         }, player);
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "Loaded other1!\nQP Value: http://localhost:4567/test/integration_tests/url_rewrite_rules/other1\n",
-        );
+        await expectTraceOutput(browser, player, [
+            "Loaded other1!",
+            "QP Value: http://localhost:4567/test/integration_tests/url_rewrite_rules/other1",
+        ]);
     });
 
     it("does not rewrite URL of other2", async () => {
@@ -74,9 +77,7 @@ describe("URL Rewrite Rules", () => {
             );
         }, player);
 
-        expect(await getTraceOutput(browser, player)).to.equal(
-            "Loaded other2!\n",
-        );
+        await expectTraceOutput(browser, player, ["Loaded other2!"]);
     });
 
     it("rewrites URL of a clicked link", async () => {
@@ -98,5 +99,10 @@ describe("URL Rewrite Rules", () => {
         expect(await browser.getUrl()).to.equal(
             "https://www.example.com/$1/$&",
         );
+    });
+
+    it("no more traces", async function () {
+        const player = await browser.$("#objectElement");
+        assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_flashvars/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars/test.ts
@@ -26,31 +26,32 @@ describe("Object tag", () => {
         await playAndMonitor(
             browser,
             await browser.$("#test-container").$("<ruffle-embed />"),
-            `// _level0.a
-1
-
-// typeof(a)
-string
-
-// _level0.b
-3 %3
-
-// typeof(b)
-string
-
-// _level0.c
-
-
-// typeof(c)
-string
-
-// _level0.d
-undefined
-
-// typeof(d)
-undefined
-
-`,
+            [
+                "// _level0.a",
+                "1",
+                "",
+                "// typeof(a)",
+                "string",
+                "",
+                "// _level0.b",
+                "3 %3",
+                "",
+                "// typeof(b)",
+                "string",
+                "",
+                "// _level0.c",
+                "",
+                "",
+                "// typeof(c)",
+                "string",
+                "",
+                "// _level0.d",
+                "undefined",
+                "",
+                "// typeof(d)",
+                "undefined",
+                "",
+            ],
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.ts
@@ -26,31 +26,32 @@ describe("Object tag", () => {
         await playAndMonitor(
             browser,
             await browser.$("#test-container").$("<ruffle-embed />"),
-            `// _level0.a
-1
-
-// typeof(a)
-string
-
-// _level0.b
-3 %3
-
-// typeof(b)
-string
-
-// _level0.c
-
-
-// typeof(c)
-string
-
-// _level0.d
-undefined
-
-// typeof(d)
-undefined
-
-`,
+            [
+                "// _level0.a",
+                "1",
+                "",
+                "// typeof(a)",
+                "string",
+                "",
+                "// _level0.b",
+                "3 %3",
+                "",
+                "// typeof(b)",
+                "string",
+                "",
+                "// _level0.c",
+                "",
+                "",
+                "// typeof(c)",
+                "string",
+                "",
+                "// _level0.d",
+                "undefined",
+                "",
+                "// typeof(d)",
+                "undefined",
+                "",
+            ],
         );
     });
 });

--- a/web/packages/selfhosted/test/utils.ts
+++ b/web/packages/selfhosted/test/utils.ts
@@ -9,7 +9,7 @@ declare global {
 
 declare module "ruffle-core/dist/public/player" {
     interface PlayerElement {
-        __ruffle_log__: string;
+        __ruffle_log__: string[];
     }
 }
 
@@ -86,14 +86,13 @@ export async function injectRuffle(browser: WebdriverIO.Browser) {
 export async function playAndMonitor(
     browser: WebdriverIO.Browser,
     player: ChainablePromiseElement,
-    expectedOutput: string = "Hello from Flash!\n",
+    expectedOutput: string[] = ["Hello from Flash!"],
 ) {
     await throwIfError(browser);
     await waitForPlayerToLoad(browser, await player);
     await setupAndPlay(browser, await player);
 
-    const actualOutput = await getTraceOutput(browser, player);
-    expect(actualOutput).to.eql(expectedOutput);
+    await expectTraceOutput(browser, player, expectedOutput);
 }
 
 export async function setupAndPlay(
@@ -103,9 +102,9 @@ export async function setupAndPlay(
     await browser.execute(
         (playerElement) => {
             const player = playerElement as Player.PlayerElement;
-            player.__ruffle_log__ = "";
+            player.__ruffle_log__ = [];
             player.ruffle().traceObserver = (msg) => {
-                player.__ruffle_log__ += msg + "\n";
+                player.__ruffle_log__.push(msg);
                 console.log(`[trace] ${msg}`);
             };
             player.ruffle().resume();
@@ -117,30 +116,66 @@ export async function setupAndPlay(
 export async function getTraceOutput(
     browser: WebdriverIO.Browser,
     player: ChainablePromiseElement,
-) {
-    // Await any trace output
+    messageCount: number = 1,
+): Promise<string[]> {
+    // Await trace output
     await browser.waitUntil(
         async () => {
-            return (
-                (await browser.execute(
-                    (player) => {
-                        return (player as Player.PlayerElement).__ruffle_log__;
-                    },
-                    await player,
-                )) !== ""
+            const log = await browser.execute(
+                (player) => {
+                    return (player as Player.PlayerElement).__ruffle_log__;
+                },
+                await player,
             );
+            return log.length >= messageCount;
         },
         {
-            timeoutMsg: "Expected Ruffle to trace a message",
+            timeoutMsg: `Expected Ruffle to trace ${messageCount} messages`,
         },
     );
 
-    // Get the output, and replace it with an empty string for any future test
-    return await browser.execute((playerElement) => {
+    // Get the output
+    return await browser.execute(
+        (playerElement, messageCount) => {
+            const player = playerElement as Player.PlayerElement;
+            const m = messageCount as unknown as number;
+            return player.__ruffle_log__.splice(0, m);
+        },
+        player,
+        messageCount,
+    );
+}
+
+export async function expectTraceOutput(
+    browser: WebdriverIO.Browser,
+    player: ChainablePromiseElement,
+    messages: string[],
+) {
+    expect(
+        await getTraceOutput(browser, player, messages.length),
+    ).to.deep.equal(messages);
+}
+
+export async function clearTraceOutput(
+    browser: WebdriverIO.Browser,
+    player: ChainablePromiseElement,
+) {
+    await browser.execute((playerElement) => {
         const player = playerElement as Player.PlayerElement;
-        const log = player.__ruffle_log__;
-        player.__ruffle_log__ = "";
-        return log;
+        player.__ruffle_log__ = [];
+    }, player);
+}
+
+export async function assertNoMoreTraceOutput(
+    browser: WebdriverIO.Browser,
+    player: ChainablePromiseElement,
+) {
+    await browser.execute((playerElement) => {
+        const player = playerElement as Player.PlayerElement;
+        if (player.__ruffle_log__.length > 0) {
+            const log = player.__ruffle_log__.join("\n");
+            throw new Error(`Unexpected trace:\n${log}`);
+        }
     }, player);
 }
 


### PR DESCRIPTION
Before this patch there could be potential race conditions on traces if they were produced asynchronously by the SWF. The old logic waited for any trace and then asserted on all available traces, which meant that we could include some unintended traces or assert before all traces have been produced.

The new approach ensures that we wait for as many traces as we need.