### PR TITLE
web: Fix wording to clarify test checks for no Ruffle polyfill

### DIFF
--- a/web/packages/selfhosted/test/polyfill/embed_wrong_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_wrong_type/test.ts
@@ -10,7 +10,7 @@ describe("Embed with wrong type attribute value", () => {
         await openTest(browser, `polyfill/embed_wrong_type`);
     });
 
-    it("polyfills with ruffle", async () => {
+    it("doesn't polyfill with ruffle", async () => {
         await injectRuffleAndWait(browser);
         const actual = await browser
             .$("#test-container")


### PR DESCRIPTION
While looking at tests I assumed based on the comment this checked that this element polyfills with Ruffle, but it does not, per looking at expected.html