### PR TITLE
avm2: Remove `pushshort` op

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -663,7 +663,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::PushInt { value } => self.op_push_int(*value),
                 Op::PushNamespace { namespace } => self.op_push_namespace(*namespace),
                 Op::PushNull => self.op_push_null(),
-                Op::PushShort { value } => self.op_push_short(*value),
                 Op::PushString { string } => self.op_push_string(*string),
                 Op::PushTrue => self.op_push_true(),
                 Op::PushUint { value } => self.op_push_uint(*value),
@@ -978,11 +977,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn op_push_null(&mut self) -> Result<(), Error<'gc>> {
         self.push_stack(Value::Null);
-        Ok(())
-    }
-
-    fn op_push_short(&mut self, value: i16) -> Result<(), Error<'gc>> {
-        self.push_stack(value);
         Ok(())
     }
 

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -268,9 +268,6 @@ pub enum Op<'gc> {
     },
     PushNull,
     PushScope,
-    PushShort {
-        value: i16,
-    },
     PushString {
         string: AvmAtom<'gc>,
     },
@@ -369,7 +366,6 @@ impl Op<'_> {
                 | Op::PushInt { .. }
                 | Op::PushNamespace { .. }
                 | Op::PushNull
-                | Op::PushShort { .. }
                 | Op::PushString { .. }
                 | Op::PushTrue
                 | Op::PushUint { .. }
@@ -407,7 +403,6 @@ impl Op<'_> {
                 | Op::PushNull
                 | Op::PushDouble { .. }
                 | Op::PushInt { .. }
-                | Op::PushShort { .. }
                 | Op::PushUint { .. }
                 | Op::GetLocal { .. }
                 | Op::Dup

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -903,21 +903,17 @@ fn abstract_interpret_ops<'gc>(
             }
             Op::PushInt { value } => {
                 let mut new_value = OptValue::of_type(types.int);
-                if value < -(1 << 28) || value >= (1 << 28) {
-                    // will be coerced to Number
-                } else {
-                    new_value.contains_valid_integer = true;
-                    if value >= 0 {
-                        new_value.contains_valid_unsigned = true;
-                    }
+                new_value.contains_valid_integer = true;
+                if value >= 0 {
+                    new_value.contains_valid_unsigned = true;
                 }
                 stack.push(activation, new_value)?;
             }
             Op::PushUint { value } => {
                 let mut new_value = OptValue::of_type(types.uint);
-                if value < (1 << 28) {
+                new_value.contains_valid_unsigned = true;
+                if value <= (i32::MAX as u32) {
                     new_value.contains_valid_integer = true;
-                    new_value.contains_valid_unsigned = true;
                 }
                 stack.push(activation, new_value)?;
             }

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -901,14 +901,6 @@ fn abstract_interpret_ops<'gc>(
             Op::PushUndefined => {
                 stack.push_class(activation, types.void)?;
             }
-            Op::PushShort { value } => {
-                let mut new_value = OptValue::of_type(types.int);
-                new_value.contains_valid_integer = true;
-                if value >= 0 {
-                    new_value.contains_valid_unsigned = true;
-                }
-                stack.push(activation, new_value)?;
-            }
             Op::PushInt { value } => {
                 let mut new_value = OptValue::of_type(types.int);
                 if value < -(1 << 28) || value >= (1 << 28) {

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -693,8 +693,8 @@ fn translate_op<'gc>(
     }
 
     let op = match op {
-        AbcOp::PushByte { value } => Op::PushShort {
-            value: value as i8 as i16,
+        AbcOp::PushByte { value } => Op::PushInt {
+            value: value as i8 as i32,
         },
         AbcOp::PushDouble { value } => {
             let value = translation_unit.pool_double_or_err(activation, value)?;
@@ -714,7 +714,9 @@ fn translate_op<'gc>(
         }
         AbcOp::PushNaN => Op::PushDouble { value: f64::NAN },
         AbcOp::PushNull => Op::PushNull,
-        AbcOp::PushShort { value } => Op::PushShort { value },
+        AbcOp::PushShort { value } => Op::PushInt {
+            value: value as i32,
+        },
         AbcOp::PushString { value } => {
             let string = translation_unit.pool_string_or_err(value, activation)?;
 


### PR DESCRIPTION
This is possible after #21925 and unblocks some additional (future) peephole optimizations for us.

Also make `contains_valid_integer` and `contains_valid_unsigned` track those states more accurately.