### PR TITLE
desktop: Improve logging on desktop a bit

### DIFF
--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -265,6 +265,8 @@ impl GuiController {
         opt: LaunchOptions,
         content_descriptor: ContentDescriptor,
     ) {
+        tracing::info!("Opening {}", content_descriptor.describe());
+
         self.close_movie(player);
         let movie_view = MovieView::new(
             self.movie_view_renderer.clone(),

--- a/frontend-utils/src/content.rs
+++ b/frontend-utils/src/content.rs
@@ -36,6 +36,20 @@ impl ContentDescriptor {
             root_content_path,
         })
     }
+
+    pub fn describe(&self) -> String {
+        #[cfg(not(feature = "fs"))]
+        {
+            format!("{}", self.url)
+        }
+
+        #[cfg(feature = "fs")]
+        if let Some(dir) = &self.root_content_path {
+            format!("{} within {}", self.url, dir.display())
+        } else {
+            format!("{}", self.url)
+        }
+    }
 }
 
 /// Similar to [`ContentDescriptor`], but represents content that is already


### PR DESCRIPTION
This PR (1) adds logging for the content being opened to make sure Ruffle opens the right URL and (2) reduces font registration log level to debug.

1. It's useful e.g. in flatpak where we'd like to know quickly what's the path Ruffle tried to load. Due to filesystem isolation the path can be different than the one selected. See https://github.com/flathub/rs.ruffle.Ruffle/issues/38.
2. We didn't have too many issues related to GUI fonts and these logs are a bit spammy, so set them to debug and in case they are needed, they can be enabled manually.