### PR TITLE
avm2: Fix passing primitive values to `isPrototypeOf`

### DIFF
--- a/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/isPrototypeOf/output.ruffle.txt
+++ b/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/isPrototypeOf/output.ruffle.txt
@@ -1,8 +1,0 @@
-RegExp.prototype.isPrototypeOf(re)) PASSED!
-String.prototype.isPrototypeOf(str) FAILED! expected: true got: false
-String.prototype.isPrototypeOf(re) PASSED!
-String.prototype.isPrototypeOf(new Number()) PASSED!
-Object.prototype.isPrototypeOf(str) FAILED! expected: true got: false
-Object.prototype.isPrototypeOf(re) PASSED!
-String.prototype.isPrototypeOf(myobj) PASSED!
-Object.prototype.isPrototypeOf(myobj2) PASSED!

--- a/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/isPrototypeOf/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/isPrototypeOf/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
This fixes the avmplus test `ecma3/ObjectObjects/isPrototypeOf`