### PR TITLE
avm2: Allow any i32 in `Value::Integer`

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2014,8 +2014,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value1 = self.pop_stack();
 
         let sum_value = match (value1, value2) {
-            // note: with not-yet-guaranteed assumption that Integer < 1<<28, this won't overflow.
-            (Value::Integer(n1), Value::Integer(n2)) => (n1 + n2).into(),
+            (Value::Integer(n1), Value::Integer(n2)) => {
+                if let Some(res) = n1.checked_add(n2) {
+                    res.into()
+                } else {
+                    ((n1 as i64 + n2 as i64) as f64).into()
+                }
+            }
             (Value::Number(n1), Value::Number(n2)) => (n1 + n2).into(),
             (Value::String(s), value2) => Value::String(AvmString::concat(
                 self.gc(),
@@ -2260,8 +2265,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value1 = self.pop_stack();
 
         let sub_value: Value<'gc> = match (value1, value2) {
-            // note: with not-yet-guaranteed assumption that Integer < 1<<28, this won't underflow.
-            (Value::Integer(n1), Value::Integer(n2)) => (n1 - n2).into(),
+            (Value::Integer(n1), Value::Integer(n2)) => {
+                if let Some(res) = n1.checked_sub(n2) {
+                    res.into()
+                } else {
+                    ((n1 as i64 - n2 as i64) as f64).into()
+                }
+            }
             (Value::Number(n1), Value::Number(n2)) => (n1 - n2).into(),
             _ => {
                 let value2 = value2.coerce_to_number(self)?;


### PR DESCRIPTION
This is a performance optimization, as it gets rid of range checks when operating on values. Since we already implement value normalization, we don't have to make sure the value is the proper type at all times, only when differentiating between Number and Integer. This allows us to drop range checks and allow any Integer and any Number even if they are not representable in Flash Player.

This should improve performance in most cases, where we don't need a range check. This introduces overflow checks in `op_add` and `op_subtract`, but they should be faster than range checks which happened after each op anyway.
