### PR TITLE
web: Fix incorrect match rule for DHL exclusion

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -28,7 +28,7 @@
                 "https://kick.com/*", // See https://github.com/ruffle-rs/ruffle/issues/21708
                 "https://*.dhl.com/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
                 "https://*.dhl.de/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
-                "https://*.*.dhl/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
+                "https://mydhl.express.dhl/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
             ],
             "js": ["dist/content.js"],
             "all_frames": true,


### PR DESCRIPTION
Fixup for #23332 - the extension currently fails to install in Chrome/Chromium. mydhl.express.dhl seems to be the only DHL site that actually uses the .dhl TLD (express.dhl just redirects to mydhl.express.dhl).