### PR TITLE
core: Fix mouse cursor not inheriting from button-mode parent MovieClips

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3177,13 +3177,13 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
         // The nearest button-mode ancestor governs the cursor, so stop at the first one.
         let mut current: Option<DisplayObject<'gc>> = Some(self.into());
         while let Some(obj) = current {
-            if let Some(mc) = obj.as_movie_clip() {
-                if mc.is_button_mode(context) {
-                    if mc.use_hand_cursor(context) && mc.enabled(context) {
-                        return MouseCursor::Hand;
-                    }
-                    break;
+            if let Some(mc) = obj.as_movie_clip()
+                && mc.is_button_mode(context)
+            {
+                if mc.use_hand_cursor(context) && mc.enabled(context) {
+                    return MouseCursor::Hand;
                 }
+                break;
             }
             current = obj.parent();
         }


### PR DESCRIPTION
Fixes #21379

Previously, `mouse_cursor` only checked whether the hovered object itself was a button-mode clip, so hovering over a child inside a button-mode Sprite would always show the arrow cursor.

This walks the ancestor chain to find the nearest button-mode MovieClip and uses its `useHandCursor`/`enabled` state to determine the cursor, stopping at the first match so a disabled intermediate ancestor isn't silently skipped.