### PR TITLE
tests: Make bare_numbers = false the default

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -55,13 +55,13 @@ log_fetch = false
 
 # Sometimes floating point math doesn't exactly 100% match between Flash and Rust.
 # If you encounter this in a test, the following section will change the output
-# testing from "exact" to "approximate" (when it comes to floating point numbers, at least.)
+# testing from "exact" to "approximate" (when it comes to floating point numbers, at least).
 [approximations]
 
 # Should output lines solely consisting of a single number be subject to approximations?
-bare_numbers = true
+bare_numbers = false
 
-# A list of regex patterns with capture groups to additionally treat as approximate numbers.
+# A list of regex patterns with capture groups to treat as approximate numbers.
 number_patterns = []
 
 # The upper bound of any rounding errors.

--- a/tests/framework/src/options/approximations.rs
+++ b/tests/framework/src/options/approximations.rs
@@ -6,16 +6,11 @@ use serde::Deserialize;
 #[derive(Clone, Deserialize, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct Approximations {
-    #[serde(default = "default_for_bare_numbers")]
+    #[serde(default)]
     pub bare_numbers: bool,
     number_patterns: Vec<String>,
     epsilon: Option<f64>,
     max_relative: Option<f64>,
-}
-
-// Serde requires defaults to be provided through functions
-fn default_for_bare_numbers() -> bool {
-    true
 }
 
 impl Approximations {

--- a/tests/tests/swfs/avm1/edittext_align/test.toml
+++ b/tests/tests/swfs/avm1/edittext_align/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 3.0

--- a/tests/tests/swfs/avm1/edittext_bullet/test.toml
+++ b/tests/tests/swfs/avm1/edittext_bullet/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 1.0

--- a/tests/tests/swfs/avm1/edittext_hscroll/test.toml
+++ b/tests/tests/swfs/avm1/edittext_hscroll/test.toml
@@ -1,6 +1,7 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 2.0
 
 [player_options]

--- a/tests/tests/swfs/avm1/edittext_letter_spacing/test.toml
+++ b/tests/tests/swfs/avm1/edittext_letter_spacing/test.toml
@@ -1,5 +1,6 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 # TODO: Discrepancy in wrapping in letterSpacing = 0.1 test.
 epsilon = 12.0

--- a/tests/tests/swfs/avm1/edittext_margins/test.toml
+++ b/tests/tests/swfs/avm1/edittext_margins/test.toml
@@ -1,5 +1,6 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 # TODO: Discrepancy in wrapping.
 epsilon = 4.0

--- a/tests/tests/swfs/avm1/edittext_tab_stops/test.toml
+++ b/tests/tests/swfs/avm1/edittext_tab_stops/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 5.0

--- a/tests/tests/swfs/avm1/edittext_underline/test.toml
+++ b/tests/tests/swfs/avm1/edittext_underline/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 4.0

--- a/tests/tests/swfs/avm1/gettextextent/test.toml
+++ b/tests/tests/swfs/avm1/gettextextent/test.toml
@@ -1,6 +1,7 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 # TODO: Flash Player breaks single words that are longer than the line, but we don't.
 epsilon = 30.0
 

--- a/tests/tests/swfs/avm1/local_to_global/test.toml
+++ b/tests/tests/swfs/avm1/local_to_global/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 0.051

--- a/tests/tests/swfs/avm1/math_swf6/test.toml
+++ b/tests/tests/swfs/avm1/math_swf6/test.toml
@@ -4,5 +4,4 @@ known_failure = true
 [approximations]
 epsilon = 1e-14 # roughly 50 ulps
 # We only want to apply approximations to non-integers.
-bare_numbers = false
 number_patterns = ["(\\d+\\.\\d+)"]

--- a/tests/tests/swfs/avm1/math_swf7/test.toml
+++ b/tests/tests/swfs/avm1/math_swf7/test.toml
@@ -4,5 +4,4 @@ known_failure = true
 [approximations]
 epsilon = 1e-14 # roughly 50 ulps
 # We only want to apply approximations to non-integers.
-bare_numbers = false
 number_patterns = ["(\\d+\\.\\d+)"]

--- a/tests/tests/swfs/avm1/math_swf8/test.toml
+++ b/tests/tests/swfs/avm1/math_swf8/test.toml
@@ -4,5 +4,4 @@ known_failure = true
 [approximations]
 epsilon = 1e-14 # roughly 50 ulps
 # We only want to apply approximations to non-integers.
-bare_numbers = false
 number_patterns = ["(\\d+\\.\\d+)"]

--- a/tests/tests/swfs/avm1/movieclip_getbounds/test.toml
+++ b/tests/tests/swfs/avm1/movieclip_getbounds/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 0.051

--- a/tests/tests/swfs/avm1/stage_object_properties/test.toml
+++ b/tests/tests/swfs/avm1/stage_object_properties/test.toml
@@ -1,4 +1,5 @@
 num_frames = 6
 
 [approximations]
+bare_numbers = true
 epsilon = 0.051

--- a/tests/tests/swfs/avm1/stage_object_properties_swf6/test.toml
+++ b/tests/tests/swfs/avm1/stage_object_properties_swf6/test.toml
@@ -1,4 +1,5 @@
 num_frames = 4
 
 [approximations]
+bare_numbers = true
 epsilon = 0.051

--- a/tests/tests/swfs/avm2/bevel_filter/test.toml
+++ b/tests/tests/swfs/avm2/bevel_filter/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 0.01

--- a/tests/tests/swfs/avm2/blur_filter/test.toml
+++ b/tests/tests/swfs/avm2/blur_filter/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 0.00001

--- a/tests/tests/swfs/avm2/coerce_string_precision/test.toml
+++ b/tests/tests/swfs/avm2/coerce_string_precision/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 max_relative = 0.000000000000006661338147750939

--- a/tests/tests/swfs/avm2/displayobject_height/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_height/test.toml
@@ -1,5 +1,6 @@
 num_frames = 7
 
 [approximations]
+bare_numbers = true
 # TODO: height/width appears to be off by 1 twip sometimes
 epsilon = 0.06

--- a/tests/tests/swfs/avm2/displayobject_rotation/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_rotation/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 0.0000000001

--- a/tests/tests/swfs/avm2/displayobject_width/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_width/test.toml
@@ -1,4 +1,5 @@
 num_frames = 7
 
 [approximations]
+bare_numbers = true
 epsilon = 0.06

--- a/tests/tests/swfs/avm2/divide/test.toml
+++ b/tests/tests/swfs/avm2/divide/test.toml
@@ -1,5 +1,6 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 # TODO: Discrepancy in float formatting.
 epsilon = 0.0

--- a/tests/tests/swfs/avm2/drop_shadow_filter/test.toml
+++ b/tests/tests/swfs/avm2/drop_shadow_filter/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 0.001

--- a/tests/tests/swfs/avm2/edittext_bullet/test.toml
+++ b/tests/tests/swfs/avm2/edittext_bullet/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 1.0

--- a/tests/tests/swfs/avm2/edittext_letter_spacing/test.toml
+++ b/tests/tests/swfs/avm2/edittext_letter_spacing/test.toml
@@ -1,5 +1,6 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 # TODO: Discrepancy in wrapping in letterSpacing = 0.1 test.
 epsilon = 12.0

--- a/tests/tests/swfs/avm2/edittext_margins/test.toml
+++ b/tests/tests/swfs/avm2/edittext_margins/test.toml
@@ -1,5 +1,6 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 # TODO: Discrepancy in wrapping.
 epsilon = 5.0

--- a/tests/tests/swfs/avm2/glow_filter/test.toml
+++ b/tests/tests/swfs/avm2/glow_filter/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 0.001

--- a/tests/tests/swfs/avm2/gradient_bevel_filter/test.toml
+++ b/tests/tests/swfs/avm2/gradient_bevel_filter/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 0.001

--- a/tests/tests/swfs/avm2/gradient_glow_filter/test.toml
+++ b/tests/tests/swfs/avm2/gradient_glow_filter/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 epsilon = 0.001

--- a/tests/tests/swfs/avm2/math/test.toml
+++ b/tests/tests/swfs/avm2/math/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 max_relative = 0.000000000000006661338147750939

--- a/tests/tests/swfs/avm2/number_toexponential/test.toml
+++ b/tests/tests/swfs/avm2/number_toexponential/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 max_relative = 0.001

--- a/tests/tests/swfs/avm2/number_tofixed/test.toml
+++ b/tests/tests/swfs/avm2/number_tofixed/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 max_relative = 0.001

--- a/tests/tests/swfs/avm2/number_toprecision/test.toml
+++ b/tests/tests/swfs/avm2/number_toprecision/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 max_relative = 0.001

--- a/tests/tests/swfs/avm2/parse_float/test.toml
+++ b/tests/tests/swfs/avm2/parse_float/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 max_relative = 0.0000000000000011102230246251565

--- a/tests/tests/swfs/avm2/parse_float_swf10/test.toml
+++ b/tests/tests/swfs/avm2/parse_float_swf10/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
 
 [approximations]
+bare_numbers = true
 max_relative = 0.0000000000000011102230246251565


### PR DESCRIPTION
It's better to be explicit than implicit.  Before this patch, by default approximations were applied to lines with only a number.  Now, in order to enable this behavior, bare_numbers = true has to be set explicitly.