### PR TITLE
web: Improve software renderer detection

### DIFF
--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -753,15 +753,17 @@ export class InnerPlayer {
         // Show a hardware acceleration warning when software rendering is detected.
         // The device type is unreliable through WebGL/ANGLE (always "Other"), so we
         // also match known software renderer names (WARP, SwiftShader, Mesa llvmpipe).
-        const isSoftwareRenderer =
-            this.rendererDebugInfo.includes("Adapter Device Type: Cpu") ||
-            this.rendererDebugInfo.includes(
-                "Adapter Device Type: VirtualGpu",
-            ) ||
-            this.rendererDebugInfo.includes("Microsoft Basic Render Driver") ||
-            this.rendererDebugInfo.includes("SwiftShader") ||
-            this.rendererDebugInfo.includes("llvmpipe") ||
-            this.rendererDebugInfo.includes("softpipe");
+        const softwareRendererIndicators = [
+            "Adapter Device Type: Cpu",
+            "Adapter Device Type: VirtualGpu",
+            "Microsoft Basic Render Driver",
+            "SwiftShader",
+            "llvmpipe",
+            "softpipe",
+        ];
+        const isSoftwareRenderer = softwareRendererIndicators.some(
+            (indicator) => this.rendererDebugInfo.includes(indicator),
+        );
         if (isSoftwareRenderer) {
             this.container.addEventListener(
                 "mouseover",

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -750,7 +750,19 @@ export class InnerPlayer {
 
         this.rendererDebugInfo = this.instance!.renderer_debug_info();
 
-        if (this.rendererDebugInfo.includes("Adapter Device Type: Cpu")) {
+        // Show a hardware acceleration warning when software rendering is detected.
+        // The device type is unreliable through WebGL/ANGLE (always "Other"), so we
+        // also match known software renderer names (WARP, SwiftShader, Mesa llvmpipe).
+        const isSoftwareRenderer =
+            this.rendererDebugInfo.includes("Adapter Device Type: Cpu") ||
+            this.rendererDebugInfo.includes(
+                "Adapter Device Type: VirtualGpu",
+            ) ||
+            this.rendererDebugInfo.includes("Microsoft Basic Render Driver") ||
+            this.rendererDebugInfo.includes("SwiftShader") ||
+            this.rendererDebugInfo.includes("llvmpipe") ||
+            this.rendererDebugInfo.includes("softpipe");
+        if (isSoftwareRenderer) {
             this.container.addEventListener(
                 "mouseover",
                 this.openHardwareAccelerationModal.bind(this),


### PR DESCRIPTION
### Problem

`Adapter Device Type: Cpu` alone doesn't catch all software renderers. WebGL/ANGLE often reports the device type as `Other` even when no hardware acceleration is active.

### Changes

Added checks for additional known software renderers alongside the existing check:

- `VirtualGpu` - virtual GPU environments (VMs, cloud)
- `Microsoft Basic Render Driver` - WARP fallback driver
- `SwiftShader` - Google's software renderer (headless Chrome, CI)
- `llvmpipe` / `softpipe` - Mesa software rasterizers on Linux

The hardware acceleration warning now triggers reliably across all common software rendering scenarios.