### PR TITLE
web: Remove npm token in favour of OIDC

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -517,8 +517,6 @@ jobs:
         run: npm publish --tag latest --access public --provenance
         continue-on-error: true
         working-directory: web/packages/selfhosted/dist
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Package selfhosted
         run: zip -r "${{ needs.create-nightly-release.outputs.package_prefix }}-web-selfhosted.zip" .


### PR DESCRIPTION
Our npm publishing will not work now. I've configured the repo over on npm side, and we need to make the workflow generate oidc tokens to proceed.

Absolutely untested, but according to the docs it's all that's needed.

https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/