### PR TITLE
avm2: Pass owned Strings through error helpers instead of borrowing

### DIFF
--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -9,6 +9,7 @@ use crate::avm2::value::Value;
 use crate::string::{AvmString, WString};
 
 use ruffle_macros::istr;
+use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 use std::mem::size_of;
 
@@ -122,7 +123,7 @@ pub fn make_null_or_undefined_error<'gc>(
                 name.to_qualified_name(activation.gc())
             ));
         }
-        make_error!(type_error(activation, &msg, 1009))
+        make_error!(type_error(activation, msg, 1009))
     }
 }
 
@@ -174,7 +175,7 @@ pub fn make_reference_error<'gc>(
     };
 
     let class = activation.avm2().classes().referenceerror;
-    make_error!(error_constructor(activation, class, &msg, code as u32))
+    make_error!(error_constructor(activation, class, msg, code as u32))
 }
 
 pub enum XmlErrorCode {
@@ -244,7 +245,7 @@ pub fn make_unknown_ns_error<'gc>(
     make_error!(if ns.is_empty() {
         type_error(
             activation,
-            &format!(
+            format!(
                 "Error #1084: Element or attribute (\":{local_name}\") does not match QName production: QName::=(NCName':')?NCName."
             ),
             1084,
@@ -253,7 +254,7 @@ pub fn make_unknown_ns_error<'gc>(
         // Note: Flash also uses this error message for attributes.
         type_error(
             activation,
-            &format!(
+            format!(
                 "Error #1083: The prefix \"{}\" for element \"{local_name}\" is not bound.",
                 String::from_utf8_lossy(ns),
             ),
@@ -277,7 +278,7 @@ pub fn make_error_1002<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_1003<'gc>(activation: &mut Activation<'_, 'gc>, radix: i32) -> Error<'gc> {
     make_error!(range_error(
         activation,
-        &format!("Error #1003: The radix argument must be between 2 and 36; got {radix}."),
+        format!("Error #1003: The radix argument must be between 2 and 36; got {radix}."),
         1003,
     ))
 }
@@ -287,7 +288,7 @@ pub fn make_error_1003<'gc>(activation: &mut Activation<'_, 'gc>, radix: i32) ->
 pub fn make_error_1005<'gc>(activation: &mut Activation<'_, 'gc>, length: f64) -> Error<'gc> {
     make_error!(range_error(
         activation,
-        &format!("Error #1005: Array index is not a positive integer ({length})."),
+        format!("Error #1005: Array index is not a positive integer ({length})."),
         1005,
     ))
 }
@@ -325,7 +326,7 @@ pub fn make_error_1010<'gc>(
             name.to_qualified_name(activation.gc())
         ));
     }
-    make_error!(type_error(activation, &msg, 1010))
+    make_error!(type_error(activation, msg, 1010))
 }
 
 pub enum Error1014Type {
@@ -360,7 +361,7 @@ pub fn make_error_1014<'gc>(
     kind: Error1014Type,
     class_name: AvmString<'gc>,
 ) -> Error<'gc> {
-    let message = &format!("Error #1014: Class {class_name} could not be found.");
+    let message = format!("Error #1014: Class {class_name} could not be found.");
     make_error!(match kind {
         Error1014Type::ReferenceError => reference_error(activation, message, 1014),
         Error1014Type::VerifyError => verify_error(activation, message, 1014),
@@ -373,7 +374,7 @@ pub fn make_error_1016<'gc>(activation: &mut Activation<'_, 'gc>, class: Class<'
     let class_name = class.name().to_qualified_name_err_message(activation.gc());
     make_error!(type_error(
         activation,
-        &format!("Error #1016: Descendants operator (..) not supported on type {class_name}",),
+        format!("Error #1016: Descendants operator (..) not supported on type {class_name}",),
         1016,
     ))
 }
@@ -410,7 +411,7 @@ pub fn make_error_1019<'gc>(
         "Error #1019: Getscopeobject  is out of bounds.".to_string()
     };
 
-    make_error!(verify_error(activation, &message, 1019))
+    make_error!(verify_error(activation, message, 1019))
 }
 
 #[inline(never)]
@@ -458,7 +459,7 @@ pub fn make_error_1024<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_1025<'gc>(activation: &mut Activation<'_, 'gc>, index: u32) -> Error<'gc> {
     make_error!(verify_error(
         activation,
-        &format!("Error #1025: An invalid register {index} was accessed."),
+        format!("Error #1025: An invalid register {index} was accessed."),
         1025,
     ))
 }
@@ -478,7 +479,7 @@ pub fn make_error_1026<'gc>(
     } else {
         format!("Error #1026: Slot {slot_id} exceeds slotCount.")
     };
-    make_error!(verify_error(activation, &message, 1026))
+    make_error!(verify_error(activation, message, 1026))
 }
 
 #[inline(never)]
@@ -500,7 +501,7 @@ pub fn make_error_1030<'gc>(
 ) -> Error<'gc> {
     make_error!(verify_error(
         activation,
-        &format!(
+        format!(
             "Error #1030: Stack depth is unbalanced. {} != {}.",
             first_len, second_len,
         ),
@@ -517,7 +518,7 @@ pub fn make_error_1031<'gc>(
 ) -> Error<'gc> {
     make_error!(verify_error(
         activation,
-        &format!(
+        format!(
             "Error #1031: Scope depth is unbalanced. {} != {}.",
             first_len, second_len,
         ),
@@ -530,7 +531,7 @@ pub fn make_error_1031<'gc>(
 pub fn make_error_1032<'gc>(activation: &mut Activation<'_, 'gc>, index: u32) -> Error<'gc> {
     make_error!(verify_error(
         activation,
-        &format!("Error #1032: Cpool index {index} is out of range."),
+        format!("Error #1032: Cpool index {index} is out of range."),
         1032,
     ))
 }
@@ -563,7 +564,7 @@ pub fn make_error_1034<'gc>(
 
     make_error!(type_error(
         activation,
-        &format!("Error #1034: Type Coercion failed: cannot convert {debug_str} to {class_name}."),
+        format!("Error #1034: Type Coercion failed: cannot convert {debug_str} to {class_name}."),
         1034,
     ))
 }
@@ -625,7 +626,7 @@ pub fn make_error_1050<'gc>(activation: &mut Activation<'_, 'gc>, value: Value<'
 
     make_error!(type_error(
         activation,
-        &format!("Error #1050: Cannot convert {class_name} to primitive."),
+        format!("Error #1050: Cannot convert {class_name} to primitive."),
         1050,
     ))
 }
@@ -645,7 +646,7 @@ pub fn make_error_1051<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_1052<'gc>(activation: &mut Activation<'_, 'gc>, func_name: &str) -> Error<'gc> {
     make_error!(uri_error(
         activation,
-        &format!("Error #1052: Invalid URI passed to {func_name} function."),
+        format!("Error #1052: Invalid URI passed to {func_name} function."),
         1052,
     ))
 }
@@ -659,7 +660,7 @@ pub fn make_error_1053<'gc>(
 ) -> Error<'gc> {
     make_error!(verify_error(
         activation,
-        &format!("Error #1053: Illegal override of {trait_name} in {class_name}."),
+        format!("Error #1053: Illegal override of {trait_name} in {class_name}."),
         1053,
     ))
 }
@@ -713,7 +714,7 @@ pub fn make_error_1063<'gc>(
 
     make_error!(argument_error(
         activation,
-        &format!(
+        format!(
             "Error #1063: Argument count mismatch on {function_name}. Expected {expected_num_params}, got {passed_arg_count}.",
         ),
         1063,
@@ -732,7 +733,7 @@ pub fn make_error_1064<'gc>(
 
     make_error!(type_error(
         activation,
-        &format!("Error #1064: Cannot call method {function_name} as constructor.",),
+        format!("Error #1064: Cannot call method {function_name} as constructor.",),
         1064,
     ))
 }
@@ -749,7 +750,7 @@ pub fn make_error_1065<'gc>(
 
     make_error!(reference_error(
         activation,
-        &format!("Error #1065: Variable {local_name} is not defined."),
+        format!("Error #1065: Variable {local_name} is not defined."),
         1065,
     ))
 }
@@ -786,7 +787,7 @@ pub fn make_error_1070<'gc>(
 
     make_error!(reference_error(
         activation,
-        &format!("Error #1070: Method {multiname_name} not found on {class_name}",),
+        format!("Error #1070: Method {multiname_name} not found on {class_name}",),
         1070,
     ))
 }
@@ -846,7 +847,7 @@ pub fn make_error_1080<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_1085<'gc>(activation: &mut Activation<'_, 'gc>, tag: &str) -> Error<'gc> {
     make_error!(type_error(
         activation,
-        &format!(
+        format!(
             "Error #1085: The element type \"{tag}\" must be terminated by the matching end-tag \"</{tag}>\"."
         ),
         1085,
@@ -858,7 +859,7 @@ pub fn make_error_1085<'gc>(activation: &mut Activation<'_, 'gc>, tag: &str) -> 
 pub fn make_error_1086<'gc>(activation: &mut Activation<'_, 'gc>, method_name: &str) -> Error<'gc> {
     make_error!(type_error(
         activation,
-        &format!("Error #1086: The {method_name} method only works on lists containing one item."),
+        format!("Error #1086: The {method_name} method only works on lists containing one item."),
         1086,
     ))
 }
@@ -901,7 +902,7 @@ pub fn make_error_1098<'gc>(
 ) -> Error<'gc> {
     make_error!(type_error(
         activation,
-        &format!("Error #1098: Illegal prefix {prefix} for no namespace."),
+        format!("Error #1098: Illegal prefix {prefix} for no namespace."),
         1098,
     ))
 }
@@ -923,7 +924,7 @@ pub fn make_error_1103<'gc>(activation: &mut Activation<'_, 'gc>, class: Class<'
 
     make_error!(verify_error(
         activation,
-        &format!(
+        format!(
             "Error #1103: Class {} cannot extend final base class.",
             class_name
         ),
@@ -965,7 +966,7 @@ pub fn make_error_1110<'gc>(
 
     make_error!(verify_error(
         activation,
-        &format!(
+        format!(
             "Error #1110: Class {} cannot extend {}.",
             class_name, super_class_name
         ),
@@ -987,7 +988,7 @@ pub fn make_error_1111<'gc>(
 
     make_error!(verify_error(
         activation,
-        &format!(
+        format!(
             "Error #1111: {} cannot implement {}.",
             class_name, interface_name
         ),
@@ -1000,7 +1001,7 @@ pub fn make_error_1111<'gc>(
 pub fn make_error_1112<'gc>(activation: &mut Activation<'_, 'gc>, arg_count: usize) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!(
+        format!(
             "Error #1112: Argument count mismatch on class coercion.  Expected 1, got {}.",
             arg_count
         ),
@@ -1033,7 +1034,7 @@ pub fn make_error_1114<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_1115<'gc>(activation: &mut Activation<'_, 'gc>, name: &str) -> Error<'gc> {
     make_error!(type_error(
         activation,
-        &format!("Error #1115: {name} is not a constructor."),
+        format!("Error #1115: {name} is not a constructor."),
         1115,
     ))
 }
@@ -1056,7 +1057,7 @@ pub fn make_error_1117<'gc>(
 ) -> Error<'gc> {
     make_error!(type_error(
         activation,
-        &format!("Error #1117: Invalid XML name: {}.", name.as_wstr()),
+        format!("Error #1117: Invalid XML name: {}.", name.as_wstr()),
         1117,
     ))
 }
@@ -1088,7 +1089,7 @@ pub fn make_error_1123<'gc>(activation: &mut Activation<'_, 'gc>, class: Class<'
 
     make_error!(type_error(
         activation,
-        &format!("Error #1123: Filter operator not supported on type {class_name}."),
+        format!("Error #1123: Filter operator not supported on type {class_name}."),
         1123,
     ))
 }
@@ -1112,7 +1113,7 @@ pub fn make_error_1125<'gc>(
 ) -> Error<'gc> {
     make_error!(range_error(
         activation,
-        &format!("Error #1125: The index {index} is out of range {range}."),
+        format!("Error #1125: The index {index} is out of range {range}."),
         1125,
     ))
 }
@@ -1148,7 +1149,7 @@ pub fn make_error_1128<'gc>(
 
     make_error!(type_error(
         activation,
-        &format!(
+        format!(
             "Error #1128: Incorrect number of type parameters for {}. Expected 1, got {}.",
             class_name, param_count
         ),
@@ -1207,7 +1208,7 @@ pub fn make_error_1506<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_1507<'gc>(activation: &mut Activation<'_, 'gc>, param_name: &str) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!("Error #1507: Argument {param_name} cannot be null."),
+        format!("Error #1507: Argument {param_name} cannot be null."),
         1507,
     ))
 }
@@ -1217,7 +1218,7 @@ pub fn make_error_1507<'gc>(activation: &mut Activation<'_, 'gc>, param_name: &s
 pub fn make_error_1508<'gc>(activation: &mut Activation<'_, 'gc>, param_name: &str) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!("Error #1508: The value specified for argument {param_name} is invalid."),
+        format!("Error #1508: The value specified for argument {param_name} is invalid."),
         1508,
     ))
 }
@@ -1271,7 +1272,7 @@ pub fn make_error_2005<'gc>(
 ) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!(
+        format!(
             "Error #2005: Parameter {param_index} is of the incorrect type. Should be type {param_name}."
         ),
         2005,
@@ -1293,7 +1294,7 @@ pub fn make_error_2006<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_2007<'gc>(activation: &mut Activation<'_, 'gc>, param_name: &str) -> Error<'gc> {
     make_error!(type_error(
         activation,
-        &format!("Error #2007: Parameter {param_name} must be non-null."),
+        format!("Error #2007: Parameter {param_name} must be non-null."),
         2007,
     ))
 }
@@ -1303,7 +1304,7 @@ pub fn make_error_2007<'gc>(activation: &mut Activation<'_, 'gc>, param_name: &s
 pub fn make_error_2008<'gc>(activation: &mut Activation<'_, 'gc>, param_name: &str) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!("Error #2008: Parameter {param_name} must be one of the accepted values."),
+        format!("Error #2008: Parameter {param_name} must be one of the accepted values."),
         2008,
     ))
 }
@@ -1316,7 +1317,7 @@ pub fn make_error_2012<'gc>(
 ) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!("Error #2012: {class_name} class cannot be instantiated."),
+        format!("Error #2012: {class_name} class cannot be instantiated."),
         2012,
     ))
 }
@@ -1336,7 +1337,7 @@ pub fn make_error_2015<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_2022<'gc>(activation: &mut Activation<'_, 'gc>, class: Class<'gc>) -> Error<'gc> {
     make_error!(type_error(
         activation,
-        &format!(
+        format!(
             "Error #2022: Class {}$ must inherit from DisplayObject to link to a symbol.",
             class.name().local_name()
         ),
@@ -1349,7 +1350,7 @@ pub fn make_error_2022<'gc>(activation: &mut Activation<'_, 'gc>, class: Class<'
 pub fn make_error_2023<'gc>(activation: &mut Activation<'_, 'gc>, class: Class<'gc>) -> Error<'gc> {
     make_error!(type_error(
         activation,
-        &format!(
+        format!(
             "Error #2023: Class {}$ must inherit from Sprite to link to the root.",
             class.name().local_name()
         ),
@@ -1386,7 +1387,7 @@ pub fn make_error_2027<'gc>(
 ) -> Error<'gc> {
     make_error!(range_error(
         activation,
-        &format!("Error #2027: Parameter {param_name} must be a non-negative number; got {value}."),
+        format!("Error #2027: Parameter {param_name} must be a non-negative number; got {value}."),
         2027,
     ))
 }
@@ -1476,7 +1477,7 @@ pub fn make_error_2084<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_2085<'gc>(activation: &mut Activation<'_, 'gc>, param_name: &str) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!("Error #2085: Parameter {param_name} must be non-empty string."),
+        format!("Error #2085: Parameter {param_name} must be non-empty string."),
         2007,
     ))
 }
@@ -1510,7 +1511,7 @@ pub fn make_error_2109<'gc>(
 ) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!("Error #2109: Frame label {frame_label} not found in scene {scene}."),
+        format!("Error #2109: Frame label {frame_label} not found in scene {scene}."),
         2109,
     ))
 }
@@ -1570,7 +1571,7 @@ pub fn make_error_2162<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_2165<'gc>(activation: &mut Activation<'_, 'gc>, input_name: &str) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!(
+        format!(
             "Error #2165: The Shader input {} does not have enough data.",
             input_name
         ),
@@ -1625,7 +1626,7 @@ pub fn make_error_2182<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 pub fn make_error_2186<'gc>(activation: &mut Activation<'_, 'gc>, focal_length: f64) -> Error<'gc> {
     make_error!(argument_error(
         activation,
-        &format!("Error #2186: Invalid focalLength {focal_length}."),
+        format!("Error #2186: Invalid focalLength {focal_length}."),
         2186,
     ))
 }
@@ -1744,9 +1745,9 @@ pub fn make_error_3783<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 
 #[inline(never)]
 #[cold]
-fn range_error<'gc>(
+fn range_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().rangeerror;
@@ -1755,9 +1756,9 @@ fn range_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn eval_error<'gc>(
+fn eval_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().evalerror;
@@ -1766,9 +1767,9 @@ fn eval_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn argument_error<'gc>(
+fn argument_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().argumenterror;
@@ -1777,9 +1778,9 @@ fn argument_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn security_error<'gc>(
+fn security_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().securityerror;
@@ -1788,9 +1789,9 @@ fn security_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn type_error<'gc>(
+fn type_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().typeerror;
@@ -1799,9 +1800,9 @@ fn type_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn reference_error<'gc>(
+fn reference_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().referenceerror;
@@ -1810,9 +1811,9 @@ fn reference_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn verify_error<'gc>(
+fn verify_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().verifyerror;
@@ -1821,9 +1822,9 @@ fn verify_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn illegal_operation_error<'gc>(
+fn illegal_operation_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().illegaloperationerror;
@@ -1832,9 +1833,9 @@ fn illegal_operation_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn io_error<'gc>(
+fn io_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().ioerror;
@@ -1843,9 +1844,9 @@ fn io_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn eof_error<'gc>(
+fn eof_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().eoferror;
@@ -1854,9 +1855,9 @@ fn eof_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn uri_error<'gc>(
+fn uri_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().urierror;
@@ -1865,9 +1866,9 @@ fn uri_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn syntax_error<'gc>(
+fn syntax_error<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().syntaxerror;
@@ -1876,15 +1877,19 @@ fn syntax_error<'gc>(
 
 #[inline(never)]
 #[cold]
-fn error<'gc>(activation: &mut Activation<'_, 'gc>, message: &str, code: u32) -> ErrorObject<'gc> {
+fn error<'a, 'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    message: impl Into<Cow<'a, str>>,
+    code: u32,
+) -> ErrorObject<'gc> {
     let class = activation.avm2().classes().error;
     error_constructor(activation, class, message, code)
 }
 
-fn error_constructor<'gc>(
+fn error_constructor<'a, 'gc>(
     activation: &mut Activation<'_, 'gc>,
     class: ClassObject<'gc>,
-    message: &str,
+    message: impl Into<Cow<'a, str>>,
     code: u32,
 ) -> ErrorObject<'gc> {
     let message = AvmString::new_utf8(activation.gc(), message);

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -12,6 +12,7 @@ use crate::avm2::{Avm2, FunctionArgs, Value as Avm2Value};
 use crate::context::UpdateContext;
 use crate::string::AvmString;
 use gc_arena::Collect;
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
@@ -162,10 +163,11 @@ impl Value {
             Value::Number(value) => Avm1Value::Number(value),
             Value::String(value) => {
                 let value = if activation.swf_version() < 9 && value.trim().is_empty() {
-                    "null"
+                    Cow::Borrowed("null")
                 } else {
-                    &value
+                    Cow::Owned(value)
                 };
+
                 Avm1Value::String(AvmString::new_utf8(activation.gc(), value))
             }
             Value::Object(values) => {


### PR DESCRIPTION
Discovered during the making of #23122