### PR TITLE
web: Open new tabs beside the current one by extension

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -248,13 +248,18 @@ async function onAdded(
 
 function onMessage(
     request: unknown,
-    _sender: chrome.runtime.MessageSender,
+    sender: chrome.runtime.MessageSender,
     _sendResponse: (response: unknown) => void,
 ): void {
     if (isMessage(request)) {
         if (request.type === "open_url_in_player") {
+            const index =
+                sender.tab?.index !== undefined
+                    ? sender.tab.index + 1
+                    : undefined;
             chrome.tabs.create({
                 url: utils.runtime.getURL(`player.html#${request.url}`),
+                index,
             });
         }
     }

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -37,21 +37,6 @@ export let declarativeNetRequest:
     | typeof browser.declarativeNetRequest
     | typeof chrome.declarativeNetRequest;
 
-function promisify<T>(
-    func: (callback: (result: T) => void) => void,
-): Promise<T> {
-    return new Promise((resolve, reject) => {
-        func((result) => {
-            const error = chrome.runtime.lastError;
-            if (error) {
-                reject(error);
-            } else {
-                resolve(result);
-            }
-        });
-    });
-}
-
 if (typeof browser !== "undefined") {
     i18n = browser.i18n;
     scripting = browser.scripting as ScriptingType;
@@ -73,10 +58,22 @@ if (typeof browser !== "undefined") {
 }
 export const openOptionsPage: () => Promise<void> = () =>
     runtime.openOptionsPage();
-export const openPlayerPage: () => Promise<void> = () =>
-    promisify((cb: () => void) => tabs.create({ url: "/player.html" }, cb));
-export const openOnboardPage: () => Promise<void> = () =>
-    promisify((cb: () => void) => tabs.create({ url: "/onboard.html" }, cb));
+
+async function getAdjacentTabIndex(): Promise<number | undefined> {
+    const [activeTab] = await tabs.query({
+        active: true,
+        currentWindow: true,
+    });
+    return activeTab?.index !== undefined ? activeTab.index + 1 : undefined;
+}
+export const openPlayerPage: () => Promise<void> = async () => {
+    const index = await getAdjacentTabIndex();
+    await tabs.create({ url: "/player.html", index });
+};
+export const openOnboardPage: () => Promise<void> = async () => {
+    const index = await getAdjacentTabIndex();
+    await tabs.create({ url: "/onboard.html", index });
+};
 
 export async function getOptions(): Promise<Options> {
     const options = await storage.sync.get();

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -71,8 +71,7 @@ export const openPlayerPage: () => Promise<void> = async () => {
     await tabs.create({ url: "/player.html", index });
 };
 export const openOnboardPage: () => Promise<void> = async () => {
-    const index = await getAdjacentTabIndex();
-    await tabs.create({ url: "/onboard.html", index });
+    await tabs.create({ url: "/onboard.html" });
 };
 
 export async function getOptions(): Promise<Options> {


### PR DESCRIPTION
Hello! Thanks for maintaining Ruffle. I can't always go back to my childhood to play old games without your hard work.

The logic about opening new tabs in the browser extension can be improved. I have so many tabs open. New ones opened by Ruffle always go to the end of the looooong tab list. I asked AI and have modified the code to let new tabs open beside the current one.

I'm not able to test the "onboard.html" page because I can't find a way to trigger the "INSTALL" event with unpacked extension. In Firefox Nightly, installing XPI file with setting `xpinstall.signatures.required` to `false` does not work. I can't figure it out.

The two changes about "player.html" have been tested, though.

Here is the commit message:

```
* Changes:
    * Open new tabs beside the current tab instead of at default position (after all tabs).
    * Remove redundant "promisify" wrapper from "tabs.create" calls.
* Test Environment:
    * Windows 11, Firefox 143.0.
    * Windows 11, Chrome 146.0.7680.80.

```

Please review, thank you!