### PR TITLE
avm2: Implement DisplayObject.rotationZ

### DIFF
--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -426,20 +426,39 @@ pub fn set_rotation_y<'gc>(
 }
 
 pub fn get_rotation_z<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _this: Value<'gc>,
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm2_stub_getter!(activation, "flash.display.DisplayObject", "rotationZ");
-    Ok(0.into())
+    let this = this.as_object().unwrap();
+
+    if let Some(dobj) = this.as_display_object() {
+        let rot: f64 = dobj.rotation().into();
+        let rem = rot % 360.0;
+
+        if rem <= 180.0 {
+            return Ok(rem.into());
+        } else {
+            return Ok((rem - 360.0).into());
+        }
+    }
+
+    Ok(Value::Undefined)
 }
 
 pub fn set_rotation_z<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _this: Value<'gc>,
-    _args: &[Value<'gc>],
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm2_stub_setter!(activation, "flash.display.DisplayObject", "rotationZ");
+    let this = this.as_object().unwrap();
+
+    if let Some(dobj) = this.as_display_object() {
+        let new_rotation = args.get_f64(0);
+        dobj.set_rotation(Degrees::from(new_rotation));
+        dobj.base().set_has_matrix3d_stub(true);
+    }
+
     Ok(Value::Undefined)
 }
 


### PR DESCRIPTION
Generated via Claude code Opus 4.6
Since I don't understand the code, perhaps more like a demonstration that it's relatively easy to implement?

Fixes https://github.com/ruffle-rs/ruffle/issues/12483