### PR TITLE
chore: Bump `brace-expansion` and `browserstack-local` web deps

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1765,9 +1765,9 @@
             }
         },
         "node_modules/@isaacs/brace-expansion": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+            "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5835,9 +5835,9 @@
             }
         },
         "node_modules/browserstack-local": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/browserstack-local/-/browserstack-local-1.5.8.tgz",
-            "integrity": "sha512-8p8APDD7bY8E806pZBratRQmd9quqB8o3jiOqxVHWTiYGAW5ePMqFDKbZaedUkFM52Dnfl5Gxviz2bHXiiV3DQ==",
+            "version": "1.5.9",
+            "resolved": "https://registry.npmjs.org/browserstack-local/-/browserstack-local-1.5.9.tgz",
+            "integrity": "sha512-p8H3alMqUK9lq8JHhsDdZ4tpnSgbHyRyKnZu9U+9p7XzR/SpvTm/zkfsSJsnUZBoiYFe+B1VaGZ4cL5f2ya6mw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
Fixing CVE-2025-57283 and CVE-2026-25547.