### PR TITLE
core: Rename `TDisplayObject::object` to `TDisplayObject::object1`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -346,7 +346,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let mut parent_activation =
             Activation::from_nothing(self.context, self.id.child("[Actions Parent]"), active_clip);
         let clip_obj = active_clip
-            .object()
+            .object1()
             .coerce_to_object(&mut parent_activation);
         let child_scope = Gc::new(
             parent_activation.gc(),
@@ -382,7 +382,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     where
         for<'c> F: FnOnce(&mut Activation<'c, 'gc>) -> R,
     {
-        let clip_obj = match active_clip.object() {
+        let clip_obj = match active_clip.object1() {
             Value::Object(o) => o,
             _ => panic!("No script object for display object"),
         };
@@ -767,7 +767,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let variable = self.get_variable(fn_name)?;
 
         let result = variable.call_with_default_this(
-            self.target_clip_or_root().object().coerce_to_object(self),
+            self.target_clip_or_root().object1().coerce_to_object(self),
             fn_name,
             self,
             &args,
@@ -879,7 +879,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let swf_version = self.swf_version();
         let func_data = parent_data.to_unbounded_subslice(action.actions);
         let constant_pool = self.constant_pool();
-        let bc = self.base_clip.object().coerce_to_object(self);
+        let bc = self.base_clip.object1().coerce_to_object(self);
         let func = Avm1Function::from_swf_function(
             self.gc(),
             swf_version,
@@ -1284,7 +1284,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             }
             if is_load_vars {
                 if let Some(clip_target) = clip_target {
-                    let target_obj = clip_target.object().coerce_to_object(self);
+                    let target_obj = clip_target.object1().coerce_to_object(self);
                     let request = self.locals_into_request(
                         url,
                         NavigationMethod::from_send_vars_method(action.send_vars_method()),
@@ -1850,7 +1850,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 // Revert the target to the base clip, or `None` if the base was also removed
                 self.set_target_clip(Some(self.base_clip()));
 
-                let clip_obj = self.target_clip_or_root().object().coerce_to_object(self);
+                let clip_obj = self.target_clip_or_root().object1().coerce_to_object(self);
 
                 self.set_scope(Scope::new_target_scope(self.scope(), clip_obj, self.gc()));
             }
@@ -1997,7 +1997,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let clip_obj = self
             .target_clip_or_base_clip()
-            .object()
+            .object1()
             .coerce_to_object(self);
 
         self.set_scope(Scope::new_target_scope(self.scope(), clip_obj, self.gc()));
@@ -2556,7 +2556,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
 
         let root = start.avm1_root();
-        let start = start.object().coerce_to_object(self);
+        let start = start.object1().coerce_to_object(self);
         Ok(self
             .resolve_target_path(root, start, &path, false, true)?
             .and_then(|o| o.as_display_object()))
@@ -2588,7 +2588,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // (`/bar` means `_root.bar`)
         let (mut object, mut is_slash_path) = if path.starts_with(b'/') {
             path = &path[1..];
-            (root.object().coerce_to_object(self), true)
+            (root.object1().coerce_to_object(self), true)
         } else {
             (start, false)
         };
@@ -2610,7 +2610,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 }
                 path = path.slice(3..).unwrap_or_default();
                 if let Some(parent) = object.as_display_object().and_then(|o| o.avm1_parent()) {
-                    parent.object()
+                    parent.object1()
                 } else {
                     // Tried to get parent of root, bail out.
                     return Ok(None);
@@ -2655,14 +2655,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                         // If an object doesn't have an object representation, e.g. Graphic, then trying to access it
                         // Returns the parent instead
                         if path_has_slash {
-                            child.object()
+                            child.object1()
                         } else if let crate::display_object::DisplayObject::Graphic(_) = child {
                             child
                                 .parent()
-                                .map(|p| p.object())
+                                .map(|p| p.object1())
                                 .unwrap_or(Value::Undefined)
                         } else {
-                            child.object()
+                            child.object1()
                         }
                     } else {
                         let name = AvmString::new(self.gc(), name);
@@ -2728,7 +2728,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         // Finally! It's a plain old variable name.
         // Resolve using scope chain, as normal.
-        if let Value::Object(object) = start.object() {
+        if let Value::Object(object) = start.object1() {
             Ok(Some((object, path)))
         } else {
             Ok(None)
@@ -2929,7 +2929,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Obtain the value of `_root`.
     pub fn root_object(&self) -> Value<'gc> {
-        self.base_clip().avm1_root().object()
+        self.base_clip().avm1_root().object1()
     }
 
     /// Returns whether property keys should be case sensitive based on the current SWF version.
@@ -2978,7 +2978,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             Scope::new(
                 self.scope,
                 ScopeClass::Target,
-                object.object().coerce_to_object(self),
+                object.object1().coerce_to_object(self),
             ),
         );
     }
@@ -3081,7 +3081,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let base_clip = self.base_clip();
         let new_target_clip;
         let root = base_clip.avm1_root();
-        let start = base_clip.object().coerce_to_object(self);
+        let start = base_clip.object1().coerce_to_object(self);
         if target.is_empty() {
             new_target_clip = Some(base_clip);
         } else if let Some(clip) = self
@@ -3117,7 +3117,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         self.set_target_clip(new_target_clip);
 
-        let clip_obj = self.target_clip_or_root().object().coerce_to_object(self);
+        let clip_obj = self.target_clip_or_root().object1().coerce_to_object(self);
 
         self.set_scope(Scope::new_target_scope(self.scope(), clip_obj, self.gc()));
         Ok(FrameControl::Continue)

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -234,7 +234,7 @@ impl<'gc> Avm1Function<'gc> {
 
     fn load_root(&self, frame: &mut Activation<'_, 'gc>, preload_r: &mut u8) {
         if self.flags.contains(FunctionFlags::PRELOAD_ROOT) {
-            let root = frame.base_clip().avm1_root().object();
+            let root = frame.base_clip().avm1_root().object1();
             frame.set_local_register(*preload_r, root);
             *preload_r += 1;
         }
@@ -246,7 +246,7 @@ impl<'gc> Avm1Function<'gc> {
             // and _global ends up incorrectly taking _parent's register.
             // See test for more info.
             if let Some(parent) = frame.base_clip().avm1_parent() {
-                frame.set_local_register(*preload_r, parent.object());
+                frame.set_local_register(*preload_r, parent.object1());
                 *preload_r += 1;
             }
         }
@@ -305,7 +305,7 @@ impl<'gc> Avm1Function<'gc> {
             // * Use the base clip of `this`.
             // * Allocate a new scope using the given base clip. No previous scope is closed over.
             let swf_version = base_clip.swf_version().max(5);
-            let base_clip_obj = match base_clip.object() {
+            let base_clip_obj = match base_clip.object1() {
                 Value::Object(o) => o,
                 _ => unreachable!(),
             };

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -809,7 +809,7 @@ fn attach_movie<'gc>(
         };
         new_clip.post_instantiation(activation.context, init_object, Instantiator::Avm1, true);
 
-        Ok(new_clip.object().coerce_to_object(activation).into())
+        Ok(new_clip.object1().coerce_to_object(activation).into())
     } else {
         avm_warn!(activation, "Unable to attach '{}'", export_name);
         Ok(Value::Undefined)
@@ -847,7 +847,7 @@ fn create_empty_movie_clip<'gc>(
     movie_clip.replace_at_depth(activation.context, new_clip.into(), depth);
     new_clip.post_instantiation(activation.context, None, Instantiator::Avm1, true);
 
-    Ok(new_clip.object())
+    Ok(new_clip.object1())
 }
 
 fn create_text_field<'gc>(
@@ -897,7 +897,7 @@ fn create_text_field<'gc>(
 
     if activation.swf_version() >= 8 {
         //SWF8+ returns the `TextField` instance here
-        Ok(text_field.object())
+        Ok(text_field.object1())
     } else {
         Ok(Value::Undefined)
     }
@@ -936,7 +936,7 @@ fn duplicate_movie_clip<'gc>(
         return Ok(Value::Undefined);
     }
 
-    Ok(new_clip.map_or(Value::Undefined, |clip| clip.object()))
+    Ok(new_clip.map_or(Value::Undefined, |clip| clip.object1()))
 }
 
 pub fn clone_sprite<'gc>(
@@ -1032,8 +1032,8 @@ fn get_instance_at_depth<'gc>(
                 // NOTE: this behavior was guessed from observing behavior for Text and Graphic;
                 // I didn't test other variants like Bitmap, MorphSpahe, Video
                 // or objects that weren't fully initialized yet.
-                match child.object() {
-                    Value::Undefined => Ok(movie_clip.object()),
+                match child.object1() {
+                    Value::Undefined => Ok(movie_clip.object1()),
                     obj => Ok(obj),
                 }
             }
@@ -1593,7 +1593,7 @@ fn load_movie<'gc>(
     let url = url_val.coerce_to_string(activation)?;
     let method = args.get(1).cloned().unwrap_or(Value::Undefined);
     let method = NavigationMethod::from_method_str(&method.coerce_to_string(activation)?);
-    let target_obj = target.object().coerce_to_object(activation);
+    let target_obj = target.object1().coerce_to_object(activation);
     let request = activation.object_into_request(target_obj, url, method);
     let future = activation.context.load_manager.load_movie_into_clip(
         activation.context.player.clone(),
@@ -1616,7 +1616,7 @@ fn load_variables<'gc>(
     let url = url_val.coerce_to_string(activation)?;
     let method = args.get(1).cloned().unwrap_or(Value::Undefined);
     let method = NavigationMethod::from_method_str(&method.coerce_to_string(activation)?);
-    let target = target.object().coerce_to_object(activation);
+    let target = target.object1().coerce_to_object(activation);
     let request = activation.object_into_request(target, url, method);
     let future = activation.context.load_manager.load_form_into_object(
         activation.context.player.clone(),
@@ -1643,7 +1643,7 @@ fn transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let constructor = activation.prototypes().transform_constructor;
-    let cloned = constructor.construct(activation, &[this.object()])?;
+    let cloned = constructor.construct(activation, &[this.object1()])?;
     Ok(cloned)
 }
 

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -115,7 +115,7 @@ pub fn get_focus<'gc>(
     Ok(match focus {
         Some(focus) => focus
             .as_displayobject()
-            .object()
+            .object1()
             .coerce_to_string(activation)
             .unwrap_or_else(|_| istr!(""))
             .into(),

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -38,13 +38,13 @@ pub fn get_property<'gc>(
         .and_then(|o| o.child_by_name(&name, activation.is_case_sensitive()))
     {
         return if is_slash_path {
-            Some(child.object())
+            Some(child.object1())
         // If an object doesn't have an object representation, e.g. Graphic, then trying to access it
         // Returns the parent instead
         } else if let crate::display_object::DisplayObject::Graphic(_) = child {
-            child.parent().map(|p| p.object())
+            child.parent().map(|p| p.object1())
         } else {
-            Some(child.object())
+            Some(child.object1())
         };
     }
 
@@ -150,11 +150,11 @@ fn resolve_path_property<'gc>(
 ) -> Option<Value<'gc>> {
     let case_sensitive = activation.is_case_sensitive();
     if name.eq_with_case(b"_root", case_sensitive) {
-        return Some(dobj.avm1_root().object());
+        return Some(dobj.avm1_root().object1());
     } else if name.eq_with_case(b"_parent", case_sensitive) {
         return Some(
             dobj.avm1_parent()
-                .map(|dn| dn.object().coerce_to_object(activation))
+                .map(|dn| dn.object1().coerce_to_object(activation))
                 .map(Value::Object)
                 .unwrap_or(Value::Undefined),
         );
@@ -171,7 +171,7 @@ fn resolve_path_property<'gc>(
             let level_id = parse_level_id(&name[6..]);
             let level = activation
                 .get_level(level_id)
-                .map(|o| o.object())
+                .map(|o| o.object1())
                 .unwrap_or(Value::Undefined);
             return Some(level);
         }

--- a/core/src/avm1/object_reference.rs
+++ b/core/src/avm1/object_reference.rs
@@ -74,11 +74,11 @@ impl<'gc> MovieClipReference<'gc> {
         // We can't use as_display_object here as we explicitly don't want to convert `SuperObjects`
         let display_object = object.as_display_object_no_super()?;
         let (path, cached) = if let DisplayObject::MovieClip(mc) = display_object {
-            (mc.path(), display_object.object())
+            (mc.path(), display_object.object1())
         } else if activation.swf_version() <= 5 {
             let display_object = Self::process_swf5_references(activation, display_object)?;
 
-            (display_object.path(), display_object.object())
+            (display_object.path(), display_object.object1())
         } else {
             return None;
         };
@@ -171,7 +171,7 @@ impl<'gc> MovieClipReference<'gc> {
 
             Some((
                 false,
-                display_object.object().coerce_to_object(activation),
+                display_object.object1().coerce_to_object(activation),
                 display_object,
             ))
         } else {

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -159,7 +159,7 @@ impl<'gc> Avm1<'gc> {
         );
 
         let clip_obj = active_clip
-            .object()
+            .object1()
             .coerce_to_object(&mut parent_activation);
         let child_scope = Gc::new(
             parent_activation.gc(),
@@ -197,7 +197,7 @@ impl<'gc> Avm1<'gc> {
     where
         for<'b> F: FnOnce(&mut Activation<'b, 'gc>) -> R,
     {
-        let clip_obj = match active_clip.object() {
+        let clip_obj = match active_clip.object1() {
             Value::Object(o) => o,
             _ => panic!("No script object for display object"),
         };
@@ -243,7 +243,7 @@ impl<'gc> Avm1<'gc> {
         );
 
         let clip_obj = active_clip
-            .object()
+            .object1()
             .coerce_to_object(&mut parent_activation);
         let child_scope = Gc::new(
             parent_activation.gc(),

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -21,7 +21,7 @@ where
             .expect("Root should exist for freshly made movie");
         let mut activation =
             Activation::from_nothing(context, ActivationIdentifier::root("[Test]"), root);
-        let this = root.object().coerce_to_object(&mut activation);
+        let this = root.object1().coerce_to_object(&mut activation);
         let result = test(&mut activation, this);
         if let Err(e) = result {
             panic!("Encountered exception during test: {e}");

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -422,7 +422,7 @@ impl<'gc> UpdateContext<'gc> {
         // Set the version parameter on the root.
         let mut activation =
             Activation::from_stub(self, ActivationIdentifier::root("[Version Setter]"));
-        let object = root.object().coerce_to_object(&mut activation);
+        let object = root.object1().coerce_to_object(&mut activation);
         let version_string = activation
             .context
             .system

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -1482,7 +1482,7 @@ impl DisplayObjectWindow {
                 );
                 ui.end_row();
 
-                if let crate::avm1::Value::Object(object) = object.object() {
+                if let crate::avm1::Value::Object(object) = object.object1() {
                     ui.label("AVM1 Object");
                     if ui.button(format!("{:p}", object.as_ptr())).clicked() {
                         messages.push(Message::TrackAVM1Object(AVM1ObjectHandle::new(

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -2520,7 +2520,7 @@ pub trait TDisplayObject<'gc>:
         // Noop for most symbols; only shapes can replace their innards with another Graphic.
     }
 
-    fn object(self) -> Avm1Value<'gc> {
+    fn object1(self) -> Avm1Value<'gc> {
         Avm1Value::Undefined // TODO: Implement for every type and delete this fallback.
     }
 
@@ -2755,7 +2755,7 @@ pub trait TDisplayObject<'gc>:
     where
         F: FnOnce(&mut UpdateContext<'gc>) -> bool,
     {
-        if let Avm1Value::Object(object) = self.object() {
+        if let Avm1Value::Object(object) = self.object1() {
             let mut activation = Activation::from_nothing(
                 context,
                 Avm1ActivationIdentifier::root("[AVM1 Boolean Property]"),
@@ -2781,7 +2781,7 @@ pub trait TDisplayObject<'gc>:
         value: Avm1Value<'gc>,
         context: &mut UpdateContext<'gc>,
     ) {
-        if let Avm1Value::Object(object) = self.object() {
+        if let Avm1Value::Object(object) = self.object1() {
             let mut activation = Activation::from_nothing(
                 context,
                 Avm1ActivationIdentifier::root("[AVM1 Property Set]"),

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -216,7 +216,7 @@ impl<'gc> Avm1Button<'gc> {
         default: bool,
         context: &mut UpdateContext<'gc>,
     ) -> bool {
-        if let Value::Object(object) = self.object() {
+        if let Value::Object(object) = self.object1() {
             let mut activation = Activation::from_nothing(
                 context,
                 ActivationIdentifier::root("[AVM1 Boolean Property]"),
@@ -346,7 +346,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         false
     }
 
-    fn object(self) -> Value<'gc> {
+    fn object1(self) -> Value<'gc> {
         self.0
             .object
             .get()

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -1111,7 +1111,7 @@ impl<'gc> ChildContainer<'gc> {
                 return true;
             // otherwise, check for a dynamic unload handler
             } else {
-                let obj = child.object().coerce_to_object(activation);
+                let obj = child.object1().coerce_to_object(activation);
                 if obj.has_property(activation, istr!("onUnload")) {
                     return true;
                 }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2100,7 +2100,7 @@ impl<'gc> EditText<'gc> {
     }
 
     fn initialize_as_broadcaster(self, activation: &mut Avm1Activation<'_, 'gc>) {
-        if let Avm1Value::Object(object) = self.object() {
+        if let Avm1Value::Object(object) = self.object1() {
             activation
                 .context
                 .avm1
@@ -2125,7 +2125,7 @@ impl<'gc> EditText<'gc> {
     }
 
     fn on_changed(self, activation: &mut Avm1Activation<'_, 'gc>) {
-        if let Avm1Value::Object(object) = self.object() {
+        if let Avm1Value::Object(object) = self.object1() {
             let _ = object.call_method(
                 istr!("broadcastMessage"),
                 &[istr!("onChanged").into(), object.into()],
@@ -2144,7 +2144,7 @@ impl<'gc> EditText<'gc> {
     }
 
     fn on_scroller(self, activation: &mut Avm1Activation<'_, 'gc>) {
-        if let Avm1Value::Object(object) = self.object() {
+        if let Avm1Value::Object(object) = self.object1() {
             let _ = object.call_method(
                 istr!("broadcastMessage"),
                 &[istr!("onScroller").into(), object.into()],
@@ -2428,7 +2428,7 @@ impl<'gc> EditText<'gc> {
         );
         // [NA]: Should all `from_nothings` be scoped to root? It definitely should here.
         activation.set_scope_to_display_object(parent);
-        let this = parent.object().coerce_to_object(&mut activation);
+        let this = parent.object1().coerce_to_object(&mut activation);
 
         if let Some((name, args)) = address.split_once(b',') {
             let name = AvmString::new(activation.gc(), name);
@@ -2562,7 +2562,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         }
     }
 
-    fn object(self) -> Avm1Value<'gc> {
+    fn object1(self) -> Avm1Value<'gc> {
         self.0
             .object
             .get()

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -634,9 +634,9 @@ pub trait TInteractiveObject<'gc>:
         other: Option<InteractiveObject<'gc>>,
     ) {
         let self_do = self.as_displayobject();
-        if let Avm1Value::Object(object) = self_do.object() {
+        if let Avm1Value::Object(object) = self_do.object1() {
             let other = other
-                .map(|d| d.as_displayobject().object())
+                .map(|d| d.as_displayobject().object1())
                 .unwrap_or(Avm1Value::Null);
 
             let method_name = if focused {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2600,7 +2600,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
     }
 
-    fn object(self) -> Avm1Value<'gc> {
+    fn object1(self) -> Avm1Value<'gc> {
         self.0
             .object1
             .get()

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -544,7 +544,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         self.0.movie.clone()
     }
 
-    fn object(self) -> Avm1Value<'gc> {
+    fn object1(self) -> Avm1Value<'gc> {
         self.0
             .object
             .get()

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -192,10 +192,10 @@ impl<'gc> FocusTracker<'gc> {
                     istr!(context, "onSetFocus"),
                     &[
                         old.map(|o| o.as_displayobject())
-                            .map(|v| v.object())
+                            .map(|v| v.object1())
                             .unwrap_or(Value::Null),
                         new.map(|o| o.as_displayobject())
-                            .map(|v| v.object())
+                            .map(|v| v.object1())
                             .unwrap_or(Value::Null),
                     ],
                     context,

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1159,7 +1159,7 @@ impl<'gc> Loader<'gc> {
 
                         // Clear deletable properties on the target before loading
                         // Properties written during the subsequent onLoad events will persist
-                        let clip_value = mc.object();
+                        let clip_value = mc.object1();
                         if let Value::Object(clip_object) = clip_value {
                             let mut activation = Activation::from_nothing(
                                 uc,
@@ -1189,7 +1189,7 @@ impl<'gc> Loader<'gc> {
                         // Make a copy of the properties on the root, so we can put them back after replacing it
                         let mut root_properties: IndexMap<AvmString, Value> = IndexMap::new();
                         if let Some(root) = uc.stage.root_clip() {
-                            let root_val = root.object();
+                            let root_val = root.object1();
                             if let Value::Object(root_object) = root_val {
                                 let mut activation = Activation::from_nothing(
                                     uc,
@@ -1210,7 +1210,7 @@ impl<'gc> Loader<'gc> {
                         // Add the copied properties back onto the new root
                         if !root_properties.is_empty() {
                             if let Some(root) = uc.stage.root_clip() {
-                                let val = root.object();
+                                let val = root.object1();
                                 if let Value::Object(clip_object) = val {
                                     let mut activation = Activation::from_nothing(
                                         uc,
@@ -1985,7 +1985,7 @@ impl<'gc> Loader<'gc> {
                         clip,
                         broadcaster,
                         istr!(uc, "broadcastMessage"),
-                        &[istr!(uc, "onLoadStart").into(), clip.object()],
+                        &[istr!(uc, "onLoadStart").into(), clip.object1()],
                         uc,
                     );
                 }
@@ -2357,7 +2357,7 @@ impl<'gc> Loader<'gc> {
                         istr!(uc, "broadcastMessage"),
                         &[
                             istr!(uc, "onLoadProgress").into(),
-                            clip.object(),
+                            clip.object1(),
                             cur_len.into(),
                             total_len.into(),
                         ],
@@ -2437,7 +2437,7 @@ impl<'gc> Loader<'gc> {
                 if !flashvars.is_empty() {
                     let mut activation =
                         Activation::from_nothing(uc, ActivationIdentifier::root("[Loader]"), dobj);
-                    let object = dobj.object().coerce_to_object(&mut activation);
+                    let object = dobj.object1().coerce_to_object(&mut activation);
                     for (key, value) in flashvars.iter() {
                         object.define_value(
                             activation.gc(),
@@ -2506,7 +2506,7 @@ impl<'gc> Loader<'gc> {
                         // TODO: Pass an actual httpStatus argument instead of 0.
                         &[
                             istr!(uc, "onLoadComplete").into(),
-                            target_clip.object(),
+                            target_clip.object1(),
                             status.into(),
                         ],
                         uc,
@@ -2579,7 +2579,7 @@ impl<'gc> Loader<'gc> {
                         istr!(uc, "broadcastMessage"),
                         &[
                             istr!(uc, "onLoadError").into(),
-                            clip.object(),
+                            clip.object1(),
                             error_message.into(),
                         ],
                         uc,
@@ -2710,7 +2710,7 @@ impl<'gc> Loader<'gc> {
                         ActionType::Method {
                             object: broadcaster,
                             name: istr!(strings, "broadcastMessage"),
-                            args: vec![istr!(strings, "onLoadInit").into(), clip.object()],
+                            args: vec![istr!(strings, "onLoadInit").into(), clip.object1()],
                         },
                         false,
                     );

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -640,7 +640,7 @@ impl Player {
 
             let display_obj = Player::get_context_menu_display_object(context);
 
-            let menu = if let Some(Value::Object(obj)) = display_obj.map(|obj| obj.object()) {
+            let menu = if let Some(Value::Object(obj)) = display_obj.map(|obj| obj.object1()) {
                 let mut activation =
                     Activation::from_stub(context, ActivationIdentifier::root("[ContextMenu]"));
                 let menu_object = if let Ok(Value::Object(menu)) =
@@ -781,7 +781,7 @@ impl Player {
                     display_object,
                 );
 
-                let params = vec![display_object.object(), Value::Object(item)];
+                let params = vec![display_object.object1(), Value::Object(item)];
 
                 let _ = callback.call(
                     "[Context Menu Callback]",
@@ -801,7 +801,7 @@ impl Player {
             run_mouse_pick(context, false).map(|picked_obj| picked_obj.as_displayobject());
 
         while let Some(display_obj) = picked_obj {
-            if let Value::Object(obj) = display_obj.object() {
+            if let Value::Object(obj) = display_obj.object1() {
                 let mut activation =
                     Activation::from_stub(context, ActivationIdentifier::root("[ContextMenu]"));
 
@@ -1090,7 +1090,7 @@ impl Player {
 
                         for display_object in activation.context.stage.iter_render_list() {
                             let level = display_object.depth();
-                            let object = display_object.object().coerce_to_object(&mut activation);
+                            let object = display_object.object1().coerce_to_object(&mut activation);
                             dumper.print_variables(
                                 &format!("Level #{level}:"),
                                 &format!("_level{level}"),
@@ -2142,7 +2142,7 @@ impl Player {
                         action.clip,
                     );
                     if let Ok(prototype) = constructor.get(istr!("prototype"), &mut activation) {
-                        if let Value::Object(object) = action.clip.object() {
+                        if let Value::Object(object) = action.clip.object1() {
                             object.define_value(
                                 activation.gc(),
                                 istr!("__proto__"),


### PR DESCRIPTION
This makes it consistent with `object2`. There are no functional changes.