### PR TITLE
web: Note Ruffle does not collect user data (Firefox)

### DIFF
--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -49,7 +49,7 @@ function transformManifest(content, env) {
                 id: firefoxExtensionId,
                 data_collection_permissions: {
                     required: ["none"]
-                }
+                },
             },
         };
         manifest.background = {

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -48,7 +48,7 @@ function transformManifest(content, env) {
             gecko: {
                 id: firefoxExtensionId,
                 data_collection_permissions: {
-                    required: ["none"]
+                    required: ["none"],
                 },
             },
         };

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -47,6 +47,9 @@ function transformManifest(content, env) {
         manifest.browser_specific_settings = {
             gecko: {
                 id: firefoxExtensionId,
+                data_collection_permissions: {
+                    required: ["none"]
+                }
             },
         };
         manifest.background = {


### PR DESCRIPTION
https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/#specifying-data-types

https://github.com/ruffle-rs/ruffle/actions/runs/18668416338/job/53224480952#step:17:31

> description: '"/browser_specific_settings/gecko/data_collection_permissions" property will be required in the future. Please add this key to the manifest.