### PR TITLE
avm2: Improve DisplayObject.rotationZ stubs

### DIFF
--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -427,20 +427,22 @@ pub fn set_rotation_y<'gc>(
 
 pub fn get_rotation_z<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Value<'gc>,
-    _args: &[Value<'gc>],
+    this: Value<'gc>,
+    args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    // TODO This probably interacts with Matrix3D.
     avm2_stub_getter!(activation, "flash.display.DisplayObject", "rotationZ");
-    Ok(0.into())
+    get_rotation(activation, this, args)
 }
 
 pub fn set_rotation_z<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Value<'gc>,
-    _args: &[Value<'gc>],
+    this: Value<'gc>,
+    args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    // TODO This probably interacts with Matrix3D.
     avm2_stub_setter!(activation, "flash.display.DisplayObject", "rotationZ");
-    Ok(Value::Undefined)
+    set_rotation(activation, this, args)
 }
 
 pub fn get_scale_z<'gc>(


### PR DESCRIPTION
* Fixes https://github.com/ruffle-rs/ruffle/issues/12483
* Supersedes https://github.com/ruffle-rs/ruffle/pull/23467

Z axis is placed perpendicular to the x/y plane, and effectively is the same as regular rotation. The API as described in docs works also the same way.

By delegating DisplayObject.rotationZ to DisplayObject.rotation, we can make the content work that used rotationZ the same way as rotation.

This does not address potential interactions with Matrix3D, etc., and thus the method is still marked as a stub.