### PR TITLE
render: Conditionally derive PartialEq in `shape_utils` for tests only

### DIFF
--- a/render/src/shape_utils.rs
+++ b/render/src/shape_utils.rs
@@ -98,7 +98,8 @@ pub fn calculate_shape_bounds(shape_records: &[swf::ShapeRecord]) -> swf::Rectan
 /// `DrawPath` represents a solid fill or a stroke.
 /// Fills are always closed paths, while strokes may be open or closed.
 /// Closed paths will have the first point equal to the last point.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum DrawPath<'a> {
     Stroke {
         style: &'a LineStyle,
@@ -114,7 +115,7 @@ pub enum DrawPath<'a> {
 
 /// `DistilledShape` represents a ready-to-be-consumed collection of paths (both fills and strokes)
 /// that has been converted down from another source (such as SWF's `swf::Shape` format).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct DistilledShape<'a> {
     pub paths: Vec<DrawPath<'a>>,
     pub shape_bounds: Rectangle<Twips>,
@@ -135,7 +136,8 @@ impl<'a> From<&'a swf::Shape> for DistilledShape<'a> {
 
 /// `DrawCommands` trace the outline of a path.
 /// Fills follow the even-odd fill rule, with opposite winding for holes.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub enum DrawCommand {
     MoveTo(swf::Point<Twips>),
     LineTo(swf::Point<Twips>),


### PR DESCRIPTION
Supersedes #16905 - this implements the suggestion to use `#[cfg_attr(test, derive(PartialEq))]` instead of removing the derives entirely, as they are still needed for tests.