### PR TITLE
chore: Bump `svgo`, `tar`, and `terser-webpack-plugin` in web/

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14434,11 +14434,14 @@
             "license": "MIT"
         },
         "node_modules/sax": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-            "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+            "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
             "dev": true,
-            "license": "BlueOak-1.0.0"
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
         },
         "node_modules/scheduler": {
             "version": "0.27.0",
@@ -15671,9 +15674,9 @@
             "dev": true
         },
         "node_modules/svgo": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
-            "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+            "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15683,7 +15686,7 @@
                 "css-what": "^6.1.0",
                 "csso": "^5.0.5",
                 "picocolors": "^1.1.1",
-                "sax": "^1.4.1"
+                "sax": "^1.5.0"
             },
             "bin": {
                 "svgo": "bin/svgo.js"
@@ -15844,9 +15847,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-            "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+            "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -15930,16 +15933,15 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.16",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-            "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+            "version": "5.3.17",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+            "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^4.3.0",
-                "serialize-javascript": "^6.0.2",
                 "terser": "^5.31.1"
             },
             "engines": {


### PR DESCRIPTION
Resolves https://github.com/advisories/GHSA-xpqw-6gx7-v673 and https://github.com/advisories/GHSA-qffp-2rhf-9h96, and one instance of https://github.com/advisories/GHSA-5c6j-r48x-rmvq (a few remain).