### PR TITLE
extension: Make it if cleanup fails RuleCondition test does nothing

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -22,7 +22,7 @@ async function isHeaderConditionSupported() {
                     action: {
                         type:
                             chrome.declarativeNetRequest.RuleActionType
-                                ?.BLOCK ?? "block",
+                                ?.ALLOW ?? "allow",
                     },
                 },
             ],
@@ -43,7 +43,7 @@ async function isHeaderConditionSupported() {
                     action: {
                         type:
                             chrome.declarativeNetRequest.RuleActionType
-                                ?.BLOCK ?? "block",
+                                ?.ALLOW ?? "allow",
                     },
                 },
             ],


### PR DESCRIPTION
This section of code tests if the responseHeaders RuleCondition is supported and not behind a flag, but if the RuleCondition is enabled behind a flag it will successfully register a rule which matches any request, even if it doesn't match the unsupported RuleCondition. What that means is on Chromium 121-127 a rule is registered via lines 37 - 50 that blocks every request. It shouldn't matter though, as that rule is removed by lines 57 - 59, but just in case that fails to remove the rule, it's better if the rule does nothing.