### PR TITLE
avm1: Clean up use of BitmapData in BitmapData functions

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1401,6 +1401,7 @@ fn compare<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    // Note that these error values are specific to this function, there's no standard between functions
     const EQUIVALENT: i32 = 0;
     const NOT_BITMAP: i32 = -1;
     const BITMAP_DISPOSED: i32 = -2;


### PR DESCRIPTION
(yay net negative code diff, even with more cases being handled!)

This is split off from my current "test every argument" stuff, which is escalating too much. No tests for the new error codes, they'll come later with the big tests. Make code less indented, make code more correct. Make gooder.

(easier to review with "hide whitespace")