### PR TITLE
avm2: Add `SetSlotCoerceI` op to improve Crossbridge performance

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -726,6 +726,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::GetDescendants { multiname } => self.op_get_descendants(*multiname),
                 Op::GetSlot { index } => self.op_get_slot(*index),
                 Op::SetSlot { index } => self.op_set_slot(*index),
+                Op::SetSlotCoerceI { index } => self.op_set_slot_coerce_i(*index),
                 Op::SetSlotNoCoerce { index } => self.op_set_slot_no_coerce(*index),
                 Op::SetGlobalSlot { index } => self.op_set_global_slot(*index),
                 Op::Construct { num_args } => self.op_construct(*num_args),
@@ -1685,6 +1686,21 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .expect("Cannot set_slot on primitive");
 
         object.set_slot(index, value, self)?;
+
+        Ok(())
+    }
+
+    fn op_set_slot_coerce_i(&mut self, index: usize) -> Result<(), Error<'gc>> {
+        let value = self.pop_stack();
+        let object = self
+            .pop_stack()
+            .null_check(self, None)?
+            .as_object()
+            .expect("Cannot set_slot on primitive");
+
+        let value = value.coerce_to_i32(self)?;
+
+        object.set_slot_no_coerce(index, value.into(), self.gc());
 
         Ok(())
     }

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -309,6 +309,10 @@ pub enum Op<'gc> {
         // note: 0-indexed, as opposed to FP.
         index: usize,
     },
+    SetSlotCoerceI {
+        // note: 0-indexed, as opposed to FP.
+        index: usize,
+    },
     SetSlotNoCoerce {
         // note: 0-indexed, as opposed to FP.
         index: usize,

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -1446,6 +1446,9 @@ fn abstract_interpret_ops<'gc>(
                 // Skip the coercion when possible
                 if set_value.matches_type(resolved_value_class) {
                     optimize_op_to!(Op::SetSlotNoCoerce { index: slot_id });
+                } else if resolved_value_class.is_some_and(|c| c.is_builtin_int()) {
+                    // Special case for integer coercion, for performance
+                    optimize_op_to!(Op::SetSlotCoerceI { index: slot_id });
                 }
             }
             Op::GetPropertyStatic { multiname } => {
@@ -1547,6 +1550,9 @@ fn abstract_interpret_ops<'gc>(
 
                                 if set_value.matches_type(resolved_value_class) {
                                     optimize_op_to!(Op::SetSlotNoCoerce { index: slot_id });
+                                } else if resolved_value_class.is_some_and(|c| c.is_builtin_int()) {
+                                    // Special case for integer coercion, for performance
+                                    optimize_op_to!(Op::SetSlotCoerceI { index: slot_id });
                                 } else {
                                     optimize_op_to!(Op::SetSlot { index: slot_id });
                                 }
@@ -1602,6 +1608,9 @@ fn abstract_interpret_ops<'gc>(
 
                             if set_value.matches_type(resolved_value_class) {
                                 optimize_op_to!(Op::SetSlotNoCoerce { index: slot_id });
+                            } else if resolved_value_class.is_some_and(|c| c.is_builtin_int()) {
+                                // Special case for integer coercion, for performance
+                                optimize_op_to!(Op::SetSlotCoerceI { index: slot_id });
                             } else {
                                 optimize_op_to!(Op::SetSlot { index: slot_id });
                             }
@@ -2116,6 +2125,7 @@ fn abstract_interpret_ops<'gc>(
             | Op::ConstructSlot { .. }
             | Op::GetScriptGlobals { .. }
             | Op::PopJump { .. }
+            | Op::SetSlotCoerceI { .. }
             | Op::SetSlotNoCoerce { .. } => unreachable!("Custom ops should not be encountered"),
         }
     }


### PR DESCRIPTION
Tested mostly on #14816