### PR TITLE
core: Rename `PLACED_BY_SCRIPT` to `PLACED_BY_AVM2_SCRIPT`

### DIFF
--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -36,7 +36,7 @@ pub fn initialize_for_allocator<'gc>(
     class: ClassObject<'gc>,
 ) -> Object<'gc> {
     let obj = StageObject::for_display_object(context.gc(), dobj, class);
-    dobj.set_placed_by_script(true);
+    dobj.set_placed_by_avm2_script(true);
     dobj.set_object2(context, obj);
 
     // [NA] Should these run for everything?

--- a/core/src/avm2/globals/flash/display/display_object_container.rs
+++ b/core/src/avm2/globals/flash/display/display_object_container.rs
@@ -109,7 +109,7 @@ fn validate_remove_operation<'gc>(
 fn remove_child_from_displaylist<'gc>(context: &mut UpdateContext<'gc>, child: DisplayObject<'gc>) {
     if let Some(parent) = child.parent() {
         if let Some(mut ctr) = parent.as_container() {
-            child.set_placed_by_script(true);
+            child.set_placed_by_avm2_script(true);
             ctr.remove_child(context, child);
         }
     }
@@ -123,7 +123,7 @@ pub(super) fn add_child_to_displaylist<'gc>(
     index: usize,
 ) {
     if let Some(mut ctr) = parent.as_container() {
-        child.set_placed_by_script(true);
+        child.set_placed_by_avm2_script(true);
         ctr.insert_at_index(context, child, index);
     }
 }
@@ -348,7 +348,7 @@ pub fn remove_child_at<'gc>(
             }
 
             let child = ctr.child_by_index(target_child as usize).unwrap();
-            child.set_placed_by_script(true);
+            child.set_placed_by_avm2_script(true);
 
             ctr.remove_child(activation.context, child);
 
@@ -483,8 +483,8 @@ pub fn swap_children_at<'gc>(
             let child0 = ctr.child_by_index(index0 as usize).unwrap();
             let child1 = ctr.child_by_index(index1 as usize).unwrap();
 
-            child0.set_placed_by_script(true);
-            child1.set_placed_by_script(true);
+            child0.set_placed_by_avm2_script(true);
+            child1.set_placed_by_avm2_script(true);
 
             ctr.swap_at_index(activation.context, index0 as usize, index1 as usize);
         }
@@ -521,8 +521,8 @@ pub fn swap_children<'gc>(
                 .position(|a| DisplayObject::ptr_eq(a, child1))
                 .ok_or(make_error_2025(activation))?;
 
-            child0.set_placed_by_script(true);
-            child1.set_placed_by_script(true);
+            child0.set_placed_by_avm2_script(true);
+            child1.set_placed_by_avm2_script(true);
 
             ctr.swap_at_index(activation.context, index0, index1);
         }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -780,20 +780,20 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.set_flag(DisplayObjectFlags::TRANSFORMED_BY_SCRIPT, value);
     }
 
-    fn placed_by_script(&self) -> bool {
-        self.contains_flag(DisplayObjectFlags::PLACED_BY_SCRIPT)
-    }
-
-    fn set_placed_by_script(&self, value: bool) {
-        self.set_flag(DisplayObjectFlags::PLACED_BY_SCRIPT, value);
-    }
-
     fn placed_by_avm1_script(&self) -> bool {
         self.contains_flag(DisplayObjectFlags::PLACED_BY_AVM1_SCRIPT)
     }
 
     fn set_placed_by_avm1_script(&self, value: bool) {
         self.set_flag(DisplayObjectFlags::PLACED_BY_AVM1_SCRIPT, value);
+    }
+
+    fn placed_by_avm2_script(&self) -> bool {
+        self.contains_flag(DisplayObjectFlags::PLACED_BY_AVM2_SCRIPT)
+    }
+
+    fn set_placed_by_avm2_script(&self, value: bool) {
+        self.set_flag(DisplayObjectFlags::PLACED_BY_AVM2_SCRIPT, value);
     }
 
     fn is_bitmap_cached_preference(&self) -> bool {
@@ -2167,30 +2167,31 @@ pub trait TDisplayObject<'gc>:
         self.base().set_has_scroll_rect(value)
     }
 
-    /// Whether this display object has been created by ActionScript 3.
-    /// When this flag is set, changes from SWF `RemoveObject` tags are
-    /// ignored.
-    #[no_dynamic]
-    fn placed_by_script(self) -> bool {
-        self.base().placed_by_script()
-    }
-
-    /// Sets whether this display object has been created by ActionScript 3.
-    /// When this flag is set, changes from SWF `RemoveObject` tags are
-    /// ignored.
-    #[no_dynamic]
-    fn set_placed_by_script(self, value: bool) {
-        self.base().set_placed_by_script(value)
-    }
-
+    /// Whether this display object has been created by ActionScript 1/2.
     #[no_dynamic]
     fn placed_by_avm1_script(self) -> bool {
         self.base().placed_by_avm1_script()
     }
 
+    /// Sets whether this display object has been created by ActionScript 1/2.
     #[no_dynamic]
     fn set_placed_by_avm1_script(self, value: bool) {
         self.base().set_placed_by_avm1_script(value);
+    }
+
+    /// Whether this display object has been created by ActionScript 3.
+    /// When this flag is set, changes from SWF `RemoveObject` tags are
+    /// ignored.
+    #[no_dynamic]
+    fn placed_by_avm2_script(self) -> bool {
+        self.base().placed_by_avm2_script()
+    }
+
+    /// When this flag is set, changes from SWF `RemoveObject` tags are
+    /// ignored.
+    #[no_dynamic]
+    fn set_placed_by_avm2_script(self, value: bool) {
+        self.base().set_placed_by_avm2_script(value)
     }
 
     /// Whether this display object has been instantiated by the timeline.
@@ -2269,11 +2270,11 @@ pub trait TDisplayObject<'gc>:
     #[no_dynamic]
     #[inline(never)]
     fn on_construction_complete(self, context: &mut UpdateContext<'gc>) {
-        let placed_by_script = self.placed_by_script();
+        let placed_by_avm2_script = self.placed_by_avm2_script();
         self.fire_added_events(context);
-        // Check `self.placed_by_script()` before we fire events, since those
-        // events might `placed_by_script`
-        if !placed_by_script {
+        // Check `self.placed_by_avm2_script()` before we fire events, since those
+        // events might `placed_by_avm2_script`
+        if !placed_by_avm2_script {
             self.set_on_parent_field(context);
         }
 
@@ -2295,7 +2296,7 @@ pub trait TDisplayObject<'gc>:
 
     #[no_dynamic]
     fn fire_added_events(self, context: &mut UpdateContext<'gc>) {
-        if !self.placed_by_script() {
+        if !self.placed_by_avm2_script() {
             // Since we construct AVM2 display objects after they are
             // allocated and placed on the render list, we have to emit all
             // events after this point.
@@ -2894,7 +2895,7 @@ bitflags! {
         /// Whether this object has been placed in a container by ActionScript 3.
         /// When this flag is set, changes from SWF `RemoveObject` tags are ignored.
         // TODO [KJ] Can we repurpose it to cover PLACED_BY_AVM1_SCRIPT too?
-        const PLACED_BY_SCRIPT         = 1 << 4;
+        const PLACED_BY_AVM2_SCRIPT    = 1 << 4;
 
         /// Whether this object has been instantiated by a SWF tag.
         /// When this flag is set, attempts to change the object's name from AVM2 throw an exception.
@@ -2935,7 +2936,7 @@ bitflags! {
 
         /// Whether this object has been placed by an AVM1 method,
         /// i.e. attachMovie, createEmptyMovieClip, duplicateMovieClip.
-        // TODO [KJ] Can this be merged with PLACED_BY_SCRIPT?
+        // TODO [KJ] Can this be merged with PLACED_BY_AVM2_SCRIPT?
         const PLACED_BY_AVM1_SCRIPT    = 1 << 15;
     }
 }

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -455,7 +455,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
                 let object = Avm2StageObject::for_display_object(context.gc(), self.into(), class);
                 object_cell.set(Some(object));
 
-                if !self.placed_by_script() {
+                if !self.placed_by_avm2_script() {
                     // This is run before we actually call the constructor - the un-constructed object
                     // is exposed to ActionScript via `parent.<childName>`.
                     self.set_on_parent_field(context);

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -449,7 +449,7 @@ pub trait TDisplayObjectContainer<'gc>:
         for removed in removed_list {
             // The `remove_range` method is only ever called as a result of an ActionScript
             // call
-            removed.set_placed_by_script(true);
+            removed.set_placed_by_avm2_script(true);
             self.raw_container_mut(context.gc())
                 .remove_child_from_depth_list(removed);
 
@@ -740,7 +740,7 @@ impl<'gc> ChildContainer<'gc> {
 
             // Only set the parent's field to 'null' if the child was not placed/modified
             // on the render list by AVM2 code.
-            if !child.placed_by_script() {
+            if !child.placed_by_avm2_script() {
                 let parent = child.parent().expect(
                     "Parent must be removed *after* calling `remove_child_from_render_list`",
                 );
@@ -808,7 +808,7 @@ impl<'gc> ChildContainer<'gc> {
                 .iter()
                 .position(|x| DisplayObject::ptr_eq(*x, prev_child))
             {
-                if !prev_child.placed_by_script() {
+                if !prev_child.placed_by_avm2_script() {
                     self.replace_id(position, child);
                     Some(prev_child)
                 } else {

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -55,7 +55,7 @@ impl<'gc> LoaderDisplay<'gc> {
             },
         ));
 
-        obj.set_placed_by_script(true);
+        obj.set_placed_by_avm2_script(true);
         activation.context.orphan_manager.add_orphan_obj(obj.into());
         obj
     }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1661,7 +1661,7 @@ impl<'gc> MovieClip<'gc> {
                 .collect();
 
             for child in children {
-                if !child.placed_by_script() {
+                if !child.placed_by_avm2_script() {
                     self.remove_child(context, child);
                 } else {
                     self.remove_child_from_depth_list(context, child);
@@ -1794,7 +1794,7 @@ impl<'gc> MovieClip<'gc> {
         //    different in reality, but the spirit is there :)
 
         let is_candidate_for_removal = if self.movie().is_action_script_3() {
-            old_object.place_frame() > frame || old_object.placed_by_script()
+            old_object.place_frame() > frame || old_object.placed_by_avm2_script()
         } else {
             old_object.depth() < AVM_DEPTH_BIAS
         };
@@ -2104,7 +2104,7 @@ impl<'gc> MovieClip<'gc> {
 
             let child = self.child_by_depth(depth);
             if let Some(child) = child {
-                if !child.placed_by_script() {
+                if !child.placed_by_avm2_script() {
                     self.remove_child(context, child);
                 } else {
                     self.remove_child_from_depth_list(context, child);
@@ -2481,7 +2481,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                 // when we have children placed on the load frame, but 'this.getChildAt(0)'
                 // will return 'null' since the children haven't had their AVM2 objects
                 // constructed by `construct_frame` yet.
-            } else if !(is_load_frame && self.placed_by_script()) {
+            } else if !(is_load_frame && self.placed_by_avm2_script()) {
                 let running_construct_frame = self
                     .0
                     .contains_flag(MovieClipFlags::RUNNING_CONSTRUCT_FRAME);
@@ -4315,7 +4315,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         }?;
 
         if let Some(child) = self.child_by_depth(remove_object.depth.into()) {
-            if !child.placed_by_script() {
+            if !child.placed_by_avm2_script() {
                 self.remove_child(context, child);
             } else {
                 self.remove_child_from_depth_list(context, child);

--- a/core/src/orphan_manager.rs
+++ b/core/src/orphan_manager.rs
@@ -78,14 +78,14 @@ impl<'gc> OrphanManager<'gc> {
                 // indefinitely (if there are no remaining strong references, they will eventually
                 // be garbage collected).
                 //
-                // To detect this, we check 'placed_by_script'. This flag get set to 'true'
+                // To detect this, we check 'placed_by_avm2_script'. This flag get set to 'true'
                 // for objects constructed from ActionScript, and for objects moved around
                 // in the timeline (add/remove child, swap depths) by ActionScript. A
                 // RemoveObject tag will only affect objects instantiated by the timeline,
                 // which have not been moved in the displaylist by ActionScript. Therefore,
-                // any orphan we see that has 'placed_by_script()' should stay on the orphan
+                // any orphan we see that has 'placed_by_avm2_script()' should stay on the orphan
                 // list, because it was not removed by a RemoveObject tag.
-                dobj.placed_by_script()
+                dobj.placed_by_avm2_script()
             } else {
                 false
             }


### PR DESCRIPTION
This is mirroring `PLACED_BY_AVM1_SCRIPT` and makes it more clear that this flag is used by AVM2 only.