### PR TITLE
avm1: Version gate Accessibility properties

### DIFF
--- a/core/src/avm1/globals/accessibility.rs
+++ b/core/src/avm1/globals/accessibility.rs
@@ -7,9 +7,9 @@ use crate::avm1::{Object, Value};
 use crate::avm1_stub;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
-    "isActive" => method(is_active; DONT_DELETE | READ_ONLY);
-    "sendEvent" => method(send_event; DONT_DELETE | READ_ONLY);
-    "updateProperties" => method(update_properties; DONT_DELETE | READ_ONLY);
+    "isActive" => method(is_active; DONT_DELETE | READ_ONLY | VERSION_6);
+    "sendEvent" => method(send_event; DONT_DELETE | READ_ONLY | VERSION_6);
+    "updateProperties" => method(update_properties; DONT_DELETE | READ_ONLY | VERSION_6);
 };
 
 pub fn create<'gc>(context: &mut DeclContext<'_, 'gc>) -> Object<'gc> {

--- a/tests/tests/swfs/from_gnash/actionscript.all/Accessibility-v5/test.toml
+++ b/tests/tests/swfs/from_gnash/actionscript.all/Accessibility-v5/test.toml
@@ -1,2 +1,1 @@
 num_frames = 30
-known_failure = true


### PR DESCRIPTION
They should be available since SWF6 only.

Fixes `from_gnash/actionscript.all/Accessibility-v5`