### PR TITLE
web: Restyle panic screen with error details modal

### DIFF
--- a/web/packages/core/src/internal/ui/panic.tsx
+++ b/web/packages/core/src/internal/ui/panic.tsx
@@ -420,14 +420,8 @@ export function showPanicScreen(
                     )}
                 </ul>
             </div>
-            <div
-                id="panic-details-modal"
-                class="hidden"
-                ref={detailsModal}
-            >
-                <div
-                    id="panic-details-content"
-                >
+            <div id="panic-details-modal" class="hidden" ref={detailsModal}>
+                <div id="panic-details-content">
                     <span
                         class="panic-copy-button"
                         title="Copy to clipboard"

--- a/web/packages/core/src/internal/ui/panic.tsx
+++ b/web/packages/core/src/internal/ui/panic.tsx
@@ -49,9 +49,9 @@ function createPanicAction({
     errorText: string;
 }) {
     if (action.type === "show_details") {
-        const onClick = () => {
+        const onClick = (event: MouseEvent) => {
+            event.preventDefault();
             showDetails();
-            return false;
         };
         return (
             <li>
@@ -396,21 +396,17 @@ export function showPanicScreen(
     const errorText = errorArray.join("");
     const { body, actions } = createPanicError(error);
 
-    const panicBody = createRef<HTMLDivElement>();
+    const detailsModal = createRef<HTMLDivElement>();
+    const copyButton = createRef<HTMLSpanElement>();
     const showDetails = () => {
-        panicBody.current!.classList.add("details");
-        panicBody.current!.replaceChildren(
-            <textarea readOnly>{errorText}</textarea>,
-        );
+        detailsModal.current!.classList.remove("hidden");
     };
 
     container.textContent = "";
     container.appendChild(
         <div id="panic">
             <div id="panic-title">{text("panic-title")}</div>
-            <div id="panic-body" ref={panicBody}>
-                {body}
-            </div>
+            <div id="panic-body">{body}</div>
             <div id="panic-footer">
                 <ul>
                     {actions.map((action) =>
@@ -423,6 +419,38 @@ export function showPanicScreen(
                         }),
                     )}
                 </ul>
+            </div>
+            <div
+                id="panic-details-modal"
+                class="hidden"
+                ref={detailsModal}
+            >
+                <div
+                    id="panic-details-content"
+                >
+                    <span
+                        class="panic-copy-button"
+                        title="Copy to clipboard"
+                        ref={copyButton}
+                        onClick={() => {
+                            if (!copyButton.current) {
+                                return;
+                            }
+                            navigator.clipboard?.writeText(errorText);
+                            copyButton.current.classList.add("copied");
+                            setTimeout(() => {
+                                copyButton.current?.classList.remove("copied");
+                            }, 2000);
+                        }}
+                    ></span>
+                    <span
+                        class="close-modal"
+                        onClick={() =>
+                            detailsModal.current!.classList.add("hidden")
+                        }
+                    ></span>
+                    <textarea readOnly>{errorText}</textarea>
+                </div>
             </div>
         </div>,
     );

--- a/web/packages/core/src/internal/ui/static-styles.css
+++ b/web/packages/core/src/internal/ui/static-styles.css
@@ -3,7 +3,11 @@
     pointer-events: inherit;
 
     --ruffle-blue: #37528c;
+    --ruffle-blue-dark: #253559;
     --ruffle-orange: #ffad33;
+    --modal-background: #fafafa;
+    --modal-foreground-rgb: 0, 0, 0;
+    --modal-foreground-filter: none;
 
     display: inline-block;
     position: relative;
@@ -88,48 +92,119 @@
 
 /* Includes inverted colors from play button! */
 #panic {
-    font-size: 20px;
+    font-size: 15px;
     text-align: center;
     background: linear-gradient(180deg, #fd3a40 0%, #fda138 100%);
     color: white;
     display: flex;
     flex-flow: column;
-    justify-content: space-around;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 16px;
     overflow: auto;
 
     a {
-        color: var(--ruffle-blue);
-        font-weight: bold;
+        color: white;
+        text-underline-offset: 2px;
     }
 }
 
 #panic-title {
-    font-size: xxx-large;
+    font-size: 30px;
     font-weight: bold;
+    letter-spacing: -0.5px;
 }
 
 #panic-body {
-    &.details {
-        flex: 0.9;
-        margin: 0 10px;
+    max-width: 480px;
+    width: 100%;
+    opacity: 0.85;
+}
+
+#panic-details-modal {
+    position: absolute;
+    inset: 0;
+    background: #0008;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    box-sizing: border-box;
+    z-index: 1;
+}
+
+#panic-details-content {
+    position: relative;
+    background-color: var(--modal-background);
+    color: rgb(var(--modal-foreground-rgb));
+    width: 100%;
+    max-width: 720px;
+    height: 80%;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 6px 0 #0008;
+    padding: 44px 12px 12px;
+    box-sizing: border-box;
+
+    .panic-copy-button {
+        position: absolute;
+        top: 14px;
+        right: 40px;
+        width: 16px;
+        height: 16px;
+        background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 -960 960 960' width='16px' fill='black'><path d='M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z'/></svg>");
+        cursor: pointer;
+        filter: var(--modal-foreground-filter);
+        border-radius: 4px;
+        opacity: 0.6;
+        transition:
+            opacity 0.15s,
+            background-image 0s;
+
+        &:hover {
+            opacity: 1;
+        }
+
+        &.copied {
+            background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 -960 960 960' width='16px' fill='%2322c55e'><path d='M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z'/></svg>");
+            filter: none;
+            opacity: 1;
+            pointer-events: none;
+            cursor: default;
+        }
     }
 
     textarea {
         width: 100%;
         height: 100%;
+        font-family: monospace;
+        font-size: 12px;
         resize: none;
+        background: rgb(var(--modal-foreground-rgb), 0.07);
+        border: none;
+        border-radius: 8px;
+        color: rgb(var(--modal-foreground-rgb));
+        padding: 10px;
+        box-sizing: border-box;
+        outline: none;
+    }
+
+    textarea::-webkit-scrollbar {
+        width: 6px;
+    }
+
+    textarea::-webkit-scrollbar-thumb {
+        background: rgb(var(--modal-foreground-rgb), 0.25);
+        border-radius: 3px;
+    }
+
+    textarea::-webkit-scrollbar-track {
+        background: transparent;
     }
 }
 
-#panic ul {
-    padding: 0;
-    display: flex;
-    list-style-type: none;
-    justify-content: space-evenly;
-}
-
 #message-overlay {
-    position: absolute;
     background: var(--ruffle-blue);
     color: var(--ruffle-orange);
     opacity: 1;
@@ -165,32 +240,47 @@
         color: var(--ruffle-orange);
         border: 2px solid var(--ruffle-orange);
         font-weight: bold;
-        font-size: 1.25em;
-        border-radius: 0.6em;
-        padding: 10px;
+        font-size: 16px;
+        font-family: inherit;
+        border-radius: 8px;
+        padding: 10px 16px;
         text-decoration: none;
-        margin: 2% 0;
-    }
-
-    a:hover,
-    button:hover {
-        background: #ffffff4c;
+        margin: 8px 0;
+        transition: background 0.15s;
     }
 }
 
-#continue-btn {
-    cursor: pointer;
-    background: var(--ruffle-blue);
-    color: var(--ruffle-orange);
-    border: 2px solid var(--ruffle-orange);
-    font-weight: bold;
-    font-size: 20px;
-    border-radius: 20px;
-    padding: 10px;
+#panic ul {
+    padding: 0;
+    margin: 0;
+    display: flex;
+    list-style-type: none;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 8px;
 
-    &:hover {
-        background: #ffffff4c;
+    li a {
+        display: inline-block;
+        background: transparent;
+        border: 1px solid rgb(255 255 255 / 70%);
+        border-radius: 8px;
+        padding: 8px 16px;
+        color: white;
+        text-decoration: none;
+        font-weight: bold;
+        font-size: 13px;
+        font-family: inherit;
+        transition: background 0.15s;
+
+        &:hover {
+            background: rgb(255 255 255 / 20%);
+        }
     }
+}
+
+#message-overlay a:hover,
+#message-overlay button:hover {
+    background: #ffffff4c;
 }
 
 #context-menu-overlay,
@@ -270,7 +360,7 @@
     max-width: 316px;
     max-height: 10px;
     height: 20%;
-    background: #253559;
+    background: var(--ruffle-blue-dark);
 }
 
 .loadbar-inner {


### PR DESCRIPTION
This PR:

- Redesigns the panic screen with a centered flex layout.
- Adds an error details modal with a copy button and styled textarea.
- Updates the panic action links to inline badge buttons.

**Old:**
<img width="767" height="478" alt="Screenshot" src="https://github.com/user-attachments/assets/32fb6177-c393-4e07-82ac-c7feb71d9ec1" />

**New:**
<img width="768" height="478" alt="Screenshot" src="https://github.com/user-attachments/assets/a6a6b1cb-eab0-457c-a712-a2108f8a14cf" />