### PR TITLE
render: Flush GPU work periodically during cache entry processing to fix OOM error

### DIFF
--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -592,6 +592,10 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                     &mut self.active_frame.command_encoder,
                 );
             }
+            // Periodically flush GPU work to prevent OOM when many cache entries
+            // accumulate (e.g. when a large container's cacheAsBitmap is skipped
+            // but its hundreds of children each have their own bitmap caches).
+            self.active_frame.maybe_flush(&self.descriptors);
         }
 
         self.surface.draw_commands_and_copy_to(


### PR DESCRIPTION
(This is my first Ruffle contribution, please review critically - this was AI generated but did fix the issue I'm seeing)

When rendering objects with extremely large dimensions whose cacheAsBitmap is skipped (in my case 6.7M × 6.7M pixel objects), their children's bitmap caches are all submitted in a single GPU frame without any intermediate flushes. This accumulates GPU resources until the device runs out of memory.

**Root Cause**
In submit_frame, the cache_entries loop renders all cached bitmaps sequentially without calling maybe_flush(). The existing maybe_flush() mechanism (which periodically submits GPU work to prevent OOM) was only being invoked during command rendering, not during cache entry rendering.

**Fix**
Call self.active_frame.maybe_flush() inside the cache_entries loop, matching the pattern already used elsewhere to bound GPU resource accumulation within a single frame.

**Testing**
Tested with a SWF file that previously triggered a WGPU OOM crash due to a ~6.7 million pixel object. The crash no longer occurs.