### PR TITLE
avm1: Add `_global.textRenderer`

### DIFF
--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -673,6 +673,7 @@ pub fn create_globals<'gc>(
         (globals, b"Accessibility", accessibility, Attribute::DONT_ENUM),
         (globals, b"System", system, Attribute::DONT_ENUM),
         (globals, b"flash", flash, Attribute::DONT_ENUM | Attribute::VERSION_8),
+        (globals, b"textRenderer", text_renderer.constr, Attribute::empty()),
         (globals, b"LocalConnection", local_connection.constr, Attribute::DONT_ENUM),
         (globals, b"MovieClipLoader", movie_clip_loader.constr, Attribute::DONT_ENUM),
         (globals, b"PrintJob", print_job.constr, Attribute::DONT_ENUM),

--- a/tests/tests/swfs/avm1/global_proto_decls/output.ruffle.txt
+++ b/tests/tests/swfs/avm1/global_proto_decls/output.ruffle.txt
@@ -50,6 +50,12 @@ Testing _global.LocalConnection.prototype
   domain, own, DONT_ENUM, type=[function]
   constructor, own, type=[function]
   __proto__, own, type=[object]
+Testing _global.textRenderer
+  prototype, own, type=[object]
+  __proto__, own, type=[object]
+Testing _global.textRenderer.prototype
+  constructor, own, type=[function]
+  __proto__, own, type=[object]
 Testing _global.flash
   external, own, type=[object]
   net, own, type=[object]

--- a/tests/tests/swfs/avm1/global_proto_decls_delete/output.ruffle.txt
+++ b/tests/tests/swfs/avm1/global_proto_decls_delete/output.ruffle.txt
@@ -6,6 +6,8 @@ Testing _global.MovieClipLoader
   __proto__, DONT_DELETE
 Testing _global.LocalConnection
   __proto__, DONT_DELETE
+Testing _global.textRenderer
+  __proto__, DONT_DELETE
 Testing _global.flash
   __proto__, DONT_DELETE
 Testing _global.System

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp10.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp10.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp11-14.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp11-14.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp13-18.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp13-18.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp32.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp32.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp9.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp9.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp10.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp10.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp11-14.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp11-14.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp13-18.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp13-18.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp32.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp32.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp9.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp9.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(undefined)
 testing _global.System(object)
 testing _global.System.IME(object)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp11-14.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp11-14.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(object)
 testing _global.flash.external(object)
 testing _global.flash.external.ExternalInterface(function)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp13-18.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp13-18.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(object)
 testing _global.flash.external(object)
 testing _global.flash.external.ExternalInterface(function)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp32.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp32.ruffle.txt
@@ -58,6 +58,13 @@ Testing constructor()
 Testing __constructor__()
 testing _global.LocalConnection.__constructor__(undefined)
 Testing __proto__()
+testing _global.textRenderer(function)
+Trying to construct _global.textRenderer
+Object was constructed
+Testing constructor()
+Testing __constructor__()
+testing _global.textRenderer.__constructor__(undefined)
+Testing __proto__()
 testing _global.flash(object)
 testing _global.flash.external(object)
 testing _global.flash.external.ExternalInterface(function)


### PR DESCRIPTION
In addition to `_global.flash.text.TextRenderer`, there's also `_global.textRenderer` which is the same thing.

AVM1 globals assigns objects to the variable `o` in order to set properties without repeating the full path. It looks like `TextRenderer` was assigned to the variable `textRenderer` instead by accident, causing it being defined in globals.