### PR TITLE
chore: Deduplicate code and enable clippy::branches_sharing_code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ unused_async = "deny"
 used_underscore_items = "deny"
 dbg_macro = "warn"
 enum_glob_use = "deny"
+branches_sharing_code = "warn"
 
 # TODO Enable used_underscore_binding when false positives get fixed.
 

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -508,22 +508,22 @@ pub fn remove_namespace<'gc>(
         }
     }
 
-    // 6. If ns.prefix == undefined
-    if ns.prefix.is_none() {
+    {
         let E4XNodeKind::Element { namespaces, .. } = &mut *node.kind_mut(activation.gc()) else {
             unreachable!()
         };
-        // 6.a. If there exists a namespace n ∈ x.[[InScopeNamespaces]],
-        // such that n.uri == ns.uri, remove the namespace n from x.[[InScopeNamespaces]]
-        namespaces.retain(|namespace| namespace.uri != ns.uri);
-    } else {
+
+        // 6. If ns.prefix == undefined
+        if ns.prefix.is_none() {
+            // 6.a. If there exists a namespace n ∈ x.[[InScopeNamespaces]],
+            // such that n.uri == ns.uri, remove the namespace n from x.[[InScopeNamespaces]]
+            namespaces.retain(|namespace| namespace.uri != ns.uri);
         // 7. Else
-        let E4XNodeKind::Element { namespaces, .. } = &mut *node.kind_mut(activation.gc()) else {
-            unreachable!()
-        };
-        // 7.a. If there exists a namespace n ∈ x.[[InScopeNamespaces]],
-        // such that n.uri == ns.uri and n.prefix == ns.prefix, remove the namespace n from x.[[InScopeNamespaces]]
-        namespaces.retain(|namespace| *namespace != ns);
+        } else {
+            // 7.a. If there exists a namespace n ∈ x.[[InScopeNamespaces]],
+            // such that n.uri == ns.uri and n.prefix == ns.prefix, remove the namespace n from x.[[InScopeNamespaces]]
+            namespaces.retain(|namespace| *namespace != ns);
+        }
     }
 
     let E4XNodeKind::Element { children, .. } = &*node.kind() else {

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -1302,54 +1302,44 @@ fn copy_on_cpu<'gc>(
         return;
     }
 
-    if source.ptr_eq(dest) {
-        let dest = dest.sync(renderer);
-        let mut write = dest.borrow_mut(context);
+    let dest_is_source = source.ptr_eq(dest);
+    let mut dest = dest.sync(renderer).borrow_mut(context);
 
+    if dest_is_source {
         for y in 0..dest_region.height() {
             for x in 0..dest_region.width() {
                 let mut color =
-                    write.get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
+                    dest.get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
                 if blend {
-                    color = write
+                    color = dest
                         .get_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y)
                         .blend_over(&color);
                 }
-                write.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
+                dest.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
             }
         }
-
-        write.set_cpu_dirty(context, dest_region);
     } else {
-        let dest = dest.sync(renderer);
-        let mut dest_write = dest.borrow_mut(context);
-        let source_read = source.read_area(source_region, renderer);
+        let source = source.read_area(source_region, renderer);
 
-        if !blend && (dest_write.transparency() || !source_read.transparency()) {
+        if !blend && (dest.transparency() || !source.transparency()) {
             // Copying (not blending) anything to a transparent texture,
             // or copying an opaque texture to an opaque texture,
             // means we can skip alpha premultiplication
 
             if dest_region == source_region
-                && dest_region.width() == dest_write.width()
-                && dest_region.height() == dest_write.height()
-                && dest_region.width() == source_read.width()
-                && dest_region.height() == source_read.height()
+                && dest_region.width() == dest.width()
+                && dest_region.height() == dest.height()
+                && dest_region.width() == source.width()
+                && dest_region.height() == source.height()
             {
                 // Copying an entire texture that's the same size and type? Just replace the whole thing
-                dest_write
-                    .raw_pixels_mut()
-                    .copy_from_slice(source_read.raw_pixels());
+                dest.raw_pixels_mut().copy_from_slice(source.raw_pixels());
             } else {
                 for y in 0..dest_region.height() {
                     for x in 0..dest_region.width() {
-                        let color = source_read
+                        let color = source
                             .get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
-                        dest_write.set_pixel32_raw(
-                            dest_region.x_min + x,
-                            dest_region.y_min + y,
-                            color,
-                        );
+                        dest.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
                     }
                 }
             }
@@ -1357,27 +1347,27 @@ fn copy_on_cpu<'gc>(
             // Copying (not blending) a transparent texture to an opaque texture,
             // or blending anything to anything
 
-            let opaque = !dest_write.transparency();
+            let opaque = !dest.transparency();
 
             for y in 0..dest_region.height() {
                 for x in 0..dest_region.width() {
-                    let mut color = source_read
-                        .get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
+                    let mut color =
+                        source.get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
                     if blend {
-                        color = dest_write
+                        color = dest
                             .get_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y)
                             .blend_over(&color);
                     }
                     if opaque {
                         color = color.with_alpha(255);
                     }
-                    dest_write.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
+                    dest.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
                 }
             }
         }
-
-        dest_write.set_cpu_dirty(context, dest_region);
     }
+
+    dest.set_cpu_dirty(context, dest_region);
 }
 
 fn blend_and_transform<'gc>(
@@ -1388,51 +1378,47 @@ fn blend_and_transform<'gc>(
     dest_region: PixelRegion,
     transform: &ColorTransform,
 ) {
-    if source.ptr_eq(dest) {
-        let dest = dest.sync(context.renderer);
-        let mut write = dest.borrow_mut(context.gc());
+    let dest_is_source = source.ptr_eq(dest);
+    let mut dest = dest.sync(context.renderer).borrow_mut(context.gc());
 
+    if dest_is_source {
         for y in 0..dest_region.height() {
             for x in 0..dest_region.width() {
                 let mut color =
-                    write.get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
+                    dest.get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
                 color = Color::from(transform * swf::Color::from(color.to_un_multiplied_alpha()))
                     .to_premultiplied_alpha(true);
-                color = write
+                color = dest
                     .get_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y)
                     .blend_over(&color);
-                if !write.transparency() {
+                if !dest.transparency() {
                     color = color.with_alpha(255);
                 }
-                write.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
+                dest.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
             }
         }
-
-        write.set_cpu_dirty(context.gc(), dest_region);
     } else {
-        let dest = dest.sync(context.renderer);
-        let mut dest_write = dest.borrow_mut(context.gc());
-        let source_read = source.read_area(source_region, context.renderer);
-        let opaque = !dest_write.transparency();
+        let source = source.read_area(source_region, context.renderer);
+        let opaque = !dest.transparency();
 
         for y in 0..dest_region.height() {
             for x in 0..dest_region.width() {
                 let mut color =
-                    source_read.get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
+                    source.get_pixel32_raw(source_region.x_min + x, source_region.y_min + y);
                 color = Color::from(transform * swf::Color::from(color.to_un_multiplied_alpha()))
                     .to_premultiplied_alpha(true);
-                color = dest_write
+                color = dest
                     .get_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y)
                     .blend_over(&color);
                 if opaque {
                     color = color.with_alpha(255);
                 }
-                dest_write.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
+                dest.set_pixel32_raw(dest_region.x_min + x, dest_region.y_min + y, color);
             }
         }
-
-        dest_write.set_cpu_dirty(context.gc(), dest_region);
     }
+
+    dest.set_cpu_dirty(context.gc(), dest_region);
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -1705,9 +1705,6 @@ fn summary_color_transform(ct: ColorTransform) -> Cow<'static, str> {
         if let Some(entry) = summary_color_transform_entry("C", ct.r_multiply, ct.r_add) {
             lines.push(entry);
         }
-        if let Some(entry) = summary_color_transform_entry("A", ct.a_multiply, ct.a_add) {
-            lines.push(entry);
-        }
     } else {
         if let Some(entry) = summary_color_transform_entry("R", ct.r_multiply, ct.r_add) {
             lines.push(entry);
@@ -1718,9 +1715,10 @@ fn summary_color_transform(ct: ColorTransform) -> Cow<'static, str> {
         if let Some(entry) = summary_color_transform_entry("B", ct.b_multiply, ct.b_add) {
             lines.push(entry);
         }
-        if let Some(entry) = summary_color_transform_entry("A", ct.a_multiply, ct.a_add) {
-            lines.push(entry);
-        }
+    }
+
+    if let Some(entry) = summary_color_transform_entry("A", ct.a_multiply, ct.a_add) {
+        lines.push(entry);
     }
 
     if lines.is_empty() {

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -848,15 +848,14 @@ impl<'gc> ChildContainer<'gc> {
                     .position(|x| DisplayObject::ptr_eq(*x, above_child))
                 {
                     self.insert_id(position, child);
-                    None
                 } else {
                     self.push_id(child);
-                    None
                 }
             } else {
                 self.push_id(child);
-                None
             }
+
+            None
         }
     }
 

--- a/frontend-utils/src/recents/write.rs
+++ b/frontend-utils/src/recents/write.rs
@@ -37,6 +37,7 @@ impl<'a> RecentsWriter<'a> {
                 .iter()
                 .position(|x| x.content_descriptor == recent.content_descriptor);
 
+            #[expect(clippy::branches_sharing_code)]
             if let Some(index) = existing {
                 // Existing entry, just move it to the top.
 

--- a/render/src/utils.rs
+++ b/render/src/utils.rs
@@ -147,13 +147,12 @@ pub fn remove_invalid_jpeg_data(data: &[u8]) -> Cow<'_, [u8]> {
     // Some JPEGs are missing the final EOI marker (JPEG optimizers truncate it?)
     // Flash and most image decoders will still display these images, but jpeg-decoder errors.
     // Glue on an EOI marker if its not already there and hope for the best.
-    if data.ends_with(&[0xFF, EOI]) {
-        data
-    } else {
+    if !data.ends_with(&[0xFF, EOI]) {
         tracing::warn!("JPEG is missing EOI marker and may not decode properly");
         data.to_mut().extend_from_slice(&[0xFF, EOI]);
-        data
     }
+
+    data
 }
 
 /// Some SWFs report unreasonable bitmap dimensions (#1191).


### PR DESCRIPTION
In some cases we had code duplicated across all possible branches, this patch moves the code out of those branches preventing duplication and enables a lint to catch such cases.