### PR TITLE
chore: Bump wgpu-hal to 26.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6478,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "26.0.5"
+version = "26.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f66204fca99d4e5a4e9efe76042218f4f7019eaf85b33b62ecacb763e7fbd99"
+checksum = "a8d0e67224cc7305b3b4eb2cc57ca4c4c3afc665c1d1bee162ea806e19c47bdd"
 dependencies = [
  "android_system_properties",
  "arrayvec",


### PR DESCRIPTION
Changes: https://github.com/gfx-rs/wgpu/releases/tag/v26.0.6
We do use `wgpu::PresentMode::Fifo`, so this may help.