### PR TITLE
avm1: Stub missing Camera properties

### DIFF
--- a/core/src/avm1/globals/camera.rs
+++ b/core/src/avm1/globals/camera.rs
@@ -4,22 +4,104 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{DeclContext, StaticDeclarations, SystemClass};
 use crate::avm1::{Object, Value};
+use crate::avm1_stub;
 
-const PROTO_DECLS: StaticDeclarations = |_| declare_properties! {};
+const PROTO_DECLS: StaticDeclarations = declare_static_properties! {
+    "setMode" => method(set_mode; DONT_ENUM | DONT_DELETE);
+    "setQuality" => method(set_quality; DONT_ENUM | DONT_DELETE);
+    "setKeyFrameInterval" => method(set_key_frame_interval; DONT_ENUM | DONT_DELETE);
+    "setMotionLevel" => method(set_motion_level; DONT_ENUM | DONT_DELETE);
+    "setLoopback" => method(set_loopback; DONT_ENUM | DONT_DELETE);
+    "setCursor" => method(set_cursor; DONT_ENUM | DONT_DELETE);
+};
+
+const OBJECT_DECLS: StaticDeclarations = declare_static_properties! {
+    "get" => method(get);
+    "names" => property(get_names);
+};
 
 pub fn create_class<'gc>(
     context: &mut DeclContext<'_, 'gc>,
     super_proto: Object<'gc>,
 ) -> SystemClass<'gc> {
-    let class = context.class(constructor, super_proto);
+    let class = context.empty_class(super_proto);
     context.define_properties_on(class.proto, PROTO_DECLS(context));
+    context.define_properties_on(class.constr, OBJECT_DECLS(context));
     class
 }
 
-fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+fn get<'gc>(
+    activation: &mut Activation<'_, 'gc>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm1_stub!(activation, "Camera", "get");
+    // Camera.get() returns null when there's no camera.
+    Ok(Value::Null)
+}
+
+fn get_names<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm1_stub!(activation, "Camera", "names");
+    activation
+        .prototypes()
+        .array_constructor
+        .construct(activation, &[])
+}
+
+fn set_mode<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm1_stub!(activation, "Camera", "setMode");
+    Ok(Value::Undefined)
+}
+
+fn set_quality<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm1_stub!(activation, "Camera", "setQuality");
+    Ok(Value::Undefined)
+}
+
+fn set_key_frame_interval<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm1_stub!(activation, "Camera", "setKeyFrameInterval");
+    Ok(Value::Undefined)
+}
+
+fn set_motion_level<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm1_stub!(activation, "Camera", "setMotionLevel");
+    Ok(Value::Undefined)
+}
+
+fn set_loopback<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm1_stub!(activation, "Camera", "setLoopback");
+    Ok(Value::Undefined)
+}
+
+fn set_cursor<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm1_stub!(activation, "Camera", "setCursor");
     Ok(Value::Undefined)
 }

--- a/tests/tests/swfs/avm1/global_proto_decls/output.ruffle.txt
+++ b/tests/tests/swfs/avm1/global_proto_decls/output.ruffle.txt
@@ -1564,9 +1564,17 @@ Testing _global.Camera
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
+  names, own, READ_ONLY, type=[object]
+  get, own, type=[function]
   prototype, own, type=[object]
   __proto__, own, type=[object]
 Testing _global.Camera.prototype
+  setCursor, own, DONT_ENUM, type=[function]
+  setLoopback, own, DONT_ENUM, type=[function]
+  setMotionLevel, own, DONT_ENUM, type=[function]
+  setKeyFrameInterval, own, DONT_ENUM, type=[function]
+  setQuality, own, DONT_ENUM, type=[function]
+  setMode, own, DONT_ENUM, type=[function]
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.NetStream

--- a/tests/tests/swfs/avm1/global_proto_decls_delete/output.ruffle.txt
+++ b/tests/tests/swfs/avm1/global_proto_decls_delete/output.ruffle.txt
@@ -731,6 +731,12 @@ Testing _global.Camera
   prototype, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Camera.prototype
+  setCursor, DONT_DELETE
+  setLoopback, DONT_DELETE
+  setMotionLevel, DONT_DELETE
+  setKeyFrameInterval, DONT_DELETE
+  setQuality, DONT_DELETE
+  setMode, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.NetStream
   apply, DONT_DELETE

--- a/tests/tests/swfs/from_gnash/actionscript.all/Camera-v6/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/Camera-v6/output.ruffle.txt
@@ -6,9 +6,9 @@ PASSED: cameraObj [./Camera.as:44]
 PASSED: cameraObj2 [./Camera.as:46]
 PASSED: cameraObj != cameraObj2 [./Camera.as:47]
 PASSED: typeof(cameraObj) == 'object' [./Camera.as:48]
-FAILED: expected: "function" obtained: undefined [./Camera.as:49]
-FAILED: expected: "function" obtained: undefined [./Camera.as:50]
-FAILED: expected: "function" obtained: undefined [./Camera.as:51]
+PASSED: typeof(cameraObj.setCursor) == "function" [./Camera.as:49]
+PASSED: typeof(cameraObj.setKeyFrameInterval) == "function" [./Camera.as:50]
+PASSED: typeof(cameraObj.setLoopback) == "function" [./Camera.as:51]
 PASSED: !Camera.prototype.hasOwnProperty("activityLevel") [./Camera.as:54]
 PASSED: !Camera.prototype.hasOwnProperty("bandwidth") [./Camera.as:55]
 PASSED: !Camera.prototype.hasOwnProperty("currentFps") [./Camera.as:56]
@@ -21,9 +21,9 @@ PASSED: !Camera.prototype.hasOwnProperty("motionTimeout") [./Camera.as:62]
 PASSED: !Camera.prototype.hasOwnProperty("muted") [./Camera.as:63]
 PASSED: !Camera.prototype.hasOwnProperty("name") [./Camera.as:64]
 PASSED: !Camera.prototype.hasOwnProperty("quality") [./Camera.as:65]
-FAILED: Camera.get [./Camera.as:70]
+PASSED: Camera.get [./Camera.as:70]
 PASSED: cameraObj.get == undefined [./Camera.as:71]
-Camera.get() returns: 
+Camera.get() returns: null
 PASSED: !Camera.prototype.hasOwnProperty("names") [./Camera.as:78]
 PASSED: !Camera.prototype.hasOwnProperty("get") [./Camera.as:79]
 PASSED: !Camera.prototype.hasOwnProperty("activityLevel") [./Camera.as:98]
@@ -85,6 +85,6 @@ FAILED: expected: 18000 obtained:  [./Camera.as:184]
 FAILED: expected: 75 obtained:  [./Camera.as:185]
 FAILED: expected: 18000 obtained:  [./Camera.as:189]
 FAILED: expected: 100 obtained:  [./Camera.as:190]
-#passed: 37
-#failed: 46
+#passed: 41
+#failed: 42
 #total tests run: 83

--- a/tests/tests/swfs/from_gnash/actionscript.all/Camera-v7/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/Camera-v7/output.ruffle.txt
@@ -6,9 +6,9 @@ PASSED: cameraObj [./Camera.as:44]
 PASSED: cameraObj2 [./Camera.as:46]
 PASSED: cameraObj != cameraObj2 [./Camera.as:47]
 PASSED: typeof(cameraObj) == 'object' [./Camera.as:48]
-FAILED: expected: "function" obtained: undefined [./Camera.as:49]
-FAILED: expected: "function" obtained: undefined [./Camera.as:50]
-FAILED: expected: "function" obtained: undefined [./Camera.as:51]
+PASSED: typeof(cameraObj.setCursor) == "function" [./Camera.as:49]
+PASSED: typeof(cameraObj.setKeyFrameInterval) == "function" [./Camera.as:50]
+PASSED: typeof(cameraObj.setLoopback) == "function" [./Camera.as:51]
 PASSED: !Camera.prototype.hasOwnProperty("activityLevel") [./Camera.as:54]
 PASSED: !Camera.prototype.hasOwnProperty("bandwidth") [./Camera.as:55]
 PASSED: !Camera.prototype.hasOwnProperty("currentFps") [./Camera.as:56]
@@ -21,9 +21,9 @@ PASSED: !Camera.prototype.hasOwnProperty("motionTimeout") [./Camera.as:62]
 PASSED: !Camera.prototype.hasOwnProperty("muted") [./Camera.as:63]
 PASSED: !Camera.prototype.hasOwnProperty("name") [./Camera.as:64]
 PASSED: !Camera.prototype.hasOwnProperty("quality") [./Camera.as:65]
-FAILED: Camera.get [./Camera.as:70]
+PASSED: Camera.get [./Camera.as:70]
 PASSED: cameraObj.get == undefined [./Camera.as:71]
-Camera.get() returns: undefined
+Camera.get() returns: null
 PASSED: !Camera.prototype.hasOwnProperty("names") [./Camera.as:78]
 PASSED: !Camera.prototype.hasOwnProperty("get") [./Camera.as:79]
 PASSED: !Camera.prototype.hasOwnProperty("activityLevel") [./Camera.as:98]
@@ -85,6 +85,6 @@ FAILED: expected: 18000 obtained: undefined [./Camera.as:184]
 FAILED: expected: 75 obtained: undefined [./Camera.as:185]
 FAILED: expected: 18000 obtained: undefined [./Camera.as:189]
 FAILED: expected: 100 obtained: undefined [./Camera.as:190]
-#passed: 37
-#failed: 46
+#passed: 41
+#failed: 42
 #total tests run: 83

--- a/tests/tests/swfs/from_gnash/actionscript.all/Camera-v8/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/Camera-v8/output.ruffle.txt
@@ -6,9 +6,9 @@ PASSED: cameraObj [./Camera.as:44]
 PASSED: cameraObj2 [./Camera.as:46]
 PASSED: cameraObj != cameraObj2 [./Camera.as:47]
 PASSED: typeof(cameraObj) == 'object' [./Camera.as:48]
-FAILED: expected: "function" obtained: undefined [./Camera.as:49]
-FAILED: expected: "function" obtained: undefined [./Camera.as:50]
-FAILED: expected: "function" obtained: undefined [./Camera.as:51]
+PASSED: typeof(cameraObj.setCursor) == "function" [./Camera.as:49]
+PASSED: typeof(cameraObj.setKeyFrameInterval) == "function" [./Camera.as:50]
+PASSED: typeof(cameraObj.setLoopback) == "function" [./Camera.as:51]
 PASSED: !Camera.prototype.hasOwnProperty("activityLevel") [./Camera.as:54]
 PASSED: !Camera.prototype.hasOwnProperty("bandwidth") [./Camera.as:55]
 PASSED: !Camera.prototype.hasOwnProperty("currentFps") [./Camera.as:56]
@@ -21,9 +21,9 @@ PASSED: !Camera.prototype.hasOwnProperty("motionTimeout") [./Camera.as:62]
 PASSED: !Camera.prototype.hasOwnProperty("muted") [./Camera.as:63]
 PASSED: !Camera.prototype.hasOwnProperty("name") [./Camera.as:64]
 PASSED: !Camera.prototype.hasOwnProperty("quality") [./Camera.as:65]
-FAILED: Camera.get [./Camera.as:70]
+PASSED: Camera.get [./Camera.as:70]
 PASSED: cameraObj.get == undefined [./Camera.as:71]
-Camera.get() returns: undefined
+Camera.get() returns: null
 PASSED: !Camera.prototype.hasOwnProperty("names") [./Camera.as:78]
 PASSED: !Camera.prototype.hasOwnProperty("get") [./Camera.as:79]
 PASSED: !Camera.prototype.hasOwnProperty("activityLevel") [./Camera.as:98]
@@ -85,6 +85,6 @@ FAILED: expected: 18000 obtained: undefined [./Camera.as:184]
 FAILED: expected: 75 obtained: undefined [./Camera.as:185]
 FAILED: expected: 18000 obtained: undefined [./Camera.as:189]
 FAILED: expected: 100 obtained: undefined [./Camera.as:190]
-#passed: 37
-#failed: 46
+#passed: 41
+#failed: 42
 #total tests run: 83

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp10.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp10.ruffle.txt
@@ -1093,6 +1093,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp11-14.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp11-14.ruffle.txt
@@ -1093,6 +1093,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp13-18.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp13-18.ruffle.txt
@@ -1093,6 +1093,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp32.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp32.ruffle.txt
@@ -1093,6 +1093,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp9.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp9.ruffle.txt
@@ -1093,6 +1093,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp10.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp10.ruffle.txt
@@ -1021,6 +1021,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp11-14.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp11-14.ruffle.txt
@@ -1021,6 +1021,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp13-18.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp13-18.ruffle.txt
@@ -1021,6 +1021,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp32.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp32.ruffle.txt
@@ -1021,6 +1021,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp9.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp9.ruffle.txt
@@ -1021,6 +1021,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp11-14.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp11-14.ruffle.txt
@@ -1334,6 +1334,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp13-18.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp13-18.ruffle.txt
@@ -1334,6 +1334,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp32.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp32.ruffle.txt
@@ -1334,6 +1334,12 @@ Testing __proto__()
 testing _global.Camera(function)
 Trying to construct _global.Camera
 Object was constructed
+Testing setCursor()
+Testing setLoopback()
+Testing setMotionLevel()
+Testing setKeyFrameInterval()
+Testing setQuality()
+Testing setMode()
 Testing constructor()
 Testing __constructor__()
 testing _global.Camera.__constructor__(undefined)


### PR DESCRIPTION
Stubbed methods:
* Camera.get(),
* Camera.setMode(),
* Camera.setQuality(),
* Camera.setKeyFrameInterval(),
* Camera.setMotionLevel(),
* Camera.setLoopback(),
* Camera.setCursor().

Stubbed properties:
* Camera.names.