### PR TITLE
chore: Bump winit to 0.30.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7244,9 +7244,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
-version = "0.30.12"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
  "ahash",
  "android-activity",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -28,7 +28,7 @@ ruffle_frontend_utils = { path = "../frontend-utils", features = ["cpal", "fs", 
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = "0.2.4"
-winit = "0.30.12"
+winit = "0.30.13"
 webbrowser = "1.1.0"
 url = { workspace = true }
 dirs = "6.0"


### PR DESCRIPTION
Split out from https://github.com/ruffle-rs/ruffle/pull/23171.

Updates `winit` from 0.30.12 to 0.30.13
- [Release notes](https://github.com/rust-windowing/winit/releases)
- [Changelog](https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rust-windowing/winit/compare/v0.30.12...v0.30.13)