### PR TITLE
extension: Add Costco domains to content script exclude list

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -29,6 +29,18 @@
                 "https://*.dhl.com/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
                 "https://*.dhl.de/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
                 "https://mydhl.express.dhl/*", // See https://github.com/ruffle-rs/ruffle/issues/23325
+                "https://*.costco.com/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.ca/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.co.uk/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.com.mx/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.co.kr/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.co.jp/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.com.tw/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.com.au/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.es/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.fr/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.is/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
+                "https://*.costco.com.cn/*", // See https://github.com/ruffle-rs/ruffle/issues/23440
             ],
             "js": ["dist/content.js"],
             "all_frames": true,


### PR DESCRIPTION
* Fixes https://github.com/ruffle-rs/ruffle/issues/23440

Exclude Costco's global domains from the extension's content script to prevent potential interference, as reported in #23440.