### PR TITLE
web: For all tests that polyfill with Ruffle, wait for element to exist

### DIFF
--- a/web/packages/selfhosted/test/polyfill/embed_default/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_default/test.ts
@@ -12,6 +12,7 @@ describe("Embed tag", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/embed_missing_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_type/test.ts
@@ -12,6 +12,7 @@ describe("Embed without type attribute", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/embed_unexpected_string/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_unexpected_string/test.ts
@@ -12,6 +12,7 @@ describe("Embed with unexpected string", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.ts
@@ -12,6 +12,7 @@ describe("Object with clsid and embed", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_default/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_default/test.ts
@@ -12,6 +12,7 @@ describe("Object tag", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_double_object/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_double_object/test.ts
@@ -12,6 +12,7 @@ describe("Object with another object tag", () => {
 
     it("polyfills only the first tag with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_double_object_classid/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_double_object_classid/test.ts
@@ -12,6 +12,7 @@ describe("Object using classid with another object tag without classid", () => {
 
     it("polyfills only the second tag with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_flashvars/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars/test.ts
@@ -12,6 +12,7 @@ describe("Object tag", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.ts
@@ -12,6 +12,7 @@ describe("Object tag", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_ie_only/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_ie_only/test.ts
@@ -12,6 +12,7 @@ describe("Object for old IE must work everywhere", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type/test.ts
@@ -12,6 +12,7 @@ describe("Object without type attribute", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.ts
@@ -12,6 +12,7 @@ describe("Object without type and classid attributes", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.ts
@@ -12,6 +12,7 @@ describe("Object with unexpected string", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/test.ts
@@ -12,6 +12,7 @@ describe("Object with ruffle-embed tag", () => {
 
     it("already polyfilled with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_wrong_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_wrong_type/test.ts
@@ -12,6 +12,7 @@ describe("Object with wrong type attribute value", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/remove_object/test.ts
+++ b/web/packages/selfhosted/test/polyfill/remove_object/test.ts
@@ -12,6 +12,7 @@ describe("Remove object", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/spl/test.ts
+++ b/web/packages/selfhosted/test/polyfill/spl/test.ts
@@ -12,6 +12,7 @@ describe("SPL", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });


### PR DESCRIPTION
I can switch to `playAndMonitor`, but this should suffice and many tests do this already.