### PR TITLE
chore: Update cargo-edit version to ^0.13

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -46,7 +46,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-edit
-          version: '^0.12'
+          version: '^0.13'
 
       - name: Install cargo-get
         uses: baptiste0928/cargo-install@v3


### PR DESCRIPTION
Looks like the cargo-edit install was added in #20786 on June 2025. By that point, version 0.13 was already released September 2024 (https://github.com/killercup/cargo-edit/releases/tag/v0.13.0). The only breaking change I can find is the removal of `--offline`, which I don't think we use (https://github.com/killercup/cargo-edit/pull/907). I don't see anything else [here](https://github.com/killercup/cargo-edit/compare/v0.12.3...v0.13.8) at a cursory glance of the 90 commits that should be a breaking change. https://github.com/ruffle-rs/ruffle/actions/runs/21693350581 has an annotated warning about this.