### PR TITLE
core: Fix Fullscreen reporting wrong displayState

### DIFF
--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -169,7 +169,7 @@ impl<'gc> Stage<'gc> {
                 scale_mode: Default::default(),
                 forced_scale_mode: Cell::new(false),
                 display_state: Cell::new(if fullscreen {
-                    StageDisplayState::FullScreen
+                    StageDisplayState::FullScreenInteractive
                 } else {
                     StageDisplayState::Normal
                 }),
@@ -373,7 +373,7 @@ impl<'gc> Stage<'gc> {
         if self.is_fullscreen() {
             self.set_display_state(context, StageDisplayState::Normal);
         } else {
-            self.set_display_state(context, StageDisplayState::FullScreen);
+            self.set_display_state(context, StageDisplayState::FullScreenInteractive);
         }
     }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -828,7 +828,7 @@ impl Player {
     pub fn set_fullscreen(&mut self, is_fullscreen: bool) {
         self.mutate_with_update_context(|context| {
             let display_state = if is_fullscreen {
-                StageDisplayState::FullScreen
+                StageDisplayState::FullScreenInteractive
             } else {
                 StageDisplayState::Normal
             };


### PR DESCRIPTION
Ruffle allows kb input, so it's FULLSCREEN_INTERACTIVE
This is used on Matt's Hidden Cats