### PR TITLE
desktop: Fix incorrect height when setting viewport size on_metadata

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -342,7 +342,7 @@ impl MainWindow {
         if let Some(mut player) = self.player.get() {
             player.set_viewport_dimensions(ViewportDimensions {
                 width: viewport_size.width,
-                height: viewport_size.height - height_offset as u32,
+                height: viewport_size.height - (height_offset * viewport_scale_factor) as u32,
                 scale_factor: viewport_scale_factor,
             });
         }


### PR DESCRIPTION
Fixes #22475

The height_offset (24) was not taking the scale factor into account, resulting in an incorrect height when viewport size was set.

This behavior wasn't noticeable when the movie is reloaded after the window was resized or when loading another movie of a different size, because `WindowEvent::Resized` (the handler for which does set the dimensions correctly) was fired immediately afterward.

Not sure why this didn't seem observable on Windows prior to this fix, maybe the `Resized` event always fires on reload no matter what, or maybe the scale factor was always `1` for me?

I have not tested this on other platforms besides macOS, would appreciate it if someone could do that.