### PR TITLE
core: Move FontMetrics to GlyphSource

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1275,9 +1275,10 @@ impl<'gc> EditText<'gc> {
         if let Some((text, _tf, font, params, color)) =
             lbox.as_renderable_text(self.0.text_spans.borrow().displayed_text())
         {
-            let baseline = font.get_baseline_for_height(params.height());
-            let descent = font.get_descent_for_height(params.height());
-            let caret_height = baseline + descent;
+            let metrics = font.metrics();
+            let ascent = metrics.ascent(params.height());
+            let descent = metrics.descent(params.height());
+            let caret_height = ascent + descent;
             let mut caret_x = Twips::ZERO;
             font.evaluate(
                 text,
@@ -1321,7 +1322,7 @@ impl<'gc> EditText<'gc> {
             } = lbox.content()
             {
                 // Draw underline
-                let underline_y = baseline + (max_descent / 2);
+                let underline_y = ascent + (max_descent / 2);
                 let underline_width = lbox.bounds().width();
                 self.render_underline(context, underline_width, underline_y, color);
             }
@@ -2252,8 +2253,10 @@ impl<'gc> EditText<'gc> {
         let font_set = first_font_set?;
         let text_format = first_format?;
         let size = Twips::from_pixels(text_format.size?);
-        let ascent = font_set.get_baseline_for_height(size);
-        let descent = font_set.get_descent_for_height(size);
+
+        let metrics = font_set.metrics();
+        let ascent = metrics.ascent(size);
+        let descent = metrics.descent(size);
         let leading = Twips::from_pixels(text_format.leading?);
 
         Some(LayoutMetrics {

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -455,10 +455,10 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
         self.has_line_break = true;
 
         let font_size = Twips::from_pixels(self.current_line_span.font.size);
-        let font = self.font_set.unwrap();
+        let metrics = self.font_set.unwrap().metrics();
         self.max_font_size = font_size;
-        self.max_ascent = font.get_baseline_for_height(font_size);
-        self.max_descent = font.get_descent_for_height(font_size);
+        self.max_ascent = metrics.ascent(font_size);
+        self.max_descent = metrics.descent(font_size);
         self.max_leading = Twips::from_pixels(span.leading);
     }
 
@@ -490,9 +490,9 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
     /// Enter a new span.
     fn newspan(&mut self, first_span: &TextSpan) {
         let font_size = Twips::from_pixels(first_span.font.size);
-        let font = self.font_set.unwrap();
-        let ascent = font.get_baseline_for_height(font_size);
-        let descent = font.get_descent_for_height(font_size);
+        let metrics = self.font_set.unwrap().metrics();
+        let ascent = metrics.ascent(font_size);
+        let descent = metrics.descent(font_size);
         let leading = Twips::from_pixels(first_span.leading);
         if self.is_start_of_line() {
             self.current_line_span = first_span.clone();
@@ -679,8 +679,9 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
     fn append_text_fragment(&mut self, text: &'a WStr, start: usize, end: usize, span: &TextSpan) {
         let font_set = self.font_set.expect("text fragment requires a font");
         let params = EvalParameters::from_span(span);
-        let ascent = font_set.get_baseline_for_height(params.height());
-        let descent = font_set.get_descent_for_height(params.height());
+        let metrics = font_set.metrics();
+        let ascent = metrics.ascent(params.height());
+        let descent = metrics.descent(params.height());
         let text_width = font_set.measure(text, params);
         let box_origin = self.cursor - (Twips::ZERO, ascent).into();
 
@@ -709,8 +710,9 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
         );
 
         let params = EvalParameters::from_span(span);
-        let ascent = bullet_font.get_baseline_for_height(params.height());
-        let descent = bullet_font.get_descent_for_height(params.height());
+        let metrics = bullet_font.metrics();
+        let ascent = metrics.ascent(params.height());
+        let descent = metrics.descent(params.height());
         let bullet = WStr::from_units(&[0x2022u16]);
         let text_width = bullet_font.measure(bullet, params);
         let box_origin = bullet_cursor - (Twips::ZERO, ascent).into();

--- a/web/src/ui/font_renderer.rs
+++ b/web/src/ui/font_renderer.rs
@@ -140,9 +140,13 @@ impl CanvasFontRenderer {
 }
 
 impl FontRenderer for CanvasFontRenderer {
+    fn scale(&self) -> f32 {
+        (Self::SIZE_PX * Self::SCALE) as f32
+    }
+
     fn get_font_metrics(&self) -> FontMetrics {
         FontMetrics {
-            scale: (Self::SIZE_PX * Self::SCALE) as f32,
+            scale: self.scale(),
             ascent: (self.ascent * Self::SCALE) as i32,
             descent: (self.descent * Self::SCALE) as i32,
             leading: 0,


### PR DESCRIPTION
Each GlyphSource can provide its own metrics.  This is done in line with
how device fonts works in Flash Player and how the external renderer
should provide font metrics.  The metrics can differ for different size
of text.