### PR TITLE
avm2: Set EditText width during creation

### DIFF
--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -170,6 +170,7 @@ fn apply_format<'gc>(
 
     let measured_text = display_object.measure_text(activation.context);
 
+    display_object.set_width(activation.context, measured_text.0.to_pixels());
     display_object.set_height(activation.context, measured_text.1.to_pixels());
 
     Ok(())


### PR DESCRIPTION
Fixes #12490.

I do not fully understand this tbh and not sure if this is the correct fix.

What happens is that the game tries to cache movie clips using bitmaps and without this fix the bounds of the movieclip are absolutely massive, resulting in a bitmap so big that it is invalid. (The width of the TextEdit is set to the default 1 000 000 from the createTextLine method signature: https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/text/engine/TextBlock.html#createTextLine().

I expect that this will need a test, but I do not want to waste time on this before it is vibe-checked by someone who has a proper understanding of this code area.