### PR TITLE
frontend_utils: Put desktop-specific code behind features

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -24,7 +24,7 @@ ruffle_render = { path = "../render", features = ["clap"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }
 ruffle_video_external = { path = "../video/external", features = ["openh264"], optional = true }
-ruffle_frontend_utils = { path = "../frontend-utils", features = ["cpal"] }
+ruffle_frontend_utils = { path = "../frontend-utils", features = ["cpal", "fs", "navigator", "executor"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = "0.2.3"

--- a/frontend-utils/Cargo.toml
+++ b/frontend-utils/Cargo.toml
@@ -12,6 +12,9 @@ workspace = true
 
 [features]
 cpal = ["dep:cpal", "dep:bytemuck"]
+fs = []
+navigator = ["fs", "dep:async-io", "dep:tokio"]
+executor = ["dep:tokio"]
 
 [dependencies]
 toml_edit = { version = "0.23.6", features = ["parse"] }
@@ -24,7 +27,7 @@ ruffle_core = { path = "../core", default-features = false }
 ruffle_render = { path = "../render", default-features = false }
 async-channel = { workspace = true }
 slotmap = { workspace = true }
-async-io = "2.6.0"
+async-io = { version = "2.6.0", optional = true }
 futures-lite = "2.6.1"
 reqwest = { version = "0.12.24", default-features = false, features = [
     "rustls-tls",
@@ -33,7 +36,7 @@ reqwest = { version = "0.12.24", default-features = false, features = [
     "http2",
     "macos-system-configuration",
 ] }
-tokio = { workspace = true, features = ["net"] }
+tokio = { workspace = true, features = ["net"], optional = true }
 cpal = { workspace = true, optional = true }
 bytemuck = { workspace = true, optional = true }
 

--- a/frontend-utils/src/backends.rs
+++ b/frontend-utils/src/backends.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "cpal")]
 pub mod audio;
+#[cfg(feature = "executor")]
 pub mod executor;
+#[cfg(feature = "navigator")]
 pub mod navigator;
+#[cfg(feature = "fs")]
 pub mod storage;

--- a/frontend-utils/src/content.rs
+++ b/frontend-utils/src/content.rs
@@ -1,7 +1,5 @@
-use crate::backends::navigator::NavigatorInterface;
 use crate::bundle::Bundle;
 use std::fmt::{Debug, Formatter};
-use std::io::{ErrorKind, Read};
 use url::Url;
 
 pub enum PlayingContent {
@@ -40,11 +38,14 @@ impl PlayingContent {
         }
     }
 
+    #[cfg(feature = "navigator")]
     pub async fn get_local_file(
         &self,
         url: &Url,
-        interface: impl NavigatorInterface,
+        interface: impl crate::backends::navigator::NavigatorInterface,
     ) -> Result<Vec<u8>, std::io::Error> {
+        use std::io::{ErrorKind, Read};
+
         match self {
             PlayingContent::DirectFile(_) => {
                 let path = url

--- a/frontend-utils/src/recents.rs
+++ b/frontend-utils/src/recents.rs
@@ -20,6 +20,7 @@ impl Recent {
     /// Checks if a recent entry is available.
     ///
     /// If the URL is local file, it will be checked if it exists, otherwise returns `true`.
+    #[cfg(feature = "fs")]
     pub fn is_available(&self) -> bool {
         if self.url.scheme() == "file" {
             return match self.url.to_file_path() {


### PR DESCRIPTION
This patch adds features to frontend-utils so that it's usable on web. Most of the crate is platform-agnostic, except backends, which can depend on filesystem or async executors.