### PR TITLE
core: Use arrow mouse cursor for LoaderDisplay interactive

### DIFF
--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -1,6 +1,7 @@
 use crate::avm1::Object as Avm1Object;
 use crate::avm2::Activation;
 use crate::avm2::StageObject as Avm2StageObject;
+use crate::backend::ui::MouseCursor;
 use crate::context::RenderContext;
 use crate::context::UpdateContext;
 use crate::display_object::TInteractiveObject;
@@ -202,6 +203,10 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
             }
         }
         Avm2MousePick::Miss
+    }
+
+    fn mouse_cursor(self, _context: &mut UpdateContext<'gc>) -> MouseCursor {
+        MouseCursor::Arrow
     }
 }
 


### PR DESCRIPTION
Previously, if a mouse pick landed on the Loader (like a loaded movie having only a graphics shape), then in Ruffle it would show the hand cursor, but Flash Player has the arrow cursor.

Unsure if this needs a test, since I'm not sure how that could be tested headless.