### PR TITLE
avm2: Avoid using `unsafe` in `ScriptObjectData::set_slot`

### DIFF
--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -10,7 +10,7 @@ use crate::avm2::vtable::VTable;
 use crate::avm2::{Error, Multiname, QName};
 use crate::context::UpdateContext;
 use crate::string::AvmString;
-use gc_arena::barrier::{Write, unlock};
+use gc_arena::barrier::{field, unlock};
 use gc_arena::{
     Collect, DynamicRoot, Gc, GcWeak, Mutation, Rootable,
     lock::{Lock, RefLock},
@@ -297,12 +297,9 @@ impl<'gc> ScriptObjectWrapper<'gc> {
 
     /// Set a slot by its index.
     pub fn set_slot(self, id: usize, value: Value<'gc>, mc: &Mutation<'gc>) {
-        let slot = self.0.slots.get(id).expect("Slot index out of bounds");
+        let slots_write = field!(Gc::write(mc, self.0), ScriptObjectData, slots).as_deref();
 
-        Gc::write(mc, self.0);
-        // SAFETY: We just triggered a write barrier on the Gc.
-        let slot_write = unsafe { Write::assume(slot) };
-        slot_write.unlock().set(value);
+        slots_write[id].unlock().set(value);
     }
 
     /// Retrieve a bound method from the method table.


### PR DESCRIPTION
This uses the feature added in kyren/gc-arena#130 to remove the usage of `unsafe` code in the method. This doesn't seem to significantly change the codegen of the method.