### PR TITLE
wgpu: Render blends to content-sized regions

### DIFF
--- a/render/wgpu/shaders/blend/alpha.wgsl
+++ b/render/wgpu/shaders/blend/alpha.wgsl
@@ -2,27 +2,41 @@
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    @location(0) dst_uv: vec2<f32>,
+    @location(1) src_uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+struct BlendTransforms {
+    world_matrix: mat4x4<f32>,
+    dst_uv_transform: vec4<f32>,
+    src_uv_transform: vec4<f32>,
+};
+
+@group(1) @binding(0) var<uniform> transforms: BlendTransforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
+
+fn apply_uv_transform(uv: vec2<f32>, t: vec4<f32>) -> vec2<f32> {
+    let transformed = uv * t.zw + t.xy;
+    return select(uv, transformed, any(t != vec4<f32>(0.0)));
+}
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 1.0, 1.0);
     let uv = vec2<f32>((pos.x + 1.0) / 2.0, -((pos.y - 1.0) / 2.0));
-    return VertexOutput(pos, uv);
+    let dst_uv = apply_uv_transform(uv, transforms.dst_uv_transform);
+    let src_uv = apply_uv_transform(uv, transforms.src_uv_transform);
+    return VertexOutput(pos, dst_uv, src_uv);
 }
 
 @fragment
 fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // dst is the parent pixel we're blending onto
-    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.uv);
+    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.dst_uv);
     // src is the pixel that we want to apply
-    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.uv);
+    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.src_uv);
 
     if (src.a > 0.0) {
         return vec4<f32>(dst.rgb * src.a, src.a * dst.a);

--- a/render/wgpu/shaders/blend/darken.wgsl
+++ b/render/wgpu/shaders/blend/darken.wgsl
@@ -2,19 +2,33 @@
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    @location(0) dst_uv: vec2<f32>,
+    @location(1) src_uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+struct BlendTransforms {
+    world_matrix: mat4x4<f32>,
+    dst_uv_transform: vec4<f32>,
+    src_uv_transform: vec4<f32>,
+};
+
+@group(1) @binding(0) var<uniform> transforms: BlendTransforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
+
+fn apply_uv_transform(uv: vec2<f32>, t: vec4<f32>) -> vec2<f32> {
+    let transformed = uv * t.zw + t.xy;
+    return select(uv, transformed, any(t != vec4<f32>(0.0)));
+}
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 1.0, 1.0);
     let uv = vec2<f32>((pos.x + 1.0) / 2.0, -((pos.y - 1.0) / 2.0));
-    return VertexOutput(pos, uv);
+    let dst_uv = apply_uv_transform(uv, transforms.dst_uv_transform);
+    let src_uv = apply_uv_transform(uv, transforms.src_uv_transform);
+    return VertexOutput(pos, dst_uv, src_uv);
 }
 
 fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
@@ -24,9 +38,9 @@ fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
 @fragment
 fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // dst is the parent pixel we're blending onto
-    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.uv);
+    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.dst_uv);
     // src is the pixel that we want to apply
-    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.uv);
+    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.src_uv);
 
     if (src.a > 0.0) {
         return vec4<f32>(src.rgb * (1.0 - dst.a) + dst.rgb * (1.0 - src.a) + src.a * dst.a * blend_func(src.rgb / src.a, dst.rgb / dst.a), src.a + dst.a * (1.0 - src.a));

--- a/render/wgpu/shaders/blend/difference.wgsl
+++ b/render/wgpu/shaders/blend/difference.wgsl
@@ -2,19 +2,33 @@
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    @location(0) dst_uv: vec2<f32>,
+    @location(1) src_uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+struct BlendTransforms {
+    world_matrix: mat4x4<f32>,
+    dst_uv_transform: vec4<f32>,
+    src_uv_transform: vec4<f32>,
+};
+
+@group(1) @binding(0) var<uniform> transforms: BlendTransforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
+
+fn apply_uv_transform(uv: vec2<f32>, t: vec4<f32>) -> vec2<f32> {
+    let transformed = uv * t.zw + t.xy;
+    return select(uv, transformed, any(t != vec4<f32>(0.0)));
+}
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 1.0, 1.0);
     let uv = vec2<f32>((pos.x + 1.0) / 2.0, -((pos.y - 1.0) / 2.0));
-    return VertexOutput(pos, uv);
+    let dst_uv = apply_uv_transform(uv, transforms.dst_uv_transform);
+    let src_uv = apply_uv_transform(uv, transforms.src_uv_transform);
+    return VertexOutput(pos, dst_uv, src_uv);
 }
 
 fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
@@ -24,9 +38,9 @@ fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
 @fragment
 fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // dst is the parent pixel we're blending onto
-    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.uv);
+    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.dst_uv);
     // src is the pixel that we want to apply
-    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.uv);
+    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.src_uv);
 
     if (src.a > 0.0) {
         return vec4<f32>(src.rgb * (1.0 - dst.a) + dst.rgb * (1.0 - src.a) + src.a * dst.a * blend_func(src.rgb / src.a, dst.rgb / dst.a), src.a + dst.a * (1.0 - src.a));

--- a/render/wgpu/shaders/blend/erase.wgsl
+++ b/render/wgpu/shaders/blend/erase.wgsl
@@ -2,27 +2,41 @@
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    @location(0) dst_uv: vec2<f32>,
+    @location(1) src_uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+struct BlendTransforms {
+    world_matrix: mat4x4<f32>,
+    dst_uv_transform: vec4<f32>,
+    src_uv_transform: vec4<f32>,
+};
+
+@group(1) @binding(0) var<uniform> transforms: BlendTransforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
+
+fn apply_uv_transform(uv: vec2<f32>, t: vec4<f32>) -> vec2<f32> {
+    let transformed = uv * t.zw + t.xy;
+    return select(uv, transformed, any(t != vec4<f32>(0.0)));
+}
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 1.0, 1.0);
     let uv = vec2<f32>((pos.x + 1.0) / 2.0, -((pos.y - 1.0) / 2.0));
-    return VertexOutput(pos, uv);
+    let dst_uv = apply_uv_transform(uv, transforms.dst_uv_transform);
+    let src_uv = apply_uv_transform(uv, transforms.src_uv_transform);
+    return VertexOutput(pos, dst_uv, src_uv);
 }
 
 @fragment
 fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // dst is the parent pixel we're blending onto
-    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.uv);
+    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.dst_uv);
     // src is the pixel that we want to apply
-    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.uv);
+    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.src_uv);
 
     if (src.a > 0.0) {
         return vec4<f32>(dst.rgb * (1.0 - src.a), (1.0 - src.a) * dst.a);

--- a/render/wgpu/shaders/blend/hardlight.wgsl
+++ b/render/wgpu/shaders/blend/hardlight.wgsl
@@ -2,19 +2,33 @@
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    @location(0) dst_uv: vec2<f32>,
+    @location(1) src_uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+struct BlendTransforms {
+    world_matrix: mat4x4<f32>,
+    dst_uv_transform: vec4<f32>,
+    src_uv_transform: vec4<f32>,
+};
+
+@group(1) @binding(0) var<uniform> transforms: BlendTransforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
+
+fn apply_uv_transform(uv: vec2<f32>, t: vec4<f32>) -> vec2<f32> {
+    let transformed = uv * t.zw + t.xy;
+    return select(uv, transformed, any(t != vec4<f32>(0.0)));
+}
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 1.0, 1.0);
     let uv = vec2<f32>((pos.x + 1.0) / 2.0, -((pos.y - 1.0) / 2.0));
-    return VertexOutput(pos, uv);
+    let dst_uv = apply_uv_transform(uv, transforms.dst_uv_transform);
+    let src_uv = apply_uv_transform(uv, transforms.src_uv_transform);
+    return VertexOutput(pos, dst_uv, src_uv);
 }
 
 fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
@@ -28,9 +42,9 @@ fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
 @fragment
 fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // dst is the parent pixel we're blending onto
-    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.uv);
+    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.dst_uv);
     // src is the pixel that we want to apply
-    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.uv);
+    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.src_uv);
 
     if (src.a > 0.0) {
         return vec4<f32>(src.rgb * (1.0 - dst.a) + dst.rgb * (1.0 - src.a) + src.a * dst.a * blend_func(src.rgb / src.a, dst.rgb / dst.a), src.a + dst.a * (1.0 - src.a));

--- a/render/wgpu/shaders/blend/invert.wgsl
+++ b/render/wgpu/shaders/blend/invert.wgsl
@@ -2,19 +2,33 @@
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    @location(0) dst_uv: vec2<f32>,
+    @location(1) src_uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+struct BlendTransforms {
+    world_matrix: mat4x4<f32>,
+    dst_uv_transform: vec4<f32>,
+    src_uv_transform: vec4<f32>,
+};
+
+@group(1) @binding(0) var<uniform> transforms: BlendTransforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
+
+fn apply_uv_transform(uv: vec2<f32>, t: vec4<f32>) -> vec2<f32> {
+    let transformed = uv * t.zw + t.xy;
+    return select(uv, transformed, any(t != vec4<f32>(0.0)));
+}
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 1.0, 1.0);
     let uv = vec2<f32>((pos.x + 1.0) / 2.0, -((pos.y - 1.0) / 2.0));
-    return VertexOutput(pos, uv);
+    let dst_uv = apply_uv_transform(uv, transforms.dst_uv_transform);
+    let src_uv = apply_uv_transform(uv, transforms.src_uv_transform);
+    return VertexOutput(pos, dst_uv, src_uv);
 }
 
 fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
@@ -24,9 +38,9 @@ fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
 @fragment
 fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // dst is the parent pixel we're blending onto
-    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.uv);
+    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.dst_uv);
     // src is the pixel that we want to apply
-    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.uv);
+    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.src_uv);
 
     if (src.a > 0.0) {
         return vec4<f32>(src.rgb * (1.0 - dst.a) + dst.rgb * (1.0 - src.a) + src.a * dst.a * (1.0 - dst.rgb / dst.a), src.a + dst.a * (1.0 - src.a));

--- a/render/wgpu/shaders/blend/lighten.wgsl
+++ b/render/wgpu/shaders/blend/lighten.wgsl
@@ -2,19 +2,33 @@
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    @location(0) dst_uv: vec2<f32>,
+    @location(1) src_uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+struct BlendTransforms {
+    world_matrix: mat4x4<f32>,
+    dst_uv_transform: vec4<f32>,
+    src_uv_transform: vec4<f32>,
+};
+
+@group(1) @binding(0) var<uniform> transforms: BlendTransforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
+
+fn apply_uv_transform(uv: vec2<f32>, t: vec4<f32>) -> vec2<f32> {
+    let transformed = uv * t.zw + t.xy;
+    return select(uv, transformed, any(t != vec4<f32>(0.0)));
+}
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 1.0, 1.0);
     let uv = vec2<f32>((pos.x + 1.0) / 2.0, -((pos.y - 1.0) / 2.0));
-    return VertexOutput(pos, uv);
+    let dst_uv = apply_uv_transform(uv, transforms.dst_uv_transform);
+    let src_uv = apply_uv_transform(uv, transforms.src_uv_transform);
+    return VertexOutput(pos, dst_uv, src_uv);
 }
 
 fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
@@ -24,9 +38,9 @@ fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
 @fragment
 fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // dst is the parent pixel we're blending onto
-    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.uv);
+    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.dst_uv);
     // src is the pixel that we want to apply
-    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.uv);
+    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.src_uv);
 
     if (src.a > 0.0) {
         return vec4<f32>(src.rgb * (1.0 - dst.a) + dst.rgb * (1.0 - src.a) + src.a * dst.a * blend_func(src.rgb / src.a, dst.rgb / dst.a), src.a + dst.a * (1.0 - src.a));

--- a/render/wgpu/shaders/blend/multiply.wgsl
+++ b/render/wgpu/shaders/blend/multiply.wgsl
@@ -2,19 +2,34 @@
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    @location(0) dst_uv: vec2<f32>,
+    @location(1) src_uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+struct BlendTransforms {
+    world_matrix: mat4x4<f32>,
+    dst_uv_transform: vec4<f32>,
+    src_uv_transform: vec4<f32>,
+};
+
+@group(1) @binding(0) var<uniform> transforms: BlendTransforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
+
+fn apply_uv_transform(uv: vec2<f32>, t: vec4<f32>) -> vec2<f32> {
+    let transformed = uv * t.zw + t.xy;
+    return select(uv, transformed, any(t != vec4<f32>(0.0)));
+}
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 1.0, 1.0);
     let uv = vec2<f32>((pos.x + 1.0) / 2.0, -((pos.y - 1.0) / 2.0));
-    return VertexOutput(pos, uv);
+    // (0,0,0,0) = identity for both UV transforms.
+    let dst_uv = apply_uv_transform(uv, transforms.dst_uv_transform);
+    let src_uv = apply_uv_transform(uv, transforms.src_uv_transform);
+    return VertexOutput(pos, dst_uv, src_uv);
 }
 
 fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
@@ -24,9 +39,8 @@ fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
 @fragment
 fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // dst is the parent pixel we're blending onto
-    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.uv);
-    // src is the pixel that we want to apply
-    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.uv);
+    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.dst_uv);
+    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.src_uv);
 
     // Flash does the following, which makes this not a pure multiply:
     // If src.a is 0, don't write anything

--- a/render/wgpu/shaders/blend/overlay.wgsl
+++ b/render/wgpu/shaders/blend/overlay.wgsl
@@ -2,19 +2,33 @@
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
+    @location(0) dst_uv: vec2<f32>,
+    @location(1) src_uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+struct BlendTransforms {
+    world_matrix: mat4x4<f32>,
+    dst_uv_transform: vec4<f32>,
+    src_uv_transform: vec4<f32>,
+};
+
+@group(1) @binding(0) var<uniform> transforms: BlendTransforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
+
+fn apply_uv_transform(uv: vec2<f32>, t: vec4<f32>) -> vec2<f32> {
+    let transformed = uv * t.zw + t.xy;
+    return select(uv, transformed, any(t != vec4<f32>(0.0)));
+}
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 1.0, 1.0);
     let uv = vec2<f32>((pos.x + 1.0) / 2.0, -((pos.y - 1.0) / 2.0));
-    return VertexOutput(pos, uv);
+    let dst_uv = apply_uv_transform(uv, transforms.dst_uv_transform);
+    let src_uv = apply_uv_transform(uv, transforms.src_uv_transform);
+    return VertexOutput(pos, dst_uv, src_uv);
 }
 
 fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
@@ -28,9 +42,9 @@ fn blend_func(src: vec3<f32>, dst: vec3<f32>) -> vec3<f32> {
 @fragment
 fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // dst is the parent pixel we're blending onto
-    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.uv);
+    var dst: vec4<f32> = textureSample(parent_texture, texture_sampler, in.dst_uv);
     // src is the pixel that we want to apply
-    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.uv);
+    var src: vec4<f32> = textureSample(current_texture, texture_sampler, in.src_uv);
 
     if (src.a > 0.0) {
         return vec4<f32>(src.rgb * (1.0 - dst.a) + dst.rgb * (1.0 - src.a) + src.a * dst.a * blend_func(src.rgb / src.a, dst.rgb / dst.a), src.a + dst.a * (1.0 - src.a));

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -258,6 +258,12 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
         scale: f32,
     ) -> Mesh {
         let shape_id = shape.id;
+        let bounds = (
+            shape.shape_bounds.x_min.to_pixels() as f32,
+            shape.shape_bounds.y_min.to_pixels() as f32,
+            shape.shape_bounds.x_max.to_pixels() as f32,
+            shape.shape_bounds.y_max.to_pixels() as f32,
+        );
         let lyon_mesh =
             self.shape_tessellator
                 .tessellate_shape_with_scale(shape, bitmap_source, scale);
@@ -317,6 +323,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
             draws,
             vertex_buffer,
             index_buffer,
+            bounds,
         }
     }
 

--- a/render/wgpu/src/buffer_pool.rs
+++ b/render/wgpu/src/buffer_pool.rs
@@ -66,15 +66,30 @@ impl TexturePool {
         viewport_width: u32,
         viewport_height: u32,
     ) -> Arc<Globals> {
+        self.get_globals_with_offset(descriptors, 0, 0, viewport_width, viewport_height)
+    }
+
+    pub fn get_globals_with_offset(
+        &mut self,
+        descriptors: &Descriptors,
+        offset_x: u32,
+        offset_y: u32,
+        viewport_width: u32,
+        viewport_height: u32,
+    ) -> Arc<Globals> {
         self.globals_cache
             .entry(GlobalsKey {
+                offset_x,
+                offset_y,
                 viewport_width,
                 viewport_height,
             })
             .or_insert_with(|| {
-                Arc::new(Globals::new(
+                Arc::new(Globals::new_with_offset(
                     &descriptors.device,
                     &descriptors.bind_layouts.globals,
+                    offset_x,
+                    offset_y,
                     viewport_width,
                     viewport_height,
                 ))
@@ -93,6 +108,8 @@ struct TextureKey {
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 struct GlobalsKey {
+    offset_x: u32,
+    offset_y: u32,
     viewport_width: u32,
     viewport_height: u32,
 }

--- a/render/wgpu/src/globals.rs
+++ b/render/wgpu/src/globals.rs
@@ -21,15 +21,32 @@ impl Globals {
         viewport_width: u32,
         viewport_height: u32,
     ) -> Self {
+        Self::new_with_offset(device, layout, 0, 0, viewport_width, viewport_height)
+    }
+
+    /// Create globals that map a sub-region of viewport space to NDC.
+    /// Content at (offset_x, offset_y) maps to top-left of the render target.
+    pub fn new_with_offset(
+        device: &wgpu::Device,
+        layout: &wgpu::BindGroupLayout,
+        offset_x: u32,
+        offset_y: u32,
+        viewport_width: u32,
+        viewport_height: u32,
+    ) -> Self {
+        let w = viewport_width as f32;
+        let h = viewport_height as f32;
+        let ox = offset_x as f32;
+        let oy = offset_y as f32;
         let temp_label = create_debug_label!("Globals buffer");
         let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: temp_label.as_deref(),
             contents: bytemuck::cast_slice(&[GlobalsUniform {
                 view_matrix: [
-                    [1.0 / (viewport_width as f32 / 2.0), 0.0, 0.0, 0.0],
-                    [0.0, -1.0 / (viewport_height as f32 / 2.0), 0.0, 0.0],
+                    [2.0 / w, 0.0, 0.0, 0.0],
+                    [0.0, -2.0 / h, 0.0, 0.0],
                     [0.0, 0.0, 1.0, 0.0],
-                    [-1.0, 1.0, 0.0, 1.0],
+                    [-2.0 * ox / w - 1.0, 2.0 * oy / h + 1.0, 0.0, 1.0],
                 ],
             }]),
             usage: wgpu::BufferUsages::UNIFORM,

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -76,6 +76,24 @@ pub struct Transforms {
     add_color: [f32; 4],
 }
 
+/// Per-draw uniform for the complex-blend pipeline.
+///
+/// The blend shaders never apply a color transform, so this is a byte-compatible
+/// reinterpretation of [`Transforms`] that carries UV transforms instead of the
+/// color-transform vectors. Each UV transform is `[off_x, off_y, scale_x, scale_y]`
+/// applied as `uv * scale + off`; an all-zero vector is treated as identity.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct BlendTransforms {
+    world_matrix: [[f32; 4]; 4],
+    /// UV transform for sampling the parent (destination) texture.
+    dst_uv_transform: [f32; 4],
+    /// UV transform for sampling the current (source) texture.
+    src_uv_transform: [f32; 4],
+}
+
+const _: () = assert!(std::mem::size_of::<BlendTransforms>() == std::mem::size_of::<Transforms>());
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
 struct TextureTransforms {

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -21,6 +21,8 @@ pub struct Mesh {
     pub draws: Vec<Draw>,
     pub vertex_buffer: wgpu::Buffer,
     pub index_buffer: wgpu::Buffer,
+    /// Object-space bounding box: (min_x, min_y, max_x, max_y).
+    pub bounds: (f32, f32, f32, f32),
 }
 
 impl ShapeHandleImpl for Mesh {}

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -115,7 +115,68 @@ impl Surface {
         nearest_layer: LayerRef<'frame>,
         texture_pool: &mut TexturePool,
     ) -> CommandTarget {
-        let target = CommandTarget::new(
+        self.draw_commands_internal(
+            render_target_mode,
+            descriptors,
+            meshes,
+            commands,
+            staging_belt,
+            dynamic_transforms,
+            draw_encoder,
+            nearest_layer,
+            texture_pool,
+            0,
+            0,
+        )
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    #[instrument(level = "debug", skip_all)]
+    pub fn draw_commands_with_offset<'frame, 'global: 'frame>(
+        &self,
+        render_target_mode: RenderTargetMode,
+        descriptors: &'global Descriptors,
+        meshes: &'global Vec<Mesh>,
+        commands: CommandList,
+        staging_belt: &'global mut wgpu::util::StagingBelt,
+        dynamic_transforms: &'global DynamicTransforms,
+        draw_encoder: &'frame mut wgpu::CommandEncoder,
+        nearest_layer: LayerRef<'frame>,
+        texture_pool: &mut TexturePool,
+        offset_x: u32,
+        offset_y: u32,
+    ) -> CommandTarget {
+        self.draw_commands_internal(
+            render_target_mode,
+            descriptors,
+            meshes,
+            commands,
+            staging_belt,
+            dynamic_transforms,
+            draw_encoder,
+            nearest_layer,
+            texture_pool,
+            offset_x,
+            offset_y,
+        )
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    fn draw_commands_internal<'frame, 'global: 'frame>(
+        &self,
+        render_target_mode: RenderTargetMode,
+        descriptors: &'global Descriptors,
+        meshes: &'global Vec<Mesh>,
+        commands: CommandList,
+        staging_belt: &'global mut wgpu::util::StagingBelt,
+        dynamic_transforms: &'global DynamicTransforms,
+        draw_encoder: &'frame mut wgpu::CommandEncoder,
+        nearest_layer: LayerRef<'frame>,
+        texture_pool: &mut TexturePool,
+        offset_x: u32,
+        offset_y: u32,
+    ) -> CommandTarget {
+        let target = CommandTarget::new_with_offset(
             descriptors,
             texture_pool,
             self.size,
@@ -123,6 +184,8 @@ impl Surface {
             self.sample_count,
             render_target_mode,
             draw_encoder,
+            offset_x,
+            offset_y,
         );
 
         let mut num_masks = 0;
@@ -137,6 +200,8 @@ impl Surface {
             self.quality,
             target.width(),
             target.height(),
+            offset_x,
+            offset_y,
             match nearest_layer {
                 LayerRef::Current => LayerRef::Parent(&target),
                 layer => layer,
@@ -144,7 +209,8 @@ impl Surface {
             texture_pool,
         );
 
-        for chunk in chunks {
+        let mut chunks = std::collections::VecDeque::from(chunks);
+        while let Some(chunk) = chunks.pop_front() {
             match chunk {
                 Chunk::Draw {
                     chunk,
@@ -198,8 +264,11 @@ impl Surface {
                     texture,
                     blend_mode: ChunkBlendMode::Shader(shader),
                     needs_stencil,
+                    region: _,
+                    blend_transform: _,
                 } => {
                     assert!(!needs_stencil, "Shader blend mode not implemented in masks");
+                    // PixelBender shaders use their own UV — always full-viewport blend buffer.
                     let parent_blend_buffer =
                         target.update_blend_buffer(descriptors, texture_pool, draw_encoder);
                     run_pixelbender_shader_impl(
@@ -212,7 +281,7 @@ impl Surface {
                                 channels: 0xFF,
                                 name: "background".to_string(),
                                 texture: Some(ImageInputTexture::TextureRef(
-                                    parent_blend_buffer.texture(),
+                                    parent_blend_buffer.texture,
                                 )),
                             },
                             PixelBenderShaderArgument::ImageInput {
@@ -222,7 +291,7 @@ impl Surface {
                                 texture: Some(ImageInputTexture::TextureRef(texture.texture())),
                             },
                         ],
-                        parent_blend_buffer.texture(),
+                        parent_blend_buffer.texture,
                         draw_encoder,
                         target.color_attachments(),
                         target.sample_count(),
@@ -234,6 +303,8 @@ impl Surface {
                     texture,
                     blend_mode: ChunkBlendMode::Complex(blend_mode),
                     needs_stencil,
+                    region,
+                    blend_transform,
                 } => {
                     let parent = match blend_mode {
                         ComplexBlend::Alpha | ComplexBlend::Erase => {
@@ -249,29 +320,46 @@ impl Surface {
                         _ => &target,
                     };
 
-                    let parent_blend_buffer =
-                        parent.update_blend_buffer(descriptors, texture_pool, draw_encoder);
+                    let region = region.filter(|r| {
+                        r.x + r.width <= parent.width() && r.y + r.height <= parent.height()
+                    });
+                    // If the region was rejected above we fall back to a
+                    // full-viewport parent blend buffer, so the region
+                    // positioning/UV transform must be dropped too — otherwise it
+                    // would be applied against the full-viewport buffer and sample
+                    // the wrong texels.
+                    let blend_transform = if region.is_some() {
+                        blend_transform
+                    } else {
+                        None
+                    };
+                    let _region_blend_buf;
+                    let parent_blend_buffer = if let Some(r) = region {
+                        _region_blend_buf = parent.update_blend_buffer_region(
+                            descriptors,
+                            texture_pool,
+                            draw_encoder,
+                            r.x,
+                            r.y,
+                            r.width,
+                            r.height,
+                        );
+                        _region_blend_buf.as_source()
+                    } else {
+                        parent.update_blend_buffer(descriptors, texture_pool, draw_encoder)
+                    };
 
                     let blend_bind_group =
                         descriptors
                             .device
                             .create_bind_group(&wgpu::BindGroupDescriptor {
-                                label: create_debug_label!(
-                                    "Complex blend binds {:?} {}",
-                                    blend_mode,
-                                    if needs_stencil {
-                                        "(with stencil)"
-                                    } else {
-                                        "(Stencilless)"
-                                    }
-                                )
-                                .as_deref(),
+                                label: None,
                                 layout: &descriptors.bind_layouts.blend,
                                 entries: &[
                                     wgpu::BindGroupEntry {
                                         binding: 0,
                                         resource: wgpu::BindingResource::TextureView(
-                                            parent_blend_buffer.view(),
+                                            parent_blend_buffer.view,
                                         ),
                                     },
                                     wgpu::BindGroupEntry {
@@ -288,6 +376,24 @@ impl Surface {
                                     },
                                 ],
                             });
+
+                    // Upload blend transform (region positioning + UV offset/scale)
+                    // BEFORE starting the render pass.
+                    let use_blend_transform = if let Some(ref bt) = blend_transform {
+                        let data = bytemuck::cast_slice(std::slice::from_ref(bt.as_ref()));
+                        let size = std::num::NonZeroU64::new(data.len() as u64).unwrap();
+                        let mut staging = staging_belt.write_buffer(
+                            draw_encoder,
+                            &dynamic_transforms.buffer,
+                            0,
+                            size,
+                            &descriptors.device,
+                        );
+                        staging.copy_from_slice(data);
+                        true
+                    } else {
+                        false
+                    };
 
                     let mut render_pass =
                         draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -333,7 +439,12 @@ impl Surface {
                         );
                     }
 
-                    render_pass.set_bind_group(1, target.whole_frame_bind_group(descriptors), &[0]);
+                    let transforms_bind_group = if use_blend_transform {
+                        &dynamic_transforms.bind_group
+                    } else {
+                        target.whole_frame_bind_group(descriptors)
+                    };
+                    render_pass.set_bind_group(1, transforms_bind_group, &[0]);
                     render_pass.set_bind_group(2, &blend_bind_group, &[]);
 
                     render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos.slice(..));

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -259,6 +259,7 @@ impl Surface {
 
                     num_masks = renderer.num_masks();
                     mask_state = renderer.mask_state();
+                    target.mark_blend_buffer_stale();
                 }
                 Chunk::Blend {
                     texture,
@@ -298,6 +299,7 @@ impl Surface {
                         &FilterSource::for_entire_texture(texture.texture()),
                     )
                     .expect("Failed to run PixelBender blend mode");
+                    target.mark_blend_buffer_stale();
                 }
                 Chunk::Blend {
                     texture,
@@ -454,6 +456,7 @@ impl Surface {
                     );
 
                     render_pass.draw_indexed(0..6, 0, 0..1);
+                    target.mark_blend_buffer_stale();
                 }
             }
         }

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -7,10 +7,10 @@ use crate::dynamic_transforms::DynamicTransforms;
 use crate::mesh::{DrawType, Mesh, as_mesh};
 use crate::surface::Surface;
 use crate::surface::target::CommandTarget;
-use crate::{Descriptors, MaskState, Pipelines, Transforms, as_texture};
+use crate::{BlendTransforms, Descriptors, MaskState, Pipelines, Transforms, as_texture};
 use ruffle_render::backend::ShapeHandle;
 use ruffle_render::bitmap::{BitmapHandle, PixelSnapping};
-use ruffle_render::commands::{CommandHandler, CommandList, RenderBlendMode};
+use ruffle_render::commands::{Command, CommandHandler, CommandList, RenderBlendMode};
 use ruffle_render::lines::{emulate_line, emulate_line_rect};
 use ruffle_render::matrix::Matrix;
 use ruffle_render::pixel_bender::PixelBenderShaderHandle;
@@ -434,6 +434,15 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
     }
 }
 
+/// Region within the viewport that a blend covers.
+#[derive(Debug, Clone, Copy)]
+pub struct BlendRegion {
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+}
+
 pub enum Chunk {
     Draw {
         chunk: Vec<DrawCommand>,
@@ -444,6 +453,12 @@ pub enum Chunk {
         texture: PoolOrArcTexture,
         blend_mode: ChunkBlendMode,
         needs_stencil: bool,
+        /// Region within the viewport that this blend covers.
+        region: Option<BlendRegion>,
+        /// If set, a positioned transform carrying the UV offset/scale used to
+        /// sample the region-sized parent/current textures. Boxed to keep the
+        /// enum small.
+        blend_transform: Option<Box<BlendTransforms>>,
     },
 }
 
@@ -513,6 +528,8 @@ pub fn chunk_blends<'a>(
     quality: StageQuality,
     width: u32,
     height: u32,
+    offset_x: u32,
+    offset_y: u32,
     nearest_layer: LayerRef,
     texture_pool: &mut TexturePool,
 ) -> Vec<Chunk> {
@@ -525,6 +542,8 @@ pub fn chunk_blends<'a>(
         quality,
         width,
         height,
+        offset_x,
+        offset_y,
         nearest_layer,
         texture_pool,
     )
@@ -536,6 +555,8 @@ struct WgpuCommandHandler<'a> {
     quality: StageQuality,
     width: u32,
     height: u32,
+    offset_x: u32,
+    offset_y: u32,
     nearest_layer: LayerRef<'a>,
     meshes: &'a Vec<Mesh>,
     staging_belt: &'a mut wgpu::util::StagingBelt,
@@ -562,14 +583,13 @@ impl<'a> WgpuCommandHandler<'a> {
         quality: StageQuality,
         width: u32,
         height: u32,
+        offset_x: u32,
+        offset_y: u32,
         nearest_layer: LayerRef<'a>,
         texture_pool: &'a mut TexturePool,
     ) -> Self {
         let transforms = Self::new_transforms(descriptors, dynamic_transforms);
 
-        // DirectX does support drawing lines, but it's very inconsistent.
-        // With MSAA, lines have 1.4px thickness, which makes them too thick.
-        // Without MSAA, lines have 1px thickness, but their placement is sometimes off.
         let emulate_lines = descriptors.backend == Backend::Dx12;
 
         Self {
@@ -577,6 +597,8 @@ impl<'a> WgpuCommandHandler<'a> {
             quality,
             width,
             height,
+            offset_x,
+            offset_y,
             nearest_layer,
             meshes,
             staging_belt,
@@ -673,23 +695,164 @@ impl<'a> WgpuCommandHandler<'a> {
     }
 }
 
+/// Compute the AABB of a command in viewport space.
+fn command_aabb(cmd: &Command) -> Option<(f32, f32, f32, f32)> {
+    let corners: [(f32, f32); 4] = match cmd {
+        Command::RenderBitmap {
+            bitmap,
+            transform,
+            pixel_snapping,
+            ..
+        } => {
+            let tex = as_texture(bitmap);
+            let tw = tex.texture.width() as f32;
+            let th = tex.texture.height() as f32;
+            let mut m = transform.matrix;
+            pixel_snapping.apply(&mut m);
+            let tx = m.tx.to_pixels() as f32;
+            let ty = m.ty.to_pixels() as f32;
+            [
+                (tx, ty),
+                (tx + m.a * tw, ty + m.b * tw),
+                (tx + m.c * th, ty + m.d * th),
+                (tx + m.a * tw + m.c * th, ty + m.b * tw + m.d * th),
+            ]
+        }
+        Command::RenderShape { shape, transform } => {
+            let mesh = as_mesh(shape);
+            let (bx0, by0, bx1, by1) = mesh.bounds;
+            let m = &transform.matrix;
+            let tx = m.tx.to_pixels() as f32;
+            let ty = m.ty.to_pixels() as f32;
+            [
+                (tx + m.a * bx0 + m.c * by0, ty + m.b * bx0 + m.d * by0),
+                (tx + m.a * bx1 + m.c * by0, ty + m.b * bx1 + m.d * by0),
+                (tx + m.a * bx0 + m.c * by1, ty + m.b * bx0 + m.d * by1),
+                (tx + m.a * bx1 + m.c * by1, ty + m.b * bx1 + m.d * by1),
+            ]
+        }
+        Command::DrawRect { matrix, .. }
+        | Command::DrawLine { matrix, .. }
+        | Command::DrawLineRect { matrix, .. } => {
+            let tx = matrix.tx.to_pixels() as f32;
+            let ty = matrix.ty.to_pixels() as f32;
+            [
+                (tx, ty),
+                (tx + matrix.a, ty + matrix.b),
+                (tx + matrix.c, ty + matrix.d),
+                (tx + matrix.a + matrix.c, ty + matrix.b + matrix.d),
+            ]
+        }
+        Command::PushMask | Command::ActivateMask | Command::DeactivateMask | Command::PopMask => {
+            return None;
+        }
+        _ => return None,
+    };
+    let min_x = corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min);
+    let min_y = corners.iter().map(|c| c.1).fold(f32::INFINITY, f32::min);
+    let max_x = corners
+        .iter()
+        .map(|c| c.0)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let max_y = corners
+        .iter()
+        .map(|c| c.1)
+        .fold(f32::NEG_INFINITY, f32::max);
+    Some((min_x, min_y, max_x, max_y))
+}
+
+/// Compute a tight BlendRegion for commands, clipped to viewport.
+/// Returns None if bounds can't be computed, or the region isn't strictly
+/// smaller than the viewport (in which case a full-viewport blend is cheaper).
+fn compute_blend_region(
+    commands: &[Command],
+    offset_x: u32,
+    offset_y: u32,
+    width: u32,
+    height: u32,
+) -> Option<BlendRegion> {
+    let mut r_min_x = f32::INFINITY;
+    let mut r_min_y = f32::INFINITY;
+    let mut r_max_x = f32::NEG_INFINITY;
+    let mut r_max_y = f32::NEG_INFINITY;
+    for cmd in commands {
+        let (x0, y0, x1, y1) = command_aabb(cmd)?;
+        r_min_x = r_min_x.min(x0);
+        r_min_y = r_min_y.min(y0);
+        r_max_x = r_max_x.max(x1);
+        r_max_y = r_max_y.max(y1);
+    }
+    let off_x = offset_x as f32;
+    let off_y = offset_y as f32;
+    let lx0 = (r_min_x - off_x).max(0.0);
+    let ly0 = (r_min_y - off_y).max(0.0);
+    let lx1 = (r_max_x - off_x).min(width as f32);
+    let ly1 = (r_max_y - off_y).min(height as f32);
+    if lx0 >= lx1 || ly0 >= ly1 {
+        return None;
+    }
+    let x = lx0.floor() as u32;
+    let y = ly0.floor() as u32;
+    let w = (lx1.ceil() as u32)
+        .saturating_sub(x)
+        .min(width.saturating_sub(x))
+        .max(1);
+    let h = (ly1.ceil() as u32)
+        .saturating_sub(y)
+        .min(height.saturating_sub(y))
+        .max(1);
+    // Only use a region when it's strictly smaller than the viewport — otherwise
+    // the full-viewport blend is already the cheapest option.
+    if w < width || h < height {
+        Some(BlendRegion {
+            x,
+            y,
+            width: w,
+            height: h,
+        })
+    } else {
+        None
+    }
+}
+
 impl CommandHandler for WgpuCommandHandler<'_> {
     fn blend(&mut self, commands: CommandList, blend_mode: RenderBlendMode) {
-        let surface = Surface::new(
-            self.descriptors,
-            self.quality,
-            self.width,
-            self.height,
-            wgpu::TextureFormat::Rgba8Unorm,
-        );
         let target_layer = if let RenderBlendMode::Builtin(BlendMode::Layer) = &blend_mode {
             LayerRef::Current
         } else {
             self.nearest_layer
         };
         let blend_type = BlendType::from(blend_mode);
+
+        // Compute tight bounds for the blend region.
+        // Shader (PixelBender) blends use their own UV logic — no regional sizing.
+        let blend_region = if matches!(&blend_type, BlendType::Shader(_)) {
+            None
+        } else {
+            compute_blend_region(
+                &commands.commands,
+                self.offset_x,
+                self.offset_y,
+                self.width,
+                self.height,
+            )
+        };
+        let (surface_w, surface_h, surface_offset_x, surface_offset_y) =
+            if let Some(ref r) = blend_region {
+                (r.width, r.height, r.x + self.offset_x, r.y + self.offset_y)
+            } else {
+                (self.width, self.height, self.offset_x, self.offset_y)
+            };
+
+        let surface = Surface::new(
+            self.descriptors,
+            self.quality,
+            surface_w,
+            surface_h,
+            wgpu::TextureFormat::Rgba8Unorm,
+        );
         let clear_color = blend_type.default_color();
-        let target = surface.draw_commands(
+        let target = surface.draw_commands_with_offset(
             RenderTargetMode::FreshWithColor(clear_color),
             self.descriptors,
             self.meshes,
@@ -699,6 +862,8 @@ impl CommandHandler for WgpuCommandHandler<'_> {
             self.draw_encoder,
             target_layer,
             self.texture_pool,
+            surface_offset_x,
+            surface_offset_y,
         );
         target.ensure_cleared(self.draw_encoder);
 
@@ -717,7 +882,13 @@ impl CommandHandler for WgpuCommandHandler<'_> {
         match blend_type {
             BlendType::Trivial(blend_mode) => {
                 let transform = Transform {
-                    matrix: Matrix::scale(target.width() as f32, target.height() as f32),
+                    matrix: Matrix {
+                        a: target.width() as f32,
+                        d: target.height() as f32,
+                        tx: Twips::from_pixels(surface_offset_x as f64),
+                        ty: Twips::from_pixels(surface_offset_y as f64),
+                        ..Default::default()
+                    },
                     color_transform: Default::default(),
                     perspective_projection: None,
                 };
@@ -778,10 +949,40 @@ impl CommandHandler for WgpuCommandHandler<'_> {
                     BlendType::Shader(shader) => ChunkBlendMode::Shader(shader),
                     _ => unreachable!(),
                 };
+                // UV transform: map viewport UV → region-local UV (0-1).
+                // src_uv = uv * scale + offset, where:
+                //   scale = viewport_size / region_size
+                //   offset = -region_pos / region_size
+                // Both textures are region-sized → same UV transform for both
+                let blend_transform = blend_region.map(|r| {
+                    let uv_scale_x = self.width as f32 / r.width as f32;
+                    let uv_scale_y = self.height as f32 / r.height as f32;
+                    let uv_off_x = -(r.x as f32) / r.width as f32;
+                    let uv_off_y = -(r.y as f32) / r.height as f32;
+                    let uv = [uv_off_x, uv_off_y, uv_scale_x, uv_scale_y];
+                    // The quad is composited into the parent target using that
+                    // target's globals, which expect absolute viewport coordinates,
+                    // so position it at `surface_offset` (= region origin + this
+                    // level's offset), matching the trivial-blend path. The UV
+                    // transform stays in this level's local space (the globals
+                    // subtract the level offset back out).
+                    Box::new(BlendTransforms {
+                        world_matrix: [
+                            [r.width as f32, 0.0, 0.0, 0.0],
+                            [0.0, r.height as f32, 0.0, 0.0],
+                            [0.0, 0.0, 1.0, 0.0],
+                            [surface_offset_x as f32, surface_offset_y as f32, 0.0, 1.0],
+                        ],
+                        dst_uv_transform: uv,
+                        src_uv_transform: uv,
+                    })
+                });
                 self.result.push(Chunk::Blend {
                     texture: target.take_color_texture(),
                     blend_mode: chunk_blend_mode,
                     needs_stencil: self.num_masks > 0,
+                    region: blend_region,
+                    blend_transform,
                 });
                 self.needs_stencil = self.num_masks > 0;
             }

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -844,9 +844,29 @@ impl CommandHandler for WgpuCommandHandler<'_> {
                 (self.width, self.height, self.offset_x, self.offset_y)
             };
 
+        // Skip MSAA for bitmap-only content that is axis-aligned: the pixels are
+        // pre-rasterized (no internal vector edges to smooth), and an unrotated,
+        // unskewed bitmap's outer quad edges run along the pixel grid. A rotated or
+        // skewed bitmap (matrix.b/c != 0) has diagonal edges that still need MSAA.
+        // The `b == 0 && c == 0` test mirrors the axis-aligned check in
+        // `PixelSnapping::Auto`.
+        let offscreen_quality = if commands.commands.iter().all(|c| match c {
+            Command::RenderBitmap { transform, .. } => {
+                transform.matrix.b == 0.0 && transform.matrix.c == 0.0
+            }
+            Command::PushMask
+            | Command::ActivateMask
+            | Command::DeactivateMask
+            | Command::PopMask => true,
+            _ => false,
+        }) {
+            StageQuality::Low
+        } else {
+            self.quality
+        };
         let surface = Surface::new(
             self.descriptors,
-            self.quality,
+            offscreen_quality,
             surface_w,
             surface_h,
             wgpu::TextureFormat::Rgba8Unorm,

--- a/render/wgpu/src/surface/target.rs
+++ b/render/wgpu/src/surface/target.rs
@@ -37,17 +37,11 @@ impl ResolveBuffer {
     }
 
     pub fn view(&self) -> &wgpu::TextureView {
-        match self.texture {
-            PoolOrArcTexture::Pool(ref texture) => &texture.1,
-            PoolOrArcTexture::Manual(ref texture) => &texture.1,
-        }
+        self.texture.view()
     }
 
     pub fn texture(&self) -> &wgpu::Texture {
-        match self.texture {
-            PoolOrArcTexture::Pool(ref texture) => &texture.0,
-            PoolOrArcTexture::Manual(ref texture) => &texture.0,
-        }
+        self.texture.texture()
     }
 
     pub fn take_texture(self) -> PoolOrArcTexture {
@@ -74,14 +68,14 @@ pub enum PoolOrArcTexture {
 impl PoolOrArcTexture {
     pub fn texture(&self) -> &wgpu::Texture {
         match self {
-            PoolOrArcTexture::Pool(texture) => &texture.0,
-            PoolOrArcTexture::Manual(texture) => &texture.0,
+            PoolOrArcTexture::Pool(t) => &t.0,
+            PoolOrArcTexture::Manual(t) => &t.0,
         }
     }
     pub fn view(&self) -> &wgpu::TextureView {
         match self {
-            PoolOrArcTexture::Pool(texture) => &texture.1,
-            PoolOrArcTexture::Manual(texture) => &texture.1,
+            PoolOrArcTexture::Pool(t) => &t.1,
+            PoolOrArcTexture::Manual(t) => &t.1,
         }
     }
 }
@@ -114,17 +108,11 @@ impl FrameBuffer {
     }
 
     pub fn view(&self) -> &wgpu::TextureView {
-        match self.texture {
-            PoolOrArcTexture::Pool(ref texture) => &texture.1,
-            PoolOrArcTexture::Manual(ref texture) => &texture.1,
-        }
+        self.texture.view()
     }
 
     pub fn texture(&self) -> &wgpu::Texture {
-        match self.texture {
-            PoolOrArcTexture::Pool(ref texture) => &texture.0,
-            PoolOrArcTexture::Manual(ref texture) => &texture.0,
-        }
+        self.texture.texture()
     }
 
     pub fn take_texture(self) -> PoolOrArcTexture {
@@ -136,7 +124,12 @@ impl FrameBuffer {
     }
 }
 
-#[derive(Debug)]
+/// A readable texture+view pair for use as blend shader input.
+pub struct BlendSource<'a> {
+    pub texture: &'a wgpu::Texture,
+    pub view: &'a wgpu::TextureView,
+}
+
 pub struct BlendBuffer {
     texture: PoolEntry<(wgpu::Texture, wgpu::TextureView), AlwaysCompatible>,
 }
@@ -150,8 +143,14 @@ impl BlendBuffer {
         pool: &mut TexturePool,
     ) -> Self {
         let texture = pool.get_texture(descriptors, size, usage, format, 1);
-
         Self { texture }
+    }
+
+    pub fn as_source(&self) -> BlendSource<'_> {
+        BlendSource {
+            texture: self.texture(),
+            view: self.view(),
+        }
     }
 
     pub fn view(&self) -> &wgpu::TextureView {
@@ -215,7 +214,36 @@ impl CommandTarget {
         render_target_mode: RenderTargetMode,
         encoder: &mut wgpu::CommandEncoder,
     ) -> Self {
-        let globals = pool.get_globals(descriptors, size.width, size.height);
+        Self::new_with_offset(
+            descriptors,
+            pool,
+            size,
+            format,
+            sample_count,
+            render_target_mode,
+            encoder,
+            0,
+            0,
+        )
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    pub fn new_with_offset(
+        descriptors: &Descriptors,
+        pool: &mut TexturePool,
+        size: wgpu::Extent3d,
+        format: wgpu::TextureFormat,
+        sample_count: u32,
+        render_target_mode: RenderTargetMode,
+        encoder: &mut wgpu::CommandEncoder,
+        offset_x: u32,
+        offset_y: u32,
+    ) -> Self {
+        let globals = if offset_x == 0 && offset_y == 0 {
+            pool.get_globals(descriptors, size.width, size.height)
+        } else {
+            pool.get_globals_with_offset(descriptors, offset_x, offset_y, size.width, size.height)
+        };
 
         let mut make_pooled_frame_buffer = || {
             FrameBuffer::new(
@@ -278,10 +306,6 @@ impl CommandTarget {
             }
 
             if sample_count > 1 {
-                // Both our frame buffer and resolve buffer need to start out
-                // in the same state, so copy our existing texture to the freshly
-                // allocated frame buffer. We cannot use `copy_texture_to_texture`,
-                // since the sample counts are different.
                 run_copy_pipeline(
                     descriptors,
                     format,
@@ -328,8 +352,6 @@ impl CommandTarget {
         if self.color_needs_clear.get().is_some() {
             return;
         }
-        // If we aren't clearing with a color (eg a texture instead)
-        // the there's no point in creating a new render pass that does nothing.
         if self.render_target_mode.color().is_some() {
             encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: create_debug_label!("Clearing command target").as_deref(),
@@ -398,12 +420,13 @@ impl CommandTarget {
         })
     }
 
+    /// Get the full-viewport blend source.
     pub fn update_blend_buffer(
         &self,
         descriptors: &Descriptors,
         pool: &mut TexturePool,
         encoder: &mut wgpu::CommandEncoder,
-    ) -> &BlendBuffer {
+    ) -> BlendSource<'_> {
         let blend_buffer = self.blend_buffer.get_or_init(|| {
             BlendBuffer::new(
                 descriptors,
@@ -435,6 +458,56 @@ impl CommandTarget {
             },
             self.frame_buffer.size(),
         );
+        blend_buffer.as_source()
+    }
+
+    /// Copy only a sub-region into a bounds-sized blend buffer.
+    /// When the full blend buffer is up-to-date, copies from it instead.
+    #[expect(clippy::too_many_arguments)]
+    pub fn update_blend_buffer_region(
+        &self,
+        descriptors: &Descriptors,
+        pool: &mut TexturePool,
+        encoder: &mut wgpu::CommandEncoder,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> BlendBuffer {
+        let alloc_size = wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        };
+        let blend_buffer = BlendBuffer::new(
+            descriptors,
+            alloc_size,
+            self.format,
+            wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC,
+            pool,
+        );
+        self.ensure_cleared(encoder);
+        encoder.copy_texture_to_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: self
+                    .resolve_buffer
+                    .as_ref()
+                    .map(|b| b.texture())
+                    .unwrap_or_else(|| self.frame_buffer.texture()),
+                mip_level: 0,
+                origin: wgpu::Origin3d { x, y, z: 0 },
+                aspect: Default::default(),
+            },
+            wgpu::TexelCopyTextureInfo {
+                texture: blend_buffer.texture(),
+                mip_level: 0,
+                origin: Default::default(),
+                aspect: Default::default(),
+            },
+            alloc_size,
+        );
         blend_buffer
     }
 
@@ -460,6 +533,10 @@ fn get_whole_frame_bind_group<'a>(
 ) -> &'a wgpu::BindGroup {
     &once_cell
         .get_or_init(|| {
+            // Shared by the copy pipeline (which only reads `world_matrix`) and the
+            // full-viewport blend path. The copy pipeline ignores the color vectors,
+            // and the blend shaders reinterpret these bytes as `BlendTransforms` — an
+            // all-zero UV transform, i.e. identity (no region remapping).
             let transform = Transforms {
                 world_matrix: [
                     [size.width as f32, 0.0, 0.0, 0.0],
@@ -467,7 +544,7 @@ fn get_whole_frame_bind_group<'a>(
                     [0.0, 0.0, 1.0, 0.0],
                     [0.0, 0.0, 0.0, 1.0],
                 ],
-                mult_color: [1.0, 1.0, 1.0, 1.0],
+                mult_color: [0.0, 0.0, 0.0, 0.0],
                 add_color: [0.0, 0.0, 0.0, 0.0],
             };
             let transforms_buffer = create_buffer_with_data(

--- a/render/wgpu/src/surface/target.rs
+++ b/render/wgpu/src/surface/target.rs
@@ -5,7 +5,7 @@ use crate::descriptors::Descriptors;
 use crate::globals::Globals;
 use crate::utils::create_buffer_with_data;
 use crate::utils::run_copy_pipeline;
-use std::cell::OnceCell;
+use std::cell::{Cell, OnceCell};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -202,6 +202,8 @@ pub struct CommandTarget {
     whole_frame_bind_group: OnceCell<(wgpu::Buffer, wgpu::BindGroup)>,
     color_needs_clear: OnceCell<bool>,
     render_target_mode: RenderTargetMode,
+    /// Whether the framebuffer has been modified since the last blend buffer copy.
+    blend_buffer_stale: Cell<bool>,
 }
 
 impl CommandTarget {
@@ -337,6 +339,7 @@ impl CommandTarget {
             whole_frame_bind_group,
             color_needs_clear: OnceCell::new(),
             render_target_mode,
+            blend_buffer_stale: Cell::new(true),
         }
     }
 
@@ -420,7 +423,12 @@ impl CommandTarget {
         })
     }
 
-    /// Get the full-viewport blend source.
+    /// Mark the framebuffer as modified (needs re-copy before next blend).
+    pub fn mark_blend_buffer_stale(&self) {
+        self.blend_buffer_stale.set(true);
+    }
+
+    /// Get the full-viewport blend source, skipping copy if unchanged since last call.
     pub fn update_blend_buffer(
         &self,
         descriptors: &Descriptors,
@@ -438,6 +446,10 @@ impl CommandTarget {
                 pool,
             )
         });
+        if !self.blend_buffer_stale.get() {
+            return blend_buffer.as_source();
+        }
+        self.blend_buffer_stale.set(false);
         self.ensure_cleared(encoder);
         encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
@@ -488,6 +500,27 @@ impl CommandTarget {
                 | wgpu::TextureUsages::COPY_SRC,
             pool,
         );
+        // Prefer copying from cached full blend buffer when available
+        if !self.blend_buffer_stale.get()
+            && let Some(full_bb) = self.blend_buffer.get()
+        {
+            encoder.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: full_bb.texture(),
+                    mip_level: 0,
+                    origin: wgpu::Origin3d { x, y, z: 0 },
+                    aspect: Default::default(),
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: blend_buffer.texture(),
+                    mip_level: 0,
+                    origin: Default::default(),
+                    aspect: Default::default(),
+                },
+                alloc_size,
+            );
+            return blend_buffer;
+        }
         self.ensure_cleared(encoder);
         encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {


### PR DESCRIPTION
Assisted by Claude Opus 4.7. 

Previously every blend operation allocated a full-viewport offscreen texture, regardless of how much of the viewport the blended content actually covered. On scenes with many small blended elements this wastes GPU memory and bandwidth on copying and sampling pixels that are guaranteed to be empty.

This change computes a tight axis-aligned bounding box of each blend's commands in viewport space (`compute_blend_region` in `surface/commands.rs`), and when the region is strictly smaller than the viewport renders the blend into a region-sized surface positioned with an offset transform (`Globals::new_with_offset`, `CommandTarget::new_with_offset`, `Surface::draw_commands_with_offset`).

To make the complex blend shaders sample the correct slice of the parent framebuffer when the current texture is region-sized, the shaders now take separate `dst_uv` and `src_uv` varyings and apply a UV transform stored in the existing `mult_color` / `add_color` fields of `Transforms`. The zero vector is treated as identity so the full-viewport path is unchanged. `update_blend_buffer_region` copies only the needed sub-rectangle from the framebuffer.

Two further optimizations ride along:

- `CommandTarget` now tracks `blend_buffer_stale`, so consecutive blends that don't modify the framebuffer skip the redundant framebuffer-to-blend-buffer copy entirely.
- Blends whose commands are purely `RenderBitmap` (and mask ops) are rendered at `StageQuality::Low`, since pre-rasterized bitmaps have no vector edges for MSAA to smooth.

`Mesh` gains a cached object-space `bounds` tuple so shape commands can participate in AABB computation without retessellating.