### PR TITLE
avm1: Some `Function` refactors

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -259,6 +259,131 @@ impl<'gc> Avm1Function<'gc> {
             *preload_r += 1;
         }
     }
+
+    /// Execute the given function bytecode.
+    #[expect(clippy::too_many_arguments)]
+    fn exec(
+        &self,
+        name: ExecutionName<'gc>,
+        activation: &mut Activation<'_, 'gc>,
+        this: Value<'gc>,
+        depth: u8,
+        args: &[Value<'gc>],
+        reason: ExecutionReason,
+        callee: Object<'gc>,
+    ) -> Result<Value<'gc>, Error<'gc>> {
+        let this_obj = match this {
+            Value::Object(obj) => Some(obj),
+            _ => None,
+        };
+
+        let target = activation.target_clip_or_root();
+        let is_closure = activation.swf_version() >= 6;
+
+        let this_do = this_obj
+            .and_then(|this| this.as_display_object())
+            .unwrap_or(target);
+
+        let base_clip = if is_closure || reason == ExecutionReason::Special {
+            self.base_clip
+                .resolve_reference(activation)
+                .map(|(_, _, dobj)| dobj)
+                .unwrap_or(this_do)
+        } else {
+            this_do
+        };
+        let (swf_version, parent_scope) = if is_closure {
+            // Function calls in a v6+ SWF are proper closures, and "close" over the scope that defined the function:
+            // * Use the SWF version from the SWF that defined the function.
+            // * Use the base clip from when the function was defined.
+            // * Close over the scope from when the function was defined.
+            (self.swf_version(), self.scope())
+        } else {
+            // Function calls in a v5 SWF are *not* closures, and will use the settings of
+            // `this`, regardless of the function's origin:
+            // * Use the SWF version of `this`.
+            // * Use the base clip of `this`.
+            // * Allocate a new scope using the given base clip. No previous scope is closed over.
+            let swf_version = base_clip.swf_version().max(5);
+            let base_clip_obj = match base_clip.object() {
+                Value::Object(o) => o,
+                _ => unreachable!(),
+            };
+            // TODO: It would be nice to avoid these extra Scope allocs.
+            let scope = Gc::new(
+                activation.gc(),
+                Scope::new(
+                    activation.context.avm1.global_scope(),
+                    super::scope::ScopeClass::Target,
+                    base_clip_obj,
+                ),
+            );
+            (swf_version, scope)
+        };
+
+        let child_scope = Gc::new(
+            activation.gc(),
+            Scope::new_local_scope(parent_scope, activation.gc()),
+        );
+
+        // The caller is the previous callee.
+        let arguments_caller = activation.callee;
+
+        let name = if cfg!(feature = "avm_debug") {
+            Cow::Owned(self.debug_string_for_call(activation, name, args))
+        } else {
+            Cow::Borrowed("[Anonymous]")
+        };
+
+        let is_this_inherited = self
+            .flags
+            .intersects(FunctionFlags::PRELOAD_THIS | FunctionFlags::SUPPRESS_THIS);
+        let local_this = if is_this_inherited {
+            activation.this_cell()
+        } else {
+            this
+        };
+
+        let max_recursion_depth = activation.context.avm1.max_recursion_depth();
+        let mut frame = Activation::from_action(
+            activation.context,
+            activation.id.function(name, reason, max_recursion_depth)?,
+            swf_version,
+            child_scope,
+            self.constant_pool,
+            base_clip,
+            local_this,
+            Some(callee),
+        );
+
+        frame.allocate_local_registers(self.register_count());
+
+        let mut preload_r = 1;
+        self.load_this(&mut frame, this, &mut preload_r);
+        self.load_arguments(&mut frame, args, arguments_caller, &mut preload_r);
+        self.load_super(&mut frame, this_obj, depth, &mut preload_r);
+        self.load_root(&mut frame, &mut preload_r);
+        self.load_parent(&mut frame, &mut preload_r);
+        self.load_global(&mut frame, &mut preload_r);
+
+        // Any unassigned args are set to undefined to prevent assignments from leaking to the parent scope (#2166)
+        let args_iter = args
+            .iter()
+            .cloned()
+            .chain(std::iter::repeat(Value::Undefined));
+
+        //TODO: What happens if the argument registers clash with the
+        //preloaded registers? What gets done last?
+        for (param, value) in self.params.iter().zip(args_iter) {
+            if let Some(register) = param.register {
+                frame.set_local_register(register.get(), value);
+            } else {
+                frame.force_define_local(param.name, value);
+            }
+        }
+
+        Ok(frame.run_actions(self.data.clone())?.value())
+    }
 }
 
 #[derive(Debug, Clone, Collect)]
@@ -328,11 +453,6 @@ impl<'gc> Executable<'gc> {
     const EMPTY: Self = Self::Native(|_, _, _| Ok(Value::Undefined));
 
     /// Execute the given code.
-    ///
-    /// Execution is not guaranteed to have completed when this function
-    /// returns. If on-stack execution is possible, then this function returns
-    /// a return value you must push onto the stack. Otherwise, you must
-    /// create a new stack frame and execute the action data yourself.
     #[expect(clippy::too_many_arguments)]
     pub fn exec(
         &self,
@@ -344,126 +464,14 @@ impl<'gc> Executable<'gc> {
         reason: ExecutionReason,
         callee: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        let af = match self {
+        match self {
             Executable::Native(nf) => {
                 // TODO: Change NativeFunction to accept `this: Value`.
                 let this = this.coerce_to_object(activation);
-                return nf(activation, this, args);
+                nf(activation, this, args)
             }
-            Executable::Action(af) => af,
-        };
-
-        let this_obj = match this {
-            Value::Object(obj) => Some(obj),
-            _ => None,
-        };
-
-        let target = activation.target_clip_or_root();
-        let is_closure = activation.swf_version() >= 6;
-
-        let this_do = this_obj
-            .and_then(|this| this.as_display_object())
-            .unwrap_or(target);
-
-        let base_clip = if is_closure || reason == ExecutionReason::Special {
-            af.base_clip
-                .resolve_reference(activation)
-                .map(|(_, _, dobj)| dobj)
-                .unwrap_or(this_do)
-        } else {
-            this_do
-        };
-        let (swf_version, parent_scope) = if is_closure {
-            // Function calls in a v6+ SWF are proper closures, and "close" over the scope that defined the function:
-            // * Use the SWF version from the SWF that defined the function.
-            // * Use the base clip from when the function was defined.
-            // * Close over the scope from when the function was defined.
-            (af.swf_version(), af.scope())
-        } else {
-            // Function calls in a v5 SWF are *not* closures, and will use the settings of
-            // `this`, regardless of the function's origin:
-            // * Use the SWF version of `this`.
-            // * Use the base clip of `this`.
-            // * Allocate a new scope using the given base clip. No previous scope is closed over.
-            let swf_version = base_clip.swf_version().max(5);
-            let base_clip_obj = match base_clip.object() {
-                Value::Object(o) => o,
-                _ => unreachable!(),
-            };
-            // TODO: It would be nice to avoid these extra Scope allocs.
-            let scope = Gc::new(
-                activation.gc(),
-                Scope::new(
-                    activation.context.avm1.global_scope(),
-                    super::scope::ScopeClass::Target,
-                    base_clip_obj,
-                ),
-            );
-            (swf_version, scope)
-        };
-
-        let child_scope = Gc::new(
-            activation.gc(),
-            Scope::new_local_scope(parent_scope, activation.gc()),
-        );
-
-        // The caller is the previous callee.
-        let arguments_caller = activation.callee;
-
-        let name = if cfg!(feature = "avm_debug") {
-            Cow::Owned(af.debug_string_for_call(activation, name, args))
-        } else {
-            Cow::Borrowed("[Anonymous]")
-        };
-
-        let is_this_inherited = af
-            .flags
-            .intersects(FunctionFlags::PRELOAD_THIS | FunctionFlags::SUPPRESS_THIS);
-        let local_this = if is_this_inherited {
-            activation.this_cell()
-        } else {
-            this
-        };
-
-        let max_recursion_depth = activation.context.avm1.max_recursion_depth();
-        let mut frame = Activation::from_action(
-            activation.context,
-            activation.id.function(name, reason, max_recursion_depth)?,
-            swf_version,
-            child_scope,
-            af.constant_pool,
-            base_clip,
-            local_this,
-            Some(callee),
-        );
-
-        frame.allocate_local_registers(af.register_count());
-
-        let mut preload_r = 1;
-        af.load_this(&mut frame, this, &mut preload_r);
-        af.load_arguments(&mut frame, args, arguments_caller, &mut preload_r);
-        af.load_super(&mut frame, this_obj, depth, &mut preload_r);
-        af.load_root(&mut frame, &mut preload_r);
-        af.load_parent(&mut frame, &mut preload_r);
-        af.load_global(&mut frame, &mut preload_r);
-
-        // Any unassigned args are set to undefined to prevent assignments from leaking to the parent scope (#2166)
-        let args_iter = args
-            .iter()
-            .cloned()
-            .chain(std::iter::repeat(Value::Undefined));
-
-        //TODO: What happens if the argument registers clash with the
-        //preloaded registers? What gets done last?
-        for (param, value) in af.params.iter().zip(args_iter) {
-            if let Some(register) = param.register {
-                frame.set_local_register(register.get(), value);
-            } else {
-                frame.force_define_local(param.name, value);
-            }
+            Executable::Action(af) => af.exec(name, activation, this, depth, args, reason, callee),
         }
-
-        Ok(frame.run_actions(af.data.clone())?.value())
     }
 }
 
@@ -512,9 +520,6 @@ impl<'gc> FunctionObject<'gc> {
     }
 
     /// Construct a function with any combination of regular and constructor parts.
-    ///
-    /// Since prototypes need to link back to themselves, this function builds
-    /// both objects itself and returns the function to you, fully allocated.
     ///
     /// `fn_proto` refers to the implicit proto of the function object, and the
     /// `prototype` refers to the explicit prototype of the function.
@@ -642,21 +647,7 @@ impl<'gc> FunctionObject<'gc> {
         this: Object<'gc>,
         args: &[Value<'gc>],
     ) -> Result<(), Error<'gc>> {
-        // TODO: de-duplicate code.
-        this.define_value(
-            activation.gc(),
-            istr!("__constructor__"),
-            callee.into(),
-            Attribute::DONT_ENUM,
-        );
-        if activation.swf_version() < 7 {
-            this.define_value(
-                activation.gc(),
-                istr!("constructor"),
-                callee.into(),
-                Attribute::DONT_ENUM,
-            );
-        }
+        Self::define_constructor_props(activation, this, callee.into());
 
         // Always ignore the constructor's return value.
         let _ = self.as_constructor().exec(
@@ -683,21 +674,7 @@ impl<'gc> FunctionObject<'gc> {
             .coerce_to_object(activation);
         let this = Object::new(activation.strings(), Some(prototype));
 
-        // TODO: de-duplicate code.
-        this.define_value(
-            activation.gc(),
-            istr!("__constructor__"),
-            callee.into(),
-            Attribute::DONT_ENUM,
-        );
-        if activation.swf_version() < 7 {
-            this.define_value(
-                activation.gc(),
-                istr!("constructor"),
-                callee.into(),
-                Attribute::DONT_ENUM,
-            );
-        }
+        Self::define_constructor_props(activation, this, callee.into());
 
         let result = self.as_constructor().exec(
             ExecutionName::Static("[ctor]"),
@@ -714,6 +691,27 @@ impl<'gc> FunctionObject<'gc> {
             Ok(result)
         } else {
             Ok(this.into())
+        }
+    }
+
+    fn define_constructor_props(
+        activation: &mut Activation<'_, 'gc>,
+        this: Object<'gc>,
+        callee: Value<'gc>,
+    ) {
+        this.define_value(
+            activation.gc(),
+            istr!("__constructor__"),
+            callee,
+            Attribute::DONT_ENUM,
+        );
+        if activation.swf_version() < 7 {
+            this.define_value(
+                activation.gc(),
+                istr!("constructor"),
+                callee,
+                Attribute::DONT_ENUM,
+            );
         }
     }
 }

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -297,7 +297,7 @@ pub fn create_timer<'gc>(
     use crate::timer::TimerCallback;
 
     let (callback, interval) = match args.get(0) {
-        Some(Value::Object(o)) if o.as_executable().is_some() => (
+        Some(Value::Object(o)) if o.as_function().is_some() => (
             TimerCallback::Avm1Function {
                 func: *o,
                 params: args.get(2..).unwrap_or_default().to_vec(),

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -450,9 +450,8 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let this = match this.native() {
-        NativeObject::BevelFilter(bevel_filter) => bevel_filter,
-        _ => return Ok(Value::Undefined),
+    let NativeObject::BevelFilter(this) = this.native() else {
+        return Ok(Value::Undefined);
     };
 
     Ok(match index {

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -160,9 +160,8 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let this = match this.native() {
-        NativeObject::BlurFilter(blur_filter) => blur_filter,
-        _ => return Ok(Value::Undefined),
+    let NativeObject::BlurFilter(this) = this.native() else {
+        return Ok(Value::Undefined);
     };
 
     Ok(match index {

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -145,9 +145,8 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let this = match this.native() {
-        NativeObject::ColorMatrixFilter(color_matrix_filter) => color_matrix_filter,
-        _ => return Ok(Value::Undefined),
+    let NativeObject::ColorMatrixFilter(this) = this.native() else {
+        return Ok(Value::Undefined);
     };
 
     Ok(match index {

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -357,9 +357,8 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let this = match this.native() {
-        NativeObject::ConvolutionFilter(convolution_filter) => convolution_filter,
-        _ => return Ok(Value::Undefined),
+    let NativeObject::ConvolutionFilter(this) = this.native() else {
+        return Ok(Value::Undefined);
     };
 
     Ok(match index {

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -454,9 +454,8 @@ fn method<'gc>(
         _ => {}
     }
 
-    let date_ref = match this.native() {
-        NativeObject::Date(date) => date,
-        _ => return Ok(Value::Undefined),
+    let NativeObject::Date(date_ref) = this.native() else {
+        return Ok(Value::Undefined);
     };
     let date = date_ref.get();
 

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -346,9 +346,8 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let this = match this.native() {
-        NativeObject::DisplacementMapFilter(displacement_map_filter) => displacement_map_filter,
-        _ => return Ok(Value::Undefined),
+    let NativeObject::DisplacementMapFilter(this) = this.native() else {
+        return Ok(Value::Undefined);
     };
 
     Ok(match index {

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -373,9 +373,8 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let this = match this.native() {
-        NativeObject::DropShadowFilter(drop_shadow_filter) => drop_shadow_filter,
-        _ => return Ok(Value::Undefined),
+    let NativeObject::DropShadowFilter(this) = this.native() else {
+        return Ok(Value::Undefined);
     };
 
     Ok(match index {

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -62,7 +62,7 @@ pub fn call<'gc>(
     };
 
     // NOTE: does not use `Object::call`, as `super()` only works with direct calls.
-    match func.as_executable() {
+    match func.as_function() {
         Some(exec) => exec.exec(
             ExecutionName::Static("[Anonymous]"),
             activation,
@@ -103,7 +103,7 @@ pub fn apply<'gc>(
     }
 
     // NOTE: does not use `Object::call`, as `super()` only works with direct calls.
-    match func.as_executable() {
+    match func.as_function() {
         Some(exec) => exec.exec(
             ExecutionName::Static("[Anonymous]"),
             activation,

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -295,9 +295,8 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let this = match this.native() {
-        NativeObject::GlowFilter(glow_filter) => glow_filter,
-        _ => return Ok(Value::Undefined),
+    let NativeObject::GlowFilter(this) = this.native() else {
+        return Ok(Value::Undefined);
     };
 
     Ok(match index {

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -124,7 +124,7 @@ fn to_string<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if this.as_executable().is_some() {
+    if this.as_function().is_some() {
         Ok(AvmString::new_ascii_static(activation.gc(), b"[type Function]").into())
     } else {
         Ok(AvmString::new_ascii_static(activation.gc(), b"[object Object]").into())
@@ -183,7 +183,7 @@ pub fn register_class<'gc>(
 
     let constructor = match constructor {
         Value::Null | Value::Undefined => None,
-        Value::Object(obj) if obj.as_executable().is_some() => Some(*obj),
+        Value::Object(obj) if obj.as_function().is_some() => Some(*obj),
         _ => return Ok(false.into()),
     };
 
@@ -212,7 +212,7 @@ fn watch<'gc>(
         .get(1)
         .unwrap_or(&Value::Undefined)
         .coerce_to_object(activation);
-    if callback.as_executable().is_none() {
+    if callback.as_function().is_none() {
         return Ok(false.into());
     }
     let user_data = args.get(2).cloned().unwrap_or(Value::Undefined);

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -104,7 +104,7 @@ fn recursive_serialize<'gc>(
 
             match elem {
                 Value::Object(o) => {
-                    if o.as_executable().is_some() {
+                    if o.as_function().is_some() {
                     } else if o.as_display_object().is_some() {
                         writer.undefined(name.as_ref())
                     } else if let NativeObject::Array(_) = o.native() {

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -230,7 +230,7 @@ impl<'gc> Object<'gc> {
             while let Value::Object(this_proto) = proto {
                 if this_proto.has_own_virtual(activation, name) {
                     if let Some(setter) = this_proto.setter(name, activation) {
-                        if let Some(exec) = setter.as_executable() {
+                        if let Some(exec) = setter.as_function() {
                             let _ = exec.exec(
                                 ExecutionName::Static("[Setter]"),
                                 activation,
@@ -289,7 +289,7 @@ impl<'gc> Object<'gc> {
         // the method was found on the object's prototype.
         let depth = depth.max(1);
 
-        match method.as_executable() {
+        match method.as_function() {
             Some(exec) => exec.exec(
                 ExecutionName::Dynamic(name),
                 activation,
@@ -405,7 +405,7 @@ pub fn search_prototype<'gc>(
         }
 
         if let Some(getter) = p.getter(name, activation) {
-            if let Some(exec) = getter.as_executable() {
+            if let Some(exec) = getter.as_function() {
                 let result = exec.exec(
                     ExecutionName::Static("[Getter]"),
                     activation,

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -83,7 +83,7 @@ impl<'gc> SuperObject<'gc> {
             return Ok(Value::Undefined);
         };
 
-        constr.as_constructor().exec(
+        constr.exec_constructor(
             name.into(),
             activation,
             self.this().into(),
@@ -108,7 +108,7 @@ impl<'gc> SuperObject<'gc> {
                 _ => return Ok(Value::Undefined),
             };
 
-        match method.as_executable() {
+        match method.as_function() {
             Some(exec) => exec.exec(
                 ExecutionName::Dynamic(name),
                 activation,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -411,7 +411,7 @@ impl<'gc> Value<'gc> {
                     )? {
                         Value::String(s) => s,
                         _ => {
-                            if object.as_executable().is_some() {
+                            if object.as_function().is_some() {
                                 AvmString::new_ascii_static(activation.gc(), b"[type Function]")
                             } else {
                                 AvmString::new_ascii_static(activation.gc(), b"[type Object]")
@@ -454,7 +454,7 @@ impl<'gc> Value<'gc> {
             Value::Number(_) => istr!("number"),
             Value::Bool(_) => istr!("boolean"),
             Value::String(_) => istr!("string"),
-            Value::Object(object) if object.as_executable().is_some() => istr!("function"),
+            Value::Object(object) if object.as_function().is_some() => istr!("function"),
             Value::MovieClip(_) => istr!("movieclip"),
             Value::Object(_) => istr!("object"),
         }
@@ -935,7 +935,7 @@ mod test {
                 &activation.context.strings,
                 value_of_impl,
                 protos.function,
-                protos.function,
+                Some(protos.function),
             );
 
             let o = Object::new(&activation.context.strings, Some(protos.object));

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -145,7 +145,7 @@ impl Avm1ObjectWindow {
                         };
                     }
                     Value::Object(value) => {
-                        if value.as_executable().is_some() {
+                        if value.as_function().is_some() {
                             ui.label("Function");
                         } else if ui.button(object_name(value)).clicked() {
                             messages.push(Message::TrackAVM1Object(AVM1ObjectHandle::new(
@@ -357,7 +357,7 @@ impl UiExt for egui::Ui {
 fn object_name(object: Object) -> String {
     // TODO: Find a way to give more meaningful names here.
     // Matching __proto__ to a constant and taking the constants name works, but is super expensive
-    if object.as_executable().is_some() {
+    if object.as_function().is_some() {
         format!("Function {:p}", object.as_ptr())
     } else if let NativeObject::Array(_) = object.native() {
         format!("Array {:p}", object.as_ptr())


### PR DESCRIPTION
- Makes `avm1::function::Executable` private for better encapsulation;
- Deduplicate and clean up some code in `avm1/functions.rs`;
- Replace some `match`es by `let-else`s in native methods (for shorter code).

This has no behavioral changes.

