### PR TITLE
web: Don't test exact HTML for ruffle-embed with unexpected string

### DIFF
--- a/web/packages/selfhosted/test/polyfill/embed_unexpected_string/expected.html
+++ b/web/packages/selfhosted/test/polyfill/embed_unexpected_string/expected.html
@@ -1,9 +1,0 @@
-<ruffle-embed
-    type="application/x-shockwave-flash"
-    src="/test_assets/example.swf"
-    width="550"
-    height="400"
-    quality="high"
-    menu="false"
-    pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
-/>

--- a/web/packages/selfhosted/test/polyfill/embed_unexpected_string/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_unexpected_string/test.ts
@@ -1,7 +1,6 @@
-import { injectRuffleAndWait, openTest } from "../../utils.js";
-import { expect, use } from "chai";
+import { injectRuffleAndWait, openTest, playAndMonitor } from "../../utils.js";
+import { use } from "chai";
 import chaiHtml from "chai-html";
-import fs from "fs";
 
 use(chaiHtml);
 
@@ -12,13 +11,13 @@ describe("Embed with unexpected string", () => {
 
     it("polyfills with ruffle", async () => {
         await injectRuffleAndWait(browser);
-        const actual = await browser
-            .$("#test-container")
-            .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });
-        const expected = fs.readFileSync(
-            `${import.meta.dirname}/expected.html`,
-            "utf8",
+        await browser.$("<ruffle-embed />").waitForExist();
+    });
+
+    it("Plays a movie", async () => {
+        await playAndMonitor(
+            browser,
+            await browser.$("#test-container").$("<ruffle-embed />"),
         );
-        expect(actual).html.to.equal(expected);
     });
 });


### PR DESCRIPTION
As of Chromium 143+, when the embed has an unexpected string, so too does the ruffle-embed.