### PR TITLE
core: Use __jcvt() intrinsic on AArch64 for f64→i32 conversion

### DIFF
--- a/core/src/ecma_conversions.rs
+++ b/core/src/ecma_conversions.rs
@@ -44,8 +44,10 @@ pub fn f64_to_wrapping_i32(n: f64) -> i32 {
     #[cfg(target_arch = "aarch64")]
     {
         if std::arch::is_aarch64_feature_detected!("jsconv") {
-            // SAFETY: `jsconv` feature is checked in both compile time and runtime to be existed, so it's safe to call.
-            unsafe { f64_to_wrapping_int32_aarch64(n) }
+            // Converts an `f64` to an `i32` with ECMAScript `ToInt32` wrapping behavior.
+            // The value will be wrapped in the range [-2^31, 2^31).
+            // Optimized for aarch64 cpu with the fjcvtzs instruction.
+            unsafe { std::arch::aarch64::__jcvt(n) }
         } else {
             f64_to_wrapping_i32_generic(n)
         }
@@ -57,32 +59,6 @@ pub fn f64_to_wrapping_i32(n: f64) -> i32 {
 #[allow(unused)]
 fn f64_to_wrapping_i32_generic(n: f64) -> i32 {
     f64_to_wrapping_u32(n) as i32
-}
-
-/// Converts an `f64` to an `i32` with ECMAScript `ToInt32` wrapping behavior.
-/// The value will be wrapped in the range [-2^31, 2^31).
-/// Optimized for aarch64 cpu with the fjcvtzs instruction.
-///
-/// # Safety
-///
-/// The caller must ensure either:
-/// - The target platform is aarch64 with `jsconv` feature enabled, or
-/// - Runtime feature detection has been performed to verify `jsconv` support
-#[allow(unused)]
-#[cfg(target_arch = "aarch64")]
-#[target_feature(enable = "jsconv")]
-unsafe fn f64_to_wrapping_int32_aarch64(number: f64) -> i32 {
-    let ret: i32;
-    // SAFETY: fjcvtzs instruction is available under jsconv feature.
-    unsafe {
-        std::arch::asm!(
-            "fjcvtzs {dst:w}, {src:d}",
-            src = in(vreg) number,
-            dst = out(reg) ret,
-            options(nostack, nomem, pure)
-        );
-    }
-    ret
 }
 
 /// Implements the IEEE-754 "Round to nearest, ties to even" rounding rule.


### PR DESCRIPTION
In #21780, an optimisation has been added to use the `fjcvtzs` ARMv8.3 instruction when available, to convert a `f64` into an `i32`.  This made me wonder why `core::arch::aarch64` didn’t have an intrinsic for this instruction, so I implemented it in [stdarch](https://github.com/rust-lang/stdarch/pull/1938), which got pulled in Rust [yesterday](https://github.com/rust-lang/rust/pull/148402) (see [the tracking issue](https://github.com/rust-lang/rust/issues/147555)).

This PR makes use of this new intrinsic to remove the unsafe `asm!()` block, and simplify the code.