### PR TITLE
avm2: Simplify abstract_eq for numbers

### DIFF
--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -1830,20 +1830,7 @@ impl<'gc> Value<'gc> {
             (Value::Number(_) | Value::Integer(_), Value::Number(_) | Value::Integer(_)) => {
                 let a = self.coerce_to_number(activation)?;
                 let b = other.coerce_to_number(activation)?;
-
-                if a.is_nan() || b.is_nan() {
-                    return Ok(false);
-                }
-
-                if a == b {
-                    return Ok(true);
-                }
-
-                if a.abs() == 0.0 && b.abs() == 0.0 {
-                    return Ok(true);
-                }
-
-                Ok(false)
+                Ok(a == b)
             }
             (Value::String(a), Value::String(b)) => Ok(a == b),
             (Value::Bool(a), Value::Bool(b)) => Ok(a == b),


### PR DESCRIPTION
The NaN and signed zero checks are unnecessary, because they are duplicating the behavior of a==b.