### PR TITLE
core: Replace unmaintained `unic-segment` crate with `unicode-segmentation`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4455,7 +4455,7 @@ dependencies = [
  "tracing",
  "tracy-client",
  "ttf-parser",
- "unic-segment",
+ "unicode-segmentation",
  "url",
  "wasm-bindgen-futures",
  "weak-table",
@@ -5920,27 +5920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unic-char-property"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
-dependencies = [
- "unic-char-range",
-]
-
-[[package]]
-name = "unic-char-range"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
-
-[[package]]
-name = "unic-common"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
-
-[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5981,35 +5960,6 @@ dependencies = [
  "quote",
  "syn",
  "unic-langid-impl",
-]
-
-[[package]]
-name = "unic-segment"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
-dependencies = [
- "unic-ucd-segment",
-]
-
-[[package]]
-name = "unic-ucd-segment"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
-name = "unic-ucd-version"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
-dependencies = [
- "unic-common",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -63,7 +63,7 @@ image = { workspace = true, features = ["tiff"] }
 enum-map = { workspace = true }
 ttf-parser = "0.25"
 num-bigint = "0.4"
-unic-segment = "0.9.0"
+unicode-segmentation = "1.12.0"
 id3 = "1.16.3"
 either = "1.15.0"
 chardetng = "0.1.17"

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -46,7 +46,7 @@ use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::VecDeque;
 use std::sync::Arc;
 use swf::ColorTransform;
-use unic_segment::WordBoundIndices;
+use unicode_segmentation::UnicodeSegmentation;
 
 use super::interactive::Avm2MousePick;
 
@@ -1968,7 +1968,9 @@ impl<'gc> EditText<'gc> {
             return pos;
         }
         let to_utf8 = WStrToUtf8::new(head);
-        WordBoundIndices::new(&to_utf8.to_utf8_lossy())
+        to_utf8
+            .to_utf8_lossy()
+            .split_word_bound_indices()
             .rev()
             .find(|(_, span)| !span.trim().is_empty())
             .map(|(position, _)| position)
@@ -1988,7 +1990,9 @@ impl<'gc> EditText<'gc> {
             return pos;
         }
         let to_utf8 = WStrToUtf8::new(tail);
-        WordBoundIndices::new(&to_utf8.to_utf8_lossy())
+        to_utf8
+            .to_utf8_lossy()
+            .split_word_bound_indices()
             .skip_while(|(_, span)| span.trim().is_empty())
             .nth(1)
             .map(|p| p.0)


### PR DESCRIPTION
Due to https://rustsec.org/advisories/RUSTSEC-2025-0098.

This was surprisingly trivial. I'm not sure how well this is covered by CI, or how to test it well manually.