### PR TITLE
web: Mark `mouse_wheel_avm2` web integration test as flaky, allowing retries

### DIFF
--- a/web/packages/selfhosted/test/integration_tests/mouse_wheel_avm2/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/mouse_wheel_avm2/test.ts
@@ -141,5 +141,5 @@ interface TestParams {
             const player = await browser.$("#objectElement");
             assertNoMoreTraceOutput(browser, player);
         });
-    });
+    }).retries(3); // TODO: figure out and fix flakiness
 });


### PR DESCRIPTION
Yes, this is admitting defeat. For now.

I'm not proud, but I'm also not shameful. Just given in.

https://webdriver.io/docs/retry/#rerun-suites-in-mocha
https://mochajs.org/#retry-tests
https://mochajs.org/#arrow-functions