### PR TITLE
`from_shumway/localconnection` test doesn't need image comparison

### DIFF
--- a/tests/tests/swfs/from_shumway/localconnection/test.toml
+++ b/tests/tests/swfs/from_shumway/localconnection/test.toml
@@ -1,7 +1,1 @@
 num_ticks = 3
-
-[image_comparisons.output]
-tolerance = 5
-
-[player_options]
-with_renderer = { optional = true, sample_count = 1 }


### PR DESCRIPTION
The expected.png file doesn't even exist :D The actual test is covered in the output.txt