### PR TITLE
web: Don't run extension on DHL domains

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -26,6 +26,9 @@
                 "https://*.duosecurity.com/*", // See https://github.com/ruffle-rs/ruffle/pull/18299
                 "https://*.tiktok.com/*", // See https://github.com/ruffle-rs/ruffle/pull/20250
                 "https://kick.com/*", // See https://github.com/ruffle-rs/ruffle/issues/21708
+                "https://*.dhl.com/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
+                "https://*.dhl.de/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
+                "https://*.*.dhl/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
             ],
             "js": ["dist/content.js"],
             "all_frames": true,


### PR DESCRIPTION
The .dhl domain is registered to DHL (https://www.dhl.com/de-en/home/nic/registration-policy-nic/attachment-1-nic.html): see an example at https://mydhl.express.dhl/as/en/home.html

Also see https://www.dhl.com/ and https://www.dhl.de/

Fixes #23325