### PR TITLE
desktop: Add disable-library-validation to macOS entitlements to fix libopenh264 not loading

### DIFF
--- a/desktop/assets/macOSEntitlements.plist
+++ b/desktop/assets/macOSEntitlements.plist
@@ -3,6 +3,8 @@
     <dict>
         <key>com.apple.security.app-sandbox</key>
         <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
         <key>com.apple.security.files.user-selected.read-write</key>
         <true/>
         <key>com.apple.security.network.client</key>


### PR DESCRIPTION
Fixes #20008 (tested)