### PR TITLE
core: Fix CORS issues with `fpdownload.adobe.com`

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -56,6 +56,13 @@ pub enum SocketMode {
     Ask,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FetchReason {
+    LoadSwf,
+    UrlLoader,
+    Other,
+}
+
 impl NavigationMethod {
     /// Convert an SWF method enum into a NavigationMethod.
     pub fn from_send_vars_method(s: SendVarsMethod) -> Option<Self> {

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -155,6 +155,10 @@ impl Request {
         &self.url
     }
 
+    pub fn set_url(&mut self, url: String) {
+        self.url = url;
+    }
+
     /// Retrieve the navigation method for this request.
     pub fn method(&self) -> NavigationMethod {
         self.method
@@ -182,6 +186,9 @@ impl Request {
 pub trait SuccessResponse {
     /// The final URL obtained after any redirects.
     fn url(&self) -> Cow<'_, str>;
+
+    /// Rewrite the URL to a different one.
+    fn set_url(&mut self, url: String);
 
     /// Retrieve the contents of the response body.
     ///
@@ -572,6 +579,10 @@ pub fn fetch_path<NavigatorType: NavigatorBackend>(
     impl SuccessResponse for LocalResponse {
         fn url(&self) -> Cow<'_, str> {
             Cow::Borrowed(&self.url)
+        }
+
+        fn set_url(&mut self, url: String) {
+            self.url = url;
         }
 
         fn body(self: Box<Self>) -> OwnedFuture<Vec<u8>, Error> {

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -56,7 +56,7 @@ pub enum SocketMode {
     Ask,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum FetchReason {
     LoadSwf,
     UrlLoader,

--- a/core/src/compatibility_rules.rs
+++ b/core/src/compatibility_rules.rs
@@ -85,6 +85,18 @@ impl CompatibilityRules {
                         "chat.kongregate.com",
                     )],
                 },
+                // Replaces fpdownload.adobe.com with Ruffle's CDN. fpdownload.adobe.com hosts SWZ files
+                // which do not work on web due to CORS (and the reliability of fpdownload.adobe.com is
+                // questionable).
+                RuleSet {
+                    name: "fpdownload".to_string(),
+                    domain_rewrite_rules: vec![UrlRewriteRule::new(
+                        UrlRewriteStage::BeforeRequest,
+                        vec![FetchReason::UrlLoader],
+                        "fpdownload.adobe.com",
+                        "cdn.ruffle.rs",
+                    )],
+                },
             ],
         }
     }

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -846,7 +846,7 @@ pub fn load_root_movie<'gc>(
                 .display_root_movie_download_failed_message(false, error.error.to_string());
             error.error
         })?;
-        let url = response.url().into_owned();
+        let swf_url = response.url().into_owned();
         let body = response.body().await.inspect_err(|error| {
             player
                 .lock()
@@ -856,11 +856,6 @@ pub fn load_root_movie<'gc>(
         })?;
 
         // The spoofed root movie URL takes precedence over the actual URL.
-        let swf_url = player
-            .lock()
-            .unwrap()
-            .compatibility_rules()
-            .rewrite_swf_url(url);
         let spoofed_or_swf_url = player
             .lock()
             .unwrap()

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -318,7 +318,7 @@ impl<'gc> LoadManager<'gc> {
         let importer_movie = MovieClipHandle::stash(uc, importer_movie);
 
         Box::pin(async move {
-            let fetch = player.lock().unwrap().navigator().fetch(request);
+            let fetch = player.lock().unwrap().fetch(request);
 
             match wait_for_full_response(fetch).await {
                 Ok((body, url, _status, _redirected)) => {
@@ -646,7 +646,7 @@ impl<'gc> MovieLoader<'gc> {
             let request_url = request.url().to_string();
             let resolved_url = player.lock().unwrap().navigator().resolve_url(&request_url);
 
-            let fetch = player.lock().unwrap().navigator().fetch(request);
+            let fetch = player.lock().unwrap().fetch(request);
 
             let mut replacing_root_movie = false;
             player.lock().unwrap().update(|uc| -> Result<(), Error> {
@@ -835,7 +835,7 @@ pub fn load_root_movie<'gc>(
     let player = uc.player_handle();
 
     Box::pin(async move {
-        let fetch = player.lock().unwrap().navigator().fetch(request);
+        let fetch = player.lock().unwrap().fetch(request);
         let response = fetch.await.map_err(|error| {
             player
                 .lock()
@@ -896,7 +896,7 @@ pub fn load_form_into_object<'gc>(
     let target_object = ObjectHandle::stash(uc, target_object);
 
     Box::pin(async move {
-        let fetch = player.lock().unwrap().navigator().fetch(request);
+        let fetch = player.lock().unwrap().fetch(request);
 
         let response = fetch.await.map_err(|e| e.error)?;
         let response_encoding = response.text_encoding();
@@ -970,7 +970,7 @@ pub fn load_form_into_load_vars<'gc>(
     let target_object = ObjectHandle::stash(uc, target_object);
 
     Box::pin(async move {
-        let fetch = player.lock().unwrap().navigator().fetch(request);
+        let fetch = player.lock().unwrap().fetch(request);
         let response = wait_for_full_response(fetch).await;
 
         // Fire the load handler.
@@ -1054,7 +1054,7 @@ pub fn load_stylesheet<'gc>(
     let target_object = ObjectHandle::stash(uc, target_object);
 
     Box::pin(async move {
-        let fetch = player.lock().unwrap().navigator().fetch(request);
+        let fetch = player.lock().unwrap().fetch(request);
         let response = wait_for_full_response(fetch).await;
 
         // Fire the load handler.
@@ -1113,7 +1113,7 @@ pub fn load_data_into_url_loader<'gc>(
     let target = Avm2ScriptObjectHandle::stash(uc, target);
 
     Box::pin(async move {
-        let fetch = player.lock().unwrap().navigator().fetch(request);
+        let fetch = player.lock().unwrap().fetch(request);
         let response = wait_for_full_response(fetch).await;
 
         player.lock().unwrap().update(|uc| {
@@ -1269,7 +1269,7 @@ pub fn load_sound_avm1<'gc>(
     let sound_object = ObjectHandle::stash(uc, sound_object);
 
     Box::pin(async move {
-        let fetch = player.lock().unwrap().navigator().fetch(request);
+        let fetch = player.lock().unwrap().fetch(request);
         let response = wait_for_full_response(fetch).await;
 
         // Fire the load handler.
@@ -1329,7 +1329,7 @@ pub fn load_sound_avm2<'gc>(
     let sound = SoundObjectHandle::stash(uc, sound);
 
     Box::pin(async move {
-        let fetch = player.lock().unwrap().navigator().fetch(request);
+        let fetch = player.lock().unwrap().fetch(request);
         let response = wait_for_full_response(fetch).await;
 
         player.lock().unwrap().update(|uc| {
@@ -1402,7 +1402,7 @@ pub fn load_netstream<'gc>(
     let stream = NetStreamHandle::stash(uc, stream);
 
     Box::pin(async move {
-        let fetch = player.lock().unwrap().navigator().fetch(request);
+        let fetch = player.lock().unwrap().fetch(request);
         match fetch.await {
             Ok(mut response) => {
                 let expected_length = response.expected_length();
@@ -2386,7 +2386,7 @@ pub fn download_file_dialog<'gc>(
         // Download the data
         let req = Request::get(url.clone());
         // Doing this in two steps to prevent holding the player lock during fetch
-        let future = player.lock().unwrap().navigator().fetch(req);
+        let future = player.lock().unwrap().fetch(req);
         let download_res = wait_for_full_response(future).await;
 
         // Fire the load handler.
@@ -2603,7 +2603,7 @@ pub fn upload_file<'gc>(
             )),
         );
         // Doing this in two steps to prevent holding the player lock during fetch
-        let future = player.lock().unwrap().navigator().fetch(req);
+        let future = player.lock().unwrap().fetch(req);
         let result = future.await;
 
         // Fire the load handler.

--- a/core/src/net_connection.rs
+++ b/core/src/net_connection.rs
@@ -517,7 +517,7 @@ impl FlashRemoting {
             let bytes = flash_lso::packet::write::write_to_bytes(&packet, true)
                 .expect("Must be able to serialize a packet");
             let request = Request::post(url, Some((bytes, "application/x-amf".to_string())));
-            let fetch = player.lock().unwrap().navigator().fetch(request);
+            let fetch = player.lock().unwrap().fetch(request);
             let response: Result<_, ErrorResponse> = async {
                 let response = fetch.await?;
                 let url = response.url().to_string();

--- a/core/src/net_connection.rs
+++ b/core/src/net_connection.rs
@@ -4,7 +4,9 @@ use crate::avm2::object::{
     NetConnectionObject as Avm2NetConnectionObject, ResponderObject as Avm2ResponderObject,
 };
 use crate::avm2::{Activation as Avm2Activation, Avm2, EventObject as Avm2EventObject};
-use crate::backend::navigator::{ErrorResponse, NavigatorBackend, OwnedFuture, Request};
+use crate::backend::navigator::{
+    ErrorResponse, FetchReason, NavigatorBackend, OwnedFuture, Request,
+};
 use crate::context::UpdateContext;
 use crate::loader::Error;
 use crate::Player;
@@ -517,7 +519,7 @@ impl FlashRemoting {
             let bytes = flash_lso::packet::write::write_to_bytes(&packet, true)
                 .expect("Must be able to serialize a packet");
             let request = Request::post(url, Some((bytes, "application/x-amf".to_string())));
-            let fetch = player.lock().unwrap().fetch(request);
+            let fetch = player.lock().unwrap().fetch(request, FetchReason::Other);
             let response: Result<_, ErrorResponse> = async {
                 let response = fetch.await?;
                 let url = response.url().to_string();

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2520,13 +2520,13 @@ impl Player {
         mut request: Request,
         fetch_reason: FetchReason,
     ) -> OwnedFuture<Box<dyn SuccessResponse>, ErrorResponse> {
-        if matches!(fetch_reason, FetchReason::LoadSwf) {
-            let new_url = self
-                .compatibility_rules
-                .rewrite_swf_url(request.url().into(), UrlRewriteStage::BeforeRequest);
-            if let Some(new_url) = new_url {
-                request.set_url(new_url);
-            }
+        let new_url = self.compatibility_rules.rewrite_swf_url(
+            request.url().into(),
+            UrlRewriteStage::BeforeRequest,
+            fetch_reason,
+        );
+        if let Some(new_url) = new_url {
+            request.set_url(new_url);
         }
 
         let self_reference = self.self_reference.clone();
@@ -2542,15 +2542,13 @@ impl Player {
                 return Ok(response);
             };
 
-            if matches!(fetch_reason, FetchReason::LoadSwf) {
-                let new_url = player
-                    .lock()
-                    .unwrap()
-                    .compatibility_rules
-                    .rewrite_swf_url(response.url(), UrlRewriteStage::AfterResponse);
-                if let Some(new_url) = new_url {
-                    response.set_url(new_url);
-                }
+            let new_url = player.lock().unwrap().compatibility_rules.rewrite_swf_url(
+                response.url(),
+                UrlRewriteStage::AfterResponse,
+                fetch_reason,
+            );
+            if let Some(new_url) = new_url {
+                response.set_url(new_url);
             }
 
             Ok(response)

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -7,6 +7,9 @@ use crate::avm1::{Activation, ActivationIdentifier};
 use crate::avm2::object::EventObject as Avm2EventObject;
 use crate::avm2::{Activation as Avm2Activation, Avm2, CallStack, SharedObjectObject};
 use crate::avm_rng::AvmRng;
+use crate::backend::navigator::ErrorResponse;
+use crate::backend::navigator::OwnedFuture;
+use crate::backend::navigator::SuccessResponse;
 use crate::backend::ui::FontDefinition;
 use crate::backend::{
     audio::{AudioBackend, AudioManager},
@@ -2508,6 +2511,10 @@ impl Player {
         self.mutate_with_update_context(|context| {
             context.library.set_default_font(font, names);
         });
+    }
+
+    pub fn fetch(&self, request: Request) -> OwnedFuture<Box<dyn SuccessResponse>, ErrorResponse> {
+        self.navigator.fetch(request)
     }
 }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -8,6 +8,7 @@ use crate::avm2::object::EventObject as Avm2EventObject;
 use crate::avm2::{Activation as Avm2Activation, Avm2, CallStack, SharedObjectObject};
 use crate::avm_rng::AvmRng;
 use crate::backend::navigator::ErrorResponse;
+use crate::backend::navigator::FetchReason;
 use crate::backend::navigator::OwnedFuture;
 use crate::backend::navigator::SuccessResponse;
 use crate::backend::ui::FontDefinition;
@@ -2513,7 +2514,11 @@ impl Player {
         });
     }
 
-    pub fn fetch(&self, request: Request) -> OwnedFuture<Box<dyn SuccessResponse>, ErrorResponse> {
+    pub fn fetch(
+        &self,
+        request: Request,
+        _fetch_reason: FetchReason,
+    ) -> OwnedFuture<Box<dyn SuccessResponse>, ErrorResponse> {
         self.navigator.fetch(request)
     }
 }

--- a/frontend-utils/src/backends/navigator/fetch.rs
+++ b/frontend-utils/src/backends/navigator/fetch.rs
@@ -29,6 +29,10 @@ impl SuccessResponse for Response {
         std::borrow::Cow::Borrowed(&self.url)
     }
 
+    fn set_url(&mut self, url: String) {
+        self.url = url;
+    }
+
     #[expect(clippy::await_holding_lock)]
     fn body(self: Box<Self>) -> OwnedFuture<Vec<u8>, Error> {
         match self.response_body {

--- a/tests/framework/src/backends/navigator.rs
+++ b/tests/framework/src/backends/navigator.rs
@@ -30,6 +30,10 @@ impl SuccessResponse for TestResponse {
         Cow::Borrowed(&self.url)
     }
 
+    fn set_url(&mut self, url: String) {
+        self.url = url;
+    }
+
     fn body(self: Box<Self>) -> OwnedFuture<Vec<u8>, Error> {
         Box::pin(async move { Ok(self.body) })
     }


### PR DESCRIPTION
* Fixes https://github.com/ruffle-rs/ruffle/issues/21403
* Progresses https://github.com/ruffle-rs/ruffle/issues/20262
* Fixes https://github.com/ruffle-rs/ruffle/issues/19633

This domain hosts SWZ files and does not work on web due to CORS. This fixes content that requires those SWZ files and the website owner does not provide them. As a bonus we don't have to worry about reliability of `fpdownload.adobe.com` and the fact that some day it will stop working.

This needed a bit of refactoring of compatibility rules and fetch.

This PR effectively redirects all URLLoader requests from `fpdownload.adobe.com` to `cdn.ruffle.rs` which is set up with all SWZs we could find on the Wayback machine. Apparently they include all SWZs used on Flashpoint, so it's a pretty big collection.