### PR TITLE
avm1: Do not call toString() when coercing string to string

### DIFF
--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -309,7 +309,10 @@ impl<'gc> Value<'gc> {
                 istr!("0")
             }
             Value::Object(object) => {
-                if let Some(object) = object.as_display_object_no_super() {
+                if let NativeObject::String(string) = object.native() {
+                    // Strings do not have toString() called on them.
+                    string
+                } else if let Some(object) = object.as_display_object_no_super() {
                     // StageObjects are special-cased to return their path.
                     AvmString::new(activation.gc(), object.path())
                 } else {

--- a/tests/tests/swfs/from_gnash/actionscript.all/String-v5/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/String-v5/output.ruffle.txt
@@ -306,8 +306,8 @@ PASSED: !delete Object.prototype.toString [./String.as:1200]
 PASSED: delete Object.prototype.toString [./String.as:1203]
 PASSED: typeof(s.toString) == 'undefined' [./String.as:1204]
 PASSED: g+' ' == "teststring " [./String.as:1217]
-FAILED: expected: "test" obtained: fake [./String.as:1218]
-FAILED: expected: "test" obtained: fake [./String.as:1220]
+PASSED: g.substr(0,4) == "test" [./String.as:1218]
+PASSED: g.substr(0,4) == "test" [./String.as:1220]
 PASSED: o.substr(0,4) == undefined [./String.as:1223]
 PASSED: o.substr(0,4) == "fake" [./String.as:1225]
 PASSED: r == "s:hello" [./String.as:1236]
@@ -353,6 +353,6 @@ PASSED: saved1.value == 'string' [./String.as:1332]
 PASSED: saved2.value == 'another string' [./String.as:1333]
 PASSED: saved2.value.prop != saved3.value.prop [./String.as:1337]
 PASSED: saved2.value !== saved3.value [./String.as:1338]
-#passed: 335
-#failed: 17
+#passed: 337
+#failed: 15
 #total tests run: 352

--- a/tests/tests/swfs/from_gnash/actionscript.all/String-v6/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/String-v6/output.ruffle.txt
@@ -339,8 +339,8 @@ PASSED: !delete Object.prototype.toString [./String.as:1200]
 PASSED: delete Object.prototype.toString [./String.as:1203]
 PASSED: typeof(s.toString) == 'undefined' [./String.as:1204]
 PASSED: g+' ' == "teststring " [./String.as:1217]
-FAILED: expected: "test" obtained: fake [./String.as:1218]
-FAILED: expected: "test" obtained: fake [./String.as:1220]
+PASSED: g.substr(0,4) == "test" [./String.as:1218]
+PASSED: g.substr(0,4) == "test" [./String.as:1220]
 PASSED: o.substr(0,4) == undefined [./String.as:1223]
 PASSED: o.substr(0,4) == "fake" [./String.as:1225]
 PASSED: r == "s:hello" [./String.as:1236]
@@ -372,6 +372,6 @@ PASSED: saved2.value !== saved3.value [./String.as:1338]
 PASSED: a.id == 'wonder1' [./String.as:1352]
 PASSED: a.id == 'wonder2' [./String.as:1354]
 PASSED: a.id == 'wonder3' [./String.as:1356]
-#passed: 361
-#failed: 10
+#passed: 363
+#failed: 8
 #total tests run: 371

--- a/tests/tests/swfs/from_gnash/actionscript.all/String-v7/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/String-v7/output.ruffle.txt
@@ -339,8 +339,8 @@ PASSED: !delete Object.prototype.toString [./String.as:1200]
 PASSED: delete Object.prototype.toString [./String.as:1203]
 PASSED: typeof(s.toString) == 'undefined' [./String.as:1204]
 PASSED: g+' ' == "teststring " [./String.as:1217]
-FAILED: expected: "test" obtained: fake [./String.as:1218]
-FAILED: expected: "test" obtained: fake [./String.as:1220]
+PASSED: g.substr(0,4) == "test" [./String.as:1218]
+PASSED: g.substr(0,4) == "test" [./String.as:1220]
 PASSED: o.substr(0,4) == undefined [./String.as:1223]
 PASSED: o.substr(0,4) == "fake" [./String.as:1225]
 PASSED: r == "s:hello" [./String.as:1236]
@@ -372,6 +372,6 @@ PASSED: saved2.value !== saved3.value [./String.as:1338]
 PASSED: a.id == 'wonder1' [./String.as:1352]
 PASSED: a.id == 'wonder2' [./String.as:1354]
 PASSED: a.id == 'wonder3' [./String.as:1356]
-#passed: 361
-#failed: 10
+#passed: 363
+#failed: 8
 #total tests run: 371

--- a/tests/tests/swfs/from_gnash/actionscript.all/String-v8/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/String-v8/output.ruffle.txt
@@ -339,8 +339,8 @@ PASSED: !delete Object.prototype.toString [./String.as:1200]
 PASSED: delete Object.prototype.toString [./String.as:1203]
 PASSED: typeof(s.toString) == 'undefined' [./String.as:1204]
 PASSED: g+' ' == "teststring " [./String.as:1217]
-FAILED: expected: "test" obtained: fake [./String.as:1218]
-FAILED: expected: "test" obtained: fake [./String.as:1220]
+PASSED: g.substr(0,4) == "test" [./String.as:1218]
+PASSED: g.substr(0,4) == "test" [./String.as:1220]
 PASSED: o.substr(0,4) == undefined [./String.as:1223]
 PASSED: o.substr(0,4) == "fake" [./String.as:1225]
 PASSED: r == "s:hello" [./String.as:1236]
@@ -372,6 +372,6 @@ PASSED: saved2.value !== saved3.value [./String.as:1338]
 PASSED: a.id == 'wonder1' [./String.as:1352]
 PASSED: a.id == 'wonder2' [./String.as:1354]
 PASSED: a.id == 'wonder3' [./String.as:1356]
-#passed: 361
-#failed: 10
+#passed: 363
+#failed: 8
 #total tests run: 371

--- a/tests/tests/swfs/from_gnash/actionscript.all/toString_valueOf-v5/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/toString_valueOf-v5/output.ruffle.txt
@@ -46,8 +46,8 @@ PASSED: str3 == 102 [./toString_valueOf.as:182]
 FAILED: expected: "_level0" obtained:  [./toString_valueOf.as:188]
 FAILED: expected: "[type Function]" obtained:  [./toString_valueOf.as:192]
 FAILED: expected: "false" obtained:  [./toString_valueOf.as:196]
-FAILED: expected: 10 obtained: NaN [./toString_valueOf.as:201]
-FAILED: expected: 2 obtained: NaN [./toString_valueOf.as:202]
+PASSED: parseInt(str1) == 10 [./toString_valueOf.as:201]
+PASSED: parseInt(str2) == 2 [./toString_valueOf.as:202]
 PASSED: typeof(str3) == "string" [./toString_valueOf.as:204]
 PASSED: str3 == "TO_VALUETO_VALUE" [./toString_valueOf.as:206]
 PASSED: typeof(x) == "string" [./toString_valueOf.as:213]
@@ -132,6 +132,6 @@ PASSED: typeof(a) == "string" [./toString_valueOf.as:491]
 PASSED: a == "[type Object]" [./toString_valueOf.as:492]
 PASSED: ts() == "[object Object]" [./toString_valueOf.as:496]
 PASSED: s.toString() == "[object Object]" [./toString_valueOf.as:499]
-#passed: 97
-#failed: 34
+#passed: 99
+#failed: 32
 #total tests run: 131

--- a/tests/tests/swfs/from_gnash/actionscript.all/toString_valueOf-v6/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/toString_valueOf-v6/output.ruffle.txt
@@ -57,8 +57,8 @@ PASSED: str3 == 102 [./toString_valueOf.as:182]
 FAILED: expected: "_level0" obtained:  [./toString_valueOf.as:188]
 FAILED: expected: "[type Function]" obtained:  [./toString_valueOf.as:192]
 FAILED: expected: "false" obtained:  [./toString_valueOf.as:196]
-FAILED: expected: 10 obtained: NaN [./toString_valueOf.as:201]
-FAILED: expected: 2 obtained: NaN [./toString_valueOf.as:202]
+PASSED: parseInt(str1) == 10 [./toString_valueOf.as:201]
+PASSED: parseInt(str2) == 2 [./toString_valueOf.as:202]
 PASSED: typeof(str3) == "string" [./toString_valueOf.as:204]
 PASSED: str3 == "TO_VALUETO_VALUE" [./toString_valueOf.as:206]
 PASSED: typeof(x) == "string" [./toString_valueOf.as:213]
@@ -150,6 +150,6 @@ PASSED: typeof(a) == "string" [./toString_valueOf.as:491]
 PASSED: a == "[type Object]" [./toString_valueOf.as:492]
 PASSED: ts() == "[object Object]" [./toString_valueOf.as:496]
 PASSED: s.toString() == "[object Object]" [./toString_valueOf.as:499]
-#passed: 144
-#failed: 5
+#passed: 146
+#failed: 3
 #total tests run: 149

--- a/tests/tests/swfs/from_gnash/actionscript.all/toString_valueOf-v7/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/toString_valueOf-v7/output.ruffle.txt
@@ -57,8 +57,8 @@ PASSED: str3 == 102 [./toString_valueOf.as:182]
 FAILED: expected: "_level0" obtained: undefined [./toString_valueOf.as:188]
 FAILED: expected: "[type Function]" obtained: undefined [./toString_valueOf.as:192]
 FAILED: expected: "false" obtained: undefined [./toString_valueOf.as:196]
-FAILED: expected: 10 obtained: NaN [./toString_valueOf.as:201]
-FAILED: expected: 2 obtained: NaN [./toString_valueOf.as:202]
+PASSED: parseInt(str1) == 10 [./toString_valueOf.as:201]
+PASSED: parseInt(str2) == 2 [./toString_valueOf.as:202]
 PASSED: typeof(str3) == "string" [./toString_valueOf.as:204]
 PASSED: str3 == "TO_VALUETO_VALUE" [./toString_valueOf.as:206]
 PASSED: typeof(x) == "string" [./toString_valueOf.as:213]
@@ -150,6 +150,6 @@ PASSED: typeof(a) == "string" [./toString_valueOf.as:491]
 PASSED: a == "[type Object]" [./toString_valueOf.as:492]
 PASSED: ts() == "[object Object]" [./toString_valueOf.as:496]
 PASSED: s.toString() == "[object Object]" [./toString_valueOf.as:499]
-#passed: 144
-#failed: 5
+#passed: 146
+#failed: 3
 #total tests run: 149

--- a/tests/tests/swfs/from_gnash/actionscript.all/toString_valueOf-v8/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/toString_valueOf-v8/output.ruffle.txt
@@ -57,8 +57,8 @@ PASSED: str3 == 102 [./toString_valueOf.as:182]
 FAILED: expected: "_level0" obtained: undefined [./toString_valueOf.as:188]
 FAILED: expected: "[type Function]" obtained: undefined [./toString_valueOf.as:192]
 FAILED: expected: "false" obtained: undefined [./toString_valueOf.as:196]
-FAILED: expected: 10 obtained: NaN [./toString_valueOf.as:201]
-FAILED: expected: 2 obtained: NaN [./toString_valueOf.as:202]
+PASSED: parseInt(str1) == 10 [./toString_valueOf.as:201]
+PASSED: parseInt(str2) == 2 [./toString_valueOf.as:202]
 PASSED: typeof(str3) == "string" [./toString_valueOf.as:204]
 PASSED: str3 == "TO_VALUETO_VALUE" [./toString_valueOf.as:206]
 PASSED: typeof(x) == "string" [./toString_valueOf.as:213]
@@ -150,6 +150,6 @@ PASSED: typeof(a) == "string" [./toString_valueOf.as:491]
 PASSED: a == "[type Object]" [./toString_valueOf.as:492]
 PASSED: ts() == "[object Object]" [./toString_valueOf.as:496]
 PASSED: s.toString() == "[object Object]" [./toString_valueOf.as:499]
-#passed: 144
-#failed: 5
+#passed: 146
+#failed: 3
 #total tests run: 149


### PR DESCRIPTION
Flash doesn't call toString() when a string needs to be coerced to a string.