### PR TITLE
core: Optimize CPU bitmap blending and copy operations

### DIFF
--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -45,7 +45,9 @@ impl LehmerRng {
 /// unmultiplied values. Make sure to convert the color to the correct form beforehand.
 // TODO: Maybe split the type into `PremultipliedColor(u32)` and
 //   `UnmultipliedColor(u32)`?
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, bytemuck::NoUninit)]
+#[derive(
+    Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, bytemuck::Pod, bytemuck::Zeroable,
+)]
 #[repr(C, align(4))]
 pub struct Color {
     // Note: even though AS2/AS3 represent colors as (little-endian) BGRA `u32`s, this is stored
@@ -161,13 +163,19 @@ impl Color {
     /// * `self` - Must be in premultiplied form.
     /// * `source` - Must be in premultiplied form.
     #[must_use]
+    #[inline(always)]
     pub fn blend_over(&self, source: &Self) -> Self {
-        let sa = source.alpha();
+        let inv_sa = 255 - source.alpha() as u16;
 
-        let r = source.red() + ((self.red() as u16 * (255 - sa as u16)) / 255) as u8;
-        let g = source.green() + ((self.green() as u16 * (255 - sa as u16)) / 255) as u8;
-        let b = source.blue() + ((self.blue() as u16 * (255 - sa as u16)) / 255) as u8;
-        let a = source.alpha() + ((self.alpha() as u16 * (255 - sa as u16)) / 255) as u8;
+        #[inline(always)]
+        fn scale(channel: u8, factor: u16) -> u8 {
+            (channel as u16 * factor / 255) as u8
+        }
+
+        let r = source.red() + scale(self.red(), inv_sa);
+        let g = source.green() + scale(self.green(), inv_sa);
+        let b = source.blue() + scale(self.blue(), inv_sa);
+        let a = source.alpha() + scale(self.alpha(), inv_sa);
         Self::rgba(r, g, b, a)
     }
 

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -1292,6 +1292,83 @@ pub fn apply_filter<'gc>(
     }
 }
 
+/// Blend a single pixel (src-over, premultiplied alpha, two-lane u32 trick).
+#[inline(always)]
+fn blend_pixel(d: u32, s: u32) -> u32 {
+    #[cfg(target_endian = "little")]
+    let inv_a = 255 - (s >> 24);
+    #[cfg(target_endian = "big")]
+    let inv_a = 255 - (s & 0xFF);
+
+    let d02 = d & 0x00FF_00FF;
+    let d13 = (d >> 8) & 0x00FF_00FF;
+
+    let m02_raw = d02 * inv_a;
+    let m13_raw = d13 * inv_a;
+    let m02 = ((m02_raw + 0x0001_0001 + ((m02_raw >> 8) & 0x00FF_00FF)) >> 8) & 0x00FF_00FF;
+    let m13 = ((m13_raw + 0x0001_0001 + ((m13_raw >> 8) & 0x00FF_00FF)) >> 8) & 0x00FF_00FF;
+
+    let s02 = s & 0x00FF_00FF;
+    let s13 = (s >> 8) & 0x00FF_00FF;
+
+    ((m02 + s02) & 0x00FF_00FF) | (((m13 + s13) & 0x00FF_00FF) << 8)
+}
+
+/// Blend 4 pixels in parallel. Each array operation is independent, which
+/// gives LLVM a clean hint to emit a single SIMD lane-parallel sequence
+/// rather than inlining four copies of the scalar blend_pixel and then
+/// trying to discover vector parallelism by pattern matching. Four lanes
+/// is the sweet spot on SSE2 - wider windows run out of XMM registers and
+/// force spill/reload.
+#[inline(always)]
+fn blend_4(d: [u32; 4], s: [u32; 4]) -> [u32; 4] {
+    #[cfg(target_endian = "little")]
+    let inv_a: [u32; 4] = core::array::from_fn(|i| 255 - (s[i] >> 24));
+    #[cfg(target_endian = "big")]
+    let inv_a: [u32; 4] = core::array::from_fn(|i| 255 - (s[i] & 0xFF));
+
+    let d02: [u32; 4] = core::array::from_fn(|i| d[i] & 0x00FF_00FF);
+    let d13: [u32; 4] = core::array::from_fn(|i| (d[i] >> 8) & 0x00FF_00FF);
+    let s02: [u32; 4] = core::array::from_fn(|i| s[i] & 0x00FF_00FF);
+    let s13: [u32; 4] = core::array::from_fn(|i| (s[i] >> 8) & 0x00FF_00FF);
+
+    let m02_raw: [u32; 4] = core::array::from_fn(|i| d02[i] * inv_a[i]);
+    let m13_raw: [u32; 4] = core::array::from_fn(|i| d13[i] * inv_a[i]);
+
+    let m02: [u32; 4] = core::array::from_fn(|i| {
+        ((m02_raw[i] + 0x0001_0001 + ((m02_raw[i] >> 8) & 0x00FF_00FF)) >> 8) & 0x00FF_00FF
+    });
+    let m13: [u32; 4] = core::array::from_fn(|i| {
+        ((m13_raw[i] + 0x0001_0001 + ((m13_raw[i] >> 8) & 0x00FF_00FF)) >> 8) & 0x00FF_00FF
+    });
+
+    core::array::from_fn(|i| {
+        ((m02[i] + s02[i]) & 0x00FF_00FF) | (((m13[i] + s13[i]) & 0x00FF_00FF) << 8)
+    })
+}
+
+/// Blend `src` over `dst` in-place (premultiplied alpha, src-over).
+fn blend_row(dst: &mut [Color], src: &[Color]) {
+    debug_assert_eq!(dst.len(), src.len());
+    let dst_u32: &mut [u32] = bytemuck::cast_slice_mut(dst);
+    let src_u32: &[u32] = bytemuck::cast_slice(src);
+
+    let (dst_chunks, dst_remainder) = dst_u32.split_at_mut(dst_u32.len() & !3);
+    let (src_chunks, src_remainder) = src_u32.split_at(src_u32.len() & !3);
+
+    for (d4, s4) in dst_chunks
+        .chunks_exact_mut(4)
+        .zip(src_chunks.chunks_exact(4))
+    {
+        let result = blend_4([d4[0], d4[1], d4[2], d4[3]], [s4[0], s4[1], s4[2], s4[3]]);
+        d4.copy_from_slice(&result);
+    }
+
+    for (d, &s) in dst_remainder.iter_mut().zip(src_remainder.iter()) {
+        *d = blend_pixel(*d, s);
+    }
+}
+
 fn copy_on_cpu<'gc>(
     context: &Mutation<'gc>,
     renderer: &mut dyn RenderBackend,
@@ -1310,72 +1387,108 @@ fn copy_on_cpu<'gc>(
         return;
     }
 
-    let dest_is_source = source.ptr_eq(dest);
-    let mut dest = dest.sync(renderer).borrow_mut(context);
+    let width = dest_region.width() as usize;
+    let height = dest_region.height() as usize;
 
+    let dest_is_source = source.ptr_eq(dest);
+    let dest = dest.sync(renderer);
     if dest_is_source {
-        for y in 0..dest_region.height() {
-            for x in 0..dest_region.width() {
-                let mut color =
-                    dest.get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
-                if blend {
-                    color = dest
-                        .get_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y)
-                        .blend_over(&color);
-                }
-                dest.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
+        let mut write = dest.borrow_mut(context);
+        let stride = write.width() as usize;
+
+        if blend {
+            // Self-blend: need a temporary copy of source rows to avoid aliasing
+            let mut row_buf = vec![Color::default(); width];
+            for y in 0..height as u32 {
+                let src_start =
+                    (source_region.x_min + (source_region.y_min + y) * stride as u32) as usize;
+                row_buf.copy_from_slice(&write.raw_pixels()[src_start..src_start + width]);
+
+                let dst_start =
+                    (dest_region.x_min + (dest_region.y_min + y) * stride as u32) as usize;
+                let dst_row = &mut write.raw_pixels_mut()[dst_start..dst_start + width];
+                blend_row(dst_row, &row_buf);
+            }
+        } else {
+            // Self-copy without blending: use copy_within per row
+            let pixels = write.raw_pixels_mut();
+            for y in 0..height as u32 {
+                let src_start =
+                    (source_region.x_min + (source_region.y_min + y) * stride as u32) as usize;
+                let dst_start =
+                    (dest_region.x_min + (dest_region.y_min + y) * stride as u32) as usize;
+                pixels.copy_within(src_start..src_start + width, dst_start);
             }
         }
-    } else {
-        let source = source.read_area(source_region, renderer);
 
-        if !blend && (dest.transparency() || !source.transparency()) {
-            // Copying (not blending) anything to a transparent texture,
-            // or copying an opaque texture to an opaque texture,
-            // means we can skip alpha premultiplication
+        write.set_cpu_dirty(context, dest_region);
+    } else {
+        let mut dest_write = dest.borrow_mut(context);
+        let source_read = source.read_area(source_region, renderer);
+
+        let src_stride = source_read.width() as usize;
+        let dst_stride = dest_write.width() as usize;
+
+        if !blend && (dest_write.transparency() || !source_read.transparency()) {
+            // Straight copy (no blending, no alpha fixup needed)
 
             if dest_region == source_region
-                && dest_region.width() == dest.width()
-                && dest_region.height() == dest.height()
-                && dest_region.width() == source.width()
-                && dest_region.height() == source.height()
+                && dest_region.width() == dest_write.width()
+                && dest_region.height() == dest_write.height()
+                && dest_region.width() == source_read.width()
+                && dest_region.height() == source_read.height()
             {
-                // Copying an entire texture that's the same size and type? Just replace the whole thing
-                dest.raw_pixels_mut().copy_from_slice(source.raw_pixels());
+                // Full-image copy
+                dest_write
+                    .raw_pixels_mut()
+                    .copy_from_slice(source_read.raw_pixels());
             } else {
-                for y in 0..dest_region.height() {
-                    for x in 0..dest_region.width() {
-                        let color = source
-                            .get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
-                        dest.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
-                    }
+                // Row-by-row memcpy
+                let src_pixels = source_read.raw_pixels();
+                let dst_pixels = dest_write.raw_pixels_mut();
+                for y in 0..height as u32 {
+                    let src_start = (source_region.x_min
+                        + (source_region.y_min + y) * src_stride as u32)
+                        as usize;
+                    let dst_start =
+                        (dest_region.x_min + (dest_region.y_min + y) * dst_stride as u32) as usize;
+                    dst_pixels[dst_start..dst_start + width]
+                        .copy_from_slice(&src_pixels[src_start..src_start + width]);
                 }
             }
         } else {
-            // Copying (not blending) a transparent texture to an opaque texture,
-            // or blending anything to anything
+            // Blending or transparent-to-opaque copy
+            let opaque = !dest_write.transparency();
+            let src_pixels = source_read.raw_pixels();
+            let dst_pixels = dest_write.raw_pixels_mut();
 
-            let opaque = !dest.transparency();
+            for y in 0..height as u32 {
+                let src_start =
+                    (source_region.x_min + (source_region.y_min + y) * src_stride as u32) as usize;
+                let dst_start =
+                    (dest_region.x_min + (dest_region.y_min + y) * dst_stride as u32) as usize;
+                let src_row = &src_pixels[src_start..src_start + width];
+                let dst_row = &mut dst_pixels[dst_start..dst_start + width];
 
-            for y in 0..dest_region.height() {
-                for x in 0..dest_region.width() {
-                    let mut color =
-                        source.get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
-                    if blend {
-                        color = dest
-                            .get_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y)
-                            .blend_over(&color);
-                    }
+                if blend {
+                    blend_row(dst_row, src_row);
                     if opaque {
-                        color = color.with_alpha(255);
+                        for d in dst_row.iter_mut() {
+                            *d = d.with_alpha(255);
+                        }
                     }
-                    dest.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
+                } else {
+                    // transparent-to-opaque: copy and force alpha to 255
+                    dst_row.copy_from_slice(src_row);
+                    for d in dst_row.iter_mut() {
+                        *d = d.with_alpha(255);
+                    }
                 }
             }
         }
-    }
 
-    dest.set_cpu_dirty(context, dest_region);
+        dest_write.set_cpu_dirty(context, dest_region);
+    }
 }
 
 fn blend_and_transform<'gc>(


### PR DESCRIPTION
Per future CONTRIBUTING.md, I want to state that this code was generated by Claude Code, specifically Claude Opus 4.6. My workflow is iteratively profiling Ruffle with various SWFs, feeding the profiler output to the LLM, having it identify hotspots and generate optimizations, then re-profiling to verify the improvement. This is one of many PRs I intend to submit that were produced this way.

I have reviewed the code to the best of my ability, though in full transparency, I have not audited every individual line in detail.

EDIT: Here is a description of what it does: This replaces per-pixel get/set_pixel32_raw loops with row-based slice operations: memcpy for copies, and a two-lane u32 blend with div255 bit-trick for alpha compositing.

Here are some benchmarks:
| Benchmark | This PR (ms) | Nightly (ms) | Change |                                                                                                                                                                                                                                                                         
  |---|---|---|---|
  | copypixels_merge_alpha | 468 | 2459 | -81.0% |                                                                                                                                                                                                                                                                          
  | copypixels_merge_alpha_small | 33 | 168 | -80.4% |
  | colortransform_alpha_tint | 388 | 360 | +7.8% |                                                                                                                                                                                                                                                                         
  | sprite_render_pipeline | 420 | 534 | -21.3% |
  | draw_alpha_blend | 1076 | 1694 | -36.5% |
  | draw_alpha_matrix_blend | 1499 | 1639 | -8.5% |
  | particle_fade_composite | 113 | 131 | -13.7% |
  | multi_sprite_composite | 195 | 817 | -76.1% |
  | locked_buffer_composite | 32 | 158 | -79.7% |

Excerpt from my "comprehensive" SWF benchmarks (however I can share the full SWF if you want):
```actionscript                                                                                                                                                                                                                                                                                                           
  private function benchCopyPixelsMergeAlpha(n:int):void {
      var src:BitmapData = new BitmapData(256, 256, true, 0x80FF0000); // 50% alpha red                                                                                                                                                                                                                                     
      var dst:BitmapData = new BitmapData(256, 256, true, 0xFF000000); // opaque black                                                                                                                                                                                                                                      
      var rect:Rectangle = new Rectangle(0, 0, 256, 256);                                                                                                                                                                                                                                                                   
      var pt:Point = new Point(0, 0);
      for (var i:int = 0; i < n; i++) {
          dst.copyPixels(src, rect, pt, null, null, true); // mergeAlpha=true
      }
      src.dispose();
      dst.dispose();
  }
```

