### PR TITLE
avm1: Document the AVM1 `trace` vs `Action::Trace` behavior a bit more

### DIFF
--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -134,6 +134,7 @@ pub fn trace<'gc>(
     // Unlike `Action::Trace`, `_global.trace` always coerces
     // undefined to "" in SWF6 and below. It also doesn't log
     // anything outside of the Flash editor's trace window.
+    // Ruffle does not respect the latter behavior, and will treat it the same as an `Action::Trace`.
     let out = args
         .get(0)
         .unwrap_or(&Value::Undefined)

--- a/tests/tests/swfs/avm1/asnative/test.toml
+++ b/tests/tests/swfs/avm1/asnative/test.toml
@@ -1,1 +1,5 @@
+# Note that this test will not have the same result in `flashlog.txt`,
+# as `_global.trace` (and therefore `ASnative(100, 4)` does _not_ print to flashlog.txt!
+# You must use Flash's output console to see the results.
+# Ruffle does not make a distinction between the two trace outputs.
 num_frames = 1


### PR DESCRIPTION
This was surprising :D