### PR TITLE
web: Add background tick mode to keep player running in hidden tabs

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -511,8 +511,8 @@ export class InnerPlayer {
     private startBackgroundTick(): void {
         const intervalMs = 1000 / (this.metadata?.frameRate || 24);
 
-        // intervalMs is a number computed from SWF metadata, so there is no
-        // risk of code injection via the template literal below.
+        // intervalMs is always a number (dividing 1000 by anything yields a number
+        // or NaN), so no code injection via the template literal is possible.
         const workerCode = `
             const intervalMs = ${intervalMs};
             self.onmessage = () => {

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -473,33 +473,33 @@ export class InnerPlayer {
      */
     private setupTabVisibilityHandling(): void {
         document.addEventListener("visibilitychange", () => {
-                if (!this.instance) {
-                    return;
-                }
-                const mode =
-                    this.loadedConfig?.backgroundExecutionMode ??
-                    BackgroundExecutionMode.None;
-                if (document.hidden) {
-                    this.lastActivePlayingState = this.instance.is_playing();
-                    if (mode === BackgroundExecutionMode.MainThread) {
-                        this.instance.enable_background_tick_mode();
-                        if (this.lastActivePlayingState) {
-                            this.startBackgroundTick();
-                        }
-                    } else {
-                        this.instance.pause();
+            if (!this.instance) {
+                return;
+            }
+            const mode =
+                this.loadedConfig?.backgroundExecutionMode ??
+                BackgroundExecutionMode.None;
+            if (document.hidden) {
+                this.lastActivePlayingState = this.instance.is_playing();
+                if (mode === BackgroundExecutionMode.MainThread) {
+                    this.instance.enable_background_tick_mode();
+                    if (this.lastActivePlayingState) {
+                        this.startBackgroundTick();
                     }
                 } else {
-                    if (mode === BackgroundExecutionMode.MainThread) {
-                        this.stopBackgroundTick();
-                        this.instance.restart_animation_loop();
-                    } else if (this.lastActivePlayingState) {
-                        this.instance.play();
-                    }
-                    // Browsers may auto-suspend AudioContext in background tabs.
-                    this.instance.audio_context()?.resume();
+                    this.instance.pause();
                 }
-            });
+            } else {
+                if (mode === BackgroundExecutionMode.MainThread) {
+                    this.stopBackgroundTick();
+                    this.instance.restart_animation_loop();
+                } else if (this.lastActivePlayingState) {
+                    this.instance.play();
+                }
+                // Browsers may auto-suspend AudioContext in background tabs.
+                this.instance.audio_context()?.resume();
+            }
+        });
     }
 
     /**

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -467,9 +467,7 @@ export class InnerPlayer {
      * running in the background when the tab is hidden.
      * While hidden, the normal animation loop is replaced with a background tick
      * so audio and game logic continue running.
-     * When the tab becomes visible again, the animation loop is restarted and
-     * {@link pause} is called only if the instance was already paused before the
-     * tab was hidden.
+     * When the tab becomes visible again, the animation loop is restarted.
      *
      * See: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
      * @ignore

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -194,6 +194,9 @@ export class InnerPlayer {
     private instance: RuffleHandle | null;
     private newZipWriter: (() => ZipWriter) | null;
     private lastActivePlayingState: boolean;
+    private backgroundTickChannel: MessageChannel | null;
+    private backgroundTickActive: boolean;
+    private backgroundLockRelease: (() => void) | null;
 
     metadata: MovieMetadata | null;
     _readyState: ReadyState;
@@ -338,7 +341,10 @@ export class InnerPlayer {
         this.metadata = null;
 
         this.lastActivePlayingState = false;
-        this.setupPauseOnTabHidden();
+        this.backgroundTickChannel = null;
+        this.backgroundTickActive = false;
+        this.backgroundLockRelease = null;
+        this.setupTabVisibilityHandling();
     }
 
     addFSCommandHandler(handler: (command: string, args: string) => void) {
@@ -459,34 +465,103 @@ export class InnerPlayer {
     }
 
     /**
-     * Setup event listener to detect when tab is not active to pause instance playback.
-     * this.instance.play() is called when the tab becomes visible only if the
-     * the instance was not paused before tab became hidden.
+     * Sets up an event listener for tab visibility changes to keep the player
+     * running in the background when the tab is hidden.
+     * While hidden, the normal animation loop is replaced with a background tick
+     * so audio and game logic continue running.
+     * When the tab becomes visible again, the animation loop is restarted and
+     * {@link pause} is called only if the instance was already paused before the
+     * tab was hidden.
      *
      * See: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
      * @ignore
      * @internal
      */
-    private setupPauseOnTabHidden(): void {
-        document.addEventListener(
-            "visibilitychange",
-            () => {
+    private setupTabVisibilityHandling(): void {
+        document.addEventListener("visibilitychange", () => {
                 if (!this.instance) {
                     return;
                 }
-
-                // Tab just changed to be inactive. Record whether instance was playing.
                 if (document.hidden) {
                     this.lastActivePlayingState = this.instance.is_playing();
-                    this.instance.pause();
+                    this.instance.enable_background_tick_mode();
+                    this.startBackgroundTick();
+                } else {
+                    this.stopBackgroundTick();
+                    this.instance.restart_animation_loop();
+                    // Browsers may auto-suspend AudioContext in background tabs.
+                    this.instance.audio_context()?.resume();
+                    if (!this.lastActivePlayingState) {
+                        this.instance.pause();
+                    }
                 }
-                // Play only if instance was playing originally.
-                if (!document.hidden && this.lastActivePlayingState === true) {
-                    this.instance.play();
+            });
+    }
+
+    /**
+     * Starts a background tick loop that keeps audio and game logic running while the tab is hidden.
+     *
+     * @ignore
+     * @internal
+     */
+    private startBackgroundTick(): void {
+        this.backgroundTickActive = true;
+
+        if ("locks" in navigator) {
+            navigator.locks.request(
+                "ruffle-background-tick",
+                { mode: "shared" },
+                () =>
+                    new Promise<void>((resolve) => {
+                        if (!this.backgroundTickActive) {
+                            resolve();
+                        } else {
+                            this.backgroundLockRelease = resolve;
+                        }
+                    }),
+            );
+        }
+
+        const channel = new MessageChannel();
+        this.backgroundTickChannel = channel;
+        const intervalMs = 1000 / (this.metadata?.frameRate ?? 24);
+        let lastTick = performance.now();
+        channel.port1.onmessage = () => {
+            if (!this.backgroundTickActive) {
+                return;
+            }
+            const now = performance.now();
+            if (now - lastTick >= intervalMs) {
+                lastTick = now;
+                this.instance?.tick_for_background(now);
+            }
+            // Delay the next message by the remaining time in this interval to
+            // avoid spinning the event loop at full speed and burning CPU.
+            const elapsed = performance.now() - lastTick;
+            const remaining = Math.max(0, intervalMs - elapsed);
+            setTimeout(() => {
+                if (this.backgroundTickActive) {
+                    channel.port2.postMessage(0);
                 }
-            },
-            false,
-        );
+            }, remaining);
+        };
+        channel.port2.postMessage(0);
+    }
+
+    /**
+     * Stops the background tick loop and releases any held resources.
+     *
+     * @ignore
+     * @internal
+     */
+    private stopBackgroundTick(): void {
+        this.backgroundTickActive = false;
+        if (this.backgroundTickChannel) {
+            this.backgroundTickChannel.port1.onmessage = null;
+            this.backgroundTickChannel = null;
+        }
+        this.backgroundLockRelease?.();
+        this.backgroundLockRelease = null;
     }
 
     /**
@@ -797,6 +872,7 @@ export class InnerPlayer {
      */
     destroy(): void {
         if (this.instance) {
+            this.stopBackgroundTick();
             this.instance.destroy();
             this.instance = null;
             this.metadata = null;

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -485,7 +485,9 @@ export class InnerPlayer {
             if (document.hidden) {
                 this.lastActivePlayingState = this.instance.is_playing();
                 this.instance.enable_background_tick_mode();
-                this.startBackgroundTick();
+                if (this.lastActivePlayingState) {
+                    this.startBackgroundTick();
+                }
             } else {
                 this.stopBackgroundTick();
                 this.instance.restart_animation_loop();

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -195,8 +195,7 @@ export class InnerPlayer {
     private instance: RuffleHandle | null;
     private newZipWriter: (() => ZipWriter) | null;
     private lastActivePlayingState: boolean;
-    private backgroundTickActive: boolean;
-    private backgroundLockRelease: (() => void) | null;
+    private backgroundWorker: Worker | null;
 
     metadata: MovieMetadata | null;
     _readyState: ReadyState;
@@ -341,8 +340,7 @@ export class InnerPlayer {
         this.metadata = null;
 
         this.lastActivePlayingState = false;
-        this.backgroundTickActive = false;
-        this.backgroundLockRelease = null;
+        this.backgroundWorker = null;
         this.setupTabVisibilityHandling();
     }
 
@@ -503,57 +501,45 @@ export class InnerPlayer {
     }
 
     /**
-     * Starts a background tick loop that keeps audio and game logic running while the tab is hidden.
-     *
-     * @ignore
-     * @internal
+     * Starts a background tick loop while the tab is hidden.
      */
     private startBackgroundTick(): void {
-        this.backgroundTickActive = true;
+        const intervalMs = 1000 / (this.metadata?.frameRate || 24);
 
-        if ("locks" in navigator) {
-            navigator.locks.request(
-                "ruffle-background-tick",
-                { mode: "shared" },
-                () =>
-                    new Promise<void>((resolve) => {
-                        if (!this.backgroundTickActive) {
-                            resolve();
-                        } else {
-                            this.backgroundLockRelease = resolve;
-                        }
-                    }),
-            );
+        const workerCode = `
+            const intervalMs = ${intervalMs};
+            self.onmessage = () => {
+                setTimeout(() => self.postMessage("tick"), intervalMs);
+            };
+            setTimeout(() => self.postMessage("tick"), intervalMs);
+        `;
+
+        try {
+            const blob = new Blob([workerCode], {
+                type: "application/javascript",
+            });
+            const workerUrl = URL.createObjectURL(blob);
+            const worker = new Worker(workerUrl);
+            URL.revokeObjectURL(workerUrl);
+
+            this.backgroundWorker = worker;
+            worker.onmessage = () => {
+                if (this.backgroundWorker === worker) {
+                    this.instance?.tick_for_background(performance.now());
+                    worker.postMessage("ack");
+                }
+            };
+        } catch (e) {
+            console.warn("Unable to create background Worker:", e);
         }
-
-        const intervalMs = 1000 / (this.metadata?.frameRate ?? 24);
-        let lastTick = performance.now();
-        const tick = () => {
-            if (!this.backgroundTickActive) {
-                return;
-            }
-            const now = performance.now();
-            if (now - lastTick >= intervalMs) {
-                lastTick = now;
-                this.instance?.tick_for_background(now);
-            }
-            const elapsed = performance.now() - lastTick;
-            const remaining = Math.max(0, intervalMs - elapsed);
-            setTimeout(tick, remaining);
-        };
-        setTimeout(tick, intervalMs);
     }
 
     /**
      * Stops the background tick loop and releases any held resources.
-     *
-     * @ignore
-     * @internal
      */
     private stopBackgroundTick(): void {
-        this.backgroundTickActive = false;
-        this.backgroundLockRelease?.();
-        this.backgroundLockRelease = null;
+        this.backgroundWorker?.terminate();
+        this.backgroundWorker = null;
     }
 
     /**

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -1,6 +1,7 @@
 import type { RuffleHandle, ZipWriter } from "../../../dist/ruffle_web";
 import {
     AutoPlay,
+    BackgroundExecutionMode,
     ContextMenu,
     DataLoadOptions,
     DEFAULT_CONFIG,
@@ -193,7 +194,7 @@ export class InnerPlayer {
     private swfUrl?: URL;
     private instance: RuffleHandle | null;
     private newZipWriter: (() => ZipWriter) | null;
-    private backgroundTickChannel: MessageChannel | null;
+    private lastActivePlayingState: boolean;
     private backgroundTickActive: boolean;
     private backgroundLockRelease: (() => void) | null;
 
@@ -339,7 +340,7 @@ export class InnerPlayer {
         this._readyState = ReadyState.HaveNothing;
         this.metadata = null;
 
-        this.backgroundTickChannel = null;
+        this.lastActivePlayingState = false;
         this.backgroundTickActive = false;
         this.backgroundLockRelease = null;
         this.setupTabVisibilityHandling();
@@ -463,11 +464,8 @@ export class InnerPlayer {
     }
 
     /**
-     * Sets up an event listener for tab visibility changes to keep the player
-     * running in the background when the tab is hidden.
-     * While hidden, the normal animation loop is replaced with a background tick
-     * so audio and game logic continue running.
-     * When the tab becomes visible again, the animation loop is restarted.
+     * Sets up an event listener for tab visibility changes, responding
+     * according to the configured {@link BackgroundExecutionMode}.
      *
      * See: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
      * @ignore
@@ -475,21 +473,33 @@ export class InnerPlayer {
      */
     private setupTabVisibilityHandling(): void {
         document.addEventListener("visibilitychange", () => {
-            if (!this.instance) {
-                return;
-            }
-            if (document.hidden) {
-                this.instance.enable_background_tick_mode();
-                if (this.instance.is_playing()) {
-                    this.startBackgroundTick();
+                if (!this.instance) {
+                    return;
                 }
-            } else {
-                this.stopBackgroundTick();
-                this.instance.restart_animation_loop();
-                // Browsers may auto-suspend AudioContext in background tabs.
-                this.instance.audio_context()?.resume();
-            }
-        });
+                const mode =
+                    this.loadedConfig?.backgroundExecutionMode ??
+                    BackgroundExecutionMode.None;
+                if (document.hidden) {
+                    this.lastActivePlayingState = this.instance.is_playing();
+                    if (mode === BackgroundExecutionMode.MainThread) {
+                        this.instance.enable_background_tick_mode();
+                        if (this.lastActivePlayingState) {
+                            this.startBackgroundTick();
+                        }
+                    } else {
+                        this.instance.pause();
+                    }
+                } else {
+                    if (mode === BackgroundExecutionMode.MainThread) {
+                        this.stopBackgroundTick();
+                        this.instance.restart_animation_loop();
+                    } else if (this.lastActivePlayingState) {
+                        this.instance.play();
+                    }
+                    // Browsers may auto-suspend AudioContext in background tabs.
+                    this.instance.audio_context()?.resume();
+                }
+            });
     }
 
     /**
@@ -516,11 +526,9 @@ export class InnerPlayer {
             );
         }
 
-        const channel = new MessageChannel();
-        this.backgroundTickChannel = channel;
         const intervalMs = 1000 / (this.metadata?.frameRate ?? 24);
         let lastTick = performance.now();
-        channel.port1.onmessage = () => {
+        const tick = () => {
             if (!this.backgroundTickActive) {
                 return;
             }
@@ -529,17 +537,11 @@ export class InnerPlayer {
                 lastTick = now;
                 this.instance?.tick_for_background(now);
             }
-            // Delay the next message by the remaining time in this interval to
-            // avoid spinning the event loop at full speed and burning CPU.
             const elapsed = performance.now() - lastTick;
             const remaining = Math.max(0, intervalMs - elapsed);
-            setTimeout(() => {
-                if (this.backgroundTickActive) {
-                    channel.port2.postMessage(0);
-                }
-            }, remaining);
+            setTimeout(tick, remaining);
         };
-        channel.port2.postMessage(0);
+        setTimeout(tick, intervalMs);
     }
 
     /**
@@ -550,10 +552,6 @@ export class InnerPlayer {
      */
     private stopBackgroundTick(): void {
         this.backgroundTickActive = false;
-        if (this.backgroundTickChannel) {
-            this.backgroundTickChannel.port1.onmessage = null;
-            this.backgroundTickChannel = null;
-        }
         this.backgroundLockRelease?.();
         this.backgroundLockRelease = null;
     }

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -193,7 +193,6 @@ export class InnerPlayer {
     private swfUrl?: URL;
     private instance: RuffleHandle | null;
     private newZipWriter: (() => ZipWriter) | null;
-    private lastActivePlayingState: boolean;
     private backgroundTickChannel: MessageChannel | null;
     private backgroundTickActive: boolean;
     private backgroundLockRelease: (() => void) | null;
@@ -340,7 +339,6 @@ export class InnerPlayer {
         this._readyState = ReadyState.HaveNothing;
         this.metadata = null;
 
-        this.lastActivePlayingState = false;
         this.backgroundTickChannel = null;
         this.backgroundTickActive = false;
         this.backgroundLockRelease = null;
@@ -483,9 +481,8 @@ export class InnerPlayer {
                 return;
             }
             if (document.hidden) {
-                this.lastActivePlayingState = this.instance.is_playing();
                 this.instance.enable_background_tick_mode();
-                if (this.lastActivePlayingState) {
+                if (this.instance.is_playing()) {
                     this.startBackgroundTick();
                 }
             } else {
@@ -493,9 +490,6 @@ export class InnerPlayer {
                 this.instance.restart_animation_loop();
                 // Browsers may auto-suspend AudioContext in background tabs.
                 this.instance.audio_context()?.resume();
-                if (!this.lastActivePlayingState) {
-                    this.instance.pause();
-                }
             }
         });
     }

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -195,6 +195,10 @@ export class InnerPlayer {
     private instance: RuffleHandle | null;
     private newZipWriter: (() => ZipWriter) | null;
     private lastActivePlayingState: boolean;
+
+    // Non-null while ticking in the background (BackgroundExecutionMode.MainThread).
+    // Uses a ping-pong ack to avoid message queue build-up if the main thread falls behind.
+    // Set when the tab is hidden, cleared when it becomes visible again or the player is destroyed.
     private backgroundWorker: Worker | null;
 
     metadata: MovieMetadata | null;
@@ -507,6 +511,8 @@ export class InnerPlayer {
     private startBackgroundTick(): void {
         const intervalMs = 1000 / (this.metadata?.frameRate || 24);
 
+        // intervalMs is a number computed from SWF metadata, so there is no
+        // risk of code injection via the template literal below.
         const workerCode = `
             const intervalMs = ${intervalMs};
             self.onmessage = () => {

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -491,7 +491,8 @@ export class InnerPlayer {
                 if (mode === BackgroundExecutionMode.MainThread) {
                     this.stopBackgroundTick();
                     this.instance.restart_animation_loop();
-                } else if (this.lastActivePlayingState) {
+                }
+                if (this.lastActivePlayingState) {
                     this.instance.play();
                 }
                 // Browsers may auto-suspend AudioContext in background tabs.
@@ -531,6 +532,7 @@ export class InnerPlayer {
             };
         } catch (e) {
             console.warn("Unable to create background Worker:", e);
+            this.instance?.pause();
         }
     }
 

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -479,23 +479,23 @@ export class InnerPlayer {
      */
     private setupTabVisibilityHandling(): void {
         document.addEventListener("visibilitychange", () => {
-                if (!this.instance) {
-                    return;
+            if (!this.instance) {
+                return;
+            }
+            if (document.hidden) {
+                this.lastActivePlayingState = this.instance.is_playing();
+                this.instance.enable_background_tick_mode();
+                this.startBackgroundTick();
+            } else {
+                this.stopBackgroundTick();
+                this.instance.restart_animation_loop();
+                // Browsers may auto-suspend AudioContext in background tabs.
+                this.instance.audio_context()?.resume();
+                if (!this.lastActivePlayingState) {
+                    this.instance.pause();
                 }
-                if (document.hidden) {
-                    this.lastActivePlayingState = this.instance.is_playing();
-                    this.instance.enable_background_tick_mode();
-                    this.startBackgroundTick();
-                } else {
-                    this.stopBackgroundTick();
-                    this.instance.restart_animation_loop();
-                    // Browsers may auto-suspend AudioContext in background tabs.
-                    this.instance.audio_context()?.resume();
-                    if (!this.lastActivePlayingState) {
-                        this.instance.pause();
-                    }
-                }
-            });
+            }
+        });
     }
 
     /**

--- a/web/packages/core/src/public/config/default.ts
+++ b/web/packages/core/src/public/config/default.ts
@@ -1,6 +1,7 @@
 import type { BaseLoadOptions } from "./load-options";
 import {
     AutoPlay,
+    BackgroundExecutionMode,
     ContextMenu,
     Letterbox,
     LogLevel,
@@ -58,4 +59,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     urlRewriteRules: [],
     scrollingBehavior: ScrollingBehavior.Smart,
     deviceFontRenderer: DeviceFontRenderer.Embedded,
+    backgroundExecutionMode: BackgroundExecutionMode.None,
 };

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -308,6 +308,22 @@ export enum DeviceFontRenderer {
 }
 
 /**
+ * Represents the various background execution behaviours that are supported.
+ */
+export enum BackgroundExecutionMode {
+    /**
+     * Ruffle will pause when the tab is hidden and resume when it becomes visible again.
+     */
+    None = "none",
+
+    /**
+     * Ruffle will keep running on the main thread while the tab is hidden,
+     * keeping audio and game logic alive at the cost of some background CPU usage.
+     */
+    MainThread = "mainThread",
+}
+
+/**
  * Represents a host, port and proxyUrl. Used when a SWF file tries to use a Socket.
  */
 export interface SocketProxy {
@@ -789,6 +805,13 @@ export interface BaseLoadOptions {
      * @default DeviceFontRenderer.Embedded
      */
     deviceFontRenderer?: DeviceFontRenderer;
+
+    /**
+     * Controls how Ruffle behaves when the browser tab is hidden.
+     *
+     * @default BackgroundExecutionMode.None
+     */
+    backgroundExecutionMode?: BackgroundExecutionMode;
 }
 
 /**

--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -38,6 +38,15 @@
     "settings_player_version": {
         "message": "Flash player version number to emulate (range 1-32)"
     },
+    "settings_background_execution_mode": {
+        "message": "Background execution"
+    },
+    "settings_background_execution_mode_none": {
+        "message": "Pause"
+    },
+    "settings_background_execution_mode_main_thread": {
+        "message": "Run in the main thread"
+    },
     "settings_preferred_renderer": {
         "message": "Preferred renderer"
     },

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -49,6 +49,13 @@
                 <label for="log_level">Log level</label>
             </div>
             <div class="option select">
+                <select id="background_execution_mode">
+                    <option value="none" id="background_execution_mode_none">Pause</option>
+                    <option value="mainThread" id="background_execution_mode_main_thread">Keep running in background</option>
+                </select>
+                <label for="background_execution_mode">Background execution</label>
+            </div>
+            <div class="option select">
                 <select id="preferred_renderer">
                     <option value="" id="preferred_renderer_auto">Automatic</option>
                     <option value="webgpu">WebGPU</option>

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -51,7 +51,7 @@
             <div class="option select">
                 <select id="background_execution_mode">
                     <option value="none" id="background_execution_mode_none">Pause</option>
-                    <option value="mainThread" id="background_execution_mode_main_thread">Keep running in background</option>
+                    <option value="mainThread" id="background_execution_mode_main_thread">Run in the main thread</option>
                 </select>
                 <label for="background_execution_mode">Background execution</label>
             </div>

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -349,7 +349,7 @@ impl RuffleHandle {
         });
     }
 
-    /// Ticks the game core once. Intended to be called from a MessageChannel loop
+    /// Ticks the game core once. Intended to be called from a Web Worker loop
     /// after calling `enable_background_tick_mode`.
     pub fn tick_for_background(&self, timestamp: f64) {
         self.tick(timestamp);

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -125,6 +125,7 @@ struct RuffleInstance {
     timestamp: Option<f64>,
     animation_handler: Option<AnimationHandler>, // requestAnimationFrame callback
     animation_handler_id: Option<NonZeroI32>,    // requestAnimationFrame id
+    background_tick_mode: bool,
     mouse_move_callback: Option<JsCallback<PointerEvent>>,
     mouse_enter_callback: Option<JsCallback<PointerEvent>>,
     mouse_leave_callback: Option<JsCallback<PointerEvent>>,
@@ -320,6 +321,38 @@ impl RuffleHandle {
 
     pub fn is_playing(&self) -> bool {
         self.with_core(|core| core.is_playing()).unwrap_or_default()
+    }
+
+    /// Switches to background tick mode, pausing the normal animation loop.
+    /// Use `tick_for_background` to advance the player while the tab is hidden.
+    pub fn enable_background_tick_mode(&self) {
+        let _ = self.with_instance_mut(|instance| {
+            if let Some(id) = instance.animation_handler_id.take() {
+                let _ = instance.window.cancel_animation_frame(id.into());
+            }
+            instance.background_tick_mode = true;
+        });
+    }
+
+    /// Leaves background tick mode and reschedules the normal animation loop.
+    /// Does not tick the core itself.
+    pub fn restart_animation_loop(&self) {
+        let _ = self.with_instance_mut(|instance| {
+            instance.background_tick_mode = false;
+            if let Some(handler) = &instance.animation_handler {
+                let id = instance
+                    .window
+                    .request_animation_frame(handler.as_ref().unchecked_ref())
+                    .unwrap_or_default();
+                instance.animation_handler_id = NonZeroI32::new(id);
+            }
+        });
+    }
+
+    /// Ticks the game core once. Intended to be called from a MessageChannel loop
+    /// after calling `enable_background_tick_mode`.
+    pub fn tick_for_background(&self, timestamp: f64) {
+        self.tick(timestamp);
     }
 
     pub fn has_focus(&self) -> bool {
@@ -519,6 +552,7 @@ impl RuffleHandle {
             window: window.clone(),
             animation_handler: None,
             animation_handler_id: None,
+            background_tick_mode: false,
             mouse_move_callback: None,
             mouse_enter_callback: None,
             mouse_leave_callback: None,
@@ -1167,15 +1201,17 @@ impl RuffleHandle {
                 }
             }
 
-            // Request next animation frame.
-            if let Some(handler) = &instance.animation_handler {
-                let id = instance
-                    .window
-                    .request_animation_frame(handler.as_ref().unchecked_ref())
-                    .unwrap_or_default();
-                instance.animation_handler_id = NonZeroI32::new(id);
-            } else {
-                instance.animation_handler_id = None;
+            // Request next animation frame (skipped in background tick mode).
+            if !instance.background_tick_mode {
+                if let Some(handler) = &instance.animation_handler {
+                    let id = instance
+                        .window
+                        .request_animation_frame(handler.as_ref().unchecked_ref())
+                        .unwrap_or_default();
+                    instance.animation_handler_id = NonZeroI32::new(id);
+                } else {
+                    instance.animation_handler_id = None;
+                }
             }
 
             // Calculate the elapsed time since the last tick.


### PR DESCRIPTION
Related to #7289
Related to #10527

Previously, when a tab was hidden, the `requestAnimationFrame` loop would stop, halting game logic and audio. This adds a background tick mode that replaces the RAF loop with a [Web Worker](https://developer.mozilla.org/docs/Web/API/Worker)-based tick loop when the tab becomes hidden, keeping the player running.

When the tab becomes visible again, the background worker is terminated, the normal RAF loop is restarted, and the `AudioContext` is explicitly resumed since browsers may auto-suspend it in background tabs.

### New configuration option

A new `backgroundExecutionMode` config option controls background playback behavior:

| Value | Behavior |
| -----  | --------- |
| `"mainThread"` | Uses the Web Worker tick loop when the tab is hidden |
| `"none"` | Disables background execution entirely (default) |

**Example usage:**

```js
window.RufflePlayer.config = {
  "backgroundExecutionMode": "mainThread"
};
```

### Notes

- The `visibilitychange` listener no longer passes an explicit `false` as the third argument, since that is the default and every other listener in the file omits it.
- Tested in the latest version of Chrome, where it ran reliably and smoothly in the background.