### PR TITLE
avm2: Optimize Value conversions and handle usize as Integer

### DIFF
--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -61,18 +61,21 @@ pub enum Value<'gc> {
 const _: () = assert!(size_of::<Value<'_>>() <= 16);
 
 impl<'gc> From<AvmString<'gc>> for Value<'gc> {
+    #[inline(always)]
     fn from(string: AvmString<'gc>) -> Self {
         Value::String(string)
     }
 }
 
 impl<'gc> From<AvmAtom<'gc>> for Value<'gc> {
+    #[inline(always)]
     fn from(atom: AvmAtom<'gc>) -> Self {
         Value::String(atom.into())
     }
 }
 
 impl From<bool> for Value<'_> {
+    #[inline(always)]
     fn from(value: bool) -> Self {
         Value::Bool(value)
     }
@@ -82,54 +85,63 @@ impl<'gc, T> From<T> for Value<'gc>
 where
     Object<'gc>: From<T>,
 {
+    #[inline(always)]
     fn from(value: T) -> Self {
         Value::Object(Object::from(value))
     }
 }
 
 impl From<f64> for Value<'_> {
+    #[inline(always)]
     fn from(value: f64) -> Self {
         Value::Number(value)
     }
 }
 
 impl From<f32> for Value<'_> {
+    #[inline(always)]
     fn from(value: f32) -> Self {
         Value::Number(f64::from(value))
     }
 }
 
 impl From<u8> for Value<'_> {
+    #[inline(always)]
     fn from(value: u8) -> Self {
         Value::Integer(i32::from(value))
     }
 }
 
 impl From<i8> for Value<'_> {
+    #[inline(always)]
     fn from(value: i8) -> Self {
         Value::Integer(i32::from(value))
     }
 }
 
 impl From<i16> for Value<'_> {
+    #[inline(always)]
     fn from(value: i16) -> Self {
         Value::Integer(i32::from(value))
     }
 }
 
 impl From<u16> for Value<'_> {
+    #[inline(always)]
     fn from(value: u16) -> Self {
         Value::Integer(i32::from(value))
     }
 }
 
 impl From<i32> for Value<'_> {
+    #[inline(always)]
     fn from(value: i32) -> Self {
         Value::Integer(value)
     }
 }
 
 impl From<u32> for Value<'_> {
+    #[inline(always)]
     fn from(value: u32) -> Self {
         if let Some(value) = value.to_i32() {
             Value::Integer(value)
@@ -140,8 +152,13 @@ impl From<u32> for Value<'_> {
 }
 
 impl From<usize> for Value<'_> {
+    #[inline(always)]
     fn from(value: usize) -> Self {
-        Value::Number(value as f64)
+        if let Some(value) = value.to_i32() {
+            Value::Integer(value)
+        } else {
+            Value::Number(value as f64)
+        }
     }
 }
 


### PR DESCRIPTION
* Add #[inline(always)] to common From implementations for Value to improve performance in hot paths.

* Update From<usize> for Value to attempt conversion to Integer (i32) before falling back to Number, matching the behavior of other integer types and taking advantage of recent integer optimizations.

This patch shows a small, but positive performance impact through the crypto benchmark.