### PR TITLE
chore: Bump tower-http because currently used version got yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5741,9 +5741,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",


### PR DESCRIPTION
See: https://crates.io/crates/tower-http/0.6.5

`cargo-deny` has been complaining for a while now, we just don't care about it because of all the duplicates it also reports:
https://github.com/ruffle-rs/ruffle/actions/runs/19447660279/job/55645788740#step:5:6546
(We could allow the known ones in the config and make any remaining/new warnings fail CI...)