### PR TITLE
avm1: Don't panic on new NetConnection() with less than 3 args

### DIFF
--- a/core/src/avm1/globals/netconnection.rs
+++ b/core/src/avm1/globals/netconnection.rs
@@ -271,8 +271,10 @@ fn call<'gc>(
         .coerce_to_string(activation)?;
     let mut arguments = Vec::new();
 
-    for arg in &args[2..] {
-        arguments.push(Rc::new(serialize(activation, *arg)));
+    if args.len() > 2 {
+        for arg in &args[2..] {
+            arguments.push(Rc::new(serialize(activation, *arg)));
+        }
     }
 
     if let Some(handle) = net_connection.handle() {


### PR DESCRIPTION
Discovered by one of the #22050 tests (but does not make the whole test pass, other issues abound :D)