### PR TITLE
chore: Update hashbrown to 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,7 @@ version = "0.5.3"
 source = "git+https://github.com/kyren/gc-arena.git?rev=75671ae03f53718357b741ed4027560f14e90836#75671ae03f53718357b741ed4027560f14e90836"
 dependencies = [
  "gc-arena-derive",
+ "hashbrown 0.16.1",
  "indexmap",
  "slotmap",
  "smallvec",
@@ -2356,16 +2357,6 @@ dependencies = [
  "crunchy",
  "num-traits",
  "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -4480,7 +4471,7 @@ version = "0.1.0"
 dependencies = [
  "fnv",
  "gc-arena",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "quick-xml",
  "regress",
  "ruffle_macros",
@@ -4518,7 +4509,7 @@ dependencies = [
  "fnv",
  "futures",
  "gc-arena",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "id3",
  "image",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ rayon = "1.11.0"
 sha2 = "0.10.9"
 indexmap = "2.13.0"
 fnv = "1.0.7"
-hashbrown = { version = "0.14.5", features = ["raw"] }
+hashbrown = "0.16.1"
 fluent-templates = "0.13.2"
 lzma-rs = "0.3.0"
 tempfile = "3.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ egui = "0.33.3"
 clap = { version = "4.5.57", features = ["derive"] }
 cpal = "0.16.0"
 anyhow = "1.0"
-gc-arena = { git = "https://github.com/kyren/gc-arena.git", rev = "75671ae03f53718357b741ed4027560f14e90836", features = ["indexmap", "smallvec", "slotmap"] }
+gc-arena = { git = "https://github.com/kyren/gc-arena.git", rev = "75671ae03f53718357b741ed4027560f14e90836", features = ["hashbrown", "indexmap", "smallvec", "slotmap"] }
 slotmap = "1.1.1"
 async-channel = "2.5.0"
 bitflags = "2.10.0"

--- a/core/src/avm2/dynamic_map.rs
+++ b/core/src/avm2/dynamic_map.rs
@@ -1,10 +1,11 @@
+use super::{Object, string::AvmString};
 use fnv::FnvBuildHasher;
 use gc_arena::Collect;
-use hashbrown::hash_map::Entry;
-use hashbrown::raw::RawTable;
-use std::{cell::Cell, hash::Hash};
-
-use super::{Object, string::AvmString};
+use gc_arena::collect::Trace;
+use hashbrown::HashTable;
+use std::cell::Cell;
+use std::fmt::{self, Debug};
+use std::hash::{BuildHasher, Hash};
 
 #[derive(Debug, Collect, Copy, Clone)]
 #[collect(no_drop)]
@@ -26,99 +27,145 @@ pub enum DynamicKey<'gc> {
 }
 
 /// A HashMap designed for dynamic properties on an object.
-#[derive(Debug, Clone)]
+///
+/// Uses `HashTable` directly to expose stable bucket indices, which are
+/// needed for correct iteration when entries are added or removed mid-iteration.
+#[derive(Clone)]
 pub struct DynamicMap<K, V> {
-    values: hashbrown::HashMap<K, DynamicProperty<V>, FnvBuildHasher>,
-    // The last index that was given back to flash
+    table: HashTable<(K, DynamicProperty<V>)>,
+    hasher: FnvBuildHasher,
     public_index: Cell<usize>,
-    // The actual index that represents where an item is in the HashMap
+    // The actual bucket index that represents where an item is in the table
     real_index: Cell<usize>,
 }
 
-// `gc-arena` doesn't provide a `Collect` impl for the version of `hashbrown` we use.
 unsafe impl<'gc, K: Collect<'gc>, V: Collect<'gc>> Collect<'gc> for DynamicMap<K, V> {
     const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
 
-    fn trace<T: gc_arena::collect::Trace<'gc>>(&self, cc: &mut T) {
-        for (k, v) in &self.values {
-            cc.trace(k);
-            cc.trace(v);
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
+        match (K::NEEDS_TRACE, V::NEEDS_TRACE) {
+            (true, true) => self.table.iter().for_each(|(k, v)| {
+                cc.trace(k);
+                cc.trace(&v.value);
+            }),
+            (true, false) => self.table.iter().for_each(|(k, _)| cc.trace(k)),
+            (false, true) => self.table.iter().for_each(|(_, v)| cc.trace(&v.value)),
+            (false, false) => {}
         }
     }
 }
 
-impl<K: Eq + PartialEq + Hash, V> Default for DynamicMap<K, V> {
+impl<K: Debug, V: Debug> Debug for DynamicMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DynamicMap")
+            .field("table", &self.table)
+            .field("public_index", &self.public_index)
+            .field("real_index", &self.real_index)
+            .finish()
+    }
+}
+
+impl<K: Eq + Hash, V> Default for DynamicMap<K, V> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<K: Eq + PartialEq + Hash, V> DynamicMap<K, V> {
+impl<K: Eq + Hash, V> DynamicMap<K, V> {
+    fn hash_key(&self, key: &K) -> u64 {
+        self.hasher.hash_one(key)
+    }
+
     pub fn new() -> Self {
         Self {
-            values: hashbrown::HashMap::default(),
+            table: HashTable::new(),
+            hasher: FnvBuildHasher::default(),
             public_index: Cell::new(0),
             real_index: Cell::new(0),
         }
     }
 
-    pub fn as_hashmap(&self) -> &hashbrown::HashMap<K, DynamicProperty<V>, FnvBuildHasher> {
-        &self.values
+    pub fn get(&self, key: &K) -> Option<&DynamicProperty<V>> {
+        let hash = self.hash_key(key);
+
+        self.table.find(hash, |(k, _)| k == key).map(|(_, v)| v)
     }
 
-    pub fn entry(&mut self, key: K) -> Entry<'_, K, DynamicProperty<V>, FnvBuildHasher> {
-        self.values.entry(key)
+    pub fn contains_key(&self, key: &K) -> bool {
+        let hash = self.hash_key(key);
+
+        self.table.find(hash, |(k, _)| k == key).is_some()
     }
 
-    /// Gets the real index from the current public index, returns false if real index is out of bounds
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &DynamicProperty<V>)> {
+        self.table.iter().map(|(k, v)| (k, v))
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.table.iter().map(|(k, _)| k)
+    }
+
+    pub fn len(&self) -> usize {
+        self.table.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
+    /// Gets the bucket index from the current public index.
+    /// Returns `None` if the index is out of bounds.
     fn public_to_real_index(&self, index: usize) -> Option<usize> {
         let mut count = 0;
-        let raw = self.raw();
-        if raw.is_empty() {
-            return None;
-        }
-        for i in 0..raw.buckets() {
-            unsafe {
-                // SAFETY: It is impossible for i to be greater than the total buckets.
-                if raw.is_bucket_full(i) {
-                    // SAFETY: We know that this bucket is safe to access because we just checked
-                    // that it is full.
-                    let bucket = raw.bucket(i).as_ref();
-                    if bucket.1.enumerable {
-                        count += 1;
-                        if count >= index {
-                            return Some(i);
-                        }
+        let num_buckets = self.table.num_buckets();
+
+        for i in 0..num_buckets {
+            if let Some((_, v)) = self.table.get_bucket(i) {
+                if v.enumerable {
+                    count += 1;
+
+                    if count >= index {
+                        return Some(i);
                     }
                 }
             }
         }
+
         None
     }
 
-    fn raw(&self) -> &RawTable<(K, DynamicProperty<V>)> {
-        self.values.raw_table()
-    }
-
     pub fn insert(&mut self, key: K, new_value: V) {
-        match self.entry(key) {
-            Entry::Occupied(mut occupied) => {
+        let hash = self.hash_key(&key);
+
+        match self.table.find_mut(hash, |(k, _)| *k == key) {
+            Some((_, prop)) => {
                 // NOTE: When inserting a new value into an already-occupied entry,
                 // the value of the `enumerable` field isn't reset to `true`
-                let DynamicProperty { value, .. } = occupied.get_mut();
-                *value = new_value;
+                prop.value = new_value;
             }
-            Entry::Vacant(vacant) => {
-                vacant.insert(DynamicProperty {
-                    value: new_value,
-                    enumerable: true,
-                });
+            None => {
+                self.table.insert_unique(
+                    hash,
+                    (
+                        key,
+                        DynamicProperty {
+                            value: new_value,
+                            enumerable: true,
+                        },
+                    ),
+                    |(k, _)| self.hasher.hash_one(k),
+                );
             }
         }
     }
 
     pub fn remove(&mut self, key: &K) -> Option<DynamicProperty<V>> {
-        self.values.remove(key)
+        let hash = self.hash_key(key);
+
+        match self.table.find_entry(hash, |(k, _)| k == key) {
+            Ok(occupied) => Some(occupied.remove().0.1),
+            Err(_) => None,
+        }
     }
 
     pub fn next(&self, index: usize) -> Option<usize> {
@@ -152,25 +199,20 @@ impl<K: Eq + PartialEq + Hash, V> DynamicMap<K, V> {
         }
 
         let real = self.real_index.get() + 1;
-        let raw = self.raw();
-        let total_buckets = raw.buckets();
-        if !raw.is_empty() && real < total_buckets {
-            for i in real..total_buckets {
-                unsafe {
-                    // SAFETY: It is impossible for i to be greater than the total buckets.
-                    if raw.is_bucket_full(i) {
-                        // SAFETY: We know that this bucket is safe to access because we just checked
-                        // that it is full.
-                        let bucket = raw.bucket(i).as_ref();
-                        if bucket.1.enumerable {
-                            self.real_index.set(i);
-                            self.public_index.set(self.public_index.get() + 1);
-                            return Some(self.public_index.get());
-                        }
+        let num_buckets = self.table.num_buckets();
+
+        if !self.table.is_empty() && real < num_buckets {
+            for i in real..num_buckets {
+                if let Some((_, v)) = self.table.get_bucket(i) {
+                    if v.enumerable {
+                        self.real_index.set(i);
+                        self.public_index.set(self.public_index.get() + 1);
+                        return Some(self.public_index.get());
                     }
                 }
             }
         }
+
         None
     }
 
@@ -180,21 +222,24 @@ impl<K: Eq + PartialEq + Hash, V> DynamicMap<K, V> {
         } else {
             self.real_index.get()
         };
-        if !self.values.is_empty() && real_index < self.raw().buckets() {
-            unsafe {
-                let bucket = self.raw().bucket(real_index);
-                return Some(bucket.as_ref());
-            }
-        }
-        None
+
+        self.table.get_bucket(real_index)
     }
 
     pub fn key_at(&self, index: usize) -> Option<&K> {
-        self.pair_at(index).map(|p| &p.0)
+        self.pair_at(index).map(|(k, _)| k)
     }
 
     pub fn value_at(&self, index: usize) -> Option<&V> {
-        self.pair_at(index).map(|p| &p.1.value)
+        self.pair_at(index).map(|(_, p)| &p.value)
+    }
+
+    pub fn set_enumerable(&mut self, key: &K, enumerable: bool) {
+        let hash = self.hash_key(key);
+
+        if let Some((_, prop)) = self.table.find_mut(hash, |(k, _)| k == key) {
+            prop.enumerable = enumerable;
+        }
     }
 }
 

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -260,7 +260,7 @@ pub trait TObject<'gc>: 'gc + Collect<'gc> + Debug + Into<Object<'gc>> + Clone +
 
         let base = self.base();
         let values = base.values();
-        let value = values.as_hashmap().get(&key);
+        let value = values.get(&key);
         value.map(|v| v.value)
     }
 

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -55,9 +55,7 @@ impl<'gc> DictionaryObject<'gc> {
     pub fn get_property_by_object(self, name: Object<'gc>) -> Value<'gc> {
         self.base()
             .values()
-            .as_hashmap()
             .get(&DynamicKey::Object(name))
-            .cloned()
             .map(|v| v.value)
             .unwrap_or(Value::Undefined)
     }
@@ -75,11 +73,7 @@ impl<'gc> DictionaryObject<'gc> {
     }
 
     pub fn has_property_by_object(self, name: Object<'gc>) -> bool {
-        self.base()
-            .values()
-            .as_hashmap()
-            .get(&DynamicKey::Object(name))
-            .is_some()
+        self.base().values().contains_key(&DynamicKey::Object(name))
     }
 }
 

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -326,7 +326,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
         if name.valid_dynamic_name() {
             if let Some(name) = name.local_name() {
                 let key = maybe_int_property(name);
-                return self.values().as_hashmap().get(&key).is_some();
+                return self.values().contains_key(&key);
             }
         }
         false
@@ -361,10 +361,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
 
     pub fn property_is_enumerable(self, name: AvmString<'gc>) -> bool {
         let key = maybe_int_property(name);
-        self.values()
-            .as_hashmap()
-            .get(&key)
-            .is_some_and(|prop| prop.enumerable)
+        self.values().get(&key).is_some_and(|prop| prop.enumerable)
     }
 
     pub fn set_local_property_is_enumerable(
@@ -374,9 +371,7 @@ impl<'gc> ScriptObjectWrapper<'gc> {
         is_enumerable: bool,
     ) {
         let key = maybe_int_property(name);
-        self.values_mut(mc).entry(key).and_modify(|v| {
-            v.enumerable = is_enumerable;
-        });
+        self.values_mut(mc).set_enumerable(&key, is_enumerable);
     }
 
     /// Install a method into the object.
@@ -483,7 +478,8 @@ pub fn get_dynamic_property<'gc>(
     let key = maybe_int_property(local_name);
 
     if let Some(values) = local_values {
-        let value = values.as_hashmap().get(&key);
+        let value = values.get(&key);
+
         if let Some(value) = value {
             return Ok(Some(value.value));
         }
@@ -495,7 +491,8 @@ pub fn get_dynamic_property<'gc>(
         // First search dynamic properties
         let obj = this_proto.base();
         let values = obj.values();
-        let value = values.as_hashmap().get(&key);
+        let value = values.get(&key);
+
         if let Some(value) = value {
             return Ok(Some(value.value));
         }

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -295,7 +295,7 @@ impl Definition {
         let prototype = class_object.prototype();
         let prototype_base = prototype.base();
         let prototype_values = prototype_base.values();
-        for (key, value) in prototype_values.as_hashmap().iter() {
+        for (key, value) in prototype_values.iter() {
             let name = match key {
                 DynamicKey::String(name) => *name,
                 DynamicKey::Uint(key) => AvmString::new_utf8(activation.gc(), key.to_string()),


### PR DESCRIPTION
Now there are only 2 versions of hashbrown instead of 3. This also allows implementing the 'add proper entry API?' TODO easily and removing a lot of unsafe code. 