### PR TITLE
avm1: Trace uncaught errors properly

### DIFF
--- a/tests/tests/swfs/avm1/uncaught_exception/output.txt
+++ b/tests/tests/swfs/avm1/uncaught_exception/output.txt
@@ -1,1 +1,1 @@
-Oh no!
+Warning: Uncaught exception, Oh no!

--- a/tests/tests/swfs/avm1/uncaught_exception_bubbled/output.txt
+++ b/tests/tests/swfs/avm1/uncaught_exception_bubbled/output.txt
@@ -1,1 +1,1 @@
-Oh no!
+Warning: Uncaught exception, Oh no!


### PR DESCRIPTION
This makes sure Ruffle traces uncaught errors the same way as Flash. This makes it possible to use Flash's output in Ruffle tests.