### PR TITLE
 avm2: Store call stack for all errors and print it for primitive errors too

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -658,6 +658,10 @@ impl<'gc> Avm2<'gc> {
         self.call_stack
     }
 
+    pub fn capture_call_stack(&self) -> CallStack<'gc> {
+        self.call_stack.borrow().clone()
+    }
+
     fn push_scope(&mut self, scope: Scope<'gc>) {
         self.scope_stack.push(scope);
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -844,12 +844,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         &mut self,
         method: Method<'gc>,
         ip: usize,
-        error: Error<'gc>,
+        original_error: Error<'gc>,
     ) -> Result<usize, Error<'gc>> {
-        let error = if let Some(error) = error.as_avm_error() {
+        let error = if let Some(error) = original_error.as_avm_error() {
             error
         } else {
-            return Err(error);
+            return Err(original_error);
         };
 
         let verified_info = method.get_verified_info();
@@ -869,7 +869,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
                 if matches {
                     #[cfg(feature = "avm_debug")]
-                    tracing::info!(target: "avm_caught", "Caught exception: {:?}", Error::avm_error(error));
+                    tracing::info!(target: "avm_caught", "Caught exception: {:?}", original_error);
 
                     self.reset_stack();
                     self.push_stack(error);
@@ -880,7 +880,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             }
         }
 
-        Err(Error::avm_error(error))
+        Err(original_error)
     }
 
     #[inline(always)]
@@ -2911,6 +2911,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn op_throw(&mut self) -> Result<(), Error<'gc>> {
         let error_val = self.pop_stack();
-        Err(Error::avm_error(error_val))
+        Err(Error::from_value(self, error_val))
     }
 }

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -58,7 +58,7 @@ impl<'gc> ErrorObject<'gc> {
         let base = ScriptObjectData::new(class);
 
         // Stack trace is always collected for debugging purposes.
-        let call_stack = activation.avm2().call_stack().borrow().clone();
+        let call_stack = activation.avm2().capture_call_stack();
 
         ErrorObject(Gc::new(
             activation.gc(),


### PR DESCRIPTION
For example, a
`throw 3`
will now log
```
Integer(3)
	at Test()
```
instead of
```
AvmError(Integer(3))
```

This makes our behavior closer to Flash's.