### PR TITLE
tests: Do not save expected image when it doesn't exist

### DIFF
--- a/tests/framework/src/runner/image_test.rs
+++ b/tests/framework/src/runner/image_test.rs
@@ -28,18 +28,16 @@ pub fn capture_and_compare_image(
     };
 
     let expected_image = {
-        let path = base_path.join(format!("{name}.expected.png"))?;
+        let filename = format!("{name}.expected.png");
+        let path = base_path.join(&filename)?;
         if path.exists()? {
             image::load_from_memory(&read_bytes(&path)?)
                 .context("Failed to open expected image")?
                 .into_rgba8()
-        } else if image_comparison.known_failure {
-            // If we're expecting this to be wrong, don't save a likely wrong image
-            return Err(anyhow!("Image '{name}': No image to compare to!"));
         } else {
-            write_image(&path, &actual_image)?;
             return Err(anyhow!(
-                "Image '{name}': No image to compare to! Saved actual image as expected."
+                "Image '{name}': No image to compare to! \
+                Please take an expected image from Flash Player and save it as {filename}."
             ));
         }
     };


### PR DESCRIPTION
Instead, incentivize users to take an expected image from Flash Player. That's the preferred way of obtaining expected images.