### PR TITLE
naga-agal: Remove unused sampler_configs parameter

### DIFF
--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -245,8 +245,6 @@ impl VertexAttributeFormat {
 pub struct ShaderConfig<'a> {
     pub shader_type: ShaderType,
     pub vertex_attributes: &'a [Option<VertexAttributeFormat>; 8],
-    #[expect(dead_code)] // set but never read
-    pub sampler_configs: &'a [SamplerConfig; 8],
     pub version: AgalVersion,
 }
 
@@ -473,12 +471,10 @@ impl<'a> NagaBuilder<'a> {
     pub fn build_module(
         parsed: &ParsedBytecode,
         vertex_attributes: &[Option<VertexAttributeFormat>; MAX_VERTEX_ATTRIBUTES],
-        sampler_configs: &[SamplerConfig; 8],
     ) -> Result<Module> {
         let mut builder = NagaBuilder::new(ShaderConfig {
             shader_type: parsed.shader_type,
             vertex_attributes,
-            sampler_configs,
             version: parsed.version,
         });
 

--- a/render/naga-agal/src/lib.rs
+++ b/render/naga-agal/src/lib.rs
@@ -172,9 +172,8 @@ pub fn parse_bytecode(agal: &[u8]) -> Result<ParsedBytecode, AgalError> {
 pub fn agal_to_naga(
     parsed: &ParsedBytecode,
     vertex_attributes: &[Option<VertexAttributeFormat>; MAX_VERTEX_ATTRIBUTES],
-    sampler_configs: &[SamplerConfig; MAX_TEXTURES],
 ) -> Result<Module, Error> {
-    NagaBuilder::build_module(parsed, vertex_attributes, sampler_configs)
+    NagaBuilder::build_module(parsed, vertex_attributes)
 }
 
 pub fn extract_sampler_configs(

--- a/render/naga-agal/tests/wgsl.rs
+++ b/render/naga-agal/tests/wgsl.rs
@@ -23,7 +23,7 @@ pub fn to_wgsl(module: &Module) -> String {
 macro_rules! test_shader {
     ($shader:expr, $attrs:expr, $shader_type:expr $(,)?) => {
         let parsed = parse_bytecode(&$shader).unwrap();
-        let module = agal_to_naga(&parsed, $attrs, &[Default::default(); 8]).unwrap();
+        let module = agal_to_naga(&parsed, $attrs).unwrap();
         let output = to_wgsl(&module);
         insta::assert_snapshot!(output);
     };

--- a/render/wgpu/src/context3d/current_pipeline.rs
+++ b/render/wgpu/src/context3d/current_pipeline.rs
@@ -392,7 +392,6 @@ impl CurrentPipeline {
             descriptors,
             ShaderCompileData {
                 vertex_attributes: agal_attributes,
-                sampler_configs: self.sampler_configs,
                 texture_infos,
             },
         );

--- a/render/wgpu/src/context3d/shader_pair.rs
+++ b/render/wgpu/src/context3d/shader_pair.rs
@@ -58,12 +58,8 @@ impl ShaderPairAgal {
         RefMut::map(compiled, |compiled| {
             // TODO: Figure out a way to avoid the clone when we have a cache hit
             compiled.get_or_insert_mut(data.clone(), || {
-                let vertex_naga_module = naga_agal::agal_to_naga(
-                    &self.vertex_shader,
-                    &data.vertex_attributes,
-                    &data.sampler_configs,
-                )
-                .unwrap();
+                let vertex_naga_module =
+                    naga_agal::agal_to_naga(&self.vertex_shader, &data.vertex_attributes).unwrap();
                 let vertex_module =
                     descriptors
                         .device
@@ -72,12 +68,9 @@ impl ShaderPairAgal {
                             source: wgpu::ShaderSource::Naga(Cow::Owned(vertex_naga_module)),
                         });
 
-                let fragment_naga_module = naga_agal::agal_to_naga(
-                    &self.fragment_shader,
-                    &data.vertex_attributes,
-                    &data.sampler_configs,
-                )
-                .unwrap();
+                let fragment_naga_module =
+                    naga_agal::agal_to_naga(&self.fragment_shader, &data.vertex_attributes)
+                        .unwrap();
                 let fragment_module =
                     descriptors
                         .device
@@ -163,7 +156,6 @@ pub enum ShaderTextureInfo {
 
 #[derive(Hash, Eq, PartialEq, Clone)]
 pub struct ShaderCompileData {
-    pub sampler_configs: [SamplerConfig; 8],
     pub vertex_attributes: [Option<VertexAttributeFormat>; MAX_VERTEX_ATTRIBUTES],
     pub texture_infos: [Option<ShaderTextureInfo>; 8],
 }


### PR DESCRIPTION
Low-hanging fruit on the path towards caching and reusing Stage3D shader pipelines. Less state captured per shader = less state captured per pipeline = better reuse.

Became dead in https://github.com/ruffle-rs/ruffle/pull/14494.