### PR TITLE
web: Add device font renderer setting to the extension

### DIFF
--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -44,6 +44,12 @@
     "settings_preferred_renderer_auto": {
         "message": "Automatic"
     },
+    "settings_device_font_renderer": {
+        "message": "Device font renderer"
+    },
+    "device_font_renderer_embedded": {
+        "message": "Embedded"
+    },
     "settings_advanced_options": {
         "message": "Advanced Options"
     },

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -58,6 +58,13 @@
                 </select>
                 <label for="preferred_renderer">Preferred renderer</label>
             </div>
+            <div class="option select">
+                <select id="device_font_renderer">
+                    <option value="embedded" id="device_font_renderer_embedded">Embedded</option>
+                    <option value="canvas">Canvas</option>
+                </select>
+                <label for="device_font_renderer">Device font renderer</label>
+            </div>
             <div class="option number-input">
                 <input type="number" id="player_version" min="1" max="32" placeholder="32" />
                 <label for="player_version">Flash player version number to emulate (range 1-32)</label>


### PR DESCRIPTION
This allows users to change the device font renderer and try out the new canvas device font renderer.