### PR TITLE
chore: Update gc-arena, indexmap and remove manual `Collect` impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,15 +2041,18 @@ dependencies = [
 [[package]]
 name = "gc-arena"
 version = "0.5.3"
-source = "git+https://github.com/kyren/gc-arena.git?rev=08e08414249d5914dfc3b402d7eadc133e00ce56#08e08414249d5914dfc3b402d7eadc133e00ce56"
+source = "git+https://github.com/kyren/gc-arena.git?rev=75671ae03f53718357b741ed4027560f14e90836#75671ae03f53718357b741ed4027560f14e90836"
 dependencies = [
  "gc-arena-derive",
+ "indexmap",
+ "slotmap",
+ "smallvec",
 ]
 
 [[package]]
 name = "gc-arena-derive"
 version = "0.5.3"
-source = "git+https://github.com/kyren/gc-arena.git?rev=08e08414249d5914dfc3b402d7eadc133e00ce56#08e08414249d5914dfc3b402d7eadc133e00ce56"
+source = "git+https://github.com/kyren/gc-arena.git?rev=75671ae03f53718357b741ed4027560f14e90836#75671ae03f53718357b741ed4027560f14e90836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2605,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ egui = "0.33.3"
 clap = { version = "4.5.57", features = ["derive"] }
 cpal = "0.16.0"
 anyhow = "1.0"
-gc-arena = { git = "https://github.com/kyren/gc-arena.git", rev = "08e08414249d5914dfc3b402d7eadc133e00ce56" }
+gc-arena = { git = "https://github.com/kyren/gc-arena.git", rev = "75671ae03f53718357b741ed4027560f14e90836", features = ["indexmap", "smallvec", "slotmap"] }
 slotmap = "1.1.1"
 async-channel = "2.5.0"
 bitflags = "2.10.0"
@@ -97,7 +97,7 @@ bitstream-io = "4.9.0"
 indicatif = "0.18"
 rayon = "1.11.0"
 sha2 = "0.10.9"
-indexmap = "2.12.0"
+indexmap = "2.13.0"
 fnv = "1.0.7"
 hashbrown = { version = "0.14.5", features = ["raw"] }
 fluent-templates = "0.13.2"

--- a/core/src/avm1/property_map.rs
+++ b/core/src/avm1/property_map.rs
@@ -7,14 +7,14 @@
 use crate::string::{AvmString, WStr, utils as string_utils};
 use fnv::FnvBuildHasher;
 use gc_arena::Collect;
-use gc_arena::collect::Trace;
 use indexmap::{Equivalent, IndexMap};
 use std::hash::{Hash, Hasher};
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
 /// A map from property names to values.
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, Collect)]
+#[collect(no_drop)]
 pub struct PropertyMap<'gc, V>(FnvIndexMap<PropertyName<'gc>, V>);
 
 impl<'gc, V> PropertyMap<'gc, V> {
@@ -105,15 +105,6 @@ impl<'gc, V> PropertyMap<'gc, V> {
             self.0.shift_remove(&CaseSensitive(key.as_ref()))
         } else {
             self.0.shift_remove(&CaseInsensitive(key.as_ref()))
-        }
-    }
-}
-
-unsafe impl<'gc, V: Collect<'gc>> Collect<'gc> for PropertyMap<'gc, V> {
-    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
-        for (key, value) in &self.0 {
-            cc.trace(key);
-            cc.trace(value);
         }
     }
 }

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -6,7 +6,6 @@ use crate::avm2::Namespace;
 use crate::avm2::QName;
 use fnv::FnvBuildHasher;
 use gc_arena::Collect;
-use gc_arena::collect::Trace;
 use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::mem::swap;
@@ -25,23 +24,11 @@ use std::mem::swap;
 /// The internal structure of the `PropertyMap` technically allows storage of
 /// multiple values per `QName`. It's implementation enforces the invariant
 /// that each `QName` only have one associated `V`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Collect)]
+#[collect(no_drop)]
 pub struct PropertyMap<'gc, V>(
     HashMap<AvmString<'gc>, SmallVec<[(Namespace<'gc>, V); 2]>, FnvBuildHasher>,
 );
-
-unsafe impl<'gc, V: Collect<'gc>> Collect<'gc> for PropertyMap<'gc, V> {
-    #[inline]
-    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
-        for (key, value) in self.0.iter() {
-            cc.trace(key);
-            for (ns, v) in value.iter() {
-                cc.trace(ns);
-                cc.trace(v);
-            }
-        }
-    }
-}
 
 impl<V> Default for PropertyMap<'_, V> {
     fn default() -> Self {

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -39,7 +39,6 @@ use crate::vminterface::Instantiator;
 use chardetng::EncodingDetector;
 use encoding_rs::{UTF_8, WINDOWS_1252};
 use gc_arena::Collect;
-use gc_arena::collect::Trace;
 use indexmap::IndexMap;
 use ruffle_macros::istr;
 use ruffle_render::utils::{JpegTagFormat, determine_jpeg_tag_format};
@@ -214,15 +213,9 @@ impl From<crate::avm1::Error<'_>> for Error {
 }
 
 /// Holds all in-progress loads for the player.
+#[derive(Collect)]
+#[collect(no_drop)]
 pub struct LoadManager<'gc>(SlotMap<LoaderHandle, MovieLoader<'gc>>);
-
-unsafe impl<'gc> Collect<'gc> for LoadManager<'gc> {
-    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
-        for (_, loader) in self.0.iter() {
-            cc.trace(loader);
-        }
-    }
-}
 
 impl<'gc> LoadManager<'gc> {
     /// Construct a new `LoadManager`.

--- a/core/src/net_connection.rs
+++ b/core/src/net_connection.rs
@@ -12,7 +12,6 @@ use crate::context::UpdateContext;
 use crate::loader::Error;
 use flash_lso::packet::{Header, Message, Packet};
 use flash_lso::types::{AMFVersion, Value as AmfValue};
-use gc_arena::collect::Trace;
 use gc_arena::{Collect, DynamicRoot, Gc, Rootable};
 use slotmap::{SlotMap, new_key_type};
 use std::fmt::{Debug, Formatter};
@@ -112,16 +111,10 @@ impl<'gc> From<Avm1Object<'gc>> for NetConnectionObject<'gc> {
 }
 
 /// Manages the collection of NetConnections.
+#[derive(Collect)]
+#[collect(no_drop)]
 pub struct NetConnections<'gc> {
     connections: SlotMap<NetConnectionHandle, NetConnection<'gc>>,
-}
-
-unsafe impl<'gc> Collect<'gc> for NetConnections<'gc> {
-    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
-        for (_, connection) in self.connections.iter() {
-            cc.trace(connection);
-        }
-    }
 }
 
 impl Default for NetConnections<'_> {

--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -10,7 +10,6 @@ use crate::string::AvmString;
 
 use async_channel::{Receiver, Sender, unbounded};
 use gc_arena::Collect;
-use gc_arena::collect::Trace;
 use ruffle_macros::istr;
 use slotmap::{SlotMap, new_key_type};
 use std::{
@@ -62,19 +61,15 @@ pub enum SocketAction {
 }
 
 /// Manages the collection of Sockets.
+#[derive(Collect)]
+#[collect(no_drop)]
 pub struct Sockets<'gc> {
     sockets: SlotMap<SocketHandle, Socket<'gc>>,
 
+    #[collect(require_static)]
     receiver: Receiver<SocketAction>,
+    #[collect(require_static)]
     sender: Sender<SocketAction>,
-}
-
-unsafe impl<'gc> Collect<'gc> for Sockets<'gc> {
-    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
-        for (_, socket) in self.sockets.iter() {
-            cc.trace(socket);
-        }
-    }
 }
 
 impl<'gc> Sockets<'gc> {


### PR DESCRIPTION
https://github.com/kyren/gc-arena/pull/137 and https://github.com/kyren/gc-arena/pull/138 allow us to get rid of a lot of manual `Collect` impls. Indexmap is updated to avoid duplication (gc-arena uses 2.13)