### PR TITLE
chore: Bump wasm-bindgen to 0.2.108, ...-futures to 0.4.58, and js-sys and web-sys to 0.3.85

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -388,7 +388,7 @@ jobs:
       # Be sure to update in test_web.yml, Cargo.toml, web/docker/Dockerfile,
       # and web/README.md as well.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.101
+        run: cargo install wasm-bindgen-cli --version 0.2.108
 
       # Keep the version number in sync in all workflows,
       # and in the extension builder Dockerfile!

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -30,7 +30,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.101
+        run: cargo install wasm-bindgen-cli --version 0.2.108
 
       # Keep the version number in sync in all workflows,
       # and in the extension builder Dockerfile!

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -63,7 +63,7 @@ jobs:
       # Be sure to update in release_nightly.yml, Cargo.toml, web/docker/Dockerfile,
       # and web/README.md as well.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.101
+        run: cargo install wasm-bindgen-cli --version 0.2.108
 
       # Keep the version number in sync in all workflows,
       # and in the extension builder Dockerfile!
@@ -128,7 +128,7 @@ jobs:
       # Be sure to update in release_nightly.yml, Cargo.toml, web/docker/Dockerfile,
       # and web/README.md as well.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.101
+        run: cargo install wasm-bindgen-cli --version 0.2.108
 
       # No real need to install wasm-opt here
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -6241,9 +6241,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6253,26 +6253,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.51"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -6281,9 +6268,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6291,22 +6278,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -6441,9 +6428,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,8 @@ enum-map = "2.7.3"
 flate2 = "1.1.8"
 futures = "0.3.31"
 image = { version = "0.25.9", default-features = false }
-js-sys = "0.3.78"
-web-sys = "0.3.78"
+js-sys = "0.3.85"
+web-sys = "0.3.85"
 log = "0.4"
 num-derive = "0.4.2"
 num-traits = "0.2.19"
@@ -78,7 +78,7 @@ url = "2.5.8"
 quick-xml = "0.37.5"
 regress = { git = "https://github.com/ruffle-rs/regras3", rev = "5fcb02513c5ab4e00df4346459f5a8d0521d8fed" }
 # Make sure to match wasm-bindgen-cli version to this everywhere.
-wasm-bindgen = "=0.2.101"
+wasm-bindgen = "=0.2.108"
 walkdir = "2.5.0"
 tokio = "1.49.0"
 # Switching from the `async-std` to the `tokio` runtime, which we depend on anyway.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -74,7 +74,7 @@ tracy-client = { version = "0.18.2", optional = true, default-features = false }
 workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies.wasm-bindgen-futures]
-version = "0.4.51"
+version = "0.4.58"
 
 [features]
 default = []

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -46,7 +46,7 @@ ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
 ruffle_video_external = { path = "../video/external", features = ["webcodecs"] }
 url = { workspace = true }
 wasm-bindgen = { workspace = true }
-wasm-bindgen-futures = "0.4.51"
+wasm-bindgen-futures = "0.4.58"
 serde-wasm-bindgen = "0.6.5"
 chrono = { workspace = true, features = ["wasmbind", "clock"] }
 serde = { workspace = true, features = ["derive"] }

--- a/web/README.md
+++ b/web/README.md
@@ -65,7 +65,7 @@ Note that npm 7 or newer is required. It should come bundled with Node.js 15 or 
 
 <!-- Be sure to also update the wasm-bindgen-cli version in `.github/workflows/*.yml` and `web/Cargo.toml`. -->
 
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.101`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.108`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --ta
 ENV PATH="/root/.cargo/bin:$PATH"
 # wasm-bindgen-cli version must match wasm-bindgen crate version.
 # Be sure to update in test_web.yml, release_nightly.yml, Cargo.toml, and web/README.md as well.
-RUN cargo install wasm-bindgen-cli --version 0.2.101
+RUN cargo install wasm-bindgen-cli --version 0.2.108
 
 # Building Ruffle:
 COPY . ruffle


### PR DESCRIPTION
Hopefully the non-reproducibility issues that made us revert https://github.com/ruffle-rs/ruffle/pull/21949 (https://github.com/ruffle-rs/ruffle/pull/21985) are now solved:
 - https://github.com/wasm-bindgen/wasm-bindgen/issues/4737
 - https://github.com/wasm-bindgen/wasm-bindgen/pull/4738
 - https://github.com/wasm-bindgen/wasm-bindgen/pull/4892