### PR TITLE
tests: Use Libdeflater instead of Zopfli for compressing PNGs

### DIFF
--- a/tests/framework/src/runner/image_test.rs
+++ b/tests/framework/src/runner/image_test.rs
@@ -294,9 +294,6 @@ fn optimize_png(image: &[u8]) -> anyhow::Result<Vec<u8>> {
     // Remove metadata that won't affect image display.
     options.strip = oxipng::StripChunks::Safe;
 
-    // Use Zopfli for better compression.
-    options.deflater = oxipng::Deflater::Zopfli(oxipng::ZopfliOptions::default());
-
     oxipng::optimize_from_memory(image, &options)
         .map_err(|e| anyhow::anyhow!("oxipng optimization failed: {}", e))
 }


### PR DESCRIPTION
Initially my tests showed that Zopfli can produce smaller images in acceptable times, but further testing shows that it's very content-dependent and sometimes can take a long time for small gains (~10%, 60s+).