### PR TITLE
core: Fix memory leaks by making MovieLibrary garbage-collectable

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1145,7 +1145,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                         }
                     } else {
                         let level = self.get_or_create_level(level_id);
-                        let future = self.context.load_manager.load_movie_into_clip(
+                        let (future, _handle) = self.context.load_manager.load_movie_into_clip(
                             self.context.player_handle(),
                             level,
                             Request::get(url.to_string()),
@@ -1267,7 +1267,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                         url,
                         NavigationMethod::from_send_vars_method(action.send_vars_method()),
                     );
-                    let future = self.context.load_manager.load_movie_into_clip(
+                    let (future, _handle) = self.context.load_manager.load_movie_into_clip(
                         self.context.player_handle(),
                         clip_target,
                         request,
@@ -1295,7 +1295,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                         mc.avm1_unload_movie(self.context);
                     }
                 } else {
-                    let future = self.context.load_manager.load_movie_into_clip(
+                    let (future, _handle) = self.context.load_manager.load_movie_into_clip(
                         self.context.player_handle(),
                         clip_target,
                         Request::get(url.to_utf8_lossy().into_owned()),
@@ -2798,8 +2798,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         if let Some(level) = self.get_level(level_id) {
             level
         } else {
-            let level: DisplayObject<'_> =
-                MovieClip::new(self.base_clip().movie(), self.gc()).into();
+            let movie = self.base_clip().movie();
+            let library = self
+                .context
+                .library
+                .library_for_movie_mut(movie, self.context.gc_context);
+            let level: DisplayObject<'_> = MovieClip::new(library, self.gc()).into();
 
             level.set_depth(level_id);
             level.set_default_root_name(self.context);

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1303,8 +1303,8 @@ fn load_bitmap<'gc>(
     );
 
     let character = library
-        .library_for_movie(movie)
-        .and_then(|l| l.character_by_export_name(name));
+        .library_for_movie(&movie, activation.gc())
+        .and_then(|l| l.borrow().character_by_export_name(name));
 
     let Some((_id, Character::Bitmap(bitmap))) = character else {
         return Ok(Value::Undefined);

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -68,7 +68,7 @@ fn load_clip<'gc>(
                 _ => None,
             };
             if let Some(target) = target {
-                let future = activation.context.load_manager.load_movie_into_clip(
+                let (future, _handle) = activation.context.load_manager.load_movie_into_clip(
                     activation.context.player_handle(),
                     target,
                     Request::get(url.to_utf8_lossy().into_owned()),

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -389,7 +389,8 @@ fn attach_sound<'gc>(
         if let Some((_, Character::Sound(sound_handle))) = activation
             .context
             .library
-            .library_for_movie_mut(movie)
+            .library_for_movie_mut(movie, activation.context.gc_context)
+            .borrow()
             .character_by_export_name(name)
         {
             sound.load_sound(activation, this, sound_handle);
@@ -705,7 +706,8 @@ fn stop<'gc>(
             if let Some((_, Character::Sound(sound))) = activation
                 .context
                 .library
-                .library_for_movie_mut(movie)
+                .library_for_movie_mut(movie, activation.context.gc_context)
+                .borrow()
                 .character_by_export_name(name)
             {
                 // Stop all sounds with the given name.

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -513,6 +513,10 @@ fn get_text_extent<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let movie = activation.base_clip().movie();
+    let library = activation
+        .context
+        .library
+        .library_for_movie_mut(movie, activation.context.gc_context);
     let text = args
         .get(0)
         .cloned()
@@ -526,7 +530,7 @@ fn get_text_extent<'gc>(
 
     let temp_edittext = EditText::new(
         activation.context,
-        movie,
+        library,
         0.0,
         0.0,
         width.unwrap_or(0.0),

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -828,7 +828,11 @@ pub fn load_playerglobal<'gc>(context: &mut UpdateContext<'gc>, domain: Domain<'
             .expect("playerglobal.swf should be valid"),
     );
 
-    let slice = SwfSlice::from(movie.clone());
+    let library = context
+        .library
+        .library_for_movie_mut(movie.clone(), context.gc_context);
+
+    let slice = SwfSlice::from(movie);
 
     let mut reader = slice.read_from(0);
 
@@ -837,7 +841,7 @@ pub fn load_playerglobal<'gc>(context: &mut UpdateContext<'gc>, domain: Domain<'
             let do_abc = reader
                 .read_do_abc_2()
                 .expect("playerglobal.swf should be valid");
-            Avm2::load_builtin_abc(context, do_abc.data, domain, movie.clone());
+            Avm2::load_builtin_abc(context, do_abc.data, domain, library);
         } else if tag_code != TagCode::End {
             panic!("playerglobal should only contain `DoAbc2` tag - found tag {tag_code:?}")
         }

--- a/core/src/avm2/globals/flash/display/Loader.as
+++ b/core/src/avm2/globals/flash/display/Loader.as
@@ -1,6 +1,4 @@
 package flash.display {
-    import __ruffle__.stub_method;
-
     import flash.display.LoaderInfo;
     import flash.display.DisplayObject;
     import flash.errors.IllegalOperationError;
@@ -30,14 +28,9 @@ package flash.display {
         public native function unload():void;
 
         [API("662")]
-        public function unloadAndStop(gc:Boolean = true):void {
-            stub_method("flash.display.Loader", "unloadAndStop");
-            this.unload();
-        }
+        public native function unloadAndStop(gc:Boolean = true):void;
 
-        public function close():void {
-            stub_method("flash.display.Loader", "close");
-        }
+        public native function close():void;
 
         override public function addChild(child:DisplayObject):DisplayObject {
             throw new IllegalOperationError("Error #2069: The Loader class does not implement this method.", 2069);

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -95,18 +95,10 @@ pub fn init<'gc>(
     // We set the underlying BitmapData instance - we start out with a dummy BitmapData,
     // which makes custom classes see a disposed BitmapData before they call super()
     let name = this.instance_class().name();
-    let character = activation
-        .context
-        .library
-        .avm2_class_registry()
-        .class_symbol(this.instance_class())
-        .and_then(|(movie, chara_id)| {
-            activation
-                .context
-                .library
-                .library_for_movie_mut(movie)
-                .character_by_id(chara_id)
-        });
+    let character = this
+        .instance_class()
+        .symbol_class_link(activation.gc())
+        .and_then(|(lib, chara_id)| lib.borrow().character_by_id(chara_id));
 
     let new_bitmap_data = if let Some(Character::Bitmap(bitmap)) = character {
         // Instantiating BitmapData from an Animate-style bitmap asset

--- a/core/src/avm2/globals/flash/display/loader_info.rs
+++ b/core/src/avm2/globals/flash/display/loader_info.rs
@@ -48,11 +48,11 @@ pub fn get_application_domain<'gc>(
     if let Some(loader_stream) = this.as_loader_info_object().map(|o| o.loader_stream()) {
         match &*loader_stream {
             LoaderStream::NotYetLoaded(movie, _, _) => {
-                let domain = activation
+                let lib = activation
                     .context
                     .library
-                    .library_for_movie_mut(movie.clone())
-                    .try_avm2_domain();
+                    .library_for_movie_mut(movie.clone(), activation.context.gc_context);
+                let domain = lib.borrow().try_avm2_domain();
 
                 if let Some(domain) = domain {
                     return Ok(DomainObject::from_domain(activation, domain).into());
@@ -63,11 +63,11 @@ pub fn get_application_domain<'gc>(
 
             // A loaded SWF will always have an AVM2 domain present.
             LoaderStream::Swf(movie, _) => {
-                let domain = activation
+                let lib = activation
                     .context
                     .library
-                    .library_for_movie_mut(movie.clone())
-                    .avm2_domain();
+                    .library_for_movie_mut(movie.clone(), activation.context.gc_context);
+                let domain = lib.borrow().avm2_domain();
                 return Ok(DomainObject::from_domain(activation, domain).into());
             }
         }

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -23,23 +23,20 @@ pub fn sprite_allocator<'gc>(
     while let Some(class) = class_def {
         if class == sprite_cls {
             let movie = activation.caller_movie_or_root();
-            let display_object = MovieClip::new(movie, activation.gc()).into();
+            let library = activation
+                .context
+                .library
+                .library_for_movie_mut(movie, activation.context.gc_context);
+            let display_object = MovieClip::new(library, activation.gc()).into();
             return Ok(
                 initialize_for_allocator(activation.context, display_object, orig_class).into(),
             );
         }
 
-        if let Some((movie, symbol)) = activation
-            .context
-            .library
-            .avm2_class_registry()
-            .class_symbol(class)
-        {
-            let child = activation
-                .context
-                .library
-                .library_for_movie_mut(movie)
-                .instantiate_by_id(symbol, activation.context.gc_context);
+        if let Some((lib, symbol)) = class.symbol_class_link(activation.gc()) {
+            let child = lib
+                .borrow()
+                .instantiate_by_id(symbol, activation.context.gc_context, lib);
 
             if let Some(child) = child {
                 return Ok(initialize_for_allocator(activation.context, child, orig_class).into());

--- a/core/src/avm2/globals/flash/events/event_dispatcher.rs
+++ b/core/src/avm2/globals/flash/events/event_dispatcher.rs
@@ -37,12 +37,18 @@ pub fn add_event_listener<'gc>(
     let listener = args.get_function(activation, 1, "listener")?;
     let use_capture = args.get_bool(2);
     let priority = args.get_i32(3);
+    let use_weak_reference = args.get_bool(4);
 
-    //TODO: If we ever get weak GC references, we should respect `useWeakReference`.
     dispatch_list
         .as_dispatch_mut(activation.gc())
         .expect("Internal properties should have what I put in them")
-        .add_event_listener(event_type, priority, listener, use_capture);
+        .add_event_listener(
+            event_type,
+            priority,
+            listener,
+            use_capture,
+            use_weak_reference,
+        );
 
     Avm2::register_broadcast_listener(activation.context, this, event_type);
 

--- a/core/src/avm2/globals/flash/media/sound.rs
+++ b/core/src/avm2/globals/flash/media/sound.rs
@@ -28,18 +28,8 @@ pub fn init<'gc>(
     if let Some(sound_object) = this.as_object().and_then(|o| o.as_sound_object()) {
         let class_def = this.instance_class(activation);
 
-        if let Some((movie, symbol)) = activation
-            .context
-            .library
-            .avm2_class_registry()
-            .class_symbol(class_def)
-        {
-            if let Some(Character::Sound(sound)) = activation
-                .context
-                .library
-                .library_for_movie_mut(movie)
-                .character_by_id(symbol)
-            {
+        if let Some((lib, symbol)) = class_def.symbol_class_link(activation.gc()) {
+            if let Some(Character::Sound(sound)) = lib.borrow().character_by_id(symbol) {
                 sound_object.set_sound(activation.context, sound);
             } else {
                 tracing::warn!(

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -68,10 +68,14 @@ pub fn create_text_line<'gc>(
 
     let class = activation.avm2().classes().textline;
     let movie = activation.caller_movie_or_root();
+    let library = activation
+        .context
+        .library
+        .library_for_movie_mut(movie, activation.context.gc_context);
 
     // FIXME: TextLine should be its own DisplayObject
     let display_object: EditText =
-        EditText::new_fte(activation.context, movie, 0.0, 0.0, width, 15.0);
+        EditText::new_fte(activation.context, library, 0.0, 0.0, width, 15.0);
 
     display_object.set_text(text.as_wstr(), activation.context);
 

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -20,7 +20,11 @@ pub fn text_field_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     // Creating a TextField from AS ignores SymbolClass linkage.
     let movie = activation.caller_movie_or_root();
-    let display_object = EditText::new(activation.context, movie, 0.0, 0.0, 100.0, 100.0).into();
+    let library = activation
+        .context
+        .library
+        .library_for_movie_mut(movie, activation.context.gc_context);
+    let display_object = EditText::new(activation.context, library, 0.0, 0.0, 100.0, 100.0).into();
 
     Ok(initialize_for_allocator(activation.context, display_object, class).into())
 }

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -17,21 +17,15 @@ pub fn byte_array_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let storage = if let Some((movie, id)) = activation
-        .context
-        .library
-        .avm2_class_registry()
-        .class_symbol(class.inner_class_definition())
+    let storage = if let Some((lib, id)) = class
+        .inner_class_definition()
+        .symbol_class_link(activation.gc())
     {
-        if let Some(lib) = activation.context.library.library_for_movie(movie) {
-            if let Some(Character::BinaryData(binary_data)) = lib.character_by_id(id) {
-                Some(ByteArrayStorage::from_vec(
-                    activation.context,
-                    binary_data.to_vec(),
-                ))
-            } else {
-                None
-            }
+        if let Some(Character::BinaryData(binary_data)) = lib.borrow().character_by_id(id) {
+            Some(ByteArrayStorage::from_vec(
+                activation.context,
+                binary_data.to_vec(),
+            ))
         } else {
             None
         }

--- a/core/src/avm2/object/font_object.rs
+++ b/core/src/avm2/object/font_object.rs
@@ -14,18 +14,12 @@ pub fn font_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    let font = if let Some((movie, id)) = activation
-        .context
-        .library
-        .avm2_class_registry()
-        .class_symbol(class.inner_class_definition())
+    let font = if let Some((lib, id)) = class
+        .inner_class_definition()
+        .symbol_class_link(activation.gc())
     {
-        if let Some(lib) = activation.context.library.library_for_movie(movie) {
-            if let Some(Character::Font(font)) = lib.character_by_id(id) {
-                Some(font)
-            } else {
-                None
-            }
+        if let Some(Character::Font(font)) = lib.borrow().character_by_id(id) {
+            Some(font)
         } else {
             None
         }

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -397,6 +397,7 @@ impl<'gc> AudioManager<'gc> {
                 {
                     sound.set_position(pos.round() as u32);
                 }
+
                 true
             } else {
                 // Sound ended.
@@ -772,11 +773,10 @@ impl<'gc> AudioManager<'gc> {
         character_id: CharacterId,
         sound_info: &SoundInfo,
     ) {
-        if let Some(handle) = context
+        let lib = context
             .library
-            .library_for_movie_mut(display_object.movie())
-            .get_sound(character_id)
-        {
+            .library_for_movie_mut(display_object.movie(), context.gc_context);
+        if let Some(handle) = lib.borrow().get_sound(character_id) {
             use swf::SoundEvent;
             // The sound event type is controlled by the "Sync" setting in the Flash IDE.
             match sound_info.event {

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -1,4 +1,5 @@
-use std::cell::OnceCell;
+use core::fmt;
+use std::cell::Cell;
 
 use crate::backend::audio::SoundHandle;
 use crate::binary_data::BinaryData;
@@ -31,24 +32,34 @@ pub enum Character<'gc> {
     BinaryData(Gc<'gc, BinaryData>),
 }
 
-#[derive(Collect, Debug)]
+#[derive(Collect)]
 #[collect(no_drop)]
 pub struct BitmapCharacter<'gc> {
     #[collect(require_static)]
     compressed: CompressedBitmap,
-    /// A lazily constructed GPU handle, used when performing fills with this bitmap
+    /// Lazily constructed GPU handle. Uses `Cell` (not `OnceCell`) so it can be
+    /// cleared via `release_handle()` to free VRAM; will be re-created from
+    /// `compressed` on next access.
     #[collect(require_static)]
-    handle: OnceCell<BitmapHandle>,
+    handle: Cell<Option<BitmapHandle>>,
     /// The bitmap class set by `SymbolClass` - this is used when we instantaite
     /// a `Bitmap` displayobject.
     avm2_class: Lock<BitmapClass<'gc>>,
+}
+
+impl fmt::Debug for BitmapCharacter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BitmapCharacter")
+            .field("compressed", &self.compressed)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'gc> BitmapCharacter<'gc> {
     pub fn new(compressed: CompressedBitmap) -> Self {
         Self {
             compressed,
-            handle: OnceCell::default(),
+            handle: Cell::new(None),
             avm2_class: Lock::new(BitmapClass::NoSubclass),
         }
     }
@@ -69,15 +80,18 @@ impl<'gc> BitmapCharacter<'gc> {
         &self,
         backend: &mut dyn RenderBackend,
     ) -> Result<BitmapHandle, RenderError> {
-        // FIXME - use `OnceCell::get_or_try_init` when stabilized.
-        if let Some(handle) = self.handle.get() {
-            return Ok(handle.clone());
+        if let Some(handle) = self.handle.take() {
+            self.handle.set(Some(handle.clone()));
+            return Ok(handle);
         }
         let decoded = self.compressed.decode()?;
         let new_handle = backend.register_bitmap(decoded)?;
-        // FIXME - do we ever want to release this handle, to avoid taking up GPU memory?
-        self.handle.set(new_handle.clone()).unwrap();
+        self.handle.set(Some(new_handle.clone()));
         Ok(new_handle)
+    }
+
+    pub fn release_handle(&self) {
+        self.handle.set(None);
     }
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -365,20 +365,25 @@ impl<'gc> UpdateContext<'gc> {
             self.root_swf.width().to_pixels() as u32,
             self.root_swf.height().to_pixels() as u32,
         );
-        self.stage.set_movie(self.gc(), self.root_swf.clone());
+        let root_lib = self
+            .library
+            .library_for_movie_mut(self.root_swf.clone(), self.gc_context);
+        self.stage.set_library(self.gc(), root_lib);
 
         let stage_domain = self.avm2.stage_domain();
         let mut activation = Avm2Activation::from_domain(self, stage_domain);
 
-        activation
-            .context
-            .library
-            .library_for_movie_mut(activation.context.root_swf.clone())
+        let lib = activation.context.library.library_for_movie_mut(
+            activation.context.root_swf.clone(),
+            activation.context.gc_context,
+        );
+        lib.borrow_mut(activation.context.gc_context)
             .set_avm2_domain(stage_domain);
         activation.context.ui.set_mouse_visible(true);
 
         let swf = activation.context.root_swf.clone();
-        let root: DisplayObject = MovieClip::player_root_movie(&mut activation, swf.clone()).into();
+        let root: DisplayObject =
+            MovieClip::player_root_movie(&mut activation, swf.clone(), lib).into();
 
         // The Stage `LoaderInfo` is permanently in the 'not yet loaded' state,
         // and has no associated `Loader` instance.

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -1505,15 +1505,15 @@ impl DisplayObjectWindow {
 
                 ui.label("Character");
                 let id = object.id();
-                if let Some(name) =
-                    context
-                        .library
-                        .library_for_movie(object.movie())
-                        .and_then(|l| {
-                            l.export_characters()
-                                .iter()
-                                .find_map(|(k, v)| if *v == id { Some(k) } else { None })
-                        })
+                if let Some(name) = context
+                    .library
+                    .library_for_movie(&object.movie(), context.gc_context)
+                    .and_then(|l| {
+                        let lib = l.borrow();
+                        lib.export_characters()
+                            .iter()
+                            .find_map(|(k, v)| if *v == id { Some(k) } else { None })
+                    })
                 {
                     ui.label(format!("{id} {name}"));
                 } else {

--- a/core/src/debug_ui/movie.rs
+++ b/core/src/debug_ui/movie.rs
@@ -88,7 +88,7 @@ impl MovieListWindow {
                         });
                     })
                     .body(|mut body| {
-                        let movies = context.library.known_movies();
+                        let movies = context.library.known_movies(context.gc_context);
 
                         for movie in movies {
                             let url_lower = movie.url().to_ascii_lowercase();
@@ -157,8 +157,10 @@ impl MovieWindow {
                 ui.horizontal(|ui| {
                     ui.selectable_value(&mut self.open_panel, Panel::Information, "Information");
 
-                    if let Some(library) = context.library.library_for_movie(movie.clone())
-                        && !library.characters().is_empty()
+                    if let Some(library) = context
+                        .library
+                        .library_for_movie(&movie, context.gc_context)
+                        && !library.borrow().characters().is_empty()
                     {
                         ui.selectable_value(&mut self.open_panel, Panel::Characters, "Characters");
                     }
@@ -177,8 +179,11 @@ impl MovieWindow {
         // Cloned up here so we can still use context afterwards
         let (characters, export_characters) = context
             .library
-            .library_for_movie(movie.clone())
-            .map(|l| (l.characters().clone(), l.export_characters().clone()))
+            .library_for_movie(movie, context.gc_context)
+            .map(|l| {
+                let lib = l.borrow();
+                (lib.characters().clone(), lib.export_characters().clone())
+            })
             .unwrap_or_default();
 
         TextEdit::singleline(&mut self.character_search)

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -308,8 +308,9 @@ impl<'gc> Callback<'gc> {
             Callback::Avm2 { method } => {
                 let domain = context
                     .library
-                    .library_for_movie(context.root_swf.clone())
+                    .library_for_movie(context.root_swf, context.gc_context)
                     .unwrap()
+                    .borrow()
                     .avm2_domain();
                 let mut activation = Avm2Activation::from_domain(context, domain);
                 let args: Vec<Avm2Value> = args

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -548,6 +548,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
                     span.style.bold,
                     span.style.italic,
                     Some(self.movie.clone()),
+                    context.gc(),
                 )
                 .filter(|f| f.has_glyphs())
         {

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -155,8 +155,12 @@ impl TextFormat {
     ) -> Self {
         let encoding = swf_movie.encoding();
         let swf_version = swf_movie.version();
-        let movie_library = context.library.library_for_movie_mut(swf_movie);
-        let font = et.font_id().and_then(|fid| movie_library.get_font(fid));
+        let movie_library = context
+            .library
+            .library_for_movie_mut(swf_movie, context.gc_context);
+        let font = et
+            .font_id()
+            .and_then(|fid| movie_library.borrow().get_font(fid));
         let font_class = et
             .font_class()
             .map(|s| s.decode(encoding).into_owned())

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2910,6 +2910,9 @@ impl PlayerBuilder {
             )
         };
 
+        let mut library = Library::empty();
+        let fake_library = library.library_for_movie_mut(fake_movie, gc_context);
+
         let data = GcRootData {
             audio_manager: AudioManager::new(),
             action_queue: ActionQueue::new(),
@@ -2922,7 +2925,7 @@ impl PlayerBuilder {
                 external_interface_provider,
                 fs_command_provider,
             ),
-            library: Library::empty(),
+            library,
             load_manager: LoadManager::new(),
             mouse_data: MouseData {
                 hovered: None,
@@ -2932,7 +2935,7 @@ impl PlayerBuilder {
             },
             avm1_shared_objects: HashMap::new(),
             avm2_shared_objects: HashMap::new(),
-            stage: Stage::empty(gc_context, fullscreen, fake_movie),
+            stage: Stage::empty(gc_context, fullscreen, fake_library),
             timers: Timers::new(),
             unbound_text_fields: Vec::new(),
             stream_manager: StreamManager::new(),


### PR DESCRIPTION
- **GC-Managed Libraries**: `MovieLibrary` is now a garbage-collected object (`Gc<RefLock<MovieLibrary>>`) that owns the underlying `SwfMovie`. The global registry holds only weak references to these libraries, ensuring they are collected when no longer in use.
- **Direct References**: Every `DisplayObject` holds a strong reference to its source library. When content is unloaded and the display tree is destroyed, the lack of strong references allows the library and swf data to be freed.
- **Registry Cleanup**: The global `Avm2ClassRegistry` has been removed. Symbol class links are now stored directly on `ClassDefinition` as `(MovieLibraryGc, CharacterId)` tuples, eliminating persistent global loop references.
- **Releasable GPU Resources**: Updated `BitmapCharacter` and `Font` to use mutable storage (Cell<Option>), allowing their GPU handles to be actively released during unload.
- **Loader Lifecycle**: `LoaderInfoObject::unload()` now explicitly releases GPU handles, clears cached bitmaps, unregisters the library, and dispatches unload events. Additionally, `Loader.close()` cancels in-progress loads, while `Loader.unloadAndStop()` recursively stops media playback and clears listeners.
- **Weak Event Listeners**: Event handlers now support weak references (`HandlerRef`). This prevents listeners from inadvertently keeping display objects alive, further reducing memory leaks.