### PR TITLE
chore: Remove underscore prefix of used symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,9 @@ unknown_lints = "allow"
 trivially_copy_pass_by_ref = "deny"
 redundant_clone = "deny"
 unused_async = "deny"
+used_underscore_items = "deny"
+
+# TODO Enable used_underscore_binding when false positives get fixed.
 
 # LONG-TERM: These lints are unhelpful.
 manual_map = "allow"             # Less readable: Suggests `opt.map(..)` instead of `if let Some(opt) { .. }`

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -221,7 +221,7 @@ pub trait TInteractiveObject<'gc>:
     /// onto other siblings of the display object instead.
     fn filter_clip_event(
         self,
-        _context: &mut UpdateContext<'gc>,
+        context: &mut UpdateContext<'gc>,
         event: ClipEvent,
     ) -> ClipEventResult;
 
@@ -265,8 +265,8 @@ pub trait TInteractiveObject<'gc>:
     /// if the event will be passed onto siblings and parents.
     fn event_dispatch(
         self,
-        _context: &mut UpdateContext<'gc>,
-        _event: ClipEvent<'gc>,
+        context: &mut UpdateContext<'gc>,
+        event: ClipEvent<'gc>,
     ) -> ClipEventResult;
 
     /// Convert the clip event into an AVM2 event and dispatch it into the

--- a/web/src/builder.rs
+++ b/web/src/builder.rs
@@ -510,7 +510,7 @@ impl RuffleInstanceBuilder {
         )))]
         std::compile_error!("You must enable one of the render backend features (e.g., webgl).");
 
-        let _is_transparent = self.wmode.as_deref() == Some("transparent");
+        let is_transparent = self.wmode.as_deref() == Some("transparent");
 
         let mut renderer_list = vec!["wgpu-webgl", "webgpu", "webgl", "canvas"];
         if let Some(preferred_renderer) = &self.preferred_renderer {
@@ -592,7 +592,7 @@ impl RuffleInstanceBuilder {
                         .map_err(|_| "Expected HtmlCanvasElement")?;
                     match ruffle_render_webgl::WebGlRenderBackend::new(
                         &canvas,
-                        _is_transparent,
+                        is_transparent,
                         self.quality,
                     ) {
                         Ok(renderer) => {
@@ -611,10 +611,8 @@ impl RuffleInstanceBuilder {
                         .into_js_result()?
                         .dyn_into()
                         .map_err(|_| "Expected HtmlCanvasElement")?;
-                    match ruffle_render_canvas::WebCanvasRenderBackend::new(
-                        &canvas,
-                        _is_transparent,
-                    ) {
+                    match ruffle_render_canvas::WebCanvasRenderBackend::new(&canvas, is_transparent)
+                    {
                         Ok(renderer) => {
                             return Ok((Box::new(renderer), canvas));
                         }


### PR DESCRIPTION
An underscore prefix signifies a symbol that is unused, if it's not unused we shouldn't prefix it with an underscore.

This also enables `clippy::used_underscore_items`. This lint does not cover fixed cases sadly; they would be covered by `clippy::used_underscore_binding`, but it has a lot of false positives in Ruffle.