### PR TITLE
web: Add way to check for initialization for tests that check for no polyfilling

### DIFF
--- a/web/packages/core/src/public/setup/public-api.ts
+++ b/web/packages/core/src/public/setup/public-api.ts
@@ -25,6 +25,7 @@ export interface PublicAPILike {
     config?: DataLoadOptions | URLLoadOptions | object;
     sources?: Record<string, SourceAPI>;
     invoked?: boolean;
+    initialized?: boolean;
     newestName?: string | null;
 
     superseded?(): void;
@@ -48,6 +49,7 @@ export class PublicAPI implements PublicAPILike {
     config: DataLoadOptions | URLLoadOptions | object;
     sources: Record<string, SourceAPI>;
     invoked: boolean;
+    initialized: boolean;
     newestName: string | null;
 
     /**
@@ -69,6 +71,7 @@ export class PublicAPI implements PublicAPILike {
         this.sources = prev?.sources || {};
         this.config = prev?.config || {};
         this.invoked = prev?.invoked || false;
+        this.initialized = prev?.initialized || false;
         this.newestName = prev?.newestName || null;
 
         prev?.superseded?.();
@@ -143,6 +146,7 @@ export class PublicAPI implements PublicAPILike {
             if (polyfills !== false) {
                 this.sources[this.newestName]!.polyfill();
             }
+            this.initialized = true;
         }
     }
 

--- a/web/packages/selfhosted/test/polyfill/embed_inside_audio/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_inside_audio/test.ts
@@ -1,4 +1,4 @@
-import { injectRuffleAndWait, openTest } from "../../utils.js";
+import { injectRuffleAndWaitForInitialization, openTest } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 import fs from "fs";
@@ -11,7 +11,7 @@ describe("Embed inside audio node", () => {
     });
 
     it("doesn't polyfill with ruffle", async () => {
-        await injectRuffleAndWait(browser);
+        await injectRuffleAndWaitForInitialization(browser);
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/embed_missing_src/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_src/test.ts
@@ -1,4 +1,4 @@
-import { injectRuffleAndWait, openTest } from "../../utils.js";
+import { injectRuffleAndWaitForInitialization, openTest } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 import fs from "fs";
@@ -11,7 +11,7 @@ describe("Embed without src attribute", () => {
     });
 
     it("doesn't polyfill with ruffle", async () => {
-        await injectRuffleAndWait(browser);
+        await injectRuffleAndWaitForInitialization(browser);
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/embed_wrong_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_wrong_type/test.ts
@@ -1,4 +1,4 @@
-import { injectRuffleAndWait, openTest } from "../../utils.js";
+import { injectRuffleAndWaitForInitialization, openTest } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 import fs from "fs";
@@ -11,7 +11,7 @@ describe("Embed with wrong type attribute value", () => {
     });
 
     it("doesn't polyfill with ruffle", async () => {
-        await injectRuffleAndWait(browser);
+        await injectRuffleAndWaitForInitialization(browser);
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/embed_youtube/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_youtube/test.ts
@@ -1,4 +1,4 @@
-import { openTest, injectRuffleAndWait } from "../../utils.js";
+import { openTest, injectRuffleAndWaitForInitialization } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 import fs from "fs";
@@ -11,7 +11,7 @@ describe("Embed with Flash YouTube video", () => {
     });
 
     it("doesn't polyfill with ruffle", async () => {
-        await injectRuffleAndWait(browser);
+        await injectRuffleAndWaitForInitialization(browser);
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_inside_audio/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_inside_audio/test.ts
@@ -1,4 +1,4 @@
-import { injectRuffleAndWait, openTest } from "../../utils.js";
+import { injectRuffleAndWaitForInitialization, openTest } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 import fs from "fs";
@@ -11,7 +11,7 @@ describe("Object inside audio node", () => {
     });
 
     it("doesn't polyfill with ruffle", async () => {
-        await injectRuffleAndWait(browser);
+        await injectRuffleAndWaitForInitialization(browser);
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_missing_data/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_missing_data/test.ts
@@ -1,4 +1,4 @@
-import { openTest, injectRuffleAndWait } from "../../utils.js";
+import { openTest, injectRuffleAndWaitForInitialization } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 import fs from "fs";
@@ -11,7 +11,7 @@ describe("Object without data attribute", () => {
     });
 
     it("doesn't polyfill with ruffle", async () => {
-        await injectRuffleAndWait(browser);
+        await injectRuffleAndWaitForInitialization(browser);
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/object_youtube/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_youtube/test.ts
@@ -1,4 +1,4 @@
-import { openTest, injectRuffleAndWait } from "../../utils.js";
+import { openTest, injectRuffleAndWaitForInitialization } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 import fs from "fs";
@@ -11,7 +11,7 @@ describe("Object with Flash YouTube video", () => {
     });
 
     it("doesn't polyfill with ruffle", async () => {
-        await injectRuffleAndWait(browser);
+        await injectRuffleAndWaitForInitialization(browser);
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/pdf/test.ts
+++ b/web/packages/selfhosted/test/polyfill/pdf/test.ts
@@ -1,4 +1,4 @@
-import { injectRuffleAndWait, openTest } from "../../utils.js";
+import { injectRuffleAndWaitForInitialization, openTest } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 import fs from "fs";
@@ -11,7 +11,7 @@ describe("PDF object", () => {
     });
 
     it("doesn't polyfill with ruffle", async () => {
-        await injectRuffleAndWait(browser);
+        await injectRuffleAndWaitForInitialization(browser);
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/polyfill/pdf_with_get/test.ts
+++ b/web/packages/selfhosted/test/polyfill/pdf_with_get/test.ts
@@ -1,4 +1,4 @@
-import { injectRuffleAndWait, openTest } from "../../utils.js";
+import { injectRuffleAndWaitForInitialization, openTest } from "../../utils.js";
 import { expect, use } from "chai";
 import chaiHtml from "chai-html";
 import fs from "fs";
@@ -11,7 +11,7 @@ describe("PDF with .swf GET", () => {
     });
 
     it("doesn't polyfill with ruffle", async () => {
-        await injectRuffleAndWait(browser);
+        await injectRuffleAndWaitForInitialization(browser);
         const actual = await browser
             .$("#test-container")
             .getHTML({ includeSelectorTag: false, pierceShadowRoot: false });

--- a/web/packages/selfhosted/test/utils.ts
+++ b/web/packages/selfhosted/test/utils.ts
@@ -22,6 +22,15 @@ export async function isRuffleLoaded(browser: WebdriverIO.Browser) {
     );
 }
 
+export async function isRuffleInitialized(browser: WebdriverIO.Browser) {
+    return await browser.execute(
+        () =>
+            window !== undefined &&
+            window.RufflePlayer !== undefined &&
+            window.RufflePlayer.initialized,
+    );
+}
+
 export async function isRufflePlayerLoaded(
     browser: WebdriverIO.Browser,
     player: ChainablePromiseElement,
@@ -39,6 +48,15 @@ export async function isRufflePlayerLoaded(
 export async function waitForRuffle(browser: WebdriverIO.Browser) {
     await browser.waitUntil(async () => await isRuffleLoaded(browser), {
         timeoutMsg: "Expected Ruffle to load",
+    });
+    await throwIfError(browser);
+}
+
+export async function waitForRuffleInitialization(
+    browser: WebdriverIO.Browser,
+) {
+    await browser.waitUntil(async () => await isRuffleInitialized(browser), {
+        timeoutMsg: "Expected Ruffle to initialize",
     });
     await throwIfError(browser);
 }
@@ -182,6 +200,13 @@ export async function assertNoMoreTraceOutput(
 export async function injectRuffleAndWait(browser: WebdriverIO.Browser) {
     await injectRuffle(browser);
     await waitForRuffle(browser);
+}
+
+export async function injectRuffleAndWaitForInitialization(
+    browser: WebdriverIO.Browser,
+) {
+    await injectRuffle(browser);
+    await waitForRuffleInitialization(browser);
 }
 
 export async function waitForPlayerToLoad(


### PR DESCRIPTION
This can be used for tests that check if polyfilling occur too and for those should eliminate the need to wait for ruffle-embed/ruffle-object to exist before continuing but at the same time for those tests perhaps checking those elements exist may be considered a better condition for which to wait anyway, since that's when the tests should have their expected.html anyway.