### PR TITLE
avm2: Include missing flash.display::GraphicsShaderFill declaration

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -800,6 +800,7 @@ pub fn init_native_system_classes(activation: &mut Activation<'_, '_>) {
                 graphicstrianglepath
             ),
             ("flash.display", "GraphicsSolidFill", graphicssolidfill),
+            ("flash.display", "GraphicsShaderFill", graphicsshaderfill),
             ("flash.display", "GraphicsStroke", graphicsstroke),
             ("flash.display", "Sprite", sprite),
             ("flash.display3D.textures", "CubeTexture", cubetexture),


### PR DESCRIPTION
Fixes #23068 (most likely).

Epic bug fact: This was forgotten by none other than myself in #12559 some 2,5 years ago.

I wasn't able to get the swf from the issue to test, but this is obviously the cause of the panic (without the declaration, the check here: https://github.com/ruffle-rs/ruffle/blob/72a2b43595fbac7adf80e5cc9fdc344e0b7ae64a/core/src/avm2/globals/flash/display/graphics.rs#L1517 is just checking against a bare Object\<'gc\>, falling through to the panic at the bottom of the method.

Of course this only prevents the panic.