### PR TITLE
tests: Add player version, currently unused

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,12 +6,11 @@ are based around running a SWF and seeing what happens.
 To create a test, make a directory that looks like the following, at minimum:
 
 - `directory/`
-  - `test.swf`
-  - `test.toml`
-  - `output.txt`
+    - `test.swf`
+    - `test.toml`
+    - `output.txt`
 
 As best practice, please also include any source used to make the SWF, such as `test.fla` and/or any ActionScript files.
-
 
 # Test Structure
 
@@ -84,6 +83,9 @@ with_video = false
 
 # The runtime to emulate ("FlashPlayer" or "AIR"). Defaults to "FlashPlayer".
 runtime = "AIR"
+
+# The version of the player to emulate. If not set, it uses the newest one ruffle knows about.
+version = 32
 
 # Whether Ruffle's default font should be available.
 # It's not recommended to enable this option, as it will introduce differences
@@ -199,4 +201,5 @@ sleep_to_meet_frame_rate = false
 
 `fscommand("quit")` is enabled for tests, and will end the test at the end of this frame or tick.
 
-You can use this to end a test prematurely before the set number of iterations elapses, which may be useful for timer tests.
+You can use this to end a test prematurely before the set number of iterations elapses, which may be useful for timer
+tests.

--- a/tests/framework/src/options/player.rs
+++ b/tests/framework/src/options/player.rs
@@ -17,6 +17,7 @@ pub struct PlayerOptions {
     with_audio: bool,
     with_video: bool,
     runtime: PlayerRuntime,
+    version: Option<u8>,
     mode: Option<PlayerMode>,
     with_default_font: bool,
 }
@@ -43,6 +44,7 @@ impl PlayerOptions {
 
         player_builder = player_builder
             .with_player_runtime(self.runtime)
+            .with_player_version(self.version)
             // Assume flashplayerdebugger is used in tests
             .with_player_mode(self.mode.unwrap_or(PlayerMode::Debug))
             .with_default_font(self.with_default_font);


### PR DESCRIPTION
Will be required for gnash tests. Defaults to None which Ruffle itself defaults to 32 currently, but it's supposed to be "the newest"