### PR TITLE
tests: Fix movie URLs in outputs

### DIFF
--- a/tests/tests/swfs/from_gnash/actionscript.all/MovieClipLoader-v7/output.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/MovieClipLoader-v7/output.txt
@@ -52,7 +52,7 @@ PASSED: mcl.loadClip( MEDIA(vars.txt), 'loadtarget' ) [./MovieClipLoader.as:351]
 PASSED: arguments.length == 1 [./MovieClipLoader.as:234]
 PASSED: target+"" != "" [./MovieClipLoader.as:238]
 PASSED: target == expected.target [./MovieClipLoader.as:239]
-onLoadStart(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/vars.txt) called
+onLoadStart(_level0.loadtarget, file:///vars.txt) called
 PASSED: arguments.length == 3 [./MovieClipLoader.as:249]
 PASSED: target == expected.target [./MovieClipLoader.as:250]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:251]
@@ -83,14 +83,14 @@ PASSED: prog.bytesTotal == bytesTotal [./MovieClipLoader.as:265]
 PASSED: progcount == 2 [./MovieClipLoader.as:268]
 PASSED: progcopy.bytesLoaded == bytesLoaded [./MovieClipLoader.as:269]
 PASSED: progcopy.bytesTotal == bytesTotal [./MovieClipLoader.as:270]
-onLoadComplete(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/vars.txt) called
+onLoadComplete(_level0.loadtarget, file:///vars.txt) called
 PASSED: arguments.length == 2 [./MovieClipLoader.as:280]
 PASSED: target == expected.target [./MovieClipLoader.as:281]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:282]
 PASSED: state.onLoadProgressCalls > 0 [./MovieClipLoader.as:283]
 PASSED: typeof(n) == 'number' [./MovieClipLoader.as:284]
 onLoadComplete second arg is 0 (number)
-onLoadInit(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/vars.txt) called
+onLoadInit(_level0.loadtarget, file:///vars.txt) called
 PASSED: arguments.length == 1 [./MovieClipLoader.as:293]
 PASSED: target == expected.target [./MovieClipLoader.as:294]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:295]
@@ -105,7 +105,7 @@ PASSED: mcl.loadClip( MEDIA(green.jpg), 'loadtarget' ) [./MovieClipLoader.as:393
 PASSED: arguments.length == 1 [./MovieClipLoader.as:234]
 PASSED: target+"" != "" [./MovieClipLoader.as:238]
 PASSED: target == expected.target [./MovieClipLoader.as:239]
-onLoadStart(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/green.jpg) called
+onLoadStart(_level0.loadtarget, file:///green.jpg) called
 PASSED: arguments.length == 3 [./MovieClipLoader.as:249]
 PASSED: target == expected.target [./MovieClipLoader.as:250]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:251]
@@ -136,14 +136,14 @@ PASSED: prog.bytesTotal == bytesTotal [./MovieClipLoader.as:265]
 PASSED: progcount == 2 [./MovieClipLoader.as:268]
 PASSED: progcopy.bytesLoaded == bytesLoaded [./MovieClipLoader.as:269]
 PASSED: progcopy.bytesTotal == bytesTotal [./MovieClipLoader.as:270]
-onLoadComplete(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/green.jpg) called
+onLoadComplete(_level0.loadtarget, file:///green.jpg) called
 PASSED: arguments.length == 2 [./MovieClipLoader.as:280]
 PASSED: target == expected.target [./MovieClipLoader.as:281]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:282]
 PASSED: state.onLoadProgressCalls > 0 [./MovieClipLoader.as:283]
 PASSED: typeof(n) == 'number' [./MovieClipLoader.as:284]
 onLoadComplete second arg is 0 (number)
-onLoadInit(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/green.jpg) called
+onLoadInit(_level0.loadtarget, file:///green.jpg) called
 PASSED: arguments.length == 1 [./MovieClipLoader.as:293]
 PASSED: target == expected.target [./MovieClipLoader.as:294]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:295]

--- a/tests/tests/swfs/from_gnash/actionscript.all/MovieClipLoader-v8/output.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/MovieClipLoader-v8/output.txt
@@ -52,7 +52,7 @@ PASSED: mcl.loadClip( MEDIA(vars.txt), 'loadtarget' ) [./MovieClipLoader.as:351]
 PASSED: arguments.length == 1 [./MovieClipLoader.as:234]
 PASSED: target+"" != "" [./MovieClipLoader.as:238]
 PASSED: target == expected.target [./MovieClipLoader.as:239]
-onLoadStart(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/vars.txt) called
+onLoadStart(_level0.loadtarget, file:///vars.txt) called
 PASSED: arguments.length == 3 [./MovieClipLoader.as:249]
 PASSED: target == expected.target [./MovieClipLoader.as:250]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:251]
@@ -83,14 +83,14 @@ PASSED: prog.bytesTotal == bytesTotal [./MovieClipLoader.as:265]
 PASSED: progcount == 2 [./MovieClipLoader.as:268]
 PASSED: progcopy.bytesLoaded == bytesLoaded [./MovieClipLoader.as:269]
 PASSED: progcopy.bytesTotal == bytesTotal [./MovieClipLoader.as:270]
-onLoadComplete(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/vars.txt) called
+onLoadComplete(_level0.loadtarget, file:///vars.txt) called
 PASSED: arguments.length == 2 [./MovieClipLoader.as:280]
 PASSED: target == expected.target [./MovieClipLoader.as:281]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:282]
 PASSED: state.onLoadProgressCalls > 0 [./MovieClipLoader.as:283]
 PASSED: typeof(n) == 'number' [./MovieClipLoader.as:284]
 onLoadComplete second arg is 0 (number)
-onLoadInit(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/vars.txt) called
+onLoadInit(_level0.loadtarget, file:///vars.txt) called
 PASSED: arguments.length == 1 [./MovieClipLoader.as:293]
 PASSED: target == expected.target [./MovieClipLoader.as:294]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:295]
@@ -105,7 +105,7 @@ PASSED: mcl.loadClip( MEDIA(green.jpg), 'loadtarget' ) [./MovieClipLoader.as:393
 PASSED: arguments.length == 1 [./MovieClipLoader.as:234]
 PASSED: target+"" != "" [./MovieClipLoader.as:238]
 PASSED: target == expected.target [./MovieClipLoader.as:239]
-onLoadStart(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/green.jpg) called
+onLoadStart(_level0.loadtarget, file:///green.jpg) called
 PASSED: arguments.length == 3 [./MovieClipLoader.as:249]
 PASSED: target == expected.target [./MovieClipLoader.as:250]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:251]
@@ -136,14 +136,14 @@ PASSED: prog.bytesTotal == bytesTotal [./MovieClipLoader.as:265]
 PASSED: progcount == 2 [./MovieClipLoader.as:268]
 PASSED: progcopy.bytesLoaded == bytesLoaded [./MovieClipLoader.as:269]
 PASSED: progcopy.bytesTotal == bytesTotal [./MovieClipLoader.as:270]
-onLoadComplete(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/green.jpg) called
+onLoadComplete(_level0.loadtarget, file:///green.jpg) called
 PASSED: arguments.length == 2 [./MovieClipLoader.as:280]
 PASSED: target == expected.target [./MovieClipLoader.as:281]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:282]
 PASSED: state.onLoadProgressCalls > 0 [./MovieClipLoader.as:283]
 PASSED: typeof(n) == 'number' [./MovieClipLoader.as:284]
 onLoadComplete second arg is 0 (number)
-onLoadInit(_level0.loadtarget, file:///C|/Users/dinnerbone/shared/testsuite/actionscript.all/green.jpg) called
+onLoadInit(_level0.loadtarget, file:///green.jpg) called
 PASSED: arguments.length == 1 [./MovieClipLoader.as:293]
 PASSED: target == expected.target [./MovieClipLoader.as:294]
 PASSED: state.onLoadStartCalls == 1 [./MovieClipLoader.as:295]


### PR DESCRIPTION
Some URLs are not adapted to tests from Flash Player.

We currently do not have a way of simulating real paths, instead, tests assume that Flash Player is run in a POSIX environment in the root directory.  Some tests were run under Windows which resulted in recording Windows paths in the output.