### PR TITLE
core: Disallow code execution with SWF version 0

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -239,6 +239,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         callee: Option<Object<'gc>>,
         local_registers: &'a [Cell<Value<'gc>>],
     ) -> Self {
+        debug_assert!(swf_version > 0, "cannot execute code with SWF version 0");
         avm_debug!(context.avm1, "START {id}");
         Self {
             context,
@@ -291,6 +292,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         avm_debug!(context.avm1, "START {id}");
 
         let swf_version = base_clip.swf_version();
+        debug_assert!(swf_version > 0, "cannot execute code with SWF version 0");
         let scope = context.avm1.global_scope(swf_version);
         Self {
             id,
@@ -1469,7 +1471,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             }
 
             if let Some(prototype) = constructor
-                .filter(|_| self.swf_version >= 7)
+                .filter(|_| self.swf_version() >= 7)
                 .and_then(|o| o.prototype(self).as_object(self))
             {
                 prototype.set_interfaces(self.gc(), interfaces);
@@ -2177,7 +2179,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 let mut activation = Activation::from_action(
                     self.context,
                     self.id.child("[Catch]"),
-                    self.swf_version,
+                    self.swf_version(),
                     self.scope,
                     self.constant_pool,
                     self.base_clip,
@@ -2865,7 +2867,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     /// For SWF version 5 and lower, this is locale-dependent,
     /// and we default to WINDOWS-1252.
     pub fn encoding(&self) -> &'static swf::Encoding {
-        swf::SwfStr::encoding_for_version(self.swf_version)
+        swf::SwfStr::encoding_for_version(self.swf_version())
     }
 
     /// Returns the SWF version of the action or function being executed.

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -669,9 +669,13 @@ impl<'gc> MovieLoader<'gc> {
                     if !mc.movie().is_action_script_3() {
                         mc.avm1_unload(uc);
 
-                        // Clear deletable properties on the target before loading
-                        // Properties written during the subsequent onLoad events will persist
-                        if let Some(clip_object) = mc.object1() {
+                        // Clear deletable properties on the target before loading.
+                        // Properties written during the subsequent onLoad events will persist.
+                        // Note: skip this step when we can't execute code (swf_version is 0).
+                        //   This will happen in case we're replacing an error movie.
+                        if let Some(clip_object) = mc.object1()
+                            && mc.swf_version() > 0
+                        {
                             let mut activation = Activation::from_nothing(
                                 uc,
                                 ActivationIdentifier::root("unknown"),


### PR DESCRIPTION
Executing code with SWF version 0 means that something's wrong, as version 0 is used for errored out movies and non-movies, which cannot contain code.

In the past, Ruffle had some bugs that caused code execution with SWF version 0 (e.g. see 33334537f39b9b3637bb77192154f6c7b2bfe76d).

This patch fixes one instance of SWF version 0 getting into an Activation, and adds a debug assertion for the SWF version to make sure that we don't introduce more such cases.