### PR TITLE
desktop: Attach console when stdout handle is null

### DIFF
--- a/desktop/src/windows.rs
+++ b/desktop/src/windows.rs
@@ -1,3 +1,5 @@
+use std::ptr::NonNull;
+
 use windows_sys::Win32::Storage::FileSystem::{FILE_TYPE_DISK, FILE_TYPE_PIPE, GetFileType};
 use windows_sys::Win32::System::Console::{
     ATTACH_PARENT_PROCESS, AttachConsole, FreeConsole, GetStdHandle, STD_OUTPUT_HANDLE,
@@ -20,25 +22,25 @@ impl Console {
     pub(super) fn attach() -> Self {
         // Check if stdout is already redirected to a file or pipe
         // SAFETY: STD_OUTPUT_HANDLE is a valid standard device constant.
-        let stdout_handle = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+        let stdout_handle = NonNull::new(unsafe { GetStdHandle(STD_OUTPUT_HANDLE) });
 
-        // GetStdHandle can return NULL on failure
-        let attached = if stdout_handle.is_null() {
-            false
-        } else {
+        let should_attach = stdout_handle.is_none_or(|mut handle| {
             // SAFETY: GetFileType accepts any handle value including INVALID_HANDLE_VALUE,
             // returning FILE_TYPE_UNKNOWN in that case.
-            let file_type = unsafe { GetFileType(stdout_handle) };
+            let file_type = unsafe { GetFileType(handle.as_mut()) };
 
-            match file_type {
-                // If output is redirected to a file or pipe, don't attach to console
-                // as that would bypass the redirection
-                FILE_TYPE_DISK | FILE_TYPE_PIPE => false,
-                // Otherwise, attach to parent console for interactive use
-                // SAFETY: ATTACH_PARENT_PROCESS is a valid constant for AttachConsole.
-                // This call fails silently if the parent has no console.
-                _ => (unsafe { AttachConsole(ATTACH_PARENT_PROCESS) }) != 0,
-            }
+            // If output is redirected to a file or pipe, don't attach to console
+            // as that would bypass the redirection
+            !matches!(file_type, FILE_TYPE_DISK | FILE_TYPE_PIPE)
+        });
+
+        let attached = if should_attach {
+            // Otherwise, attach to parent console for interactive use
+            // SAFETY: ATTACH_PARENT_PROCESS is a valid constant for AttachConsole.
+            // This call fails silently if the parent has no console.
+            (unsafe { AttachConsole(ATTACH_PARENT_PROCESS) }) != 0
+        } else {
+            false
         };
 
         Self { attached }


### PR DESCRIPTION
Supersedes #22617.

#22557 caused console output to not work when GetStdHandle returned null.