### PR TITLE
core: Track PlaceObject's ratio on DisplayObject

### DIFF
--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -454,6 +454,10 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         }
     }
 
+    fn on_ratio_changed(self, context: &mut UpdateContext<'gc>, new_ratio: u16) {
+        self.seek(context, new_ratio.into());
+    }
+
     fn id(self) -> CharacterId {
         match self.0.source.get() {
             VideoSource::Swf(swf_source) => swf_source.streamdef.id,


### PR DESCRIPTION
This patch sets PlaceObject's ratio on DisplayObject as it's also used for rewind logic. By itself this patch does not change how rewinds work.

This is pulled from https://github.com/ruffle-rs/ruffle/pull/21336 as a low-risk patch.