### PR TITLE
chore: Remove unnecessary calls to drop()

### DIFF
--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -444,11 +444,9 @@ pub fn dispatch_event<'gc>(
         parent = parent_dobj.parent();
     }
 
-    let mut evtmut = event.event_mut(activation.gc());
-
-    evtmut.set_phase(EventPhase::Capturing);
-
-    drop(evtmut);
+    event
+        .event_mut(activation.gc())
+        .set_phase(EventPhase::Capturing);
 
     for ancestor in ancestor_list.iter().rev() {
         if event.event().is_propagation_stopped() {

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -839,10 +839,8 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                         value = value.coerce_to_string(activation)?.into();
                     }
 
-                    // NOTE: Get x[i] for future operations. Also we need to drop ref to the children as we need to borrow as mutable later.
-                    let children = self.children();
-                    let child = children[index].node();
-                    drop(children);
+                    // NOTE: Get x[i] for future operations.
+                    let child = self.children()[index].node();
 
                     // 2.e. If x[i].[[Class]] == "attribute"
                     if child.is_attribute() {

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -369,9 +369,8 @@ pub trait TDisplayObjectContainer<'gc>:
     fn remove_child_directly(&self, context: &mut UpdateContext<'gc>, child: DisplayObject<'gc>) {
         dispatch_removed_event(child, context);
         let this: DisplayObjectContainer<'gc> = *self;
-        let mut write = self.raw_container_mut(context.gc());
-        write.remove_child_from_depth_list(child);
-        drop(write);
+        self.raw_container_mut(context.gc())
+            .remove_child_from_depth_list(child);
 
         let removed_from_render_list =
             ChildContainer::remove_child_from_render_list(this, child, context);
@@ -447,14 +446,12 @@ pub trait TDisplayObjectContainer<'gc>:
             dispatch_removed_event(*removed, context);
         }
 
-        let mut write = self.raw_container_mut(context.gc());
-
         for removed in removed_list {
             // The `remove_range` method is only ever called as a result of an ActionScript
             // call
             removed.set_placed_by_script(true);
-            write.remove_child_from_depth_list(removed);
-            drop(write);
+            self.raw_container_mut(context.gc())
+                .remove_child_from_depth_list(removed);
 
             let this: DisplayObjectContainer<'gc> = *self;
             ChildContainer::remove_child_from_render_list(this, removed, context);
@@ -464,11 +461,8 @@ pub trait TDisplayObjectContainer<'gc>:
             } else if removed.object2().is_some() {
                 removed.set_parent(context, None);
             }
-
-            write = self.raw_container_mut(context.gc());
         }
 
-        drop(write);
         let this: DisplayObject<'_> = (*self).into();
         this.invalidate_cached_bitmap();
     }

--- a/render/wgpu/src/filters/bevel.rs
+++ b/render/wgpu/src/filters/bevel.rs
@@ -290,7 +290,6 @@ impl BevelFilter {
             wgpu::IndexFormat::Uint32,
         );
         render_pass.draw_indexed(0..6, 0, 0..1);
-        drop(render_pass);
         target
     }
 }

--- a/render/wgpu/src/filters/color_matrix.rs
+++ b/render/wgpu/src/filters/color_matrix.rs
@@ -209,7 +209,6 @@ impl ColorMatrixFilter {
             wgpu::IndexFormat::Uint32,
         );
         render_pass.draw_indexed(0..6, 0, 0..1);
-        drop(render_pass);
         target
     }
 }

--- a/render/wgpu/src/filters/displacement_map.rs
+++ b/render/wgpu/src/filters/displacement_map.rs
@@ -283,7 +283,6 @@ impl DisplacementMapFilter {
             wgpu::IndexFormat::Uint32,
         );
         render_pass.draw_indexed(0..6, 0, 0..1);
-        drop(render_pass);
         Some(target)
     }
 }

--- a/render/wgpu/src/filters/glow.rs
+++ b/render/wgpu/src/filters/glow.rs
@@ -267,7 +267,6 @@ impl GlowFilter {
             wgpu::IndexFormat::Uint32,
         );
         render_pass.draw_indexed(0..6, 0, 0..1);
-        drop(render_pass);
         target
     }
 }

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -338,7 +338,6 @@ impl Surface {
                     );
 
                     render_pass.draw_indexed(0..6, 0, 0..1);
-                    drop(render_pass);
                 }
             }
         }


### PR DESCRIPTION
This patch removes calls to drop() when they are not necessary or there are betters ways to handle the scope of the variable.