### PR TITLE
web: Add required 'lang' attributes

### DIFF
--- a/web/packages/extension/assets/player.html
+++ b/web/packages/extension/assets/player.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en-US">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Required according to [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/WCAG20-TECHS/)