### PR TITLE
web: fix Chrome 144 headless WebGL test failures

### DIFF
--- a/web/packages/selfhosted/wdio.conf.ts
+++ b/web/packages/selfhosted/wdio.conf.ts
@@ -18,7 +18,7 @@ let setupLogging = async () => {};
 let reportLogging = async () => {};
 
 if (chrome) {
-    const args = ["--disable-gpu"];
+    const args = ["--disable-gpu", "--enable-unsafe-swiftshader"];
     if (headless) {
         args.push("--headless");
     }


### PR DESCRIPTION
SwiftShader is a CPU-based graphics implementation that Chrome uses as a
fallback when no GPU is available. Chrome has been deprecating automatic
SwiftShader fallback for WebGL due to security concerns, requiring
explicit opt-in since Chrome 139.

However, tests only started failing with Chrome 144. This is likely due
to Finch gradually rolling out the change, with Chrome 144 making it the
hardcoded default.

See: https://chromestatus.com/feature/5166674414927872
See: https://issues.chromium.org/issues/40277080
See: https://chromium.googlesource.com/chromium/src/+/1b6cf4c00bf10de746f25a045edc6b57601e2bd7