### PR TITLE
web: Add 'lang' attributes to extension pages using i18n ui_locale

### DIFF
--- a/web/packages/extension/src/onboard.ts
+++ b/web/packages/extension/src/onboard.ts
@@ -2,6 +2,7 @@ import * as utils from "./utils";
 import { buildInfo } from "ruffle-core";
 
 window.addEventListener("DOMContentLoaded", () => {
+    utils.setPageLanguage();
     document.title = utils.i18n.getMessage("onboarding_page");
     {
         const vt = document.getElementById("version-text")!;

--- a/web/packages/extension/src/options.ts
+++ b/web/packages/extension/src/options.ts
@@ -11,6 +11,7 @@ window.addEventListener("DOMContentLoaded", async () => {
             .getElementById("swf_takeover")!
             .parentElement!.classList.add("hidden");
     }
+    utils.setPageLanguage();
     document.title = utils.i18n.getMessage("settings_page");
     {
         const vt = document.getElementById("version-text")!;

--- a/web/packages/extension/src/popup.ts
+++ b/web/packages/extension/src/popup.ts
@@ -155,6 +155,7 @@ async function displayTabStatus() {
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
+    utils.setPageLanguage();
     const data = await utils.storage.sync.get({
         responseHeadersUnsupported: false,
     });

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -137,3 +137,9 @@ export async function hasHostPermissionForActiveTab() {
 
     return await hasHostPermissionForSpecifiedTab(activeTab?.url);
 }
+
+export function setPageLanguage() {
+    document.documentElement.lang = i18n
+        .getMessage("@@ui_locale")
+        .replace("_", "-");
+}


### PR DESCRIPTION
Mostly supersedes #23507, aside from the player.html change (since that page is not internationalized (see #14628)).

Uses the predefined @@ui_locale message: https://developer.chrome.com/docs/extensions/reference/api/i18n#overview-predefined.