### PR TITLE
chore: Bump webdriver to 9.21

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,10 +16,10 @@
             ],
             "devDependencies": {
                 "@eslint/js": "^9.39.2",
-                "@wdio/browserstack-service": "^9.20.1",
-                "@wdio/cli": "^9.20.1",
-                "@wdio/local-runner": "^9.20.1",
-                "@wdio/mocha-framework": "^9.20.1",
+                "@wdio/browserstack-service": "^9.21.0",
+                "@wdio/cli": "^9.21.1",
+                "@wdio/local-runner": "^9.21.0",
+                "@wdio/mocha-framework": "^9.21.0",
                 "@wdio/spec-reporter": "^9.20.0",
                 "@wdio/static-server-service": "^9.20.0",
                 "chai": "^6.2.1",
@@ -43,7 +43,7 @@
                 "typedoc-plugin-mdn-links": "^5.0.10",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.48.0",
-                "webdriverio": "^9.20.1",
+                "webdriverio": "^9.21.0",
                 "webpack": "^5.103.0",
                 "webpack-cli": "^6.0.1",
                 "workspace-version": "^0.1.4"
@@ -383,6 +383,27 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
+        },
+        "node_modules/@browserstack/wdio-browserstack-service": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@browserstack/wdio-browserstack-service/-/wdio-browserstack-service-2.0.2.tgz",
+            "integrity": "sha512-G8QefAej1fAZwIxCF5FeM5bZVrqpWXTepokzd2clGmzi9tVrHbmR4jC1L8rRGTK2X88uym8Yzb+idw9FbkJztw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bufbuild/protobuf": "^2.5.2",
+                "@grpc/grpc-js": "1.13.3"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@bufbuild/protobuf": {
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.10.2.tgz",
+            "integrity": "sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A==",
+            "dev": true,
+            "license": "(Apache-2.0 AND BSD-3-Clause)"
         },
         "node_modules/@cacheable/memory": {
             "version": "2.0.5",
@@ -1264,6 +1285,39 @@
                 "@shikijs/vscode-textmate": "^10.0.2"
             }
         },
+        "node_modules/@grpc/grpc-js": {
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.3.tgz",
+            "integrity": "sha512-FTXHdOoPbZrBjlVLHuKbDZnsTxXv2BlHF57xw6LuThXacXvtkahEPED0CKMk6obZDf65Hv4k3z62eyPNpvinIg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/proto-loader": "^0.7.13",
+                "@js-sdsl/ordered-map": "^4.4.2"
+            },
+            "engines": {
+                "node": ">=12.10.0"
+            }
+        },
+        "node_modules/@grpc/proto-loader": {
+            "version": "0.7.15",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+            "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lodash.camelcase": "^4.3.0",
+                "long": "^5.0.0",
+                "protobufjs": "^7.2.5",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1330,18 +1384,28 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@inquirer/ansi": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+            "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@inquirer/checkbox": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.0.tgz",
-            "integrity": "sha512-fdSw07FLJEU5vbpOPzXo5c6xmMGDzbZE2+niuDHX5N6mc6V0Ebso/q3xiHra4D73+PMsC8MJmcaZKuAAoaQsSA==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+            "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/figures": "^1.0.15",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -1356,14 +1420,14 @@
             }
         },
         "node_modules/@inquirer/confirm": {
-            "version": "5.1.14",
-            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
-            "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
+            "version": "5.1.21",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+            "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -1378,20 +1442,20 @@
             }
         },
         "node_modules/@inquirer/core": {
-            "version": "10.1.15",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-            "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+            "version": "10.3.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+            "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/figures": "^1.0.15",
+                "@inquirer/type": "^3.0.10",
                 "cli-width": "^4.1.0",
                 "mute-stream": "^2.0.0",
                 "signal-exit": "^4.1.0",
                 "wrap-ansi": "^6.2.0",
-                "yoctocolors-cjs": "^2.1.2"
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -1406,15 +1470,15 @@
             }
         },
         "node_modules/@inquirer/editor": {
-            "version": "4.2.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.17.tgz",
-            "integrity": "sha512-r6bQLsyPSzbWrZZ9ufoWL+CztkSatnJ6uSxqd6N+o41EZC51sQeWOzI6s5jLb+xxTWxl7PlUppqm8/sow241gg==",
+            "version": "4.2.23",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+            "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/external-editor": "^1.0.1",
-                "@inquirer/type": "^3.0.8"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/external-editor": "^1.0.3",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -1429,15 +1493,15 @@
             }
         },
         "node_modules/@inquirer/expand": {
-            "version": "4.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
-            "integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
+            "version": "4.0.23",
+            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+            "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -1452,14 +1516,14 @@
             }
         },
         "node_modules/@inquirer/external-editor": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
-            "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+            "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "chardet": "^2.1.0",
-                "iconv-lite": "^0.6.3"
+                "chardet": "^2.1.1",
+                "iconv-lite": "^0.7.0"
             },
             "engines": {
                 "node": ">=18"
@@ -1474,9 +1538,9 @@
             }
         },
         "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+            "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1484,12 +1548,16 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/@inquirer/figures": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
-            "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+            "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1497,14 +1565,14 @@
             }
         },
         "node_modules/@inquirer/input": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
-            "integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+            "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -1519,14 +1587,14 @@
             }
         },
         "node_modules/@inquirer/number": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
-            "integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+            "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -1541,15 +1609,15 @@
             }
         },
         "node_modules/@inquirer/password": {
-            "version": "4.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
-            "integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
+            "version": "4.0.23",
+            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+            "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2"
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10"
             },
             "engines": {
                 "node": ">=18"
@@ -1564,22 +1632,22 @@
             }
         },
         "node_modules/@inquirer/prompts": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.7.1.tgz",
-            "integrity": "sha512-XDxPrEWeWUBy8scAXzXuFY45r/q49R0g72bUzgQXZ1DY/xEFX+ESDMkTQolcb5jRBzaNJX2W8XQl6krMNDTjaA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+            "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/checkbox": "^4.2.0",
-                "@inquirer/confirm": "^5.1.14",
-                "@inquirer/editor": "^4.2.15",
-                "@inquirer/expand": "^4.0.17",
-                "@inquirer/input": "^4.2.1",
-                "@inquirer/number": "^3.0.17",
-                "@inquirer/password": "^4.0.17",
-                "@inquirer/rawlist": "^4.1.5",
-                "@inquirer/search": "^3.0.17",
-                "@inquirer/select": "^4.3.1"
+                "@inquirer/checkbox": "^4.3.2",
+                "@inquirer/confirm": "^5.1.21",
+                "@inquirer/editor": "^4.2.23",
+                "@inquirer/expand": "^4.0.23",
+                "@inquirer/input": "^4.3.1",
+                "@inquirer/number": "^3.0.23",
+                "@inquirer/password": "^4.0.23",
+                "@inquirer/rawlist": "^4.1.11",
+                "@inquirer/search": "^3.2.2",
+                "@inquirer/select": "^4.4.2"
             },
             "engines": {
                 "node": ">=18"
@@ -1594,15 +1662,15 @@
             }
         },
         "node_modules/@inquirer/rawlist": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
-            "integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+            "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -1617,16 +1685,16 @@
             }
         },
         "node_modules/@inquirer/search": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.17.tgz",
-            "integrity": "sha512-CuBU4BAGFqRYors4TNCYzy9X3DpKtgIW4Boi0WNkm4Ei1hvY9acxKdBdyqzqBCEe4YxSdaQQsasJlFlUJNgojw==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+            "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/figures": "^1.0.15",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -1641,17 +1709,17 @@
             }
         },
         "node_modules/@inquirer/select": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
-            "integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+            "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/figures": "^1.0.15",
+                "@inquirer/type": "^3.0.10",
+                "yoctocolors-cjs": "^2.1.3"
             },
             "engines": {
                 "node": ">=18"
@@ -1666,9 +1734,9 @@
             }
         },
         "node_modules/@inquirer/type": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
-            "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+            "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1918,6 +1986,17 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@js-sdsl/ordered-map": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+            "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/js-sdsl"
+            }
+        },
         "node_modules/@jsonjoy.com/base64": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
@@ -2116,19 +2195,93 @@
                 "spacetrim": "0.11.59"
             }
         },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
-            "integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.0.tgz",
+            "integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "debug": "^4.4.0",
+                "debug": "^4.4.3",
                 "extract-zip": "^2.0.1",
                 "progress": "^2.0.3",
                 "proxy-agent": "^6.5.0",
-                "semver": "^7.7.1",
-                "tar-fs": "^3.0.8",
+                "semver": "^7.7.3",
+                "tar-fs": "^3.1.1",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -3028,7 +3181,8 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
             "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/ws": {
             "version": "8.18.0",
@@ -3375,13 +3529,14 @@
             }
         },
         "node_modules/@wdio/browserstack-service": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/@wdio/browserstack-service/-/browserstack-service-9.20.1.tgz",
-            "integrity": "sha512-wczX2XGAieS/57q2e82sNdkwRnCwer8d1dlX86jj+ZZOhnkeSpykx9Dvw/k9ZC7j0/IKqcReLgohAgC4VKheHw==",
+            "version": "9.21.0",
+            "resolved": "https://registry.npmjs.org/@wdio/browserstack-service/-/browserstack-service-9.21.0.tgz",
+            "integrity": "sha512-P+vERbv3eO7wvrJb+XSx/DyMDjENN46aDQt7mrce7A85quOU/dlmycsD0o41Mq3peSCouWapxKcHaqDdRB2ltQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@browserstack/ai-sdk-node": "1.5.17",
+                "@browserstack/wdio-browserstack-service": "^2.0.0",
                 "@percy/appium-app": "^2.0.9",
                 "@percy/selenium-webdriver": "^2.2.2",
                 "@types/gitconfiglocal": "^2.0.1",
@@ -3394,9 +3549,10 @@
                 "formdata-node": "5.0.1",
                 "git-repo-info": "^2.1.1",
                 "gitconfiglocal": "^2.1.0",
+                "tar": "^6.1.15",
                 "undici": "^6.21.3",
                 "uuid": "^11.1.0",
-                "webdriverio": "9.20.1",
+                "webdriverio": "9.21.0",
                 "winston-transport": "^4.5.0",
                 "yauzl": "^3.0.0"
             },
@@ -3408,23 +3564,23 @@
             }
         },
         "node_modules/@wdio/cli": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.20.1.tgz",
-            "integrity": "sha512-aeU6iV79GVdUkuHfuqbx4RkaJWY1amsQbiawr8VXhFTmBhPKQdzqQEVs/G+FG2zh2ILTXZ8+spv9irWMQmpGBA==",
+            "version": "9.21.1",
+            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.21.1.tgz",
+            "integrity": "sha512-FUlufBgl44cJ20sc+YncOY+NuZVW3JZnm1LFLVSMVHHi0NCPNFbpd+MkqWvm+gVWbhcOjwtrNMFc544/W2gBpQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vitest/snapshot": "^2.1.1",
-                "@wdio/config": "9.20.1",
+                "@wdio/config": "9.21.0",
                 "@wdio/globals": "9.17.0",
                 "@wdio/logger": "9.18.0",
                 "@wdio/protocols": "9.16.2",
                 "@wdio/types": "9.20.0",
-                "@wdio/utils": "9.20.1",
+                "@wdio/utils": "9.21.0",
                 "async-exit-hook": "^2.0.1",
                 "chalk": "^5.4.1",
                 "chokidar": "^4.0.0",
-                "create-wdio": "9.18.2",
+                "create-wdio": "9.21.0",
                 "dotenv": "^17.2.0",
                 "import-meta-resolve": "^4.0.0",
                 "lodash.flattendeep": "^4.4.0",
@@ -3432,7 +3588,7 @@
                 "lodash.union": "^4.6.0",
                 "read-pkg-up": "^10.0.0",
                 "tsx": "^4.7.2",
-                "webdriverio": "9.20.1",
+                "webdriverio": "9.21.0",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -3443,15 +3599,15 @@
             }
         },
         "node_modules/@wdio/config": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.20.1.tgz",
-            "integrity": "sha512-npl2J+rjCDJPjVySgWpciOyhWddn6s7n5sepKXLR7x1ADQHl5zUFv1dHD3jx4OQ9l6lrGQSPaofuz+7e9mu+vg==",
+            "version": "9.21.0",
+            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.21.0.tgz",
+            "integrity": "sha512-8TP5/q+Agjc43LET1f0LhLmuEI803O3QtZEbSxOkkvJ7/e1jDWPm4qsL7SjQJlx8xGrW0kwRlPl7+U9Sr0dhCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@wdio/logger": "9.18.0",
                 "@wdio/types": "9.20.0",
-                "@wdio/utils": "9.20.1",
+                "@wdio/utils": "9.21.0",
                 "deepmerge-ts": "^7.0.3",
                 "glob": "^10.2.2",
                 "import-meta-resolve": "^4.0.0"
@@ -3498,16 +3654,16 @@
             }
         },
         "node_modules/@wdio/local-runner": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.20.1.tgz",
-            "integrity": "sha512-O4zMa3SKcS+3jnMT1C/IqRl6Owl5c2e4aFpz6nRPFRdcs6Cwr+d7OXw8XGdfDtgSIEcpcDws+B53De9YDZmPzA==",
+            "version": "9.21.0",
+            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.21.0.tgz",
+            "integrity": "sha512-Ydr3bFdrFxNSzijG4W+bvvFKTSbJyG3BgB0T07PcExhiVwBlN7pz2PBl6prqBq0wm7uT8HZtF/QfZCpSV1Eikw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.1.0",
                 "@wdio/logger": "9.18.0",
                 "@wdio/repl": "9.16.2",
-                "@wdio/runner": "9.20.1",
+                "@wdio/runner": "9.21.0",
                 "@wdio/types": "9.20.0",
                 "@wdio/xvfb": "9.20.0",
                 "exit-hook": "^4.0.0",
@@ -3552,9 +3708,9 @@
             }
         },
         "node_modules/@wdio/mocha-framework": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.20.1.tgz",
-            "integrity": "sha512-QGZlJhycCLdiQlGyP33zl5c9m01NvjfRTH4yyTmSXDLFrukzl8qFDDBFkjhQylnTGlsa+htcDTog4taM/4LISg==",
+            "version": "9.21.0",
+            "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.21.0.tgz",
+            "integrity": "sha512-HFCtUX3ooMIIBnMS4iwfpZijX1DqdVhVBTnUwwRghOGBXf8V2GBFBoeUrC4QxqHEfCqBDaUTkRZhjaYZggoSIw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3562,7 +3718,7 @@
                 "@types/node": "^20.11.28",
                 "@wdio/logger": "9.18.0",
                 "@wdio/types": "9.20.0",
-                "@wdio/utils": "9.20.1",
+                "@wdio/utils": "9.21.0",
                 "mocha": "^10.3.0"
             },
             "engines": {
@@ -3915,22 +4071,22 @@
             "license": "MIT"
         },
         "node_modules/@wdio/runner": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.20.1.tgz",
-            "integrity": "sha512-aoB1ytsWuN8YH2SCpY4dyD1VZHSKRub4xDo0gZ2r7fh3qup4zJCPrCNV0Dq1CcUvsq3TgGlySbfazPjSpm1g3g==",
+            "version": "9.21.0",
+            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.21.0.tgz",
+            "integrity": "sha512-JpcG7OcKCq4jILU02mWShFKQdXVu9ubg1akf8Smlau7OM2B/5lS4iYvKYjaFtsU5mVfN8I8+1NwqF+wPi81rTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.11.28",
-                "@wdio/config": "9.20.1",
+                "@wdio/config": "9.21.0",
                 "@wdio/dot-reporter": "9.20.0",
                 "@wdio/globals": "9.17.0",
                 "@wdio/logger": "9.18.0",
                 "@wdio/types": "9.20.0",
-                "@wdio/utils": "9.20.1",
+                "@wdio/utils": "9.21.0",
                 "deepmerge-ts": "^7.0.3",
-                "webdriver": "9.20.1",
-                "webdriverio": "9.20.1"
+                "webdriver": "9.21.0",
+                "webdriverio": "9.21.0"
             },
             "engines": {
                 "node": ">=18.20.0"
@@ -3949,9 +4105,9 @@
             }
         },
         "node_modules/@wdio/runner/node_modules/@types/node": {
-            "version": "20.19.25",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-            "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+            "version": "20.19.27",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+            "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4361,9 +4517,9 @@
             "license": "MIT"
         },
         "node_modules/@wdio/utils": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.20.1.tgz",
-            "integrity": "sha512-C/Gsy5NAatsGUF1eT9Ks/ErR52/X4YI7MSm7BtwNOw8v2Ko+SiCA5qXts61J0A7QYwOn4gfXfBZZnzSAng6G/w==",
+            "version": "9.21.0",
+            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.21.0.tgz",
+            "integrity": "sha512-aj8ao2V/e6Sv9gZby2ZIj4dMLjwYVba47Nlr+pOfK8N4VKKU0VRLPzvTlfK1HWaoS6u/GBbVx2pefYRrvd72BQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4373,7 +4529,7 @@
                 "decamelize": "^6.0.0",
                 "deepmerge-ts": "^7.0.3",
                 "edgedriver": "^6.1.2",
-                "geckodriver": "^5.0.0",
+                "geckodriver": "^6.1.0",
                 "get-port": "^7.0.0",
                 "import-meta-resolve": "^4.0.0",
                 "locate-app": "^2.2.24",
@@ -4619,14 +4775,15 @@
             "license": "Apache-2.0"
         },
         "node_modules/@zip.js/zip.js": {
-            "version": "2.7.57",
-            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
-            "integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+            "version": "2.8.11",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.11.tgz",
+            "integrity": "sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "bun": ">=0.7.0",
                 "deno": ">=1.0.0",
-                "node": ">=16.5.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/abort-controller": {
@@ -4785,35 +4942,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-html-community": {
@@ -5114,16 +5242,18 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.2.tgz",
-            "integrity": "sha512-S5mmkMesiduMqnz51Bfh0Et9EX0aTCJxhsI4bvzFFLs8Z1AV8RDHadfY5CyLwdoLHgXbNBEN1gQcbEtGwuvixw==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
+            "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "bare-events": "^2.5.4",
                 "bare-path": "^3.0.0",
-                "bare-stream": "^2.6.4"
+                "bare-stream": "^2.6.4",
+                "bare-url": "^2.2.2",
+                "fast-fifo": "^1.3.2"
             },
             "engines": {
                 "bare": ">=1.16.0"
@@ -5180,6 +5310,17 @@
                 "bare-events": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/bare-url": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+            "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "bare-path": "^3.0.0"
             }
         },
         "node_modules/base64-js": {
@@ -5630,9 +5771,9 @@
             }
         },
         "node_modules/chardet": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
-            "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+            "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -5694,6 +5835,16 @@
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/chrome-trace-event": {
@@ -6044,13 +6195,13 @@
             }
         },
         "node_modules/commander": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "version": "14.0.2",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+            "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^12.20.0 || >=14"
+                "node": ">=20"
             }
         },
         "node_modules/comment-parser": {
@@ -6342,9 +6493,9 @@
             "license": "MIT"
         },
         "node_modules/create-wdio": {
-            "version": "9.18.2",
-            "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.18.2.tgz",
-            "integrity": "sha512-atf81YJfyTNAJXsNu3qhpqF4OO43tHGTpr88duAc1Hk4a0uXJAPUYLnYxshOuMnfmeAxlWD+NqGU7orRiXEuJg==",
+            "version": "9.21.0",
+            "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.21.0.tgz",
+            "integrity": "sha512-L6gsQLArY3AH5uTGpf3VfUezIsmZKufkF3ixSWqCuA/m458YVKeGghu1bBOWBdDIzqa6GX4e29dv0uVam0CTpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6367,16 +6518,6 @@
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/create-wdio/node_modules/commander": {
-            "version": "14.0.2",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-            "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
             }
         },
         "node_modules/cross-env": {
@@ -6656,12 +6797,13 @@
             "license": "MIT"
         },
         "node_modules/data-uri-to-buffer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">= 12"
+                "node": ">= 14"
             }
         },
         "node_modules/debug": {
@@ -7004,6 +7146,7 @@
             "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
             "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/which": "^2.0.1",
                 "which": "^2.0.2"
@@ -7016,28 +7159,27 @@
             }
         },
         "node_modules/edgedriver": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.2.tgz",
-            "integrity": "sha512-UvFqd/IR81iPyWMcxXbUNi+xKWR7JjfoHjfuwjqsj9UHQKn80RpQmS0jf+U25IPi+gKVPcpOSKm0XkqgGMq4zQ==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.2.0.tgz",
+            "integrity": "sha512-49G6010o0VYXUMNi5OvxqE9O/kazs0qmJVqHcSHNvp1VfojO21Kb/NaJN40uy11yrlGHRp7y6a372xoCnShzlA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@wdio/logger": "^9.1.3",
-                "@zip.js/zip.js": "^2.7.53",
-                "decamelize": "^6.0.0",
+                "@wdio/logger": "^9.18.0",
+                "@zip.js/zip.js": "^2.8.11",
+                "decamelize": "^6.0.1",
                 "edge-paths": "^3.0.5",
-                "fast-xml-parser": "^5.0.8",
+                "fast-xml-parser": "^5.3.2",
                 "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.5",
-                "node-fetch": "^3.3.2",
-                "which": "^5.0.0"
+                "https-proxy-agent": "^7.0.6",
+                "which": "^6.0.0"
             },
             "bin": {
                 "edgedriver": "bin/edgedriver.js"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/edgedriver/node_modules/agent-base": {
@@ -7055,6 +7197,7 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -7068,15 +7211,17 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
             "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/edgedriver/node_modules/which": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
+            "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "isexe": "^3.1.1"
             },
@@ -7084,7 +7229,7 @@
                 "node-which": "bin/which.js"
             },
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/ee-first": {
@@ -8176,38 +8321,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fetch-blob": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "dependencies": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20 || >= 14.13"
-            }
-        },
-        "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/figures": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -8449,18 +8562,6 @@
                 "node": ">= 14.17"
             }
         },
-        "node_modules/formdata-polyfill": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "dev": true,
-            "dependencies": {
-                "fetch-blob": "^3.1.2"
-            },
-            "engines": {
-                "node": ">=12.20.0"
-            }
-        },
         "node_modules/forwarded": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -8502,6 +8603,39 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/fs-minipass/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/fs-minipass/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8535,26 +8669,25 @@
             }
         },
         "node_modules/geckodriver": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-5.0.0.tgz",
-            "integrity": "sha512-vn7TtQ3b9VMJtVXsyWtQQl1fyBVFhQy7UvJF96kPuuJ0or5THH496AD3eUyaDD11+EqCxH9t6V+EP9soZQk4YQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+            "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
-                "@wdio/logger": "^9.1.3",
-                "@zip.js/zip.js": "^2.7.53",
-                "decamelize": "^6.0.0",
+                "@wdio/logger": "^9.18.0",
+                "@zip.js/zip.js": "^2.8.11",
+                "decamelize": "^6.0.1",
                 "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.5",
-                "node-fetch": "^3.3.2",
-                "tar-fs": "^3.0.6",
-                "which": "^5.0.0"
+                "https-proxy-agent": "^7.0.6",
+                "modern-tar": "^0.7.2"
             },
             "bin": {
                 "geckodriver": "bin/geckodriver.js"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/geckodriver/node_modules/agent-base": {
@@ -8572,36 +8705,13 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/geckodriver/node_modules/isexe": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-            "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/geckodriver/node_modules/which": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-            "dev": true,
-            "dependencies": {
-                "isexe": "^3.1.1"
-            },
-            "bin": {
-                "node-which": "bin/which.js"
-            },
-            "engines": {
-                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/gensync": {
@@ -8717,16 +8827,6 @@
                 "data-uri-to-buffer": "^6.0.2",
                 "debug": "^4.3.4"
             },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/get-uri/node_modules/data-uri-to-buffer": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
@@ -9441,18 +9541,18 @@
             "license": "ISC"
         },
         "node_modules/inquirer": {
-            "version": "12.8.2",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.8.2.tgz",
-            "integrity": "sha512-oBDL9f4+cDambZVJdfJu2M5JQfvaug9lbo6fKDlFV40i8t3FGA1Db67ov5Hp5DInG4zmXhHWTSnlXBntnJ7GMA==",
+            "version": "12.11.1",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
+            "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/prompts": "^7.7.1",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/prompts": "^7.10.1",
+                "@inquirer/type": "^3.0.10",
                 "mute-stream": "^2.0.0",
-                "run-async": "^4.0.5",
+                "run-async": "^4.0.6",
                 "rxjs": "^7.8.2"
             },
             "engines": {
@@ -10711,6 +10811,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/lru-cache": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -10982,12 +11089,59 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
+        "node_modules/minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minizlib/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/mitt": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/mocha": {
             "version": "11.7.5",
@@ -11058,6 +11212,16 @@
             "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
             "dev": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/modern-tar": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.3.tgz",
+            "integrity": "sha512-4W79zekKGyYU4JXVmB78DOscMFaJth2gGhgfTl2alWE4rNe3nf4N2pqenQ0rEtIewrnD79M687Ouba3YGTLOvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
         },
         "node_modules/morgan": {
             "version": "1.10.1",
@@ -11208,24 +11372,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10.5.0"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-            "dev": true,
-            "dependencies": {
-                "data-uri-to-buffer": "^4.0.0",
-                "fetch-blob": "^3.1.4",
-                "formdata-polyfill": "^4.0.10"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/node-forge": {
@@ -12591,6 +12737,31 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/protobufjs": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/node": ">=13.7.0",
+                "long": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12957,9 +13128,9 @@
             }
         },
         "node_modules/read-pkg-up/node_modules/yocto-queue": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-            "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+            "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13475,6 +13646,7 @@
             "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.0.tgz",
             "integrity": "sha512-J92IFbskyo7OYB3Dt4aTdyhag1GlInrfbPCmMteb7aBK7PwlnGz1HI0+oyNN97j7pV9DqUAVoVgkNRMrfY47mQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"
             }
@@ -14946,6 +15118,24 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tar": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^5.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/tar-fs": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -14972,6 +15162,23 @@
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
             }
+        },
+        "node_modules/tar/node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/tar/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/temp-fs": {
             "version": "0.9.9",
@@ -15948,6 +16155,16 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/wait-port/node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || >=14"
+            }
+        },
         "node_modules/wait-port/node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -16013,19 +16230,19 @@
             }
         },
         "node_modules/webdriver": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.20.1.tgz",
-            "integrity": "sha512-QtvYqPai2NOnq7qePPH6kNSwk7+tnmSvnlOnY8dIT/Y24TPdQp44NjF/BUYAWIlqoBlZqHClQFTSVwT2qvO2Tw==",
+            "version": "9.21.0",
+            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.21.0.tgz",
+            "integrity": "sha512-XLOhpU/EFPo4TMk+0fRli4g1WriUujxrfDxGT/QRq0MJsfhSYPF8FdefFdL5gHIrJfSKscaQHGWkbnsHftfqeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.1.0",
                 "@types/ws": "^8.5.3",
-                "@wdio/config": "9.20.1",
+                "@wdio/config": "9.21.0",
                 "@wdio/logger": "9.18.0",
                 "@wdio/protocols": "9.16.2",
                 "@wdio/types": "9.20.0",
-                "@wdio/utils": "9.20.1",
+                "@wdio/utils": "9.21.0",
                 "deepmerge-ts": "^7.0.3",
                 "https-proxy-agent": "^7.0.6",
                 "undici": "^6.21.3",
@@ -16036,9 +16253,9 @@
             }
         },
         "node_modules/webdriver/node_modules/@types/node": {
-            "version": "20.19.25",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-            "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+            "version": "20.19.27",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+            "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16077,20 +16294,20 @@
             "license": "MIT"
         },
         "node_modules/webdriverio": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.20.1.tgz",
-            "integrity": "sha512-QVM/asb5sDESz37ow/BAOA0z2HtUJsuAjPKHdw+Vx92PaQP3EfHwTgxK2T5rgwa0WRNh+c+n/0nEqIvqBl01sA==",
+            "version": "9.21.0",
+            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.21.0.tgz",
+            "integrity": "sha512-7teaXajOuNdn2UyyKlqMLssJjf0vDEih+Lo+tE/gHOt/P+mB8CinZym4PGtsriZLcyt4xV+Cun3hDmXM+pL26A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.11.30",
                 "@types/sinonjs__fake-timers": "^8.1.5",
-                "@wdio/config": "9.20.1",
+                "@wdio/config": "9.21.0",
                 "@wdio/logger": "9.18.0",
                 "@wdio/protocols": "9.16.2",
                 "@wdio/repl": "9.16.2",
                 "@wdio/types": "9.20.0",
-                "@wdio/utils": "9.20.1",
+                "@wdio/utils": "9.21.0",
                 "archiver": "^7.0.1",
                 "aria-query": "^5.3.0",
                 "cheerio": "^1.0.0-rc.12",
@@ -16107,7 +16324,7 @@
                 "rgb2hex": "0.2.5",
                 "serialize-error": "^12.0.0",
                 "urlpattern-polyfill": "^10.0.0",
-                "webdriver": "9.20.1"
+                "webdriver": "9.21.0"
             },
             "engines": {
                 "node": ">=18.20.0"

--- a/web/package.json
+++ b/web/package.json
@@ -16,10 +16,10 @@
     ],
     "devDependencies": {
         "@eslint/js": "^9.39.2",
-        "@wdio/browserstack-service": "^9.20.1",
-        "@wdio/cli": "^9.20.1",
-        "@wdio/local-runner": "^9.20.1",
-        "@wdio/mocha-framework": "^9.20.1",
+        "@wdio/browserstack-service": "^9.21.0",
+        "@wdio/cli": "^9.21.1",
+        "@wdio/local-runner": "^9.21.0",
+        "@wdio/mocha-framework": "^9.21.0",
         "@wdio/spec-reporter": "^9.20.0",
         "@wdio/static-server-service": "^9.20.0",
         "chai": "^6.2.1",
@@ -43,7 +43,7 @@
         "typedoc-plugin-mdn-links": "^5.0.10",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.48.0",
-        "webdriverio": "^9.20.1",
+        "webdriverio": "^9.21.0",
         "webpack": "^5.103.0",
         "webpack-cli": "^6.0.1",
         "workspace-version": "^0.1.4"


### PR DESCRIPTION
Split from https://github.com/ruffle-rs/ruffle/pull/22534 (just for the sake of a smaller lockfile diff) + manual fix for https://github.com/dependabot/dependabot-core/issues/12823.