### PR TITLE
web: Add config option to hide message when Ruffle restores from bfcache

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -2134,8 +2134,11 @@ export class InnerPlayer {
      * Inform the user that the browser restored the file from the back/forward cache.
      */
     protected displayRestoredFromBfcacheMessage(): void {
-        // Do not display the message if another one is already shown.
-        if (this.container.querySelector("#message-overlay") !== null) {
+        // Do not display the message if another one is already shown or website opted out.
+        if (
+            this.container.querySelector("#message-overlay") !== null ||
+            this.loadedConfig?.hideRestoredMessage
+        ) {
             return;
         }
         const message = textAsParagraphs("message-restored-from-bfcache");

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -9,7 +9,7 @@ import {
     UnmuteOverlay,
     URLLoadOptions,
     WindowMode,
-    CacheBehavior,
+    BFCacheBehavior,
 } from "../../public/config";
 import { MovieMetadata, ReadyState } from "../../public/player";
 import { ruffleShadowTemplate } from "../ui/shadow-template";
@@ -2138,11 +2138,11 @@ export class InnerPlayer {
         // Do not display the message if another one is already shown or website opted out.
         if (
             this.container.querySelector("#message-overlay") !== null ||
-            this.loadedConfig?.bfcacheBehavior === CacheBehavior.Restore
+            this.loadedConfig?.bfcacheBehavior === BFCacheBehavior.Restore
         ) {
             return;
         }
-        if (this.loadedConfig?.bfcacheBehavior === CacheBehavior.Reload) {
+        if (this.loadedConfig?.bfcacheBehavior === BFCacheBehavior.Reload) {
             this.reload();
             return;
         }

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -9,6 +9,7 @@ import {
     UnmuteOverlay,
     URLLoadOptions,
     WindowMode,
+    CacheBehavior,
 } from "../../public/config";
 import { MovieMetadata, ReadyState } from "../../public/player";
 import { ruffleShadowTemplate } from "../ui/shadow-template";
@@ -2137,8 +2138,12 @@ export class InnerPlayer {
         // Do not display the message if another one is already shown or website opted out.
         if (
             this.container.querySelector("#message-overlay") !== null ||
-            this.loadedConfig?.hideRestoredMessage
+            this.loadedConfig?.bfcacheBehavior === CacheBehavior.Restore
         ) {
+            return;
+        }
+        if (this.loadedConfig?.bfcacheBehavior === CacheBehavior.Reload) {
+            this.reload();
             return;
         }
         const message = textAsParagraphs("message-restored-from-bfcache");

--- a/web/packages/core/src/public/config/default.ts
+++ b/web/packages/core/src/public/config/default.ts
@@ -22,6 +22,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     upgradeToHttps: true,
     compatibilityRules: true,
     favorFlash: true,
+    hideRestoredMessage: false,
     warnOnUnsupportedContent: true,
     logLevel: LogLevel.Error,
     showSwfDownload: false,

--- a/web/packages/core/src/public/config/default.ts
+++ b/web/packages/core/src/public/config/default.ts
@@ -10,6 +10,7 @@ import {
     UnmuteOverlay,
     WindowMode,
     ScrollingBehavior,
+    CacheBehavior,
 } from "./load-options";
 
 export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
@@ -22,7 +23,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     upgradeToHttps: true,
     compatibilityRules: true,
     favorFlash: true,
-    hideRestoredMessage: false,
+    bfcacheBehavior: CacheBehavior.Inform,
     warnOnUnsupportedContent: true,
     logLevel: LogLevel.Error,
     showSwfDownload: false,

--- a/web/packages/core/src/public/config/default.ts
+++ b/web/packages/core/src/public/config/default.ts
@@ -10,7 +10,7 @@ import {
     UnmuteOverlay,
     WindowMode,
     ScrollingBehavior,
-    CacheBehavior,
+    BFCacheBehavior,
 } from "./load-options";
 
 export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
@@ -23,7 +23,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     upgradeToHttps: true,
     compatibilityRules: true,
     favorFlash: true,
-    bfcacheBehavior: CacheBehavior.Inform,
+    bfcacheBehavior: BFCacheBehavior.Inform,
     warnOnUnsupportedContent: true,
     logLevel: LogLevel.Error,
     showSwfDownload: false,

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -451,6 +451,13 @@ export interface BaseLoadOptions {
     favorFlash?: boolean;
 
     /**
+     * Hide the message when content is restored from the back/forward cache.
+     *
+     * @default false
+     */
+    hideRestoredMessage?: boolean;
+
+    /**
      * This is no longer used and does not affect anything.
      * It is only kept for backwards compatibility.
      *

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -362,6 +362,26 @@ export enum GamepadButton {
 }
 
 /**
+ * The behavior when the bfcache takes effect
+ */
+export enum CacheBehavior {
+    /**
+     * Inform the user that the content was restore from the bfcache.
+     */
+    Inform = "inform",
+
+    /**
+     * Restore the content from the bfcache without a message.
+     */
+    Restore = "restore",
+
+    /**
+     * Reload the content so it starts fresh if the bfcache takes effect.
+     */
+    Reload = "reload",
+}
+
+/**
  * Any options used for loading a movie.
  */
 export interface BaseLoadOptions {
@@ -451,11 +471,11 @@ export interface BaseLoadOptions {
     favorFlash?: boolean;
 
     /**
-     * Hide the message when content is restored from the back/forward cache.
+     * Behavior when the bfcache takes effect
      *
-     * @default false
+     * @default CacheBehavior.Inform
      */
-    hideRestoredMessage?: boolean;
+    bfcacheBehavior?: CacheBehavior;
 
     /**
      * This is no longer used and does not affect anything.

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -364,7 +364,7 @@ export enum GamepadButton {
 /**
  * The behavior when the bfcache takes effect
  */
-export enum CacheBehavior {
+export enum BFCacheBehavior {
     /**
      * Inform the user that the content was restore from the bfcache.
      */
@@ -473,9 +473,9 @@ export interface BaseLoadOptions {
     /**
      * Behavior when the bfcache takes effect
      *
-     * @default CacheBehavior.Inform
+     * @default BFCacheBehavior.Inform
      */
-    bfcacheBehavior?: CacheBehavior;
+    bfcacheBehavior?: BFCacheBehavior;
 
     /**
      * This is no longer used and does not affect anything.


### PR DESCRIPTION
This adds a configuration option, `hideRestoredMessage`, which hides the message that appears when Ruffle is restored from the bfcache. This message was added when Toad06 switched from the unload event to the pagehide event, enabling use of the bfcache.

Note that the bfcache is never used with Ruffle on Chromium due to a "bug" (previously intended behavior), therefore this more-so affects Gecko (Firefox). See https://issues.chromium.org/issues/424552566. Basically, Adobe Flash Player would not work with the bfcache, so Chromium disables the bfcache on pages with embeds or objects that have SWF sources. Since modern Chromium no longer supports any plugins, including Flash, this is now unneeded code on Chromium's part.