### PR TITLE
avm2: Remove final from ConvolutionFilter class declaration

### DIFF
--- a/core/src/avm2/globals/flash/filters/ConvolutionFilter.as
+++ b/core/src/avm2/globals/flash/filters/ConvolutionFilter.as
@@ -1,5 +1,5 @@
 package flash.filters {
-    public final class ConvolutionFilter extends BitmapFilter {
+    public class ConvolutionFilter extends BitmapFilter {
         [Ruffle(NativeAccessible)]
         public var alpha:Number;
 


### PR DESCRIPTION
Progresses #17853 to where it previously was.
The docs do not say the class should be marked as final.
https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/filters/ConvolutionFilter.html