### PR TITLE
web: Fix flakiness of `mouse_wheel_avm2`

### DIFF
--- a/web/packages/selfhosted/test/integration_tests/mouse_wheel_avm2/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/mouse_wheel_avm2/test.ts
@@ -19,16 +19,15 @@ async function scroll(
     lines: number,
 ) {
     const canvas = await player.shadow$("canvas");
+    const canvasSize = await canvas.getSize();
+
+    const xOffset = x - canvasSize.width / 2;
+    const yOffset = y - canvasSize.height / 2;
+    await canvas.moveTo({ xOffset, yOffset });
 
     return await browser.execute(
-        (element, x, y, lines) => {
+        (element, lines) => {
             const el = element as unknown as HTMLElement;
-            el.dispatchEvent(
-                new PointerEvent("pointermove", {
-                    clientX: x as unknown as number,
-                    clientY: y as unknown as number,
-                }),
-            );
             return el.dispatchEvent(
                 new WheelEvent("wheel", {
                     deltaY: lines as unknown as number,
@@ -38,8 +37,6 @@ async function scroll(
             );
         },
         canvas,
-        x,
-        y,
         lines,
     );
 }


### PR DESCRIPTION
wdio was randomly causing the browser to fire `pointerenter` and `pointerleave` events, which resulted in the test being flaky. When `pointerleave` event was sent before moving the mouse, there was no hovered object and scroll was not dispatched to the object it should have been.

This patch uses wdio's `.moveTo()` to update the hover before dispatching scroll event, which fixes this issue.

* Supersedes https://github.com/ruffle-rs/ruffle/pull/21967

I ran a suite of hundreds of iterations of these tests and all passed. Before this patch it was almost guaranteed to get a failure after 50 iterations.