### PR TITLE
wgpu: Unify wgpu instance creation

### DIFF
--- a/desktop/src/gui/dialogs/preferences_dialog.rs
+++ b/desktop/src/gui/dialogs/preferences_dialog.rs
@@ -4,6 +4,7 @@ use crate::log::FilenamePattern;
 use crate::preferences::{GlobalPreferences, storage::StorageBackend};
 use cpal::traits::{DeviceTrait, HostTrait};
 use egui::{Align2, Button, Checkbox, ComboBox, DragValue, Grid, Ui, Widget, Window};
+use ruffle_render_wgpu::backend::create_wgpu_instance;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use std::borrow::Cow;
 use unic_langid::LanguageIdentifier;
@@ -712,11 +713,7 @@ fn find_available_graphics_backends() -> wgpu::Backends {
 
     // We have to make a new instance here, as the one created for the entire application may not have
     // all backends enabled
-    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::all(),
-        flags: wgpu::InstanceFlags::default().with_env(),
-        ..Default::default()
-    });
+    let instance = create_wgpu_instance(wgpu::Backends::all(), wgpu::BackendOptions::default());
 
     available_backends |= backend_availability(&instance, wgpu::Backends::VULKAN);
     available_backends |= backend_availability(&instance, wgpu::Backends::GL);

--- a/exporter/src/exporter.rs
+++ b/exporter/src/exporter.rs
@@ -8,12 +8,13 @@ use ruffle_core::Player;
 use ruffle_core::PlayerBuilder;
 use ruffle_core::limits::ExecutionLimit;
 use ruffle_core::tag_utils::movie_from_path;
-use ruffle_render_wgpu::backend::WgpuRenderBackend;
+use ruffle_render_wgpu::backend::{
+    WgpuRenderBackend, create_wgpu_instance, request_adapter_and_device,
+};
 use ruffle_render_wgpu::descriptors::Descriptors;
 
 use anyhow::Result;
 use anyhow::anyhow;
-use ruffle_render_wgpu::backend::request_adapter_and_device;
 use ruffle_render_wgpu::target::TextureTarget;
 use ruffle_render_wgpu::wgpu;
 
@@ -32,10 +33,7 @@ pub struct Exporter {
 
 impl Exporter {
     pub fn new(opt: &Opt) -> Result<Self> {
-        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
-            backends: opt.graphics.into(),
-            ..Default::default()
-        });
+        let instance = create_wgpu_instance(opt.graphics.into(), wgpu::BackendOptions::default());
         let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
             opt.graphics.into(),
             &instance,

--- a/tests/tests/environment.rs
+++ b/tests/tests/environment.rs
@@ -27,7 +27,9 @@ impl Environment for NativeEnvironment {
 #[cfg(feature = "imgtests")]
 mod renderer {
     use image::RgbaImage;
-    use ruffle_render_wgpu::backend::{WgpuRenderBackend, request_adapter_and_device};
+    use ruffle_render_wgpu::backend::{
+        WgpuRenderBackend, create_wgpu_instance, request_adapter_and_device,
+    };
     use ruffle_render_wgpu::descriptors::Descriptors;
     use ruffle_render_wgpu::target::TextureTarget;
     use ruffle_render_wgpu::wgpu;
@@ -95,7 +97,7 @@ mod renderer {
     */
 
     fn create_wgpu_device() -> Option<(wgpu::Instance, wgpu::Adapter, wgpu::Device, wgpu::Queue)> {
-        let instance = wgpu::Instance::new(&Default::default());
+        let instance = create_wgpu_instance(wgpu::Backends::all(), wgpu::BackendOptions::default());
         futures::executor::block_on(request_adapter_and_device(
             wgpu::Backends::all(),
             &instance,


### PR DESCRIPTION
This also disables wgpu indirect call validation (but for real this time) (As reported on Discord, #22648 didn't fix all the places)

This also has the affect that .with_env() is now applied to InstanceFlags for every place we create an instance, which I think is desirable.