### PR TITLE
chore: Enable `trivially_copy_pass_by_ref` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,13 @@ renamed_and_removed_lints = "allow"
 unknown_lints = "allow"
 
 [workspace.lints.clippy]
+# Notice: this is an important lint in Ruffle as we have a lot of trivially
+# copyable objects (e.g. Gc pointers). It may produce false positives depending
+# on platform.
+# In case it happens, add `#[allow(clippy::trivially_copy_pass_by_ref)]` and
+# add a comment explaining why.
+trivially_copy_pass_by_ref = "deny"
+
 # LONG-TERM: These lints are unhelpful.
 manual_map = "allow"             # Less readable: Suggests `opt.map(..)` instead of `if let Some(opt) { .. }`
 manual_range_contains = "allow"  # Less readable: Suggests `(a..b).contains(n)` instead of `n >= a && n < b`

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -14,6 +14,8 @@ use std::fs::File;
 use std::path::Path;
 use std::process::exit;
 
+// This function is used in macros and they require such signature with &bool.
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_false(b: &bool) -> bool {
     !(*b)
 }

--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -354,6 +354,8 @@ impl<'a> NagaBuilder<'a> {
         Ok(sampler_configs)
     }
 
+    // We're passing the reference along anyway.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn build_module(
         agal: &[u8],
         vertex_attributes: &[Option<VertexAttributeFormat>; MAX_VERTEX_ATTRIBUTES],


### PR DESCRIPTION
This lint will check if we're referencing trivially copyable objects.