### PR TITLE
web: Test with Node.js 25 instead of 22 (in addition to 24)

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["22", "24"]
+        node_version: ["24", "25"]
         os: [ubuntu-24.04, windows-2025]
 
     steps:
@@ -197,7 +197,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ["22", "24"]
+        node_version: ["24", "25"]
         os: [ubuntu-24.04, windows-2025]
 
     steps:

--- a/web/README.md
+++ b/web/README.md
@@ -57,7 +57,7 @@ should work. Additionally, headless JREs should also work.
 
 Follow the instructions to [install Node.js](https://nodejs.org/) on your machine.
 
-We recommend using the currently active LTS 22, but we do also run tests with current Node.js 24.
+We recommend using the currently active LTS 24, but we do also run tests with current Node.js 25.
 
 Note that npm 7 or newer is required. It should come bundled with Node.js 15 or newer, but can be upgraded with older Node.js versions using `npm install -g npm` as root/Administrator.
 


### PR DESCRIPTION
Referencing https://github.com/ruffle-rs/ruffle/pull/18780, https://github.com/ruffle-rs/ruffle/pull/20362, and https://github.com/ruffle-rs/ruffle/pull/21950.

This will also necessitate updating the set of required checks for PRs, as usual.