### PR TITLE
avm2: Don't store `num_locals` in `Activation`

### DIFF
--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -101,7 +101,7 @@ pub enum Op<'gc> {
     ConvertO,
     ConvertS,
     Debug {
-        is_local_register: bool,
+        register_kind: RegisterKind,
         register_name: AvmAtom<'gc>,
         register: u8,
     },
@@ -418,6 +418,13 @@ impl Op<'_> {
 pub struct LookupSwitch {
     pub default_offset: Cell<usize>,
     pub case_offsets: Box<[Cell<usize>]>,
+}
+
+#[derive(Copy, Clone, Collect, Debug)]
+#[collect(require_static)]
+pub enum RegisterKind {
+    Local { out_of_bounds: bool },
+    Unknown,
 }
 
 #[cfg(target_pointer_width = "64")]

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -8,7 +8,7 @@ use crate::avm2::error::{
 use crate::avm2::method::Method;
 use crate::avm2::multiname::Multiname;
 use crate::avm2::namespace::Namespace;
-use crate::avm2::op::{LookupSwitch, Op};
+use crate::avm2::op::{LookupSwitch, Op, RegisterKind};
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::{Activation, Error, QName};
 use crate::string::{AvmAtom, AvmString};
@@ -1242,7 +1242,12 @@ fn translate_op<'gc>(
             let register_name = pool_string(activation, translation_unit, register_name)?;
 
             Op::Debug {
-                is_local_register,
+                register_kind: if is_local_register {
+                    let out_of_bounds = u32::from(register) >= max_locals;
+                    RegisterKind::Local { out_of_bounds }
+                } else {
+                    RegisterKind::Unknown
+                },
                 register_name,
                 register,
             }


### PR DESCRIPTION
A (micro-)optimization that saves one `usize` per `Activation` on the stack.

To enable this:
- in `Op::Debug`, store whether the stack slot is out-of-bounds or not;
- in exception handling, retrieve the number of locals (used for resetting the stack) directly from the current method's body; this is slightly slower but catching errors is rare so this doesn't matter much.