### PR TITLE
core: Fix some corrupted audio by preventing negative volume

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -3162,7 +3162,7 @@ impl SoundTransform {
             left_to_right: (sound_transform.left_to_right() * 100.0) as i32,
             right_to_left: (sound_transform.right_to_left() * 100.0) as i32,
             right_to_right: (sound_transform.right_to_right() * 100.0) as i32,
-            volume: (sound_transform.volume() * 100.0) as i32,
+            volume: i32:abs((sound_transform.volume() * 100.0) as i32),
         }
     }
 


### PR DESCRIPTION
Fixes #16234

I'm not a rust programmer, if there is a more idiomatic way to do this, please let me know. Thanks! (Edit: I did compile and run this against SDT to confirm that it fixes the audio issues, with and without '--release' )

I also wasn't sure if negative volumes should be clipped to zero or just treated as positive. This makes more sense to me as it looks like they could arise when doing some weird audio panning.