### PR TITLE
avm1: Fix enumerability of prototype in function

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -490,7 +490,7 @@ impl<'gc> FunctionObject<'gc> {
                 context.gc(),
                 istr!(context, "prototype"),
                 prototype.into(),
-                Attribute::DONT_DELETE,
+                Attribute::DONT_ENUM | Attribute::DONT_DELETE,
             );
         }
 

--- a/tests/tests/swfs/avm1/global_proto_decls/output.ruffle.txt
+++ b/tests/tests/swfs/avm1/global_proto_decls/output.ruffle.txt
@@ -1,5 +1,5 @@
 Testing _global.TextSnapshot
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.TextSnapshot.prototype
   getTextRunInfo, own, type=[function]
@@ -14,7 +14,7 @@ Testing _global.TextSnapshot.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.PrintJob
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.PrintJob.prototype
   orientation, own, READ_ONLY, type=[number]
@@ -28,7 +28,7 @@ Testing _global.PrintJob.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.MovieClipLoader
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.MovieClipLoader.prototype
   broadcastMessage, own, DONT_ENUM, type=[function]
@@ -41,7 +41,7 @@ Testing _global.MovieClipLoader.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.LocalConnection
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.LocalConnection.prototype
   isPerUser, own, DONT_ENUM, READ_ONLY, type=[undefined]
@@ -52,7 +52,7 @@ Testing _global.LocalConnection.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.textRenderer
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.textRenderer.prototype
   constructor, own, type=[function]
@@ -72,7 +72,7 @@ Testing _global.flash.external.ExternalInterface
   call, own, DONT_ENUM, READ_ONLY, type=[function]
   addCallback, own, DONT_ENUM, READ_ONLY, type=[function]
   available, own, DONT_ENUM, READ_ONLY, type=[boolean]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.external.ExternalInterface.prototype
   constructor, own, type=[function]
@@ -82,13 +82,13 @@ Testing _global.flash.net
   FileReference, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.net.FileReferenceList
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.net.FileReferenceList.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.net.FileReference
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.net.FileReference.prototype
   broadcastMessage, own, DONT_ENUM, type=[function]
@@ -116,7 +116,7 @@ Testing _global.flash.geom
   Rectangle, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.geom.Transform
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.geom.Transform.prototype
   pixelBounds, own, READ_ONLY, type=[undefined]
@@ -127,7 +127,7 @@ Testing _global.flash.geom.Transform.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.geom.ColorTransform
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.geom.ColorTransform.prototype
   toString, own, type=[function]
@@ -144,7 +144,7 @@ Testing _global.flash.geom.ColorTransform.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.geom.Matrix
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.geom.Matrix.prototype
   toString, own, type=[function]
@@ -165,7 +165,7 @@ Testing _global.flash.geom.Point
   interpolate, own, type=[function]
   polar, own, type=[function]
   distance, own, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.geom.Point.prototype
   toString, own, type=[function]
@@ -179,7 +179,7 @@ Testing _global.flash.geom.Point.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.geom.Rectangle
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.geom.Rectangle.prototype
   toString, own, type=[function]
@@ -219,7 +219,7 @@ Testing _global.flash.filters
   BitmapFilter, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.DisplacementMapFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.DisplacementMapFilter.prototype
   clone, type=[function]
@@ -235,7 +235,7 @@ Testing _global.flash.filters.DisplacementMapFilter.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.ColorMatrixFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.ColorMatrixFilter.prototype
   clone, type=[function]
@@ -243,7 +243,7 @@ Testing _global.flash.filters.ColorMatrixFilter.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.ConvolutionFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.ConvolutionFilter.prototype
   clone, type=[function]
@@ -259,7 +259,7 @@ Testing _global.flash.filters.ConvolutionFilter.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.GradientBevelFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.GradientBevelFilter.prototype
   clone, type=[function]
@@ -277,7 +277,7 @@ Testing _global.flash.filters.GradientBevelFilter.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.GradientGlowFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.GradientGlowFilter.prototype
   clone, type=[function]
@@ -295,7 +295,7 @@ Testing _global.flash.filters.GradientGlowFilter.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.BevelFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.BevelFilter.prototype
   clone, type=[function]
@@ -314,7 +314,7 @@ Testing _global.flash.filters.BevelFilter.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.GlowFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.GlowFilter.prototype
   clone, type=[function]
@@ -329,7 +329,7 @@ Testing _global.flash.filters.GlowFilter.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.BlurFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.BlurFilter.prototype
   clone, type=[function]
@@ -339,7 +339,7 @@ Testing _global.flash.filters.BlurFilter.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.DropShadowFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.DropShadowFilter.prototype
   clone, type=[function]
@@ -357,7 +357,7 @@ Testing _global.flash.filters.DropShadowFilter.prototype
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.flash.filters.BitmapFilter
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.filters.BitmapFilter.prototype
   clone, own, type=[function]
@@ -372,7 +372,7 @@ Testing _global.flash.display.BitmapData
   GREEN_CHANNEL, own, type=[number]
   RED_CHANNEL, own, type=[number]
   loadBitmap, own, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.display.BitmapData.prototype
   compare, own, type=[function]
@@ -469,7 +469,7 @@ Testing _global.System.IME.JAPANESE_KATAKANA_HALF
 Testing _global.System.IME.KOREAN
 Testing _global.System.IME.UNKNOWN
 Testing _global.System.IME.broadcastMessage
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.System.IME.broadcastMessage.prototype
   apply, own, DONT_ENUM, type=[function]
@@ -480,7 +480,7 @@ Testing _global.System.IME.removeListener
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.System.IME.removeListener.prototype
   apply, own, type=[function]
@@ -491,7 +491,7 @@ Testing _global.System.IME.addListener
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.System.IME.addListener.prototype
   apply, own, type=[function]
@@ -542,7 +542,7 @@ Testing _global.System.Product
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.System.Product.prototype
   installedVersion, own, type=[function]
@@ -662,7 +662,7 @@ Testing _global.Video
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Video.prototype
   attachVideo, own, DONT_ENUM, type=[function]
@@ -727,7 +727,7 @@ Testing _global.TextFormat
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.TextFormat.prototype
   letterSpacing, own, READ_ONLY, type=[undefined]
@@ -757,7 +757,7 @@ Testing _global.TextField
   call, type=[function]
   constructor, type=[function]
   StyleSheet, own, DONT_ENUM, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.TextField.prototype
   styleSheet, own, READ_ONLY, type=[undefined]
@@ -809,7 +809,7 @@ Testing _global.Button
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Button.prototype
   tabIndex, own, READ_ONLY, type=[undefined]
@@ -1065,7 +1065,7 @@ Testing _global.LoadVars
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.LoadVars.prototype
   addRequestHeader, own, DONT_ENUM, type=[function]
@@ -1085,7 +1085,7 @@ Testing _global.XML
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.XML.prototype
   namespaceURI, READ_ONLY, type=[undefined]
@@ -1129,7 +1129,7 @@ Testing _global.XMLNode
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.XMLNode.prototype
   namespaceURI, own, READ_ONLY, type=[undefined]
@@ -1159,7 +1159,7 @@ Testing _global.Sound
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Sound.prototype
   getBytesTotal, own, DONT_ENUM, READ_ONLY, type=[function]
@@ -1315,7 +1315,7 @@ Testing _global.Array
   UNIQUESORT, own, type=[number]
   DESCENDING, own, type=[number]
   CASEINSENSITIVE, own, type=[number]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Array.prototype
   sortOn, own, DONT_ENUM, type=[function]
@@ -1338,7 +1338,7 @@ Testing _global.String
   call, type=[function]
   constructor, type=[function]
   fromCharCode, own, DONT_ENUM, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.String.prototype
   substr, own, DONT_ENUM, type=[function]
@@ -1361,7 +1361,7 @@ Testing _global.Date
   call, type=[function]
   constructor, type=[function]
   UTC, own, DONT_ENUM, READ_ONLY, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Date.prototype
   valueOf, own, type=[function]
@@ -1408,7 +1408,7 @@ Testing _global.Boolean
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Boolean.prototype
   toString, own, type=[function]
@@ -1424,7 +1424,7 @@ Testing _global.Number
   NaN, own, DONT_ENUM, READ_ONLY, type=[number]
   MIN_VALUE, own, DONT_ENUM, READ_ONLY, type=[number]
   MAX_VALUE, own, DONT_ENUM, READ_ONLY, type=[number]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Number.prototype
   toString, own, type=[function]
@@ -1500,7 +1500,7 @@ Testing _global.Error
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Error.prototype
   toString, own, type=[function]
@@ -1512,7 +1512,7 @@ Testing _global.ContextMenu
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.ContextMenu.prototype
   hideBuiltInItems, own, DONT_ENUM, type=[function]
@@ -1523,7 +1523,7 @@ Testing _global.ContextMenuItem
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.ContextMenuItem.prototype
   copy, own, DONT_ENUM, type=[function]
@@ -1537,7 +1537,7 @@ Testing _global.SharedObject
   getLocal, own, type=[function]
   getDiskUsage, own, DONT_ENUM, type=[function]
   deleteAll, own, DONT_ENUM, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.SharedObject.prototype
   onSync, own, DONT_ENUM, type=[function]
@@ -1557,7 +1557,7 @@ Testing _global.Microphone
   constructor, type=[function]
   names, own, READ_ONLY, type=[object]
   get, own, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Microphone.prototype
   setEncodeQuality, own, DONT_ENUM, type=[function]
@@ -1575,7 +1575,7 @@ Testing _global.Camera
   constructor, type=[function]
   names, own, READ_ONLY, type=[object]
   get, own, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Camera.prototype
   setCursor, own, DONT_ENUM, type=[function]
@@ -1590,7 +1590,7 @@ Testing _global.NetStream
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.NetStream.prototype
   time, own, READ_ONLY, type=[undefined]
@@ -1621,7 +1621,7 @@ Testing _global.NetConnection
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.NetConnection.prototype
   uri, own, READ_ONLY, type=[undefined]
@@ -1637,7 +1637,7 @@ Testing _global.Color
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Color.prototype
   getTransform, own, DONT_ENUM, READ_ONLY, type=[function]
@@ -1654,7 +1654,7 @@ Testing _global.AsBroadcaster
   removeListener, own, DONT_ENUM, type=[function]
   addListener, own, DONT_ENUM, type=[function]
   initialize, own, DONT_ENUM, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.AsBroadcaster.prototype
   constructor, own, type=[function]
@@ -1663,7 +1663,7 @@ Testing _global.XMLSocket
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.XMLSocket.prototype
   onXML, own, DONT_ENUM, type=[function]
@@ -1680,7 +1680,7 @@ Testing _global.MovieClip
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.MovieClip.prototype
   createTextField, own, DONT_ENUM, type=[function]
@@ -1744,7 +1744,7 @@ Testing _global.Function
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Function.prototype
   apply, own, type=[function]
@@ -1756,7 +1756,7 @@ Testing _global.Object
   call, type=[function]
   constructor, type=[function]
   registerClass, own, DONT_ENUM, READ_ONLY, type=[function]
-  prototype, own, type=[object]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.Object.prototype
   isPropertyEnumerable, own, type=[function]

--- a/tests/tests/swfs/from_gnash/actionscript.all/String-v5/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/String-v5/output.ruffle.txt
@@ -319,15 +319,15 @@ PASSED: a.length == 2 [./String.as:1253]
 PASSED: a == "123" [./String.as:1254]
 PASSED: a.length == "another string" [./String.as:1256]
 PASSED: a.length == "another string" [./String.as:1258]
-FAILED: expected: 0 obtained: 2 [./String.as:1271]
-FAILED: expected: "toString" obtained: prototype,toString [./String.as:1277]
+FAILED: expected: 0 obtained: 1 [./String.as:1271]
+PASSED: a.toString() == "toString" [./String.as:1277]
 PASSED: typeof(String.__proto__) == 'object' [./String.as:1279]
 PASSED: typeof(Object.prototype) == 'object' [./String.as:1280]
 PASSED: String.gotcha == 1 [./String.as:1282]
 PASSED: !String.__proto__.hasOwnProperty("gotcha") [./String.as:1284]
 PASSED: String.__proto__.__proto__.hasOwnProperty("gotcha") [./String.as:1285]
 PASSED: String.__proto__.__proto__ == Object.prototype [./String.as:1286]
-FAILED: expected: "gotcha,toString" obtained: gotcha,prototype,toString [./String.as:1289]
+PASSED: a.toString() == "gotcha,toString" [./String.as:1289]
 PASSED: !String.hasOwnProperty('toString') [./String.as:1298]
 PASSED: !String.hasOwnProperty('valueOf') [./String.as:1299]
 PASSED: String.hasOwnProperty('__proto__') [./String.as:1300]
@@ -353,6 +353,6 @@ PASSED: saved1.value == 'string' [./String.as:1332]
 PASSED: saved2.value == 'another string' [./String.as:1333]
 PASSED: saved2.value.prop != saved3.value.prop [./String.as:1337]
 PASSED: saved2.value !== saved3.value [./String.as:1338]
-#passed: 333
-#failed: 19
+#passed: 335
+#failed: 17
 #total tests run: 352

--- a/tests/tests/swfs/from_gnash/actionscript.all/String-v6/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/String-v6/output.ruffle.txt
@@ -353,15 +353,15 @@ PASSED: a == "123" [./String.as:1254]
 PASSED: a.length == "another string" [./String.as:1256]
 PASSED: a.length == "another string" [./String.as:1258]
 PASSED: a.hasOwnProperty('length') [./String.as:1260]
-FAILED: expected: "toString" obtained: prototype,toString [./String.as:1269]
-FAILED: expected: "toString" obtained: prototype,toString [./String.as:1277]
+PASSED: a.toString() == "toString" [./String.as:1269]
+PASSED: a.toString() == "toString" [./String.as:1277]
 PASSED: typeof(String.__proto__) == 'object' [./String.as:1279]
 PASSED: typeof(Object.prototype) == 'object' [./String.as:1280]
 PASSED: String.gotcha == 1 [./String.as:1282]
 PASSED: !String.__proto__.hasOwnProperty("gotcha") [./String.as:1284]
 PASSED: String.__proto__.__proto__.hasOwnProperty("gotcha") [./String.as:1285]
 PASSED: String.__proto__.__proto__ == Object.prototype [./String.as:1286]
-FAILED: expected: "gotcha,toString" obtained: gotcha,prototype,toString [./String.as:1289]
+PASSED: a.toString() == "gotcha,toString" [./String.as:1289]
 PASSED: typeof(saved1.value) == 'object' [./String.as:1327]
 PASSED: saved1.value == 'string' [./String.as:1328]
 PASSED: saved1.value == 'string' [./String.as:1330]
@@ -372,6 +372,6 @@ PASSED: saved2.value !== saved3.value [./String.as:1338]
 PASSED: a.id == 'wonder1' [./String.as:1352]
 PASSED: a.id == 'wonder2' [./String.as:1354]
 PASSED: a.id == 'wonder3' [./String.as:1356]
-#passed: 358
-#failed: 13
+#passed: 361
+#failed: 10
 #total tests run: 371

--- a/tests/tests/swfs/from_gnash/actionscript.all/String-v7/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/String-v7/output.ruffle.txt
@@ -353,15 +353,15 @@ PASSED: a == "123" [./String.as:1254]
 PASSED: a.length == "another string" [./String.as:1256]
 PASSED: a.length == "another string" [./String.as:1258]
 PASSED: a.hasOwnProperty('length') [./String.as:1260]
-FAILED: expected: "toString" obtained: prototype,toString [./String.as:1269]
-FAILED: expected: "toString" obtained: prototype,toString [./String.as:1277]
+PASSED: a.toString() == "toString" [./String.as:1269]
+PASSED: a.toString() == "toString" [./String.as:1277]
 PASSED: typeof(String.__proto__) == 'object' [./String.as:1279]
 PASSED: typeof(Object.prototype) == 'object' [./String.as:1280]
 PASSED: String.gotcha == 1 [./String.as:1282]
 PASSED: !String.__proto__.hasOwnProperty("gotcha") [./String.as:1284]
 PASSED: String.__proto__.__proto__.hasOwnProperty("gotcha") [./String.as:1285]
 PASSED: String.__proto__.__proto__ == Object.prototype [./String.as:1286]
-FAILED: expected: "gotcha,toString" obtained: gotcha,prototype,toString [./String.as:1289]
+PASSED: a.toString() == "gotcha,toString" [./String.as:1289]
 PASSED: typeof(saved1.value) == 'object' [./String.as:1327]
 PASSED: saved1.value == 'string' [./String.as:1328]
 PASSED: saved1.value == 'string' [./String.as:1330]
@@ -372,6 +372,6 @@ PASSED: saved2.value !== saved3.value [./String.as:1338]
 PASSED: a.id == 'wonder1' [./String.as:1352]
 PASSED: a.id == 'wonder2' [./String.as:1354]
 PASSED: a.id == 'wonder3' [./String.as:1356]
-#passed: 358
-#failed: 13
+#passed: 361
+#failed: 10
 #total tests run: 371

--- a/tests/tests/swfs/from_gnash/actionscript.all/String-v8/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/String-v8/output.ruffle.txt
@@ -353,15 +353,15 @@ PASSED: a == "123" [./String.as:1254]
 PASSED: a.length == "another string" [./String.as:1256]
 PASSED: a.length == "another string" [./String.as:1258]
 PASSED: a.hasOwnProperty('length') [./String.as:1260]
-FAILED: expected: "toString" obtained: prototype,toString [./String.as:1269]
-FAILED: expected: "toString" obtained: prototype,toString [./String.as:1277]
+PASSED: a.toString() == "toString" [./String.as:1269]
+PASSED: a.toString() == "toString" [./String.as:1277]
 PASSED: typeof(String.__proto__) == 'object' [./String.as:1279]
 PASSED: typeof(Object.prototype) == 'object' [./String.as:1280]
 PASSED: String.gotcha == 1 [./String.as:1282]
 PASSED: !String.__proto__.hasOwnProperty("gotcha") [./String.as:1284]
 PASSED: String.__proto__.__proto__.hasOwnProperty("gotcha") [./String.as:1285]
 PASSED: String.__proto__.__proto__ == Object.prototype [./String.as:1286]
-FAILED: expected: "gotcha,toString" obtained: gotcha,prototype,toString [./String.as:1289]
+PASSED: a.toString() == "gotcha,toString" [./String.as:1289]
 PASSED: typeof(saved1.value) == 'object' [./String.as:1327]
 PASSED: saved1.value == 'string' [./String.as:1328]
 PASSED: saved1.value == 'string' [./String.as:1330]
@@ -372,6 +372,6 @@ PASSED: saved2.value !== saved3.value [./String.as:1338]
 PASSED: a.id == 'wonder1' [./String.as:1352]
 PASSED: a.id == 'wonder2' [./String.as:1354]
 PASSED: a.id == 'wonder3' [./String.as:1356]
-#passed: 358
-#failed: 13
+#passed: 361
+#failed: 10
 #total tests run: 371


### PR DESCRIPTION
Split off from https://github.com/ruffle-rs/ruffle/pull/22402.

This fixes some tests and makes Ruffle behave closer to FP.