### PR TITLE
chore: Remove outdated comment

### DIFF
--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -413,7 +413,6 @@ impl<'gc> MovieLibraries<'gc> {
     }
 
     fn get_or_insert_mut(&mut self, movie: Arc<SwfMovie>) -> &mut MovieLibrary<'gc> {
-        // NOTE(Clippy): Cannot use or_default() here as PtrWeakKeyHashMap does not have such a method on its Entry API
         self.0
             .entry(movie.clone())
             .or_insert_with(|| MovieLibrary::new(movie))


### PR DESCRIPTION
MovieLibrary no longer implements Default so the comment is no longer relevant.