### PR TITLE
chore: Bump `rand` to fix an unsoundness advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,9 +4273,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
See: https://github.com/advisories/GHSA-cq8v-f236-94qc