### PR TITLE
desktop: Change macOS sandbox entitlement to allow file saving

### DIFF
--- a/desktop/assets/macOSEntitlements.plist
+++ b/desktop/assets/macOSEntitlements.plist
@@ -3,7 +3,7 @@
     <dict>
         <key>com.apple.security.app-sandbox</key>
         <true/>
-        <key>com.apple.security.files.user-selected.read-only</key>
+        <key>com.apple.security.files.user-selected.read-write</key>
         <true/>
         <key>com.apple.security.network.client</key>
         <true/>


### PR DESCRIPTION
The read-only entitlement only permits opening files via NSOpenPanel. The read-write entitlement additionally permits saving files via NSSavePanel, which is required for Flash content using FileReference.save().

Without read-write, macOS silently returns nil from [NSSavePanel savePanel] in sandboxed apps, causing a panic in the objc2-app-kit bindings.

See: https://developer.apple.com/forums/thread/104913

Fixes #22771
Fixes #22753
Fixes #22215
Fixes #21756
Fixes #21162
Fixes #20629
Fixes #20508
Fixes #19827
Fixes #19604
Fixes #19515
Fixes #19074
Fixes #17844
Fixes https://github.com/ruffle-rs/ruffle/issues/22892
Fixes https://github.com/ruffle-rs/ruffle/issues/22985

NOTE: This is currently untested, I am working on reproducing the panic and verifying that this is actually the cause, but all the evidence seems to suggest that it is.