### PR TITLE
ci: Raise warnings on uncovered blocks of lines

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -272,6 +272,10 @@ jobs:
         if: always()
         run: cat target/diff-cover/report.md >> $GITHUB_STEP_SUMMARY
 
+      - name: Warnings
+        if: always()
+        run: $COVERAGE_SCRIPT raise_warnings "target/diff-cover/report.json"
+
   dependencies:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'


### PR DESCRIPTION
This will add warnings visible in GitHub for blocks of uncovered lines.