### PR TITLE
render: Add more detail to `InvalidZlibCompression`

### DIFF
--- a/render/src/error.rs
+++ b/render/src/error.rs
@@ -15,8 +15,8 @@ pub enum Error {
     #[error("Unknown bitmap format")]
     UnknownType,
 
-    #[error("Invalid ZLIB compression")]
-    InvalidZlibCompression,
+    #[error("Invalid ZLIB compression: {0}")]
+    InvalidZlibCompression(std::io::Error),
 
     #[error("Invalid JPEG")]
     InvalidJpeg(#[from] jpeg_decoder::Error),

--- a/render/src/utils.rs
+++ b/render/src/utils.rs
@@ -491,7 +491,7 @@ fn decompress_zlib(data: &[u8]) -> Result<Vec<u8>, Error> {
     let mut decoder = flate2::bufread::ZlibDecoder::new(data);
     decoder
         .read_to_end(&mut out_data)
-        .map_err(|_| Error::InvalidZlibCompression)?;
+        .map_err(Error::InvalidZlibCompression)?;
     out_data.shrink_to_fit();
     Ok(out_data)
 }


### PR DESCRIPTION
* Related to https://github.com/ruffle-rs/ruffle/issues/17009
* Related to https://github.com/ruffle-rs/ruffle/issues/17189
* Related to https://github.com/ruffle-rs/ruffle/issues/17498
* Related to https://github.com/ruffle-rs/ruffle/issues/18283
* Related to https://github.com/ruffle-rs/ruffle/issues/21132
* Related to https://github.com/ruffle-rs/ruffle/issues/21138
* Related to https://github.com/ruffle-rs/ruffle/issues/21290
* Related to https://github.com/ruffle-rs/ruffle/issues/21423
* Related to https://github.com/ruffle-rs/ruffle/issues/21733
* Related to https://github.com/ruffle-rs/ruffle/issues/22244

This allows us to see what's wrong when this error happens.
