### PR TITLE
chore: Enable dbg_macro and enum_glob_use clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,8 @@ trivially_copy_pass_by_ref = "deny"
 redundant_clone = "deny"
 unused_async = "deny"
 used_underscore_items = "deny"
+dbg_macro = "warn"
+enum_glob_use = "deny"
 
 # TODO Enable used_underscore_binding when false positives get fixed.
 


### PR DESCRIPTION
Our style already includes those lints, this only enables them officially in case we don't catch it in review.