### PR TITLE
chore: Drop deprecated `lodash.isequal` indirect npm dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1871,22 +1871,22 @@
             }
         },
         "node_modules/@jest/expect-utils": {
-            "version": "30.0.2",
-            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.2.tgz",
-            "integrity": "sha512-FHF2YdtFBUQOo0/qdgt+6UdBFcNPF/TkVzcc+4vvf8uaBzUlONytGBeeudufIHHW1khRfM1sBbRT1VCK7n/0dQ==",
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
+            "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/get-type": "30.0.1"
+                "@jest/get-type": "30.1.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/@jest/get-type": {
-            "version": "30.0.1",
-            "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
-            "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+            "version": "30.1.0",
+            "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+            "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1908,9 +1908,9 @@
             }
         },
         "node_modules/@jest/schemas": {
-            "version": "30.0.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.1.tgz",
-            "integrity": "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==",
+            "version": "30.0.5",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+            "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1921,14 +1921,14 @@
             }
         },
         "node_modules/@jest/types": {
-            "version": "30.0.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.1.tgz",
-            "integrity": "sha512-HGwoYRVF0QSKJu1ZQX0o5ZrUrrhj0aOOFA8hXrumD7SIzjouevhawbTjmXdwOmURdGluU9DM/XvGm3NyFoiQjw==",
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+            "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/pattern": "30.0.1",
-                "@jest/schemas": "30.0.1",
+                "@jest/schemas": "30.0.5",
                 "@types/istanbul-lib-coverage": "^2.0.6",
                 "@types/istanbul-reports": "^3.0.4",
                 "@types/node": "*",
@@ -2675,9 +2675,9 @@
             "license": "MIT"
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.34.36",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.36.tgz",
-            "integrity": "sha512-JFHFhF6MqqRE49JDAGX/EPlHwxIukrKMhNwlMoB/wIJBkvu3+ciO335yDYPP3soI01FkhVXWnyNPKEl+EsC4Zw==",
+            "version": "0.34.46",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
+            "integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3255,9 +3255,9 @@
             }
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.33",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+            "version": "17.0.35",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+            "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6918,6 +6918,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -8014,37 +8024,37 @@
             }
         },
         "node_modules/expect": {
-            "version": "30.0.2",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.2.tgz",
-            "integrity": "sha512-YN9Mgv2mtTWXVmifQq3QT+ixCL/uLuLJw+fdp8MOjKqu8K3XQh3o5aulMM1tn+O2DdrWNxLZTeJsCY/VofUA0A==",
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
+            "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/expect-utils": "30.0.2",
-                "@jest/get-type": "30.0.1",
-                "jest-matcher-utils": "30.0.2",
-                "jest-message-util": "30.0.2",
-                "jest-mock": "30.0.2",
-                "jest-util": "30.0.2"
+                "@jest/expect-utils": "30.2.0",
+                "@jest/get-type": "30.1.0",
+                "jest-matcher-utils": "30.2.0",
+                "jest-message-util": "30.2.0",
+                "jest-mock": "30.2.0",
+                "jest-util": "30.2.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/expect-webdriverio": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-5.3.4.tgz",
-            "integrity": "sha512-FU+96C0nqeYTXrJcGLUDB6hPKKaSm1/tVHjFDE4EDHGCYvajAHCC2MBQJ5MomjCmp6lGMz36lDHeZj52LHylyA==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-5.6.1.tgz",
+            "integrity": "sha512-gQHqfI6SmtYBIkTeMizpHThdpXh6ej2Hk68oKZneFM6iu99ZGXvOPnmhd8VDus3xOWhVDDdf4sLsMV2/o+X6Yg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/snapshot": "^3.2.4",
-                "expect": "^30.0.0",
-                "jest-matcher-utils": "^30.0.0",
-                "lodash.isequal": "^4.5.0"
+                "@vitest/snapshot": "^4.0.16",
+                "deep-eql": "^5.0.2",
+                "expect": "^30.2.0",
+                "jest-matcher-utils": "^30.2.0"
             },
             "engines": {
-                "node": ">=18 || >=20 || >=22"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "@wdio/globals": "^9.0.0",
@@ -8064,27 +8074,27 @@
             }
         },
         "node_modules/expect-webdriverio/node_modules/@vitest/pretty-format": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-            "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
+            "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tinyrainbow": "^2.0.0"
+                "tinyrainbow": "^3.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/expect-webdriverio/node_modules/@vitest/snapshot": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-            "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
+            "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.2.4",
-                "magic-string": "^0.30.17",
+                "@vitest/pretty-format": "4.0.16",
+                "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -8099,9 +8109,9 @@
             "license": "MIT"
         },
         "node_modules/expect-webdriverio/node_modules/tinyrainbow": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+            "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9936,16 +9946,16 @@
             }
         },
         "node_modules/jest-diff": {
-            "version": "30.0.2",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.2.tgz",
-            "integrity": "sha512-2UjrNvDJDn/oHFpPrUTVmvYYDNeNtw2DlY3er8bI6vJJb9Fb35ycp/jFLd5RdV59tJ8ekVXX3o/nwPcscgXZJQ==",
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+            "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/diff-sequences": "30.0.1",
-                "@jest/get-type": "30.0.1",
+                "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
-                "pretty-format": "30.0.2"
+                "pretty-format": "30.2.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -9998,16 +10008,16 @@
             }
         },
         "node_modules/jest-matcher-utils": {
-            "version": "30.0.2",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.2.tgz",
-            "integrity": "sha512-1FKwgJYECR8IT93KMKmjKHSLyru0DqguThov/aWpFccC0wbiXGOxYEu7SScderBD7ruDOpl7lc5NG6w3oxKfaA==",
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+            "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/get-type": "30.0.1",
+                "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
-                "jest-diff": "30.0.2",
-                "pretty-format": "30.0.2"
+                "jest-diff": "30.2.0",
+                "pretty-format": "30.2.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -10060,19 +10070,19 @@
             }
         },
         "node_modules/jest-message-util": {
-            "version": "30.0.2",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.2.tgz",
-            "integrity": "sha512-vXywcxmr0SsKXF/bAD7t7nMamRvPuJkras00gqYeB1V0WllxZrbZ0paRr3XqpFU2sYYjD0qAaG2fRyn/CGZ0aw==",
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+            "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.0.1",
+                "@jest/types": "30.2.0",
                 "@types/stack-utils": "^2.0.3",
                 "chalk": "^4.1.2",
                 "graceful-fs": "^4.2.11",
                 "micromatch": "^4.0.8",
-                "pretty-format": "30.0.2",
+                "pretty-format": "30.2.0",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.6"
             },
@@ -10127,15 +10137,15 @@
             }
         },
         "node_modules/jest-mock": {
-            "version": "30.0.2",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.2.tgz",
-            "integrity": "sha512-PnZOHmqup/9cT/y+pXIVbbi8ID6U1XHRmbvR7MvUy4SLqhCbwpkmXhLbsWbGewHrV5x/1bF7YDjs+x24/QSvFA==",
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+            "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.0.1",
+                "@jest/types": "30.2.0",
                 "@types/node": "*",
-                "jest-util": "30.0.2"
+                "jest-util": "30.2.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -10152,13 +10162,13 @@
             }
         },
         "node_modules/jest-util": {
-            "version": "30.0.2",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.2.tgz",
-            "integrity": "sha512-8IyqfKS4MqprBuUpZNlFB5l+WFehc8bfCe1HSZFHzft2mOuND8Cvi9r1musli+u6F3TqanCZ/Ik4H4pXUolZIg==",
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+            "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.0.1",
+                "@jest/types": "30.2.0",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
                 "ci-info": "^4.2.0",
@@ -10667,14 +10677,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-            "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
             "dev": true,
             "license": "MIT"
         },
@@ -12745,13 +12747,13 @@
             }
         },
         "node_modules/pretty-format": {
-            "version": "30.0.2",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
-            "integrity": "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==",
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+            "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/schemas": "30.0.1",
+                "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
                 "react-is": "^18.3.1"
             },


### PR DESCRIPTION
By running `npm update expect-webdriverio`, bumping to a version that replaced it with `deep-eql`.