### PR TITLE
core: Make asfunction: URL prefix case insensitive (close #23514)

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2468,7 +2468,10 @@ impl<'gc> EditText<'gc> {
     }
 
     fn open_url(self, context: &mut UpdateContext<'gc>, url: &WStr, target: &WStr) {
-        if let Some(address) = url.strip_prefix(WStr::from_units(b"asfunction:")) {
+        if let Some(address) = url
+            .to_ascii_lowercase()
+            .strip_prefix(WStr::from_units(b"asfunction:"))
+        {
             if let Err(e) = self.execute_avm1_asfunction(context, address) {
                 error!("Couldn't execute URL \"{url:?}\": {e:?}");
             }


### PR DESCRIPTION
The `open_url` function now temporarily converts to lowercase prior to matching for asfunction.  This makes the parse for asfunction in the URL prefix case insensitive.