### PR TITLE
swf: Implement Copy for small types

### DIFF
--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -67,7 +67,7 @@ impl<'gc> ParamConfig<'gc> {
     ) -> Result<Self, Error<'gc>> {
         let param_type_name = txunit.pool_multiname_static_any(activation, config.kind)?;
 
-        let default_value = if let Some(dv) = &config.default_value {
+        let default_value = if let Some(dv) = config.default_value {
             Some(abc_default_value(txunit, dv, activation)?)
         } else {
             None

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -131,19 +131,19 @@ impl<'gc> Trait<'gc> {
     ) -> Result<Self, Error<'gc>> {
         let name = QName::from_abc_multiname(activation, unit, abc_trait.name)?;
 
-        Ok(match &abc_trait.kind {
+        Ok(match abc_trait.kind {
             AbcTraitKind::Slot {
                 slot_id,
                 type_name,
                 value,
             } => {
-                let type_name = unit.pool_multiname_static_any(activation, *type_name)?;
+                let type_name = unit.pool_multiname_static_any(activation, type_name)?;
                 let default_value = slot_default_value(unit, value, type_name, activation)?;
                 Trait {
                     name,
                     attributes: trait_attribs_from_abc_traits(abc_trait),
                     kind: TraitKind::Slot {
-                        slot_id: *slot_id,
+                        slot_id,
                         type_name,
                         default_value,
                         domain: unit.domain(),
@@ -155,8 +155,8 @@ impl<'gc> Trait<'gc> {
                 name,
                 attributes: trait_attribs_from_abc_traits(abc_trait),
                 kind: TraitKind::Method {
-                    disp_id: *disp_id,
-                    method: unit.load_method(*method, false, activation)?,
+                    disp_id,
+                    method: unit.load_method(method, false, activation)?,
                 },
                 metadata: Metadata::from_abc_index(activation, unit, &abc_trait.metadata)?,
             },
@@ -164,8 +164,8 @@ impl<'gc> Trait<'gc> {
                 name,
                 attributes: trait_attribs_from_abc_traits(abc_trait),
                 kind: TraitKind::Getter {
-                    disp_id: *disp_id,
-                    method: unit.load_method(*method, false, activation)?,
+                    disp_id,
+                    method: unit.load_method(method, false, activation)?,
                 },
                 metadata: Metadata::from_abc_index(activation, unit, &abc_trait.metadata)?,
             },
@@ -173,8 +173,8 @@ impl<'gc> Trait<'gc> {
                 name,
                 attributes: trait_attribs_from_abc_traits(abc_trait),
                 kind: TraitKind::Setter {
-                    disp_id: *disp_id,
-                    method: unit.load_method(*method, false, activation)?,
+                    disp_id,
+                    method: unit.load_method(method, false, activation)?,
                 },
                 metadata: Metadata::from_abc_index(activation, unit, &abc_trait.metadata)?,
             },
@@ -182,7 +182,7 @@ impl<'gc> Trait<'gc> {
                 name,
                 attributes: trait_attribs_from_abc_traits(abc_trait),
                 kind: TraitKind::Class {
-                    slot_id: *slot_id,
+                    slot_id,
                     class: unit.load_class(class.0, activation)?,
                 },
                 metadata: Metadata::from_abc_index(activation, unit, &abc_trait.metadata)?,
@@ -193,13 +193,13 @@ impl<'gc> Trait<'gc> {
                 type_name,
                 value,
             } => {
-                let type_name = unit.pool_multiname_static_any(activation, *type_name)?;
+                let type_name = unit.pool_multiname_static_any(activation, type_name)?;
                 let default_value = slot_default_value(unit, value, type_name, activation)?;
                 Trait {
                     name,
                     attributes: trait_attribs_from_abc_traits(abc_trait),
                     kind: TraitKind::Const {
-                        slot_id: *slot_id,
+                        slot_id,
                         type_name,
                         default_value,
                         domain: unit.domain(),
@@ -305,7 +305,7 @@ impl<'gc> Trait<'gc> {
 /// If no default value is supplied, the "null" value for the type's trait is returned.
 fn slot_default_value<'gc>(
     translation_unit: TranslationUnit<'gc>,
-    value: &Option<AbcDefaultValue>,
+    value: Option<AbcDefaultValue>,
     type_name: Option<Gc<'gc, Multiname<'gc>>>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -502,13 +502,13 @@ pub fn abc_double<'gc>(
 /// Retrieve a default value as an AVM2 `Value`.
 pub fn abc_default_value<'gc>(
     translation_unit: TranslationUnit<'gc>,
-    default: &AbcDefaultValue,
+    default: AbcDefaultValue,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     match default {
-        AbcDefaultValue::Int(i) => abc_int(translation_unit, *i).map(|v| v.into()),
-        AbcDefaultValue::Uint(u) => abc_uint(translation_unit, *u).map(|v| v.into()),
-        AbcDefaultValue::Double(d) => abc_double(translation_unit, *d).map(|v| v.into()),
+        AbcDefaultValue::Int(i) => abc_int(translation_unit, i).map(|v| v.into()),
+        AbcDefaultValue::Uint(u) => abc_uint(translation_unit, u).map(|v| v.into()),
+        AbcDefaultValue::Double(d) => abc_double(translation_unit, d).map(|v| v.into()),
         AbcDefaultValue::String(s) => translation_unit
             .pool_string(s.0, activation.strings())
             .map(Into::into),
@@ -523,7 +523,7 @@ pub fn abc_default_value<'gc>(
         | AbcDefaultValue::Explicit(ns)
         | AbcDefaultValue::StaticProtected(ns)
         | AbcDefaultValue::Private(ns) => {
-            let ns = translation_unit.pool_namespace(activation, *ns)?;
+            let ns = translation_unit.pool_namespace(activation, ns)?;
             Ok(NamespaceObject::from_namespace(activation, ns).into())
         }
     }

--- a/swf/src/avm1/types.rs
+++ b/swf/src/avm1/types.rs
@@ -176,7 +176,7 @@ pub struct GetUrl<'a> {
     pub target: &'a SwfStr,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct GetUrl2(pub(crate) GetUrlFlags);
 
 impl GetUrl2 {
@@ -257,28 +257,28 @@ pub enum SendVarsMethod {
     Post = 2,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct GotoFrame {
     pub frame: u16,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct GotoFrame2 {
     pub set_playing: bool,
     pub scene_offset: u16,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct GotoLabel<'a> {
     pub label: &'a SwfStr,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct If {
     pub offset: i16,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Jump {
     pub offset: i16,
 }
@@ -301,7 +301,7 @@ pub enum Value<'a> {
     ConstantPool(u16),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct SetTarget<'a> {
     pub target: &'a SwfStr,
 }
@@ -332,13 +332,13 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct WaitForFrame {
     pub frame: u16,
     pub num_actions_to_skip: u8,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct WaitForFrame2 {
     pub num_actions_to_skip: u8,
 }

--- a/swf/src/avm1/write.rs
+++ b/swf/src/avm1/write.rs
@@ -114,19 +114,19 @@ impl<W: Write> Writer<W> {
             Action::GetProperty => self.write_small_action(OpCode::GetProperty),
             Action::GetTime => self.write_small_action(OpCode::GetTime),
             Action::GetUrl(action) => self.write_get_url(action),
-            Action::GetUrl2(action) => self.write_get_url_2(action),
+            Action::GetUrl2(action) => self.write_get_url_2(*action),
             Action::GetVariable => self.write_small_action(OpCode::GetVariable),
-            Action::GotoFrame(action) => self.write_goto_frame(action),
-            Action::GotoFrame2(action) => self.write_goto_frame_2(action),
+            Action::GotoFrame(action) => self.write_goto_frame(*action),
+            Action::GotoFrame2(action) => self.write_goto_frame_2(*action),
             Action::GotoLabel(action) => self.write_goto_label(action),
             Action::Greater => self.write_small_action(OpCode::Greater),
-            Action::If(action) => self.write_if(action),
+            Action::If(action) => self.write_if(*action),
             Action::ImplementsOp => self.write_small_action(OpCode::ImplementsOp),
             Action::Increment => self.write_small_action(OpCode::Increment),
             Action::InitArray => self.write_small_action(OpCode::InitArray),
             Action::InitObject => self.write_small_action(OpCode::InitObject),
             Action::InstanceOf => self.write_small_action(OpCode::InstanceOf),
-            Action::Jump(action) => self.write_jump(action),
+            Action::Jump(action) => self.write_jump(*action),
             Action::Less => self.write_small_action(OpCode::Less),
             Action::Less2 => self.write_small_action(OpCode::Less2),
             Action::MBAsciiToChar => self.write_small_action(OpCode::MBAsciiToChar),
@@ -175,8 +175,8 @@ impl<W: Write> Writer<W> {
             Action::Trace => self.write_small_action(OpCode::Trace),
             Action::Try(action) => self.write_try(action),
             Action::TypeOf => self.write_small_action(OpCode::TypeOf),
-            Action::WaitForFrame(action) => self.write_wait_for_frame(action),
-            Action::WaitForFrame2(action) => self.write_wait_for_frame_2(action),
+            Action::WaitForFrame(action) => self.write_wait_for_frame(*action),
+            Action::WaitForFrame2(action) => self.write_wait_for_frame_2(*action),
             Action::With(action) => self.write_with(action),
             Action::Unknown(action) => self.write_unknown(action),
         }
@@ -263,19 +263,19 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn write_get_url_2(&mut self, action: &GetUrl2) -> Result<()> {
+    fn write_get_url_2(&mut self, action: GetUrl2) -> Result<()> {
         self.write_action_header(OpCode::GetUrl2, 1)?;
         self.write_u8(action.0.bits())?;
         Ok(())
     }
 
-    fn write_goto_frame(&mut self, action: &GotoFrame) -> Result<()> {
+    fn write_goto_frame(&mut self, action: GotoFrame) -> Result<()> {
         self.write_action_header(OpCode::GotoFrame, 2)?;
         self.write_u16(action.frame)?;
         Ok(())
     }
 
-    fn write_goto_frame_2(&mut self, action: &GotoFrame2) -> Result<()> {
+    fn write_goto_frame_2(&mut self, action: GotoFrame2) -> Result<()> {
         if action.scene_offset != 0 {
             self.write_action_header(OpCode::GotoFrame2, 3)?;
             self.write_u8(if action.set_playing { 0b11 } else { 0b01 })?;
@@ -293,13 +293,13 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn write_if(&mut self, action: &If) -> Result<()> {
+    fn write_if(&mut self, action: If) -> Result<()> {
         self.write_action_header(OpCode::If, 2)?;
         self.write_i16(action.offset)?;
         Ok(())
     }
 
-    fn write_jump(&mut self, action: &Jump) -> Result<()> {
+    fn write_jump(&mut self, action: Jump) -> Result<()> {
         self.write_action_header(OpCode::Jump, 2)?;
         self.write_i16(action.offset)?;
         Ok(())
@@ -437,14 +437,14 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn write_wait_for_frame(&mut self, action: &WaitForFrame) -> Result<()> {
+    fn write_wait_for_frame(&mut self, action: WaitForFrame) -> Result<()> {
         self.write_action_header(OpCode::WaitForFrame, 3)?;
         self.write_u16(action.frame)?;
         self.write_u8(action.num_actions_to_skip)?;
         Ok(())
     }
 
-    fn write_wait_for_frame_2(&mut self, action: &WaitForFrame2) -> Result<()> {
+    fn write_wait_for_frame_2(&mut self, action: WaitForFrame2) -> Result<()> {
         self.write_action_header(OpCode::WaitForFrame2, 1)?;
         self.write_u8(action.num_actions_to_skip)?;
         Ok(())

--- a/swf/src/avm2/types.rs
+++ b/swf/src/avm2/types.rs
@@ -41,7 +41,7 @@ impl<T> Index<T> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Namespace {
     Namespace(Index<String>),
     Package(Index<String>),
@@ -146,10 +146,7 @@ pub struct Exception {
     pub type_name: Index<Multiname>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Opcode;
-
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum DefaultValue {
     Int(Index<i32>),
     Uint(Index<u32>),
@@ -174,7 +171,7 @@ pub struct Metadata {
     pub items: Vec<MetadataItem>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct MetadataItem {
     pub key: Index<String>,
     pub value: Index<String>,

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -184,7 +184,7 @@ impl<W: Write> Writer<W> {
         if !constant_pool.namespaces.is_empty() {
             self.write_u30(constant_pool.namespaces.len() as u32 + 1)?;
             for namespace in &constant_pool.namespaces {
-                self.write_namespace(namespace)?;
+                self.write_namespace(*namespace)?;
             }
         } else {
             self.write_u32(0)?;
@@ -211,8 +211,8 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn write_namespace(&mut self, namespace: &Namespace) -> Result<()> {
-        match *namespace {
+    fn write_namespace(&mut self, namespace: Namespace) -> Result<()> {
+        match namespace {
             Namespace::Namespace(ref name) => {
                 self.write_u8(0x08)?;
                 self.write_index(name)?;
@@ -346,7 +346,7 @@ impl<W: Write> Writer<W> {
             self.write_u30(num_optional_params)?;
             let num_required = method.params.len() - num_optional_params as usize;
             for param in method.params.iter().skip(num_required) {
-                if let Some(ref value) = param.default_value {
+                if let Some(value) = param.default_value {
                     self.write_constant_value(value)?;
                 }
             }
@@ -363,8 +363,8 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn write_constant_value(&mut self, value: &DefaultValue) -> Result<()> {
-        let (index, kind) = match *value {
+    fn write_constant_value(&mut self, value: DefaultValue) -> Result<()> {
+        let (index, kind) = match value {
             DefaultValue::Undefined => (0, 0x00),
             DefaultValue::String(ref i) => (i.as_u30(), 0x01),
             DefaultValue::Int(ref i) => (i.as_u30(), 0x03),
@@ -386,8 +386,8 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn write_optional_value(&mut self, value: &Option<DefaultValue>) -> Result<()> {
-        match *value {
+    fn write_optional_value(&mut self, value: Option<DefaultValue>) -> Result<()> {
+        match value {
             None => self.write_u30(0)?,
             Some(ref value) => {
                 let (index, kind) = match *value {
@@ -489,7 +489,7 @@ impl<W: Write> Writer<W> {
             TraitKind::Slot {
                 slot_id,
                 ref type_name,
-                ref value,
+                value,
             } => {
                 self.write_u8(flags)?;
                 self.write_u30(slot_id)?;
@@ -536,7 +536,7 @@ impl<W: Write> Writer<W> {
             TraitKind::Const {
                 slot_id,
                 ref type_name,
-                ref value,
+                value,
             } => {
                 self.write_u8(flags | 6)?;
                 self.write_u30(slot_id)?;

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -611,7 +611,7 @@ pub struct ExportedAsset<'a> {
     pub name: &'a SwfStr,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct RemoveObject {
     pub depth: Depth,
     pub character_id: Option<CharacterId>,


### PR DESCRIPTION
It's better to pass small objects as value than to reference them.