### PR TITLE
tests: Add audio amplitude assertions to test framework

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -165,6 +165,22 @@ lzma = false
 # If JPEG XR support is enabled in this build
 jpegxr = false
 
+# List of frame-based audio assertions.
+[audio_assertions.ASSERTION_NAME]
+
+# List of frames where the assertions should be performed.
+# Both `from` and `to` are inclusive.
+frames = [2, 3]
+# or
+frames = { from = 2, to = 4 }
+
+# The maximum allowed audio amplitude.
+max_amplitude = 0.5
+
+# The lowest acceptable maximum amplitude.
+# The max is calculated per frame.
+min_max_amplitude = 0.4
+
 # A single device font provided for this test.
 [fonts.FONT_NAME] # FONT_NAME is a name of this particular font
 

--- a/tests/framework/src/backends/audio.rs
+++ b/tests/framework/src/backends/audio.rs
@@ -23,6 +23,12 @@ impl TestAudioBackend {
     const SAMPLE_RATE: u32 = 44100;
 }
 
+impl TestAudioBackend {
+    pub fn buffer(&self) -> &[f32] {
+        &self.buffer
+    }
+}
+
 impl AudioBackend for TestAudioBackend {
     impl_audio_mixer_backend!(mixer);
     fn play(&mut self) {}

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -56,6 +56,30 @@ fn merge_into_subtest<'a>(
     )))
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum FrameSelection {
+    Array(Vec<u32>),
+    Range { from: u32, to: u32 },
+}
+
+impl FrameSelection {
+    pub fn includes_frame(&self, frame: u32) -> bool {
+        match self {
+            FrameSelection::Array(frames) => frames.contains(&frame),
+            &FrameSelection::Range { from, to } => from <= frame && frame <= to,
+        }
+    }
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AudioAssertion {
+    pub frames: FrameSelection,
+    pub max_amplitude: Option<f32>,
+    pub min_max_amplitude: Option<f32>,
+}
+
 #[derive(Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct TestOptions {
@@ -70,6 +94,7 @@ pub struct TestOptions {
     pub output_path: String,
     pub sleep_to_meet_frame_rate: bool,
     pub image_comparisons: HashMap<String, ImageComparison>,
+    pub audio_assertions: HashMap<String, AudioAssertion>,
     pub log_warnings: bool,
     pub ignore: bool,
     pub filter: Option<TestExpression>,
@@ -93,6 +118,7 @@ impl Default for TestOptions {
             output_path: "output.txt".to_string(),
             sleep_to_meet_frame_rate: false,
             image_comparisons: Default::default(),
+            audio_assertions: Default::default(),
             log_warnings: true,
             ignore: false,
             filter: None,

--- a/tests/framework/src/runner.rs
+++ b/tests/framework/src/runner.rs
@@ -2,13 +2,13 @@ mod automation;
 mod image_test;
 mod trace;
 
-use crate::backends::{TestLogBackend, TestNavigatorBackend, TestUiBackend};
+use crate::backends::{TestAudioBackend, TestLogBackend, TestNavigatorBackend, TestUiBackend};
 use crate::environment::RenderInterface;
 use crate::fs_commands::{FsCommand, TestFsCommandProvider};
 use crate::image_trigger::ImageTrigger;
-use crate::options::TestOptions;
 use crate::options::image_comparison::ImageComparison;
 use crate::options::known_failure::KnownFailure;
+use crate::options::{AudioAssertion, TestOptions};
 use crate::runner::automation::perform_automated_event;
 use crate::runner::image_test::capture_and_compare_image;
 use crate::runner::trace::compare_trace_output;
@@ -49,6 +49,7 @@ pub struct TestRunner {
     fs_commands: mpsc::Receiver<FsCommand>,
     render_interface: Option<Box<dyn RenderInterface>>,
     images: HashMap<String, ImageComparison>,
+    audio_assertions: HashMap<String, AudioAssertion>,
     remaining_iterations: u32,
     current_iteration: u32,
     preloaded: bool,
@@ -141,6 +142,7 @@ impl TestRunner {
             log,
             fs_commands,
             images,
+            audio_assertions: test.options.audio_assertions.clone(),
             remaining_iterations,
             current_iteration: 0,
             options: test.options.clone(),
@@ -268,6 +270,8 @@ impl TestRunner {
             }
         }
 
+        self.test_audio()?;
+
         self.injector.next(|evt, _btns_down| {
             let mut player = self.player.lock().unwrap();
             perform_automated_event(evt, &mut player);
@@ -284,6 +288,55 @@ impl TestRunner {
                 comp,
                 self.render_interface.as_deref(),
             )?;
+        }
+
+        Ok(())
+    }
+
+    fn test_audio(&mut self) -> Result<()> {
+        if self.audio_assertions.is_empty() {
+            return Ok(());
+        }
+
+        let player = self.player.lock().unwrap();
+        let Some(audio) = <dyn std::any::Any>::downcast_ref::<TestAudioBackend>(player.audio())
+        else {
+            return Err(anyhow!("Audio assertions require audio"));
+        };
+
+        for assertion in self.audio_assertions.values() {
+            if !assertion.frames.includes_frame(self.current_iteration) {
+                continue;
+            }
+
+            let current_max = audio
+                .buffer()
+                .iter()
+                .map(|&v| v.abs())
+                .reduce(|a, b| a.max(b))
+                .expect("buffer should not be empty");
+
+            if let Some(max_amplitude) = assertion.max_amplitude
+                && current_max > max_amplitude
+            {
+                return Err(anyhow!(
+                    "Expected max audio amplitude to be {}, was {} at frame {}",
+                    max_amplitude,
+                    current_max,
+                    self.current_iteration
+                ));
+            }
+
+            if let Some(min_max_amplitude) = assertion.min_max_amplitude
+                && current_max < min_max_amplitude
+            {
+                return Err(anyhow!(
+                    "Expected max audio amplitude to be at least {}, was {} at frame {}",
+                    min_max_amplitude,
+                    current_max,
+                    self.current_iteration
+                ));
+            }
         }
 
         Ok(())

--- a/tests/tests/swfs/avm2/soundchannel_stop/test.toml
+++ b/tests/tests/swfs/avm2/soundchannel_stop/test.toml
@@ -1,1 +1,12 @@
 num_frames = 4
+
+[player_options]
+with_audio = true
+
+[audio_assertions.sound]
+frames = [3]
+min_max_amplitude = 0.9
+
+[audio_assertions.silence]
+frames = [4]
+max_amplitude = 0.0


### PR DESCRIPTION
This allows tests to verify that audio is playing (or silent) at specific frames by checking the maximum amplitude in the audio buffer.

- Add `AudioAssertion` and `FrameSelection` to test options.
- Implement `TestRunner::test_audio` to perform amplitude checks.
- Expose the audio buffer in `TestAudioBackend`.
- Update `soundchannel_stop` test to use these new assertions.

That could make it possible to write a test for https://github.com/ruffle-rs/ruffle/pull/23333.