### PR TITLE
avm1: Add Value::from_usize_lossy and Value::from_u64_lossy

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2068,7 +2068,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // In SWF6+, this is the same as String.length (returns number of UTF-16 code units).
         // TODO: In SWF5, this returns the byte length, even though the encoding is locale dependent.
         let val = self.context.avm1.pop().coerce_to_string(self)?;
-        self.context.avm1.push(val.len().into());
+        self.context.avm1.push(Value::from_usize_lossy(val.len()));
         Ok(FrameControl::Continue)
     }
 

--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -201,7 +201,7 @@ pub fn size<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::FileReference(file_ref) = this.native() {
         let size = file_ref.0.size.get();
-        return Ok(size.map_or(Value::Undefined, Into::into));
+        return Ok(size.map_or(Value::Undefined, Value::from_u64_lossy));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -159,13 +159,13 @@ fn get_progress<'gc>(
             result.define_value(
                 activation.gc(),
                 istr!("bytesLoaded"),
-                target.movie().compressed_len().into(),
+                Value::from_usize_lossy(target.movie().compressed_len()),
                 Attribute::empty(),
             );
             result.define_value(
                 activation.gc(),
                 istr!("bytesTotal"),
-                target.movie().compressed_len().into(),
+                Value::from_usize_lossy(target.movie().compressed_len()),
                 Attribute::empty(),
             );
         }

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -82,7 +82,7 @@ fn get_bytes_loaded<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::NetStream(ns) = this.native() {
-        return Ok(ns.bytes_loaded().into());
+        return Ok(Value::from_usize_lossy(ns.bytes_loaded()));
     }
 
     Ok(Value::Undefined)
@@ -94,7 +94,7 @@ fn get_bytes_total<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::NetStream(ns) = this.native() {
-        return Ok(ns.bytes_total().into());
+        return Ok(Value::from_usize_lossy(ns.bytes_total()));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -38,7 +38,7 @@ pub fn get_begin_index<'gc>(
         .get_as_edit_text()
         .and_then(EditText::selection)
     {
-        Ok(selection.start().into())
+        Ok(Value::from_usize_lossy(selection.start()))
     } else {
         Ok((-1).into())
     }
@@ -55,7 +55,7 @@ pub fn get_end_index<'gc>(
         .get_as_edit_text()
         .and_then(EditText::selection)
     {
-        Ok(selection.end().into())
+        Ok(Value::from_usize_lossy(selection.end()))
     } else {
         Ok((-1).into())
     }
@@ -72,7 +72,7 @@ pub fn get_caret_index<'gc>(
         .get_as_edit_text()
         .and_then(EditText::selection)
     {
-        Ok(selection.to().into())
+        Ok(Value::from_usize_lossy(selection.to()))
     } else {
         Ok((-1).into())
     }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -536,7 +536,7 @@ fn get_size<'gc>(
         Ok(0.into())
     } else {
         let bytes = flash_lso::write::write_to_bytes(&mut lso).unwrap_or_default();
-        Ok(bytes.len().into())
+        Ok(Value::from_usize_lossy(bytes.len()))
     }
 }
 

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -58,7 +58,7 @@ pub fn constructor<'gc>(
     this.define_value(
         activation.gc(),
         istr!("length"),
-        value.len().into(),
+        Value::from_usize_lossy(value.len()),
         Attribute::DONT_ENUM | Attribute::DONT_DELETE,
     );
 
@@ -175,7 +175,9 @@ fn index_of<'gc>(
 
     this.slice(start_index..)
         .and_then(|s| s.find(&pattern))
-        .map(|i| Ok((i + start_index).into()))
+        .map(|i| i + start_index)
+        .map(Value::from_usize_lossy)
+        .map(Ok)
         .unwrap_or_else(|| Ok((-1).into())) // Out of range or not found
 }
 
@@ -201,7 +203,8 @@ fn last_index_of<'gc>(
     this.slice(..start_index)
         .unwrap_or(&this)
         .rfind(&pattern)
-        .map(|i| Ok(i.into()))
+        .map(Value::from_usize_lossy)
+        .map(Ok)
         .unwrap_or_else(|| Ok((-1).into())) // Not found
 }
 

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -675,7 +675,7 @@ pub fn scroll<'gc>(
     this: EditText<'gc>,
     _activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(this.scroll().into())
+    Ok(Value::from_usize_lossy(this.scroll()))
 }
 
 pub fn set_scroll<'gc>(
@@ -692,7 +692,7 @@ pub fn maxscroll<'gc>(
     this: EditText<'gc>,
     _activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(this.maxscroll().into())
+    Ok(Value::from_usize_lossy(this.maxscroll()))
 }
 
 pub fn set_max_chars<'gc>(
@@ -721,7 +721,7 @@ pub fn bottom_scroll<'gc>(
     this: EditText<'gc>,
     _activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(this.bottom_scroll().into())
+    Ok(Value::from_usize_lossy(this.bottom_scroll()))
 }
 
 pub fn anti_alias_type<'gc>(

--- a/core/src/avm1/globals/text_snapshot.rs
+++ b/core/src/avm1/globals/text_snapshot.rs
@@ -84,7 +84,7 @@ fn get_count<'gc>(
         return Ok(Value::Undefined);
     }
 
-    Ok(object.text_snapshot().count().into())
+    Ok(Value::from_usize_lossy(object.text_snapshot().count()))
 }
 
 fn set_selected<'gc>(

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -102,18 +102,6 @@ impl From<u32> for Value<'_> {
     }
 }
 
-impl From<u64> for Value<'_> {
-    fn from(value: u64) -> Self {
-        Value::Number(value as f64)
-    }
-}
-
-impl From<usize> for Value<'_> {
-    fn from(value: usize) -> Self {
-        Value::Number(value as f64)
-    }
-}
-
 impl PartialEq for Value<'_> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -131,6 +119,26 @@ impl PartialEq for Value<'_> {
 
 /// Value coercions and conversions.
 impl<'gc> Value<'gc> {
+    /// Do the best effort of converting the [`u64`] value to [`Value`].
+    ///
+    /// This is lossless for values less or equal to 2^53. For values greater
+    /// than that, it will return a value equivalent to the closest integer
+    /// representable as IEEE 754 64-bit.
+    #[inline(always)]
+    pub fn from_u64_lossy(value: u64) -> Self {
+        Value::Number(value as f64)
+    }
+
+    /// Do the best effort of converting the [`usize`] value to [`Value`].
+    ///
+    /// This is lossless on 32-bit architectures and for values less or equal to
+    /// 2^53. For values greater than that, it will return a value equivalent to
+    /// the closest integer representable as IEEE 754 64-bit.
+    #[inline(always)]
+    pub fn from_usize_lossy(value: usize) -> Self {
+        Value::Number(value as f64)
+    }
+
     /// Yields `true` if the given value is a primitive value.
     ///
     /// Note: Boxed primitive values are not considered primitive - it is

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1031,9 +1031,17 @@ pub fn load_form_into_load_vars<'gc>(
                     let length = body.len();
 
                     // Set the properties used by the getBytesTotal and getBytesLoaded methods.
-                    that.set(istr!("_bytesTotal"), length.into(), &mut activation)?;
+                    that.set(
+                        istr!("_bytesTotal"),
+                        Value::from_usize_lossy(length),
+                        &mut activation,
+                    )?;
                     if length > 0 {
-                        that.set(istr!("_bytesLoaded"), length.into(), &mut activation)?;
+                        that.set(
+                            istr!("_bytesLoaded"),
+                            Value::from_usize_lossy(length),
+                            &mut activation,
+                        )?;
                     }
 
                     let _ = that.call_method(
@@ -1918,8 +1926,8 @@ impl<'gc> MovieLoader<'gc> {
                         &[
                             istr!(uc, "onLoadProgress").into(),
                             target_clip.object1_or_undef(),
-                            cur_len.into(),
-                            total_len.into(),
+                            Value::from_usize_lossy(cur_len),
+                            Value::from_usize_lossy(total_len),
                         ],
                         uc,
                     );
@@ -2535,7 +2543,11 @@ pub fn download_file_dialog<'gc>(
 
                                 as_broadcaster::broadcast_internal(
                                     target_object,
-                                    &[target_object.into(), total_bytes.into(), total_bytes.into()],
+                                    &[
+                                        target_object.into(),
+                                        Value::from_usize_lossy(total_bytes),
+                                        Value::from_usize_lossy(total_bytes),
+                                    ],
                                     istr!("onProgress"),
                                     &mut activation,
                                 )?;
@@ -2588,8 +2600,8 @@ pub fn download_file_dialog<'gc>(
                                             target_object,
                                             &[
                                                 target_object.into(),
-                                                body_len.into(),
-                                                body_len.into(),
+                                                Value::from_u64_lossy(body_len),
+                                                Value::from_u64_lossy(body_len),
                                             ],
                                             istr!("onProgress"),
                                             &mut activation,
@@ -2722,8 +2734,8 @@ pub fn upload_file<'gc>(
                         target_object,
                         &[
                             target_object.into(),
-                            total_size_bytes.into(),
-                            total_size_bytes.into(),
+                            Value::from_usize_lossy(total_size_bytes),
+                            Value::from_usize_lossy(total_size_bytes),
                         ],
                         istr!("onProgress"),
                         &mut activation,
@@ -2757,8 +2769,8 @@ pub fn upload_file<'gc>(
                                 target_object,
                                 &[
                                     target_object.into(),
-                                    total_size_bytes.into(),
-                                    total_size_bytes.into(),
+                                    Value::from_usize_lossy(total_size_bytes),
+                                    Value::from_usize_lossy(total_size_bytes),
                                 ],
                                 istr!("onProgress"),
                                 &mut activation,


### PR DESCRIPTION
Similarly to AVM2, the From impl for Value was not compliant with the expectations: the conversions were not always lossless.

This patch removes the impls and instead moves the conversions to Value::from_usize_lossy and Value::from_u64_lossy, which make it clear that the conversion is lossy.