### PR TITLE
desktop: Don't do anything on `CursorMoved` if position is the same

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -92,6 +92,13 @@ impl MainWindow {
                     return;
                 }
 
+                // This is needed because some platforms (like macOS)
+                // will fire this event at the same time as WindowEvent::MouseInput,
+                // which may cause inaccurate behavior in the movie
+                if position == self.mouse_pos {
+                    return;
+                }
+
                 self.mouse_pos = position;
                 let (x, y) = self.gui.window_to_movie_position(position);
                 let event = PlayerEvent::MouseMove { x, y };


### PR DESCRIPTION
Fixes #21457

Platforms like macOS will fire the CursorMoved event at the same time as MouseInput, which can cause inaccurate behavior in a movie.