### PR TITLE
web: fix Edge headless WebGL test failures

### DIFF
--- a/web/packages/selfhosted/wdio.conf.ts
+++ b/web/packages/selfhosted/wdio.conf.ts
@@ -32,7 +32,7 @@ if (chrome) {
 }
 
 if (edge) {
-    const args = ["--disable-gpu"];
+    const args = ["--disable-gpu", "--enable-unsafe-swiftshader"];
     if (headless) {
         args.push("--headless");
     }


### PR DESCRIPTION
Discovered in #22879 

Edge is Chromium-based and needs the same --enable-unsafe-swiftshader flag.