### PR TITLE
core: Use `Option::get_or_insert_default` to simplify some code

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -842,9 +842,9 @@ impl<'gc> DisplayObjectBase<'gc> {
     fn recheck_cache_as_bitmap(&self) {
         let mut write = self.cell.borrow_mut();
         let should_cache = self.is_bitmap_cached_preference() || !write.filters.is_empty();
-        if should_cache && write.cache.is_none() {
-            write.cache = Some(Default::default());
-        } else if !should_cache && write.cache.is_some() {
+        if should_cache {
+            write.cache.get_or_insert_default();
+        } else {
             write.cache = None;
         }
     }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -4659,27 +4659,13 @@ impl<'a> GotoPlaceObject<'a> {
         version: u8,
     ) -> Self {
         if is_rewind && let swf::PlaceObjectAction::Place(_) = place_object.action {
-            if place_object.matrix.is_none() {
-                place_object.matrix = Some(Default::default());
-            }
-            if place_object.color_transform.is_none() {
-                place_object.color_transform = Some(Default::default());
-            }
-            if place_object.ratio.is_none() {
-                place_object.ratio = Some(Default::default());
-            }
-            if place_object.blend_mode.is_none() {
-                place_object.blend_mode = Some(Default::default());
-            }
-            if place_object.is_bitmap_cached.is_none() {
-                place_object.is_bitmap_cached = Some(Default::default());
-            }
-            if place_object.background_color.is_none() {
-                place_object.background_color = Some(Color::from_rgba(0));
-            }
-            if place_object.filters.is_none() {
-                place_object.filters = Some(Default::default());
-            }
+            place_object.matrix.get_or_insert_default();
+            place_object.color_transform.get_or_insert_default();
+            place_object.ratio.get_or_insert_default();
+            place_object.blend_mode.get_or_insert_default();
+            place_object.is_bitmap_cached.get_or_insert_default();
+            place_object.background_color.get_or_insert_default();
+            place_object.filters.get_or_insert_default();
             // Purposely omitted properties:
             // name, clip_depth, clip_actions, amf_data
             // These properties are only set on initial placement in `MovieClip::instantiate_child`

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -868,10 +868,8 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
     }
 
     fn set_perspective_projection(self, mut perspective_projection: Option<PerspectiveProjection>) {
-        if perspective_projection.is_none() {
-            // `stage` doesn't allow null PerspectiveProjection.
-            perspective_projection = Some(Default::default());
-        }
+        // `stage` doesn't allow null PerspectiveProjection.
+        perspective_projection.get_or_insert_default();
         if self
             .base()
             .set_perspective_projection(perspective_projection)


### PR DESCRIPTION
No behavior change, this just makes some code slightly shorter.