### PR TITLE
web: Properly classify web fonts as italic

### DIFF
--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -480,7 +480,8 @@ impl RuffleInstanceBuilder {
         player.register_device_font(FontDefinition::FontFile {
             name,
             is_bold: face.is_bold(),
-            is_italic: face.is_italic(),
+            // Note: do not use is_italic() here, as we don't care about italic_angle
+            is_italic: face.style() != ttf_parser::Style::Normal,
             data: FontFileData::new(bytes),
             index,
         });


### PR DESCRIPTION
Fonts can have style regular and non-zero italic angle. This however should not classify them as italic, even if they might look like it visually.

This makes it behave the same way as on desktop.