### PR TITLE
chore: Bump jpegxr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,7 +2801,7 @@ checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 [[package]]
 name = "jpegxr"
 version = "0.3.1"
-source = "git+https://github.com/ruffle-rs/jpegxr?rev=2a429b0d71ab416e10b73d4dbdcf34cfe2900395#2a429b0d71ab416e10b73d4dbdcf34cfe2900395"
+source = "git+https://github.com/ruffle-rs/jpegxr?rev=2074e32a174ad45443dcf00f795a86d65cf0153a#2074e32a174ad45443dcf00f795a86d65cf0153a"
 dependencies = [
  "bindgen",
  "cc",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,7 +59,7 @@ egui_extras = { version = "0.33.3", default-features = false, optional = true }
 png = { version = "0.18.1", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }
-jpegxr = { git = "https://github.com/ruffle-rs/jpegxr", rev = "2a429b0d71ab416e10b73d4dbdcf34cfe2900395", optional = true }
+jpegxr = { git = "https://github.com/ruffle-rs/jpegxr", rev = "2074e32a174ad45443dcf00f795a86d65cf0153a", optional = true }
 image = { workspace = true, features = ["tiff"] }
 enum-map = { workspace = true }
 ttf-parser = "0.25"


### PR DESCRIPTION
Fixes #23133

See https://github.com/ruffle-rs/jpegxr/pull/6 for more info.