### PR TITLE
chore: Enable unused_async clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ unknown_lints = "allow"
 # add a comment explaining why.
 trivially_copy_pass_by_ref = "deny"
 redundant_clone = "deny"
+unused_async = "deny"
 
 # LONG-TERM: These lints are unhelpful.
 manual_map = "allow"             # Less readable: Suggests `opt.map(..)` instead of `if let Some(opt) { .. }`

--- a/desktop/src/gui/dialogs/export_bundle_dialog.rs
+++ b/desktop/src/gui/dialogs/export_bundle_dialog.rs
@@ -311,14 +311,13 @@ impl ExportBundleDialog {
                 player_options,
                 movie_url,
                 local_files,
-            )
-            .await;
+            );
             export_status.set(status);
         });
         ExportStatus::Exporting
     }
 
-    async fn perform_export(
+    fn perform_export(
         selected_file: Option<FileHandle>,
         bundle_name: String,
         player_options: PlayerOptions,

--- a/frontend-utils/src/bundle/exporter/fs_helper.rs
+++ b/frontend-utils/src/bundle/exporter/fs_helper.rs
@@ -413,7 +413,7 @@ mod tests {
         ));
     }
 
-    async fn perform_export(
+    fn perform_export(
         output: &Path,
         bundle_name: String,
         player_options: PlayerOptions,
@@ -444,8 +444,7 @@ mod tests {
             player_options.clone(),
             movie_url.clone(),
             Vec::new(),
-        )
-        .await;
+        );
         assert!(result.is_ok());
 
         let bundle = open_bundle(&output_path);
@@ -474,8 +473,7 @@ mod tests {
             PlayerOptions::default(),
             url_from_path(&movie_path),
             Vec::new(),
-        )
-        .await;
+        );
         assert!(result.is_err());
 
         assert!(
@@ -500,9 +498,8 @@ mod tests {
             bundle_name.clone(),
             player_options.clone(),
             url_from_path(&movie_path),
-            vec![movie_path.clone()],
-        )
-        .await;
+            vec![movie_path],
+        );
         assert!(result.is_ok());
 
         let bundle = open_bundle(&output_path);
@@ -536,14 +533,8 @@ mod tests {
             "multiple_files".to_owned(),
             PlayerOptions::default(),
             url_from_path(&movie_path),
-            vec![
-                movie_path.clone(),
-                file_a.clone(),
-                file_c.clone(),
-                file_b.clone(),
-            ],
-        )
-        .await;
+            vec![movie_path, file_a, file_c, file_b],
+        );
         assert!(result.is_ok());
 
         let bundle = open_bundle(&output_path);
@@ -579,9 +570,8 @@ mod tests {
             "root_swf_in_subdir".to_owned(),
             PlayerOptions::default(),
             url_from_path(&movie_path),
-            vec![movie_path.clone(), file_other.clone()],
-        )
-        .await;
+            vec![movie_path, file_other],
+        );
         assert!(result.is_ok());
 
         let bundle = open_bundle(&output_path);
@@ -617,8 +607,7 @@ mod tests {
             PlayerOptions::default(),
             url_from_path(&movie_path),
             vec![movie_path],
-        )
-        .await;
+        );
         assert!(result.is_err());
 
         assert!(
@@ -646,8 +635,7 @@ mod tests {
             player_options.clone(),
             url("http://example.com"),
             Vec::new(),
-        )
-        .await;
+        );
         assert!(result.is_ok());
 
         let bundle = open_bundle(&output_path);

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -360,7 +360,7 @@ impl RuffleInstanceBuilder {
 
     // TODO: This should be split into two methods that either load url or load data
     // Right now, that's done immediately afterwards in TS
-    pub async fn build(&self, parent: HtmlElement, js_player: JavascriptPlayer) -> Promise {
+    pub fn build(&self, parent: HtmlElement, js_player: JavascriptPlayer) -> Promise {
         let copy = self.clone();
         wasm_bindgen_futures::future_to_promise(async move {
             if RUFFLE_GLOBAL_PANIC.is_completed() {
@@ -496,6 +496,7 @@ impl RuffleInstanceBuilder {
         Arc::new(tracing_subscriber::registry().with(layer))
     }
 
+    #[allow(clippy::unused_async)]
     pub async fn create_renderer(
         &self,
     ) -> Result<(Box<dyn RenderBackend>, HtmlCanvasElement), Box<dyn Error>> {


### PR DESCRIPTION
RuffleInstanceBuilder::create_renderer has .await only on some platforms, so that's why #[allow(clippy::unused_async)] is added there. Also, removing the async and await trigger some redundant clone lints, so those had to also be fixed up.

RuffleInstanceBuilder::build was async unnecessarily, the asyncness was already encoded in the fact that it returns a promise. 