### PR TITLE
web: Change log level to "warn" for tests

### DIFF
--- a/web/packages/selfhosted/wdio.conf.ts
+++ b/web/packages/selfhosted/wdio.conf.ts
@@ -222,7 +222,8 @@ export const config: WebdriverIO.Config = {
     ],
     maxInstances: maxInstances,
     capabilities,
-    logLevel: "info",
+    // wdio produces a lot of spam on info
+    logLevel: "warn",
     bail: 0,
     baseUrl: "http://localhost",
     waitforTimeout: 30000,


### PR DESCRIPTION
The level "info" produces a lot of spam. Each message sent between the browser and the client is logged as info. Changing it to "warn" preserves important output only, including console logs.