### PR TITLE
chore: Enable redundant_clone clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ unknown_lints = "allow"
 # In case it happens, add `#[allow(clippy::trivially_copy_pass_by_ref)]` and
 # add a comment explaining why.
 trivially_copy_pass_by_ref = "deny"
+redundant_clone = "deny"
 
 # LONG-TERM: These lints are unhelpful.
 manual_map = "allow"             # Less readable: Suggests `opt.map(..)` instead of `if let Some(opt) { .. }`

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -491,7 +491,7 @@ impl<'gc> Avm2<'gc> {
         name: AvmString<'gc>,
         id: u16,
     ) -> Result<ClassObject<'gc>, Error<'gc>> {
-        let movie = movie_clip.movie().clone();
+        let movie = movie_clip.movie();
 
         let class_object = domain
             .get_defined_value_handling_vector(activation, name)?

--- a/core/src/backend/audio/decoders/aac.rs
+++ b/core/src/backend/audio/decoders/aac.rs
@@ -22,7 +22,7 @@ pub struct AacSubstreamDecoder {
 
 impl AacSubstreamDecoder {
     pub fn new(stream_info: &SoundStreamInfo, data_stream: Substream) -> Result<Self, Error> {
-        let tag_reader = SubstreamTagReader::new(stream_info, data_stream.clone());
+        let tag_reader = SubstreamTagReader::new(stream_info, data_stream);
         let layout = if stream_info.stream_format.is_stereo {
             audio::Layout::Stereo
         } else {

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -1221,13 +1221,11 @@ impl Glyph {
         let transform = context.transform_stack.transform();
         match glyph_handle {
             GlyphHandle::Shape(shape_handle) => {
-                context
-                    .commands
-                    .render_shape(shape_handle.clone(), transform);
+                context.commands.render_shape(shape_handle, transform);
             }
             GlyphHandle::Bitmap(bitmap_handle) => {
                 context.commands.render_bitmap(
-                    bitmap_handle.clone(),
+                    bitmap_handle,
                     transform,
                     true,
                     ruffle_render::bitmap::PixelSnapping::Auto,

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -716,7 +716,7 @@ impl FormatSpans {
             };
 
             if let Some(style) = style_sheet.get_style(selector) {
-                style.clone().mix_with(format)
+                style.mix_with(format)
             } else {
                 format
             }

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -685,7 +685,7 @@ impl<'gc> MovieLoader<'gc> {
                 Ok((body, url, _status, _redirected)) if replacing_root_movie => {
                     ContentType::sniff(&body).expect(ContentType::Swf)?;
 
-                    let movie = SwfMovie::from_data(&body, url.to_string(), loader_url)?;
+                    let movie = SwfMovie::from_data(&body, url, loader_url)?;
                     player.lock().unwrap().mutate_with_update_context(|uc| {
                         // Make a copy of the properties on the root, so we can put them back after replacing it
                         let mut root_properties: IndexMap<AvmString, Value> = IndexMap::new();
@@ -1651,10 +1651,7 @@ impl<'gc> MovieLoader<'gc> {
             ContentType::Gif | ContentType::Jpeg | ContentType::Png => {
                 let mut activation = Avm2Activation::from_nothing(uc);
 
-                let library = activation
-                    .context
-                    .library
-                    .library_for_movie_mut(movie.clone());
+                let library = activation.context.library.library_for_movie_mut(movie);
 
                 library.set_avm2_domain(domain);
 
@@ -1749,7 +1746,7 @@ impl<'gc> MovieLoader<'gc> {
                     MovieLoaderVMData::Avm1 { .. } => {
                         // If the file is no valid supported file, the MovieClip enters the error state
                         if let Some(mut mc) = clip.as_movie_clip() {
-                            MovieLoader::load_error_swf(&mut mc, uc, url.clone());
+                            MovieLoader::load_error_swf(&mut mc, uc, url);
                         }
 
                         // AVM1 fires the event with the current and total length as 0

--- a/core/src/local_connection.rs
+++ b/core/src/local_connection.rs
@@ -158,7 +158,7 @@ impl<'gc> LocalConnections<'gc> {
             None
         } else {
             self.connections.insert(key.to_owned(), connection.into());
-            Some(LocalConnectionHandle(key.to_owned()))
+            Some(LocalConnectionHandle(key))
         }
     }
 

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -171,13 +171,7 @@ impl DesktopUiBackend {
     ) -> Result<Self, Error> {
         // The window handle is only relevant to linux/wayland
         // If it fails it'll fallback to x11 or wlr-data-control
-        let clipboard = Clipboard::new(
-            window
-                .clone()
-                .display_handle()
-                .ok()
-                .map(|handle| handle.as_raw()),
-        );
+        let clipboard = Clipboard::new(window.display_handle().ok().map(|handle| handle.as_raw()));
         Ok(Self {
             window,
             event_loop,
@@ -354,7 +348,7 @@ impl UiBackend for DesktopUiBackend {
     fn close_virtual_keyboard(&self) {}
 
     fn language(&self) -> LanguageIdentifier {
-        self.preferences.language().clone()
+        self.preferences.language()
     }
 
     fn display_file_open_dialog(&mut self, filters: Vec<FileFilter>) -> Option<DialogResultFuture> {

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -66,7 +66,7 @@ impl RuffleGui {
                 preferences.clone(),
                 default_launch_options.clone(),
                 default_path,
-                window.clone(),
+                window,
                 event_loop.clone(),
             ),
             menu_bar: MenuBar::new(

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -138,11 +138,11 @@ impl GuiController {
         let gui = RuffleGui::new(
             Arc::downgrade(&window),
             event_loop,
-            initial_movie_url.clone(),
+            initial_movie_url,
             LaunchOptions::from(&preferences),
             preferences.clone(),
         );
-        let system_fonts = load_system_fonts(font_database, preferences.language().to_owned());
+        let system_fonts = load_system_fonts(font_database, preferences.language());
         egui_winit.egui_ctx().set_fonts(system_fonts);
 
         egui_extras::install_image_loaders(egui_winit.egui_ctx());

--- a/desktop/src/gui/dialogs/preferences_dialog.rs
+++ b/desktop/src/gui/dialogs/preferences_dialog.rs
@@ -631,9 +631,7 @@ fn graphics_power_name(
 }
 
 fn language_name(language: &LanguageIdentifier) -> String {
-    optional_text(language, "language-name")
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| language.to_string())
+    optional_text(language, "language-name").unwrap_or_else(|| language.to_string())
 }
 
 fn theme_preference_name(

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -145,7 +145,7 @@ fn main() -> Result<(), Error> {
     init();
 
     let opt = Opt::parse();
-    let preferences = GlobalPreferences::load(opt.clone())?;
+    let preferences = GlobalPreferences::load(opt)?;
 
     let logs_path = &preferences.cli.cache_directory.join("log");
     let log_path = preferences.log_filename_pattern().create_path(logs_path);

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -478,7 +478,7 @@ impl RuffleInstanceBuilder {
         };
 
         player.register_device_font(FontDefinition::FontFile {
-            name: name.to_string(),
+            name,
             is_bold: face.is_bold(),
             is_italic: face.is_italic(),
             data: FontFileData::new(bytes),
@@ -630,7 +630,7 @@ impl RuffleInstanceBuilder {
         &self,
         log_subscriber: Arc<Layered<WASMLayer, Registry>>,
     ) -> Box<dyn AudioBackend> {
-        if let Ok(audio) = audio::WebAudioBackend::new(log_subscriber.clone()) {
+        if let Ok(audio) = audio::WebAudioBackend::new(log_subscriber) {
             Box::new(audio)
         } else {
             tracing::error!("Unable to create audio backend. No audio will be played.");
@@ -648,7 +648,7 @@ impl RuffleInstanceBuilder {
             self.upgrade_to_https,
             self.url_rewrite_rules.clone(),
             self.base_url.clone(),
-            log_subscriber.clone(),
+            log_subscriber,
             self.open_url_mode,
             self.socket_proxy.clone(),
             self.credential_allow_list.clone(),


### PR DESCRIPTION
Per https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#redundant_clone, this is apparently not on by default, because 'False-negatives: analysis performed by this lint is conservative and limited.'

The suggestions here were correct and I think the problems this could cause are pretty limited.

