### PR TITLE
core: Fix SoundTransform to be applied before playback (close #17204)

### DIFF
--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -178,6 +178,7 @@ impl<'gc> Sound<'gc> {
                 num_loops: play.loops,
                 envelope: None,
             },
+            None,
             self.owner(),
             Some(play.sound_object),
         );

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -292,16 +292,13 @@ fn play_queued<'gc>(
         }
     }
 
-    if let Some(instance) = activation
-        .context
-        .start_sound(sound, &queued.sound_info, None, None)
-    {
-        if let Some(sound_transform) = queued.sound_transform {
-            activation
-                .context
-                .set_local_sound_transform(instance, sound_transform);
-        }
-
+    if let Some(instance) = activation.context.start_sound(
+        sound,
+        &queued.sound_info,
+        queued.sound_transform,
+        None,
+        None,
+    ) {
         queued
             .sound_channel
             .set_sound_instance(activation, instance);

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -449,12 +449,13 @@ impl<'gc> AudioManager<'gc> {
         audio: &mut dyn AudioBackend,
         sound: SoundHandle,
         settings: &swf::SoundInfo,
+        transform: Option<display_object::SoundTransform>,
         display_object: Option<DisplayObject<'gc>>,
         avm1_object: Option<Avm1Object<'gc>>,
     ) -> Option<SoundInstanceHandle> {
         if self.sounds.len() < Self::MAX_SOUNDS {
             let handle = audio.start_sound(sound, settings).ok()?;
-            let instance = SoundInstance {
+            let mut instance = SoundInstance {
                 sound: Some(sound),
                 instance: handle,
                 display_object,
@@ -463,6 +464,11 @@ impl<'gc> AudioManager<'gc> {
                 avm2_object: None,
                 stream_start_frame: None,
             };
+
+            if let Some(transform) = transform {
+                instance.transform = transform;
+            }
+
             audio.set_sound_transform(handle, self.transform_for_sound(&instance));
             self.sounds.push(instance);
             Some(handle)
@@ -773,13 +779,20 @@ impl<'gc> AudioManager<'gc> {
             match sound_info.event {
                 // "Event" sounds always play, independent of the timeline.
                 SoundEvent::Event => {
-                    let _ = context.start_sound(handle, sound_info, Some(display_object), None);
+                    let _ =
+                        context.start_sound(handle, sound_info, None, Some(display_object), None);
                 }
 
                 // "Start" sounds only play if an instance of the same sound is not already playing.
                 SoundEvent::Start => {
                     if !context.is_sound_playing_with_handle(handle) {
-                        let _ = context.start_sound(handle, sound_info, Some(display_object), None);
+                        let _ = context.start_sound(
+                            handle,
+                            sound_info,
+                            None,
+                            Some(display_object),
+                            None,
+                        );
                     }
                 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -272,11 +272,12 @@ impl<'gc> UpdateContext<'gc> {
         &mut self,
         sound: SoundHandle,
         settings: &swf::SoundInfo,
+        transform: Option<SoundTransform>,
         owner: Option<DisplayObject<'gc>>,
         avm1_object: Option<Avm1Object<'gc>>,
     ) -> Option<SoundInstanceHandle> {
         self.audio_manager
-            .start_sound(self.audio, sound, settings, owner, avm1_object)
+            .start_sound(self.audio, sound, settings, transform, owner, avm1_object)
     }
 
     pub fn attach_avm2_sound_channel(


### PR DESCRIPTION
close #17204 

This addresses an issue where Sound with a custom SoundTransform is full volume at initial playback and then applies the desired SoundTransform a few samples later creating a jump in volume at the beginning.  Part of the key here, is the sound is not associated with a display object like an Animate timeline sound and initialized in a separate .as file.

This fix simply passes the SoundTransform to the `start_sound `method in `audio.rs` as an optional property to be applied instead of the default SoundTransform.

```
var snd:Sound = new Sound();
snd.play(0, 0, new SoundTransform(.15));
```
[SoundTransform.zip](https://github.com/user-attachments/files/23401074/SoundTransform.zip)

I am a novice Rust developer, but a developer of Flash projects for over 20 years.  Since this is my first PR for Ruffle, this is just a heads up to review wisely.
