### PR TITLE
core: Fix cursor not updating in all hover cases

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1762,6 +1762,7 @@ impl Player {
             // When the mouse moves within the same object, re-evaluate the cursor,
             // since different parts of an object may use different cursors (e.g. links inside a text field).
             if is_mouse_moved && InteractiveObject::option_ptr_eq(cur_over_object, new_over_object)
+            {
                 new_cursor = match new_over_object {
                     Some(obj) => obj.mouse_cursor(context),
                     None => MouseCursor::Arrow,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1745,6 +1745,31 @@ impl Player {
             if !skip_mouse_hover && !new_over_object_updated {
                 context.mouse_data.hovered = new_over_object;
             }
+
+            // Even when hover events are skipped (mouse did not move), update the cursor
+            // if the object under the mouse changed, e.g. an animated object walked
+            // under a stationary cursor.
+            if skip_mouse_hover
+                && !InteractiveObject::option_ptr_eq(cur_over_object, new_over_object)
+            {
+                context.mouse_data.hovered = new_over_object;
+                new_cursor = match new_over_object {
+                    Some(obj) => obj.mouse_cursor(context),
+                    None => MouseCursor::Arrow,
+                };
+            }
+
+            // When the mouse moves within the same object, re-evaluate the cursor,
+            // since different parts of an object may use different cursors (e.g. links inside a text field).
+            if is_mouse_moved
+                && InteractiveObject::option_ptr_eq(cur_over_object, new_over_object)
+            {
+                new_cursor = match new_over_object {
+                    Some(obj) => obj.mouse_cursor(context),
+                    None => MouseCursor::Arrow,
+                };
+            }
+
             // Handle presses and releases.
             for button in [MouseButton::Left, MouseButton::Middle, MouseButton::Right] {
                 if !changed_mouse_buttons.contains(button) {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1761,9 +1761,7 @@ impl Player {
 
             // When the mouse moves within the same object, re-evaluate the cursor,
             // since different parts of an object may use different cursors (e.g. links inside a text field).
-            if is_mouse_moved
-                && InteractiveObject::option_ptr_eq(cur_over_object, new_over_object)
-            {
+            if is_mouse_moved && InteractiveObject::option_ptr_eq(cur_over_object, new_over_object)
                 new_cursor = match new_over_object {
                     Some(obj) => obj.mouse_cursor(context),
                     None => MouseCursor::Arrow,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1623,6 +1623,15 @@ impl Player {
             }
 
             let cur_over_object = context.mouse_data.hovered;
+            // If the object under a stationary mouse changed, process it through
+            // the normal rollover path. Preserve hover driven by keyboard focus.
+            if skip_mouse_hover
+                && !InteractiveObject::option_ptr_eq(cur_over_object, context.focus_tracker.get())
+                && !InteractiveObject::option_ptr_eq(cur_over_object, new_over_object)
+            {
+                skip_mouse_hover = false;
+            }
+
             // Check if a new object has been hovered over.
             if !skip_mouse_hover
                 && !InteractiveObject::option_ptr_eq(cur_over_object, new_over_object)
@@ -1744,19 +1753,6 @@ impl Player {
             }
             if !skip_mouse_hover && !new_over_object_updated {
                 context.mouse_data.hovered = new_over_object;
-            }
-
-            // Even when hover events are skipped (mouse did not move), update the cursor
-            // if the object under the mouse changed, e.g. an animated object walked
-            // under a stationary cursor.
-            if skip_mouse_hover
-                && !InteractiveObject::option_ptr_eq(cur_over_object, new_over_object)
-            {
-                context.mouse_data.hovered = new_over_object;
-                new_cursor = match new_over_object {
-                    Some(obj) => obj.mouse_cursor(context),
-                    None => MouseCursor::Arrow,
-                };
             }
 
             // When the mouse moves within the same object, re-evaluate the cursor,


### PR DESCRIPTION
Two cases where the cursor was not updated correctly:

1. When the mouse was stationary but the hovered object changed (e.g. an animated object moved under the cursor), `mouse_cursor()` was never called because hover events were skipped. Fixed by re-evaluating the cursor whenever the hovered object changes, regardless of mouse movement.

2. When moving the mouse within the same interactive object, `mouse_cursor()` was never called since the hovered object pointer did not change. This caused the cursor to remain stuck, most visibly in TextFields where links should show a hand cursor but did not. Fixed by re-evaluating the cursor on every mouse move over the same object.