### PR TITLE
chore: Bump Binaryen (wasm-opt) to version 129

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -396,7 +396,7 @@ jobs:
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
-          tag: version_126
+          tag: version_129
           name: wasm-opt
 
       - name: Install node packages

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -38,7 +38,7 @@ jobs:
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
-          tag: version_126
+          tag: version_129
           name: wasm-opt
 
       - name: Install fclones

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -74,7 +74,7 @@ jobs:
         uses: sigoden/install-binary@v1
         with:
           repo: WebAssembly/binaryen
-          tag: version_126
+          tag: version_129
           name: wasm-opt
 
       - name: Build

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -6,7 +6,7 @@ FROM node:24
 
 # Installing wasm-opt from GitHub:
 # Keep the version number in sync with the ones in the Actions workflows!
-RUN wget --progress=:giga https://github.com/WebAssembly/binaryen/releases/download/version_126/binaryen-version_126-x86_64-linux.tar.gz -O- | \
+RUN wget --progress=:giga https://github.com/WebAssembly/binaryen/releases/download/version_129/binaryen-version_129-x86_64-linux.tar.gz -O- | \
     tar xzf - --wildcards "*wasm-opt" --strip-components=2 && \
     mv wasm-opt /usr/local/bin
 


### PR DESCRIPTION
See:
 - https://github.com/WebAssembly/binaryen/blob/main/CHANGELOG.md#v127
 - https://github.com/WebAssembly/binaryen/blob/main/CHANGELOG.md#v128
 - https://github.com/WebAssembly/binaryen/blob/main/CHANGELOG.md#v129