### PR TITLE
core: Deduplicate file dialog filter logic between web and desktop

### DIFF
--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -47,6 +47,22 @@ pub struct FileFilter {
     pub mac_type: Option<String>,
 }
 
+impl FileFilter {
+    /// Returns extensions suitable for file dialogs.
+    /// When `is_mac` is true, uses `mac_type` if available; otherwise uses `extensions` with wildcards stripped.
+    /// `is_mac` should be true when the user uses a Mac.
+    pub fn extensions_for_dialog(&self, is_mac: bool) -> Vec<&str> {
+        if is_mac && let Some(mac_type) = &self.mac_type {
+            return mac_type.split(';').collect();
+        }
+
+        self.extensions
+            .split(';')
+            .map(|x| x.trim_start_matches("*."))
+            .collect()
+    }
+}
+
 /// A result of a file selection
 pub trait FileDialogResult: Any {
     /// Was the file selection canceled by the user

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -354,20 +354,10 @@ impl UiBackend for DesktopUiBackend {
     fn display_file_open_dialog(&mut self, filters: Vec<FileFilter>) -> Option<DialogResultFuture> {
         let mut dialog = AsyncFileDialog::new();
 
-        for filter in filters {
-            if cfg!(target_os = "macos")
-                && let Some(mac_type) = filter.mac_type
-            {
-                let extensions: Vec<&str> = mac_type.split(';').collect();
-                dialog = dialog.add_filter(&filter.description, &extensions);
-            } else {
-                let extensions: Vec<&str> = filter
-                    .extensions
-                    .split(';')
-                    .map(|x| x.trim_start_matches("*."))
-                    .collect();
-                dialog = dialog.add_filter(&filter.description, &extensions);
-            }
+        for filter in &filters {
+            let extensions = filter.extensions_for_dialog(cfg!(target_os = "macos"));
+
+            dialog = dialog.add_filter(&filter.description, &extensions);
         }
 
         let result = self.file_picker.show_dialog(dialog, |d| d.pick_file())?;


### PR DESCRIPTION
Just a factoring out of some common logic. Also moves the platform detection outside of the filter for loop. 
No functional change intended.