### PR TITLE
core: Enforce non-zero dimensions for creating empty textures

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -24,6 +24,7 @@ use ruffle_render::transform::{Transform, TransformStack};
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::fmt::Debug;
 use std::hash::Hash;
+use std::num::NonZero;
 use std::sync::Arc;
 use swf::{ColorTransform, Fixed8};
 
@@ -162,15 +163,16 @@ impl BitmapCache {
         } else {
             actual_width < 2880 && actual_height < 2880
         };
+
         if renderer.is_offscreen_supported()
-            && actual_width > 0
-            && actual_height > 0
+            && let Some(actual_width) = NonZero::new(actual_width)
+            && let Some(actual_height) = NonZero::new(actual_height)
             && acceptable_size
         {
             let handle = renderer.create_empty_texture(actual_width, actual_height);
             self.bitmap = handle.ok().map(|handle| BitmapInfo {
-                width: actual_width,
-                height: actual_height,
+                width: actual_width.get(),
+                height: actual_height.get(),
                 handle,
             });
         } else {

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -19,6 +19,7 @@ use ruffle_render::transform::Transform;
 use ruffle_web_common::{JsError, JsResult};
 use std::any::Any;
 use std::borrow::Cow;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use swf::{BlendMode, Color, ColorTransform, Point, Twips};
 use wasm_bindgen::{Clamped, JsCast, JsValue};
@@ -585,8 +586,13 @@ impl RenderBackend for WebCanvasRenderBackend {
         Err(Error::Unimplemented("Sync handle resolution".into()))
     }
 
-    fn create_empty_texture(&mut self, width: u32, height: u32) -> Result<BitmapHandle, Error> {
-        let bitmap_data = BitmapData::empty(width, height).map_err(Error::JavascriptError)?;
+    fn create_empty_texture(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+    ) -> Result<BitmapHandle, Error> {
+        let bitmap_data =
+            BitmapData::empty(width.get(), height.get()).map_err(Error::JavascriptError)?;
         Ok(BitmapHandle(Arc::new(bitmap_data)))
     }
 }

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -13,6 +13,7 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt::Debug;
+use std::num::NonZeroU32;
 use std::rc::Rc;
 use std::sync::Arc;
 use swf::{Color, Rectangle, Twips};
@@ -76,7 +77,11 @@ pub trait RenderBackend: Any {
         cache_entries: Vec<BitmapCacheEntry>,
     );
 
-    fn create_empty_texture(&mut self, width: u32, height: u32) -> Result<BitmapHandle, Error>;
+    fn create_empty_texture(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+    ) -> Result<BitmapHandle, Error>;
 
     fn register_bitmap(&mut self, bitmap: Bitmap<'_>) -> Result<BitmapHandle, Error>;
     fn update_texture(

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use crate::backend::{
@@ -135,7 +136,11 @@ impl RenderBackend for NullRenderer {
         ))
     }
 
-    fn create_empty_texture(&mut self, _width: u32, _height: u32) -> Result<BitmapHandle, Error> {
+    fn create_empty_texture(
+        &mut self,
+        _width: NonZeroU32,
+        _height: NonZeroU32,
+    ) -> Result<BitmapHandle, Error> {
         Ok(BitmapHandle(Arc::new(NullBitmapHandle)))
     }
 }

--- a/render/src/error.rs
+++ b/render/src/error.rs
@@ -9,9 +9,6 @@ pub enum Error {
     #[error("Bitmap texture is larger than the rendering device supports")]
     TooLarge,
 
-    #[error("Bitmap texture has a size of 0 and is invalid")]
-    InvalidSize,
-
     #[error("Unknown bitmap format")]
     UnknownType,
 

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -23,6 +23,7 @@ use ruffle_render::transform::Transform;
 use ruffle_web_common::{JsError, JsResult};
 use std::any::Any;
 use std::borrow::Cow;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use swf::{BlendMode, Color, Twips};
 use thiserror::Error;
@@ -1222,8 +1223,8 @@ impl RenderBackend for WebGlRenderBackend {
 
     fn create_empty_texture(
         &mut self,
-        width: u32,
-        height: u32,
+        width: NonZeroU32,
+        height: NonZeroU32,
     ) -> Result<BitmapHandle, BitmapError> {
         let texture = self
             .gl
@@ -1243,8 +1244,8 @@ impl RenderBackend for WebGlRenderBackend {
 
         Ok(BitmapHandle(Arc::new(RegistryData {
             gl: self.gl.clone(),
-            width,
-            height,
+            width: width.get(),
+            height: height.get(),
             texture,
         })))
     }

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -32,6 +32,7 @@ use ruffle_render::tessellator::ShapeTessellator;
 use std::any::Any;
 use std::borrow::Cow;
 use std::cell::Cell;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use swf::Color;
 use tracing::instrument;
@@ -1011,12 +1012,12 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
 
     fn create_empty_texture(
         &mut self,
-        width: u32,
-        height: u32,
+        width: NonZeroU32,
+        height: NonZeroU32,
     ) -> Result<BitmapHandle, BitmapError> {
-        if width == 0 || height == 0 {
-            return Err(BitmapError::InvalidSize);
-        }
+        let width = width.get();
+        let height = height.get();
+
         if width > self.descriptors.limits.max_texture_dimension_2d
             || height > self.descriptors.limits.max_texture_dimension_2d
         {


### PR DESCRIPTION
Requires #22610 because of let chains.

Turns out that the enum variant is redundant, because there was already a 0 check in the only place that calls create_empty_texture.