### PR TITLE
core: In MovieClip's `avm1_mouse_pick`, don't check for AVM2 content

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2984,17 +2984,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
                     }
                 } else if result.is_none() {
                     if let Some(child) = child.as_interactive() {
-                        result = if !child.as_displayobject().movie().is_action_script_3() {
-                            child.mouse_pick_avm1(context, point, require_button_mode)
-                        } else {
-                            let avm2_result =
-                                child.mouse_pick_avm2(context, point, require_button_mode);
-                            if let Avm2MousePick::Hit(result) = avm2_result {
-                                Some(result)
-                            } else {
-                                None
-                            }
-                        }
+                        result = child.mouse_pick_avm1(context, point, require_button_mode);
                     } else if check_non_interactive
                         && self.mouse_enabled()
                         && child.hit_test_shape(context, point, options)
@@ -3097,6 +3087,8 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
                     if child.as_displayobject().movie().is_action_script_3() {
                         child.mouse_pick_avm2(context, point, require_button_mode)
                     } else {
+                        // This is possible because SWF 9 allows moving
+                        // AVM1 content outside of the parenting LoaderDisplay.
                         let avm1_result =
                             child.mouse_pick_avm1(context, point, require_button_mode);
                         if let Some(result) = avm1_result {


### PR DESCRIPTION
This is theoretically not possible, because AVM2 movies loaded into AVM1 are always interpreted as AVM1 (https://github.com/ruffle-rs/ruffle/pull/23183), and `mouse_pick_avm1` is never run in AVM2.