### PR TITLE
ci: Remove posting coverage comment

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -271,14 +271,6 @@ jobs:
         if: always()
         run: cat target/diff-cover/report.md >> $GITHUB_STEP_SUMMARY
 
-      - name: Comment
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          $COVERAGE_SCRIPT comment_report "target/diff-cover/report.json" "${{ github.event.pull_request.number }}" "${RUN_URL}"
-
   dependencies:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'


### PR DESCRIPTION
Currently posting fails, so remove it in order not to produce build failures.