### PR TITLE
ci: Unignore known failures in coverage tests

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -225,7 +225,6 @@ jobs:
       - name: Run llvm-cov for SWF tests
         working-directory: tests
         env:
-          RUFFLE_TEST_OPTS: --ignore-known-failures
           LLVM_COV_EXCLUDE: >
             --exclude ruffle_desktop
             --exclude exporter


### PR DESCRIPTION
Since we now assert on Ruffle's output in known failures, it's not needed to ignore known failures anymore.

The reason why they were ignored was because they provided a false sense of code coverage: the code was executed, but the result didn't matter. Now the result matters even for known failures.