### PR TITLE
chore: Bump wasm-bindgen to 0.2.120, ...-futures to 0.4.70, js-sys/web-sys to 0.3.97

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -388,7 +388,7 @@ jobs:
       # Be sure to update in test_web.yml, Cargo.toml, web/docker/Dockerfile,
       # and web/README.md as well.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.108
+        run: cargo install wasm-bindgen-cli --version 0.2.120
 
       # Keep the version number in sync in all workflows,
       # and in the extension builder Dockerfile!

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -30,7 +30,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.108
+        run: cargo install wasm-bindgen-cli --version 0.2.120
 
       # Keep the version number in sync in all workflows,
       # and in the extension builder Dockerfile!

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -63,7 +63,7 @@ jobs:
       # Be sure to update in release_nightly.yml, Cargo.toml, web/docker/Dockerfile,
       # and web/README.md as well.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.108
+        run: cargo install wasm-bindgen-cli --version 0.2.120
 
       # Keep the version number in sync in all workflows,
       # and in the extension builder Dockerfile!
@@ -128,7 +128,7 @@ jobs:
       # Be sure to update in release_nightly.yml, Cargo.toml, web/docker/Dockerfile,
       # and web/README.md as well.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.108
+        run: cargo install wasm-bindgen-cli --version 0.2.120
 
       # No real need to install wasm-opt here
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,10 +2788,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -6363,9 +6365,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6376,23 +6378,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6400,9 +6398,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6413,9 +6411,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -6550,9 +6548,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,8 @@ enum-map = "2.7.3"
 flate2 = "1.1.9"
 futures = "0.3.32"
 image = { version = "0.25.10", default-features = false }
-js-sys = "0.3.85"
-web-sys = "0.3.85"
+js-sys = "0.3.97"
+web-sys = "0.3.97"
 log = "0.4"
 num-derive = "0.4.2"
 num-traits = "0.2.19"
@@ -78,7 +78,7 @@ url = "2.5.8"
 quick-xml = "0.37.5"
 regress = { git = "https://github.com/ruffle-rs/regras3", rev = "6d48179d6bd448f2cc66b76352c9f048dde968d1" }
 # Make sure to match wasm-bindgen-cli version to this everywhere.
-wasm-bindgen = "=0.2.108"
+wasm-bindgen = "=0.2.120"
 walkdir = "2.5.0"
 tokio = "1.52.1"
 rfd = { version = "0.17.2", default-features = false, features = ["wayland", "xdg-portal"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -76,7 +76,7 @@ itertools = "0.14.0"
 workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies.wasm-bindgen-futures]
-version = "0.4.58"
+version = "0.4.70"
 
 [features]
 default = []

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -189,9 +189,7 @@ impl BitmapData {
             .expect("get_context method must return a value")
             .dyn_into()
             .expect("get_context method returned something other than a CanvasRenderingContext2d");
-        context
-            .put_image_data(&image_data, 0.0, 0.0)
-            .into_js_result()?;
+        context.put_image_data(&image_data, 0, 0).into_js_result()?;
         Ok(BitmapData {
             image_data,
             canvas,
@@ -207,7 +205,7 @@ impl BitmapData {
         self.canvas.set_width(bitmap.width());
         self.canvas.set_height(bitmap.height());
         self.context
-            .put_image_data(&image_data, 0.0, 0.0)
+            .put_image_data(&image_data, 0, 0)
             .into_js_result()?;
         Ok(())
     }

--- a/video/external/Cargo.toml
+++ b/video/external/Cargo.toml
@@ -35,7 +35,7 @@ workspace = true
 optional = true
 features = [
     "CodecState", "DomException", "DomRectReadOnly", "EncodedVideoChunk",
-    "EncodedVideoChunkInit", "EncodedVideoChunkType", "VideoDecoder",
+    "EncodedVideoChunkInit", "EncodedVideoChunkType", "PlaneLayout", "VideoDecoder",
     "VideoDecoderConfig", "VideoDecoderInit", "VideoFrame", "VideoPixelFormat",
 ]
 

--- a/video/external/src/decoder/webcodecs.rs
+++ b/video/external/src/decoder/webcodecs.rs
@@ -268,7 +268,7 @@ impl VideoDecoder for H264Decoder {
             trace!("frame type: {:?}", frame_type);
 
             // The timestamp doesn't matter for us.
-            let init = EncodedVideoChunkInit::new(&Uint8Array::from(nalu), 0.0, frame_type);
+            let init = EncodedVideoChunkInit::new(&Uint8Array::from(nalu), 0, frame_type);
             let chunk = EncodedVideoChunk::new(&init).unwrap();
 
             self.decoder

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -46,7 +46,7 @@ ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
 ruffle_video_external = { path = "../video/external", features = ["webcodecs"] }
 url = { workspace = true }
 wasm-bindgen = { workspace = true }
-wasm-bindgen-futures = "0.4.58"
+wasm-bindgen-futures = "0.4.70"
 serde-wasm-bindgen = "0.6.5"
 chrono = { workspace = true, features = ["wasmbind", "clock"] }
 serde = { workspace = true, features = ["derive"] }

--- a/web/README.md
+++ b/web/README.md
@@ -65,7 +65,7 @@ Note that npm 7 or newer is required. It should come bundled with Node.js 15 or 
 
 <!-- Be sure to also update the wasm-bindgen-cli version in `.github/workflows/*.yml` and `web/Cargo.toml`. -->
 
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.108`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.120`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --ta
 ENV PATH="/root/.cargo/bin:$PATH"
 # wasm-bindgen-cli version must match wasm-bindgen crate version.
 # Be sure to update in test_web.yml, release_nightly.yml, Cargo.toml, and web/README.md as well.
-RUN cargo install wasm-bindgen-cli --version 0.2.108
+RUN cargo install wasm-bindgen-cli --version 0.2.120
 
 # Building Ruffle:
 COPY . ruffle

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -605,8 +605,8 @@ impl RuffleHandle {
                 move |js_event: PointerEvent| {
                     let _ = ruffle.with_instance(move |instance| {
                         let event = PlayerEvent::MouseMove {
-                            x: f64::from(js_event.offset_x()) * instance.device_pixel_ratio,
-                            y: f64::from(js_event.offset_y()) * instance.device_pixel_ratio,
+                            x: js_event.offset_x() * instance.device_pixel_ratio,
+                            y: js_event.offset_y() * instance.device_pixel_ratio,
                         };
                         let _ = instance.with_core_mut(|core| {
                             core.handle_event(event);
@@ -669,8 +669,8 @@ impl RuffleHandle {
                             _ => MouseButton::Unknown,
                         };
                         let event = PlayerEvent::MouseDown {
-                            x: f64::from(js_event.offset_x()) * device_pixel_ratio,
-                            y: f64::from(js_event.offset_y()) * device_pixel_ratio,
+                            x: js_event.offset_x() * device_pixel_ratio,
+                            y: js_event.offset_y() * device_pixel_ratio,
                             button,
                             // TODO The index should be provided by the browser, not calculated.
                             index: None,
@@ -701,8 +701,8 @@ impl RuffleHandle {
                                 .release_pointer_capture(js_event.pointer_id());
                         }
                         let event = PlayerEvent::MouseUp {
-                            x: f64::from(js_event.offset_x()) * instance.device_pixel_ratio,
-                            y: f64::from(js_event.offset_y()) * instance.device_pixel_ratio,
+                            x: js_event.offset_x() * instance.device_pixel_ratio,
+                            y: js_event.offset_y() * instance.device_pixel_ratio,
                             button: match js_event.button() {
                                 0 => MouseButton::Left,
                                 1 => MouseButton::Middle,

--- a/web/src/ui/font_renderer.rs
+++ b/web/src/ui/font_renderer.rs
@@ -85,9 +85,7 @@ impl CanvasFontRenderer {
         Ok(self.ctx.measure_text(text)?.width())
     }
 
-    fn ensure_canvas_large_enough(&self, width: f64, height: f64) {
-        let width = width.ceil() as u32;
-        let height = height.ceil() as u32;
+    fn ensure_canvas_large_enough(&self, width: u32, height: u32) {
         if self.canvas.width() < width || self.canvas.height() < height {
             self.canvas.set_width(width);
             self.canvas.set_height(height);
@@ -105,11 +103,12 @@ impl CanvasFontRenderer {
         let height = self.ascent + self.descent;
 
         let bitmap_width = metrics.actual_bounding_box_left() + metrics.actual_bounding_box_right();
-        let bitmap_width = bitmap_width.max(1.0); // TODO Support empty bitmaps.
+        let bitmap_width = bitmap_width.max(1.0).ceil() as i32; // TODO Support empty bitmaps.
+        let bitmap_height = height.max(1.0).ceil() as i32; // TODO Support empty bitmaps.
         let advance = Twips::from_pixels(metrics.width());
         let bitmap_tx = -metrics.actual_bounding_box_left();
 
-        self.ensure_canvas_large_enough(bitmap_width, height);
+        self.ensure_canvas_large_enough(bitmap_width as u32, bitmap_height as u32);
 
         self.ctx.clear_rect(
             0.0,
@@ -119,7 +118,7 @@ impl CanvasFontRenderer {
         );
         self.ctx.fill_text(text, -bitmap_tx, self.ascent)?;
 
-        let image_data = self.ctx.get_image_data(0.0, 0.0, bitmap_width, height)?;
+        let image_data = self.ctx.get_image_data(0, 0, bitmap_width, bitmap_height)?;
         let width = image_data.width();
         let height = image_data.height();
         let pixels = image_data.data().0;


### PR DESCRIPTION
See:
 - https://github.com/wasm-bindgen/wasm-bindgen/blob/main/CHANGELOG.md#02119 and down to 0.2.108
 - https://github.com/wasm-bindgen/wasm-bindgen/pull/5131