### PR TITLE
refactor: Simplify some match patterns

### DIFF
--- a/core/src/avm1/globals/netconnection.rs
+++ b/core/src/avm1/globals/netconnection.rs
@@ -319,10 +319,7 @@ fn connect<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if matches!(
-        args.get(0),
-        None | Some(Value::Undefined) | Some(Value::Null)
-    ) {
+    if matches!(args.get(0), None | Some(Value::Undefined | Value::Null)) {
         NetConnections::connect_to_local(activation.context, this);
         return Ok(Value::Undefined);
     }

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -107,7 +107,7 @@ fn play<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::NetStream(ns) = this.native() {
         let name = match args.get(0) {
-            Some(Value::Undefined) | Some(Value::Null) | None => None,
+            Some(Value::Undefined | Value::Null) | None => None,
             Some(v) => Some(v.coerce_to_string(activation)?),
         };
 

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -655,7 +655,7 @@ impl<'gc> Class<'gc> {
                                 (TraitKind::Getter { .. }, TraitKind::Setter { .. }) => continue,
                                 (TraitKind::Setter { .. }, TraitKind::Getter { .. }) => continue,
 
-                                (_, TraitKind::Const { .. }) | (_, TraitKind::Slot { .. }) => {
+                                (_, TraitKind::Const { .. } | TraitKind::Slot { .. }) => {
                                     did_override = true;
 
                                     // Const/Var traits override anything in avmplus

--- a/core/src/avm2/globals/flash/display/shader_job.rs
+++ b/core/src/avm2/globals/flash/display/shader_job.rs
@@ -315,7 +315,7 @@ pub fn start<'gc>(
     };
 
     match shader_handle.0.parsed_shader().output_channels() {
-        Some(3) | Some(4) => {}
+        Some(3 | 4) => {}
         channels => {
             tracing::warn!(
                 "Unsupported number of shader output channels: {channels:?}, expected 3 or 4"

--- a/core/src/avm2/globals/math.rs
+++ b/core/src/avm2/globals/math.rs
@@ -123,7 +123,7 @@ pub fn pow<'gc>(
             // Special case: If p is NaN, the result is NaN.
             (_, _) if p.is_nan() => return Ok(f64::NAN.into()),
             // Special case: If p is ±Infinity and n is ±1, the result is NaN.
-            (1.0, _) | (-1.0, _) => {
+            (1.0 | -1.0, _) => {
                 // If (1) n or p is not finite, (2) p is not NaN, (3) n is finite,
                 // p has to be infinite.
                 debug_assert!(p.is_infinite());

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -426,7 +426,7 @@ impl<'gc> ClassObject<'gc> {
     ) -> Result<Value<'gc>, Error<'gc>> {
         let property = self.instance_vtable().get_trait(multiname);
         match property {
-            Some(Property::Slot { slot_id }) | Some(Property::ConstSlot { slot_id }) => {
+            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                 let func = receiver.get_slot(slot_id);
 
                 func.call(activation, receiver.into(), arguments)
@@ -488,7 +488,7 @@ impl<'gc> ClassObject<'gc> {
         let property = self.instance_vtable().get_trait(multiname);
 
         match property {
-            Some(Property::Slot { slot_id }) | Some(Property::ConstSlot { slot_id }) => {
+            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                 Ok(receiver.get_slot(slot_id))
             }
             Some(Property::Method { disp_id }) => {
@@ -574,7 +574,7 @@ impl<'gc> ClassObject<'gc> {
 
                 Ok(())
             }
-            Some(Property::ConstSlot { .. }) | Some(Property::Virtual { set: None, .. }) => {
+            Some(Property::ConstSlot { .. } | Property::Virtual { set: None, .. }) => {
                 if activation.is_interpreter() {
                     Err(error::make_reference_error(
                         activation,

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -1531,8 +1531,7 @@ fn abstract_interpret_ops<'gc>(
                 if !multiname.has_lazy_component() {
                     if let Some(vtable) = stack_value.vtable() {
                         match vtable.get_trait(&multiname) {
-                            Some(Property::Slot { slot_id })
-                            | Some(Property::ConstSlot { slot_id }) => {
+                            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                                 // If the set value's type is the same as the type of the slot,
                                 // a SetSlotNoCoerce can be emitted. Otherwise, emit a SetSlot.
                                 let mut value_class =
@@ -1707,28 +1706,25 @@ fn abstract_interpret_ops<'gc>(
                 let stack_value = stack.pop(activation)?;
 
                 if !multiname.has_lazy_component() {
-                    if let Some(vtable) = stack_value.vtable() {
-                        match vtable.get_trait(&multiname) {
-                            Some(Property::Slot { slot_id })
-                            | Some(Property::ConstSlot { slot_id }) => {
-                                let mut value_class =
-                                    vtable.slot_class(slot_id).expect("Slot should exist");
-                                let resolved_value_class = value_class.get_class(activation)?;
+                    if let Some(vtable) = stack_value.vtable()
+                        && let Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) =
+                            vtable.get_trait(&multiname)
+                    {
+                        let mut value_class =
+                            vtable.slot_class(slot_id).expect("Slot should exist");
+                        let resolved_value_class = value_class.get_class(activation)?;
 
-                                if let Some(slot_class) = resolved_value_class {
-                                    if let Some(instance_class) = slot_class.i_class() {
-                                        optimize_op_to!(Op::ConstructSlot {
-                                            index: slot_id,
-                                            num_args
-                                        });
+                        if let Some(slot_class) = resolved_value_class
+                            && let Some(instance_class) = slot_class.i_class()
+                        {
+                            optimize_op_to!(Op::ConstructSlot {
+                                index: slot_id,
+                                num_args
+                            });
 
-                                        // ConstructProp on a c_class will construct its i_class
-                                        stack_push_done = true;
-                                        stack.push_class_not_null(activation, instance_class)?;
-                                    }
-                                }
-                            }
-                            _ => {}
+                            // ConstructProp on a c_class will construct its i_class
+                            stack_push_done = true;
+                            stack.push_class_not_null(activation, instance_class)?;
                         }
                     }
                 }
@@ -1850,8 +1846,7 @@ fn abstract_interpret_ops<'gc>(
                 if !multiname.has_lazy_component() {
                     let vtable = bound_superclass_object.instance_vtable();
                     match vtable.get_trait(&multiname) {
-                        Some(Property::Slot { slot_id })
-                        | Some(Property::ConstSlot { slot_id }) => {
+                        Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                             let mut value_class =
                                 vtable.slot_class(slot_id).expect("Slot should exist");
                             let resolved_value_class = value_class.get_class(activation)?;
@@ -2198,7 +2193,7 @@ fn optimize_get_property<'gc>(
 
     if let Some(vtable) = stack_value.vtable() {
         match vtable.get_trait(&multiname) {
-            Some(Property::Slot { slot_id }) | Some(Property::ConstSlot { slot_id }) => {
+            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                 let mut value_class = vtable.slot_class(slot_id).expect("Slot should exist");
                 let resolved_value_class = value_class.get_class(activation)?;
 
@@ -2283,7 +2278,7 @@ fn optimize_call_property<'gc>(
                 return Ok(Some((result_op, return_type)));
             }
             #[allow(clippy::collapsible_match)]
-            Some(Property::Slot { slot_id }) | Some(Property::ConstSlot { slot_id }) => {
+            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                 // Don't optimize this for `callpropvoid`
                 if push_return_value {
                     if stack_value.not_null() {

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -956,7 +956,7 @@ impl<'gc> Value<'gc> {
         let vtable = self.vtable(activation);
 
         match vtable.get_trait(multiname) {
-            Some(Property::Slot { slot_id }) | Some(Property::ConstSlot { slot_id }) => {
+            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                 // Only objects can have slots
                 let object = self.as_object().unwrap();
 
@@ -1096,7 +1096,7 @@ impl<'gc> Value<'gc> {
             Some(Property::Virtual { set: Some(set), .. }) => {
                 self.call_method(set, &[value], activation).map(|_| ())
             }
-            Some(Property::ConstSlot { .. }) | Some(Property::Virtual { set: None, .. }) => {
+            Some(Property::ConstSlot { .. } | Property::Virtual { set: None, .. }) => {
                 let instance_class = self.instance_class(activation);
 
                 Err(error::make_reference_error(
@@ -1149,7 +1149,7 @@ impl<'gc> Value<'gc> {
         let vtable = self.vtable(activation);
 
         match vtable.get_trait(multiname) {
-            Some(Property::Slot { slot_id }) | Some(Property::ConstSlot { slot_id }) => {
+            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                 // Only objects can have slots
                 let object = self.as_object().unwrap();
 
@@ -1210,7 +1210,7 @@ impl<'gc> Value<'gc> {
         let vtable = self.vtable(activation);
 
         match vtable.get_trait(multiname) {
-            Some(Property::Slot { slot_id }) | Some(Property::ConstSlot { slot_id }) => {
+            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                 // Only objects can have slots
                 let object = self.as_object().unwrap();
 
@@ -1386,7 +1386,7 @@ impl<'gc> Value<'gc> {
         let vtable = self.vtable(activation);
 
         match vtable.get_trait(multiname) {
-            Some(Property::Slot { slot_id }) | Some(Property::ConstSlot { slot_id }) => {
+            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                 // Only objects can have slots
                 let object = self.as_object().unwrap();
 

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -760,7 +760,7 @@ impl<'gc> ChildContainer<'gc> {
                         Avm2Multiname::new(activation.avm2().find_public_namespace(), name);
                     let current_val = parent_obj.get_property(&multiname, &mut activation);
                     match current_val {
-                        Ok(Avm2Value::Null) | Ok(Avm2Value::Undefined) => {
+                        Ok(Avm2Value::Null | Avm2Value::Undefined) => {
                             // When the `get_property` returns null
                             // or undefined, FP doesn't attempt to
                             // set it to `null`. This is observable:

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1778,13 +1778,12 @@ impl<'gc> MovieClip<'gc> {
                 (_, Some(prev_child), true) | (PlaceObjectAction::Modify, Some(prev_child), _) => {
                     prev_child.apply_place_object(context, &params.place_object);
                 }
-                (swf::PlaceObjectAction::Replace(id), Some(prev_child), _) => {
+                (PlaceObjectAction::Replace(id), Some(prev_child), _) => {
                     prev_child.replace_with(context, id);
                     prev_child.apply_place_object(context, &params.place_object);
                     prev_child.set_place_frame(params.frame);
                 }
-                (PlaceObjectAction::Place(id), _, _)
-                | (swf::PlaceObjectAction::Replace(id), _, _) => {
+                (PlaceObjectAction::Place(id) | PlaceObjectAction::Replace(id), _, _) => {
                     if let Some(child) =
                         clip.instantiate_child(context, id, params.depth(), &params.place_object)
                     {

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -73,10 +73,7 @@ impl MouseWheelDelta {
 impl PartialEq for MouseWheelDelta {
     fn eq(&self, rhs: &Self) -> bool {
         match (self, rhs) {
-            (Self::Lines(s), Self::Lines(r))
-            | (Self::Pixels(s), Self::Pixels(r))
-            | (Self::Pixels(s), Self::Lines(r))
-            | (Self::Lines(s), Self::Pixels(r))
+            (Self::Lines(s) | Self::Pixels(s), Self::Lines(r) | Self::Pixels(r))
                 if s.is_nan() && r.is_nan() =>
             {
                 true

--- a/core/src/html/style_sheet.rs
+++ b/core/src/html/style_sheet.rs
@@ -275,7 +275,7 @@ impl<'a> CssStream<'a> {
                         self.pos = value_start;
                         let possible_value = self.consume_until_any(&[NEWLINE, RETURN]);
                         match self.peek() {
-                            Some(NEWLINE) | Some(RETURN) => {
+                            Some(NEWLINE | RETURN) => {
                                 self.pos += 1;
                                 result.insert(name, possible_value);
                                 continue 'main;

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -925,11 +925,11 @@ impl<'gc> NetStream<'gc> {
         let buffer = slice.data();
 
         match (video_handle, codec, video_data.data) {
-            (maybe_video_handle, Some(codec), FlvVideoPacket::Data(mut data))
-            | (
+            (
                 maybe_video_handle,
                 Some(codec),
-                FlvVideoPacket::Vp6Data {
+                FlvVideoPacket::Data(mut data)
+                | FlvVideoPacket::Vp6Data {
                     hadjust: _,
                     vadjust: _,
                     mut data,

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -157,8 +157,10 @@ impl ActivePlayer {
                     }
                     content = PlayingContent::Bundle(content_descriptor.clone(), Box::new(bundle));
                 }
-                Err(BundleError::BundleDoesntExist)
-                | Err(BundleError::InvalidSource(BundleSourceError::UnknownSource)) => {
+                Err(
+                    BundleError::BundleDoesntExist
+                    | BundleError::InvalidSource(BundleSourceError::UnknownSource),
+                ) => {
                     // Do nothing and carry on opening it as a swf - this likely isn't a bundle at all
                 }
                 Err(e) => {

--- a/flv/src/video.rs
+++ b/flv/src/video.rs
@@ -127,7 +127,7 @@ impl<'a> VideoData<'a> {
             (FrameType::CommandFrame, _) => VideoPacket::CommandFrame(CommandFrame::try_from(
                 *data.first().ok_or(Error::ShortVideoBlock)?,
             )?),
-            (_, CodecId::On2Vp6) | (_, CodecId::On2Vp6Alpha) => VideoPacket::Vp6Data {
+            (_, CodecId::On2Vp6 | CodecId::On2Vp6Alpha) => VideoPacket::Vp6Data {
                 hadjust: data[0] & 0x0F,
                 vadjust: (data[0] & 0xF0) >> 4,
                 data: &data[1..],

--- a/render/naga-pixelbender/src/lib.rs
+++ b/render/naga-pixelbender/src/lib.rs
@@ -1570,9 +1570,9 @@ impl ShaderBuilder<'_> {
     ) -> Handle<Expression> {
         if matches!(
             reg.channels.as_slice(),
-            [PixelBenderRegChannel::M2x2]
-                | [PixelBenderRegChannel::M3x3]
-                | [PixelBenderRegChannel::M4x4]
+            [PixelBenderRegChannel::M2x2
+                | PixelBenderRegChannel::M3x3
+                | PixelBenderRegChannel::M4x4]
         ) {
             assert_eq!(
                 reg.kind,
@@ -1667,9 +1667,9 @@ impl ShaderBuilder<'_> {
     fn emit_dest_store(&mut self, expr: Handle<Expression>, dst: &PixelBenderReg) {
         if matches!(
             dst.channels.as_slice(),
-            [PixelBenderRegChannel::M2x2]
-                | [PixelBenderRegChannel::M3x3]
-                | [PixelBenderRegChannel::M4x4]
+            [PixelBenderRegChannel::M2x2
+                | PixelBenderRegChannel::M3x3
+                | PixelBenderRegChannel::M4x4]
         ) {
             // If we're writing to a 2x2 matrix, load the individual values from the matrix,
             // and construct a vec4f containing all of them (a 2x2 matrix is stored as a single vec4f)


### PR DESCRIPTION
This patch simplifies some match patterns by removing top-level duplication, the | operator can be used in subexpressions too.