### PR TITLE
avm1: Avoid storing owned data in `Activation`

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -348,7 +348,7 @@ impl<'gc> Avm1Function<'gc> {
         let max_recursion_depth = activation.context.avm1.max_recursion_depth();
         let mut frame = Activation::from_action(
             activation.context,
-            activation.id.function(name, reason, max_recursion_depth)?,
+            activation.id.function(&name, reason, max_recursion_depth)?,
             swf_version,
             child_scope,
             self.constant_pool,

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -12,7 +12,6 @@ use crate::string::{AvmString, StringContext};
 use crate::tag_utils::SwfSlice;
 use crate::{avm1, avm_debug};
 use gc_arena::{Collect, Gc, Mutation};
-use std::borrow::Cow;
 use swf::avm1::read::Reader;
 use tracing::instrument;
 
@@ -136,9 +135,9 @@ impl<'gc> Avm1<'gc> {
     /// Add a stack frame that executes code in timeline scope
     ///
     /// This creates a new frame stack.
-    pub fn run_stack_frame_for_action<S: Into<Cow<'static, str>>>(
+    pub fn run_stack_frame_for_action(
         active_clip: DisplayObject<'gc>,
-        name: S,
+        name: &str,
         code: SwfSlice,
         context: &mut UpdateContext<'gc>,
     ) {
@@ -284,11 +283,9 @@ impl<'gc> Avm1<'gc> {
             return;
         }
 
-        let mut activation = Activation::from_nothing(
-            context,
-            ActivationIdentifier::root(name.to_string()),
-            active_clip,
-        );
+        let name_utf8 = &name.to_utf8_lossy();
+        let mut activation =
+            Activation::from_nothing(context, ActivationIdentifier::root(name_utf8), active_clip);
 
         let _ = obj.call_method(name, args, &mut activation, ExecutionReason::Special);
     }

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -1369,11 +1369,12 @@ impl<'gc> NetStream<'gc> {
         match avm_object {
             Some(NetStreamKind::Avm1(object)) => {
                 let avm_string_name = AvmString::new_utf8_bytes(context.gc(), variable_name);
+                let activation_name = format!("[FLV {avm_string_name}]");
 
                 let root = context.stage.root_clip().expect("root");
                 let mut activation = Avm1Activation::from_nothing(
                     context,
-                    Avm1ActivationIdentifier::root(format!("[FLV {avm_string_name}]")),
+                    Avm1ActivationIdentifier::root(&activation_name),
                     root,
                 );
 


### PR DESCRIPTION
Keep local registers and activation names as bare references in `Activation`, leaving the caller responsible for allocating them if necessary.

As many activations have static names and/or no local registers (and as such don't need to allocate), this improves performance (up to a 5% reduction in wall-time in AVM1 benchmarks).

Possible further improvements (which would require unsafe code, probably):
- Use a preallocated stack for local registers (like in AVM2);
- Also use references instead of `Gc`s for the scope linked-list; this would require some way of lazily allocating scopes when they get captured by `DefineFunction` closures.