### PR TITLE
web: Make embed_unexpected_string not setAttribute on Chromium 143+

### DIFF
--- a/web/packages/selfhosted/test/polyfill/embed_unexpected_string/index.html
+++ b/web/packages/selfhosted/test/polyfill/embed_unexpected_string/index.html
@@ -10,7 +10,7 @@
             <embed
                 type="application/x-shockwave-flash"
                 src="/test_assets/example.swf"
-                "YeahWhyDoingThis"
+                =
                 width="550"
                 height="400"
                 quality="high"


### PR DESCRIPTION
Chrome release note about the cause of this change: https://developer.chrome.com/release-notes/143#allow_more_characters_in_javascript_dom_apis

https://bugzilla.mozilla.org/show_bug.cgi?id=1773312 is the Firefox bug and https://bugs.webkit.org/show_bug.cgi?id=241419 is the Safari bug. After that, this behavior should change across all major browsers, as it did for Chrome, but for now this is a strange browser difference.

Per https://dom.spec.whatwg.org/#namespaces, this will fail if I just call the attribute =