### PR TITLE
avm2: Use Value::from_usize_lossy instead of From<usize>

### DIFF
--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -69,7 +69,7 @@ pub fn get_length<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(array) = this.as_array_storage() {
-        return Ok(array.length().into());
+        return Ok(Value::from_usize_lossy(array.length()));
     }
 
     Ok(Value::Undefined)
@@ -464,7 +464,7 @@ pub fn _index_of<'gc>(
         for (i, val) in array.iter().enumerate() {
             let val = resolve_array_hole(activation, this, i, val)?;
             if i >= from_index && val == search_val {
-                return Ok(i.into());
+                return Ok(Value::from_usize_lossy(i));
             }
         }
 
@@ -495,7 +495,7 @@ pub fn _last_index_of<'gc>(
         for (i, val) in array.iter().enumerate().rev() {
             let val = resolve_array_hole(activation, this, i, val)?;
             if i <= from_index && val == search_val {
-                return Ok(i.into());
+                return Ok(Value::from_usize_lossy(i));
             }
         }
 
@@ -532,7 +532,7 @@ pub fn push<'gc>(
         for arg in args {
             array.push(*arg)
         }
-        return Ok(array.length().into());
+        return Ok(Value::from_usize_lossy(array.length()));
     }
 
     Ok(Value::Undefined)
@@ -601,7 +601,7 @@ pub fn unshift<'gc>(
         for arg in args.iter().rev() {
             array.unshift(*arg)
         }
-        return Ok(array.length().into());
+        return Ok(Value::from_usize_lossy(array.length()));
     }
 
     Ok(Value::Undefined)
@@ -677,7 +677,7 @@ pub fn splice<'gc>(
     let actual_start = resolve_index(activation, start, array_length)?;
     let delete_count = args
         .get_optional(1)
-        .unwrap_or_else(|| array_length.into())
+        .unwrap_or_else(|| Value::from_usize_lossy(array_length))
         .coerce_to_i32(activation)?
         .max(0);
 
@@ -977,7 +977,11 @@ fn sort_postprocess<'gc>(
         if options.contains(SortOptions::RETURN_INDEXED_ARRAY) {
             return Ok(build_array(
                 activation,
-                values.iter().map(|&(i, _)| i).collect(),
+                values
+                    .iter()
+                    .map(|&(i, _)| i)
+                    .map(Value::from_usize_lossy)
+                    .collect(),
             ));
         } else {
             if let Some(mut old_array) = this.as_array_storage_mut(activation.gc()) {

--- a/core/src/avm2/globals/flash/display/display_object_container.rs
+++ b/core/src/avm2/globals/flash/display/display_object_container.rs
@@ -242,7 +242,7 @@ pub fn get_num_children<'gc>(
         .as_display_object()
         .and_then(|this| this.as_container())
     {
-        return Ok(parent.num_children().into());
+        return Ok(Value::from_usize_lossy(parent.num_children()));
     }
 
     Ok(0.into())
@@ -289,7 +289,7 @@ pub fn get_child_index<'gc>(
             if let Some(target_child) = target_child {
                 for (i, child) in ctr.iter_render_list().enumerate() {
                     if DisplayObject::ptr_eq(child, target_child) {
-                        return Ok(i.into());
+                        return Ok(Value::from_usize_lossy(i));
                     }
                 }
             }

--- a/core/src/avm2/globals/flash/display/loader_info.rs
+++ b/core/src/avm2/globals/flash/display/loader_info.rs
@@ -86,9 +86,11 @@ pub fn get_bytes_total<'gc>(
 
     if let Some(loader_stream) = this.as_loader_info_object().map(|o| o.loader_stream()) {
         match &*loader_stream {
-            LoaderStream::NotYetLoaded(swf, _, _) => return Ok(swf.compressed_len().into()),
+            LoaderStream::NotYetLoaded(swf, _, _) => {
+                return Ok(Value::from_usize_lossy(swf.compressed_len()));
+            }
             LoaderStream::Swf(movie, _) => {
-                return Ok(movie.compressed_len().into());
+                return Ok(Value::from_usize_lossy(movie.compressed_len()));
             }
         }
     }
@@ -109,13 +111,13 @@ pub fn get_bytes_loaded<'gc>(
     match &*loader_stream {
         LoaderStream::NotYetLoaded(swf, None, _) => {
             if loader_info.errored() {
-                return Ok(swf.compressed_len().into());
+                return Ok(Value::from_usize_lossy(swf.compressed_len()));
             }
             Ok(0.into())
         }
         LoaderStream::Swf(swf, root) | LoaderStream::NotYetLoaded(swf, Some(root), _) => {
             if root.as_bitmap().is_some() {
-                return Ok(swf.compressed_len().into());
+                return Ok(Value::from_usize_lossy(swf.compressed_len()));
             }
             Ok(root
                 .as_movie_clip()

--- a/core/src/avm2/globals/flash/display/shader_parameter.rs
+++ b/core/src/avm2/globals/flash/display/shader_parameter.rs
@@ -32,7 +32,11 @@ pub fn make_shader_parameter<'gc>(
 
             let type_name = AvmString::new_utf8(activation.gc(), param_type.to_string());
 
-            param_object.set_slot(parameter_slots::_INDEX, index.into(), activation)?;
+            param_object.set_slot(
+                parameter_slots::_INDEX,
+                Value::from_usize_lossy(index),
+                activation,
+            )?;
             param_object.set_slot(parameter_slots::_TYPE, type_name.into(), activation)?;
             for meta in metadata {
                 let name = AvmString::new_utf8(activation.gc(), &meta.key);
@@ -63,7 +67,11 @@ pub fn make_shader_parameter<'gc>(
                 .unwrap();
 
             obj.set_slot(input_slots::_CHANNELS, (*channels).into(), activation)?;
-            obj.set_slot(input_slots::_INDEX, index.into(), activation)?;
+            obj.set_slot(
+                input_slots::_INDEX,
+                Value::from_usize_lossy(index),
+                activation,
+            )?;
             obj.set_dynamic_property(
                 istr!("name"),
                 AvmString::new_utf8(activation.gc(), name).into(),

--- a/core/src/avm2/globals/flash/net/net_stream.rs
+++ b/core/src/avm2/globals/flash/net/net_stream.rs
@@ -12,7 +12,7 @@ pub fn get_bytes_loaded<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(ns) = this.as_netstream() {
-        return Ok(ns.bytes_loaded().into());
+        return Ok(Value::from_usize_lossy(ns.bytes_loaded()));
     }
 
     Ok(Value::Undefined)
@@ -26,7 +26,7 @@ pub fn get_bytes_total<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(ns) = this.as_netstream() {
-        return Ok(ns.bytes_total().into());
+        return Ok(Value::from_usize_lossy(ns.bytes_total()));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/net/shared_object.rs
+++ b/core/src/avm2/globals/flash/net/shared_object.rs
@@ -240,7 +240,7 @@ pub fn get_size<'gc>(
         Ok(0.into())
     } else {
         let bytes = flash_lso::write::write_to_bytes(&mut lso).unwrap_or_default();
-        Ok(bytes.len().into())
+        Ok(Value::from_usize_lossy(bytes.len()))
     }
 }
 

--- a/core/src/avm2/globals/flash/net/socket.rs
+++ b/core/src/avm2/globals/flash/net/socket.rs
@@ -111,7 +111,7 @@ pub fn get_bytes_available<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(socket) = this.as_socket() {
-        return Ok(socket.read_buffer().len().into());
+        return Ok(Value::from_usize_lossy(socket.read_buffer().len()));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -90,7 +90,11 @@ pub fn create_text_line<'gc>(
 
     instance.set_slot(line_slots::_SPECIFIED_WIDTH, args.get_value(1), activation)?;
 
-    instance.set_slot(line_slots::_RAW_TEXT_LENGTH, text.len().into(), activation)?;
+    instance.set_slot(
+        line_slots::_RAW_TEXT_LENGTH,
+        Value::from_usize_lossy(text.len()),
+        activation,
+    )?;
 
     this.set_slot(
         block_slots::_TEXT_LINE_CREATION_RESULT,

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -454,7 +454,7 @@ pub fn get_length<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        return Ok(this.text_length().into());
+        return Ok(Value::from_usize_lossy(this.text_length()));
     }
 
     Ok(Value::Undefined)
@@ -861,7 +861,7 @@ pub fn get_caret_index<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         return if let Some(selection) = this.selection() {
-            Ok(selection.to().into())
+            Ok(Value::from_usize_lossy(selection.to()))
         } else {
             Ok(0.into())
         };
@@ -882,7 +882,7 @@ pub fn get_selection_begin_index<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         return if let Some(selection) = this.selection() {
-            Ok(selection.start().into())
+            Ok(Value::from_usize_lossy(selection.start()))
         } else {
             Ok(0.into())
         };
@@ -903,7 +903,7 @@ pub fn get_selection_end_index<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         return if let Some(selection) = this.selection() {
-            Ok(selection.end().into())
+            Ok(Value::from_usize_lossy(selection.end()))
         } else {
             Ok(0.into())
         };
@@ -1168,7 +1168,7 @@ pub fn get_num_lines<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        return Ok(this.layout_lines().into());
+        return Ok(Value::from_usize_lossy(this.layout_lines()));
     }
 
     Ok(Value::Undefined)
@@ -1233,7 +1233,7 @@ pub fn get_line_length<'gc>(
     }
 
     if let Some(length) = this.line_length(line_num as usize) {
-        Ok(length.into())
+        Ok(Value::from_usize_lossy(length))
     } else {
         Err(make_error_2006(activation))
     }
@@ -1281,7 +1281,7 @@ pub fn get_line_offset<'gc>(
     }
 
     if let Some(offset) = this.line_offset(line_num as usize) {
-        Ok(offset.into())
+        Ok(Value::from_usize_lossy(offset))
     } else {
         Err(make_error_2006(activation))
     }
@@ -1298,7 +1298,7 @@ pub fn get_bottom_scroll_v<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        return Ok(this.bottom_scroll().into());
+        return Ok(Value::from_usize_lossy(this.bottom_scroll()));
     }
 
     Ok(Value::Undefined)
@@ -1315,7 +1315,7 @@ pub fn get_max_scroll_v<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        return Ok(this.maxscroll().into());
+        return Ok(Value::from_usize_lossy(this.maxscroll()));
     }
 
     Ok(Value::Undefined)
@@ -1349,7 +1349,7 @@ pub fn get_scroll_v<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        return Ok(this.scroll().into());
+        return Ok(Value::from_usize_lossy(this.scroll()));
     }
 
     Ok(Value::Undefined)
@@ -1552,7 +1552,14 @@ pub fn get_text_runs<'gc>(
         })
         .map(|(start, end, _, format)| {
             let tf = TextFormatObject::from_text_format(activation, format.get_text_format())?;
-            textrun_class.construct(activation, &[start.into(), end.into(), tf.into()])
+            textrun_class.construct(
+                activation,
+                &[
+                    Value::from_usize_lossy(start),
+                    Value::from_usize_lossy(end),
+                    tf.into(),
+                ],
+            )
         })
         .collect::<Result<ArrayStorage<'gc>, Error<'gc>>>()?;
     Ok(ArrayObject::from_storage(activation.context, array).into())
@@ -1579,7 +1586,7 @@ pub fn get_line_index_of_char<'gc>(
     }
 
     if let Some(line) = this.line_index_of_char(index as usize) {
-        Ok(line.into())
+        Ok(Value::from_usize_lossy(line))
     } else {
         Ok(Value::Number(-1f64))
     }
@@ -1604,7 +1611,7 @@ pub fn get_char_index_at_point<'gc>(
     let y = args.get_f64(1);
 
     if let Some(index) = this.char_index_at_point(Point::from_pixels(x, y)) {
-        Ok(index.into())
+        Ok(Value::from_usize_lossy(index))
     } else {
         Ok(Value::Number(-1f64))
     }
@@ -1629,7 +1636,7 @@ pub fn get_line_index_at_point<'gc>(
     let y = args.get_f64(1);
 
     if let Some(index) = this.line_index_at_point(Point::from_pixels(x, y)) {
-        Ok(index.into())
+        Ok(Value::from_usize_lossy(index))
     } else {
         Ok(Value::Number(-1f64))
     }

--- a/core/src/avm2/globals/flash/utils/byte_array.rs
+++ b/core/src/avm2/globals/flash/utils/byte_array.rs
@@ -262,7 +262,7 @@ pub fn get_position<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(bytearray) = this.as_bytearray() {
-        return Ok(bytearray.position().into());
+        return Ok(Value::from_usize_lossy(bytearray.position()));
     }
 
     Ok(Value::Undefined)
@@ -291,7 +291,7 @@ pub fn get_bytes_available<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(bytearray) = this.as_bytearray() {
-        return Ok(bytearray.bytes_available().into());
+        return Ok(Value::from_usize_lossy(bytearray.bytes_available()));
     }
 
     Ok(Value::Undefined)
@@ -305,7 +305,7 @@ pub fn get_length<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(bytearray) = this.as_bytearray() {
-        return Ok(bytearray.len().into());
+        return Ok(Value::from_usize_lossy(bytearray.len()));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -119,7 +119,7 @@ pub fn get_length<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(this) = this.as_function_object() {
-        return Ok(this.executable().signature().len().into());
+        return Ok(Value::from_usize_lossy(this.executable().signature().len()));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/json.rs
+++ b/core/src/avm2/globals/json.rs
@@ -62,7 +62,7 @@ fn deserialize_json_inner<'gc>(
                 .enumerate()
                 .map(|(key, val)| {
                     let val = deserialize_json_inner(activation, val.clone(), reviver)?;
-                    let args = &[key.into(), val];
+                    let args = &[Value::from_usize_lossy(key), val];
 
                     match reviver {
                         None => Ok(val),

--- a/core/src/avm2/globals/reg_exp.rs
+++ b/core/src/avm2/globals/reg_exp.rs
@@ -160,7 +160,7 @@ pub fn get_last_index<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(re) = this.as_regexp() {
-        return Ok(re.last_index().into());
+        return Ok(Value::from_usize_lossy(re.last_index()));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -43,7 +43,7 @@ pub fn get_length<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Value::String(s) = this {
-        return Ok(s.len().into());
+        return Ok(Value::from_usize_lossy(s.len()));
     }
 
     Ok(Value::Undefined)
@@ -143,7 +143,9 @@ pub fn index_of<'gc>(
 
     this.slice(start_index..)
         .and_then(|s| s.find(&pattern))
-        .map(|i| Ok((i + start_index).into()))
+        .map(|i| i + start_index)
+        .map(Value::from_usize_lossy)
+        .map(Ok)
         .unwrap_or_else(|| Ok((-1).into())) // Out of range or not found
 }
 
@@ -172,7 +174,8 @@ pub fn last_index_of<'gc>(
     this.slice(..start_index)
         .unwrap_or(&this)
         .rfind(&pattern)
-        .map(|i| Ok(i.into()))
+        .map(Value::from_usize_lossy)
+        .map(Ok)
         .unwrap_or_else(|| Ok((-1).into())) // Not found
 }
 
@@ -276,7 +279,11 @@ pub fn match_internal<'gc>(
 
                 let array = ArrayObject::from_storage(activation.context, storage);
 
-                array.set_dynamic_property(istr!("index"), result.start().into(), activation.gc());
+                array.set_dynamic_property(
+                    istr!("index"),
+                    Value::from_usize_lossy(result.start()),
+                    activation.gc(),
+                );
                 array.set_dynamic_property(istr!("input"), this.into(), activation.gc());
 
                 return Ok(array.into());
@@ -322,7 +329,11 @@ pub fn replace<'gc>(
         let mut ret = WString::from(&this[..position]);
         // Replacement is either a function or treatable as string.
         if let Some(f) = replacement.as_object().and_then(|o| o.as_function_object()) {
-            let args = &[pattern.into(), position.into(), this.into()];
+            let args = &[
+                pattern.into(),
+                Value::from_usize_lossy(position),
+                this.into(),
+            ];
             let v = f.call(activation, Value::Null, FunctionArgs::from_slice(args))?;
             ret.push_str(v.coerce_to_string(activation)?.as_wstr());
         } else {

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -103,7 +103,7 @@ pub fn get_length<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(vector) = this.as_vector_storage() {
-        return Ok(vector.length().into());
+        return Ok(Value::from_usize_lossy(vector.length()));
     }
 
     Ok(Value::Undefined)
@@ -443,7 +443,7 @@ pub fn push<'gc>(
             vs.push(coerced_arg, activation)?;
         }
 
-        return Ok(vs.length().into());
+        return Ok(Value::from_usize_lossy(vs.length()));
     }
 
     Ok(Value::Undefined)
@@ -490,7 +490,7 @@ pub fn unshift<'gc>(
             vs.unshift(coerced_arg, activation)?;
         }
 
-        return Ok(vs.length().into());
+        return Ok(Value::from_usize_lossy(vs.length()));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -192,7 +192,7 @@ pub fn length<'gc>(
 
     let list = this.as_xml_list_object().unwrap();
     let children = list.children();
-    Ok(children.len().into())
+    Ok(Value::from_usize_lossy(children.len()))
 }
 
 pub fn child<'gc>(

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -238,7 +238,7 @@ impl<'gc> RegExp<'gc> {
                     Some(r) => activation.strings().substring(txt, r.clone()).into(),
                     None => istr!("").into(),
                 })
-                .chain(std::iter::once(m.range.start.into()))
+                .chain(std::iter::once(m.range.start).map(Value::from_usize_lossy))
                 .chain(std::iter::once(txt.into()))
                 .collect::<Vec<_>>();
 

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -151,17 +151,6 @@ impl From<u32> for Value<'_> {
     }
 }
 
-impl From<usize> for Value<'_> {
-    #[inline(always)]
-    fn from(value: usize) -> Self {
-        if let Some(value) = value.to_i32() {
-            Value::Integer(value)
-        } else {
-            Value::Number(value as f64)
-        }
-    }
-}
-
 impl PartialEq for Value<'_> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -505,6 +494,20 @@ pub fn abc_default_value<'gc>(
 }
 
 impl<'gc> Value<'gc> {
+    /// Do the best effort of converting the [`usize`] value to [`Value`].
+    ///
+    /// This is lossless on 32-bit architectures and for values less or equal to
+    /// 2^53. For values greater than that, it will return a value equivalent to
+    /// the closest integer representable as IEEE 754 64-bit.
+    #[inline(always)]
+    pub fn from_usize_lossy(value: usize) -> Self {
+        if let Some(value) = value.to_i32() {
+            Value::Integer(value)
+        } else {
+            Value::Number(value as f64)
+        }
+    }
+
     pub fn as_namespace(&self) -> Result<Namespace<'gc>, Error<'gc>> {
         match self {
             Value::Object(ns) => ns

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -14,7 +14,7 @@ use crate::avm2::object::{
 };
 use crate::avm2::{
     Activation as Avm2Activation, Avm2, BitmapDataObject, Domain as Avm2Domain,
-    Object as Avm2Object,
+    Object as Avm2Object, Value as Avm2Value,
 };
 use crate::avm2_stub_method_context;
 use crate::backend::navigator::{
@@ -1186,7 +1186,7 @@ pub fn load_data_into_url_loader<'gc>(
             ) {
                 use crate::avm2::globals::slots::flash_net_url_loader as url_loader_slots;
 
-                let body_len = body.len().into();
+                let body_len = Avm2Value::from_usize_lossy(body.len());
 
                 // TODO - update these as the download progresses
                 target


### PR DESCRIPTION
The From impl for Value was not compliant with the expectations: the conversion from usize to Value is not always lossless.

That's why this patch removes the impl and instead moves the conversion to Value::from_usize_lossy, which makes it clear that the conversion is lossy.

In most cases however, this shouldn't have any effect, as usually usize is used in relation to memory, and the first lossy value would happen at 9 PB of memory.