### PR TITLE
debug_ui: Add FTE status to EditText debug window

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -326,6 +326,14 @@ impl DisplayObjectWindow {
         Grid::new(ui.id().with("edittext"))
             .num_columns(2)
             .show(ui, |ui| {
+                ui.label("Is FTE");
+                if object.is_fte() {
+                    ui.label("Yes");
+                } else {
+                    ui.label("No");
+                }
+                ui.end_row();
+
                 ui.label("Border");
                 ui.horizontal(|ui| {
                     let mut has_border = object.has_border();


### PR DESCRIPTION
* Related to https://github.com/ruffle-rs/ruffle/issues/23349

This adds an "Is FTE" field to the EditText debug UI to indicate whether the text object is part of the Flash Text Engine.

It's useful in case we want to verify whether the issue is related to a TextField or FTE.