### PR TITLE
avm2: Fix remaining collapsible_if issues and reenable lint

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -1,9 +1,5 @@
 //! ActionScript Virtual Machine 2 (AS3) support
 
-// Temporarily allow this to ease migration to Rust 2024 edition.
-// TODO: Remove this once all instances are fixed.
-#![allow(clippy::collapsible_if)]
-
 use crate::PlayerRuntime;
 use crate::avm2::bytearray::ObjectEncoding;
 use crate::avm2::class::{AllocatorFn, CustomConstructorFn};
@@ -438,12 +434,12 @@ impl<'gc> Avm2<'gc> {
                 .get(i)
                 .copied();
 
-            if let Some(object) = object.and_then(|obj| obj.upgrade(context.gc())) {
-                if object.is_of_type(on_type.inner_class_definition()) {
-                    let mut activation = Activation::from_nothing(context);
+            if let Some(object) = object.and_then(|obj| obj.upgrade(context.gc()))
+                && object.is_of_type(on_type.inner_class_definition())
+            {
+                let mut activation = Activation::from_nothing(context);
 
-                    events::broadcast_event(&mut activation, object, event);
-                }
+                events::broadcast_event(&mut activation, object, event);
             }
         }
         // Once we're done iterating, remove dead weak references from the list.

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -189,10 +189,10 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
             let mut proto = Some(global);
             while let Some(current_proto) = proto {
-                if let Some(current_proto) = current_proto.as_object() {
-                    if current_proto.base().has_own_dynamic_property(name) {
-                        return Ok(Some(global));
-                    }
+                if let Some(current_proto) = current_proto.as_object()
+                    && current_proto.base().has_own_dynamic_property(name)
+                {
+                    return Ok(Some(global));
                 }
 
                 proto = current_proto.proto(self).map(|o| o.into());
@@ -1255,14 +1255,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         if let Value::Object(object) = object_value {
             match name_value {
                 Value::Integer(_) | Value::Number(_) => {
-                    if let Some(index) = name_value.try_as_index() {
-                        if let Some(value) = object.get_index_property(index) {
-                            let _ = self.pop_stack();
-                            let _ = self.pop_stack();
-                            self.push_stack(value);
+                    if let Some(index) = name_value.try_as_index()
+                        && let Some(value) = object.get_index_property(index)
+                    {
+                        let _ = self.pop_stack();
+                        let _ = self.pop_stack();
+                        self.push_stack(value);
 
-                            return Ok(());
-                        }
+                        return Ok(());
                     }
                 }
                 Value::Object(name_object) => {
@@ -1330,14 +1330,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         if let Value::Object(object) = object_value {
             match name_value {
                 Value::Integer(_) | Value::Number(_) => {
-                    if let Some(index) = name_value.try_as_index() {
-                        if let Some(result) = object.set_index_property(self, index, value) {
-                            let _ = self.pop_stack();
-                            let _ = self.pop_stack();
-                            let _ = self.pop_stack();
+                    if let Some(index) = name_value.try_as_index()
+                        && let Some(result) = object.set_index_property(self, index, value)
+                    {
+                        let _ = self.pop_stack();
+                        let _ = self.pop_stack();
+                        let _ = self.pop_stack();
 
-                            return result;
-                        }
+                        return result;
                     }
                 }
                 Value::Object(name_object) => {
@@ -1405,16 +1405,15 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
             let name_value = self.stack.peek(0);
             let object = self.stack.peek(1);
-            if let Some(name_object) = name_value.as_object() {
-                if let Some(dictionary) = object.as_object().and_then(|o| o.as_dictionary_object())
-                {
-                    let _ = self.pop_stack();
-                    let _ = self.pop_stack();
-                    dictionary.delete_property_by_object(name_object, self.gc());
+            if let Some(name_object) = name_value.as_object()
+                && let Some(dictionary) = object.as_object().and_then(|o| o.as_dictionary_object())
+            {
+                let _ = self.pop_stack();
+                let _ = self.pop_stack();
+                dictionary.delete_property_by_object(name_object, self.gc());
 
-                    self.push_stack(true);
-                    return Ok(());
-                }
+                self.push_stack(true);
+                return Ok(());
             }
         }
 
@@ -1490,12 +1489,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let has_prop = match value {
             Value::Object(obj) => {
-                if let Some(dictionary) = obj.as_dictionary_object() {
-                    if let Some(name_object) = name_value.as_object() {
-                        self.push_stack(dictionary.has_property_by_object(name_object));
+                if let Some(dictionary) = obj.as_dictionary_object()
+                    && let Some(name_object) = name_value.as_object()
+                {
+                    self.push_stack(dictionary.has_property_by_object(name_object));
 
-                        return Ok(());
-                    }
+                    return Ok(());
                 }
 
                 let name = name_value.coerce_to_string(self)?;
@@ -2207,11 +2206,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // to help int-indexing.
         // Once we get a generic implicit double->int conversion,
         // we can reevaluate whether this path is needed.
-        if let (Value::Integer(n1), Value::Integer(n2)) = (value1, value2) {
-            if let Some(result) = n1.checked_mul(n2) {
-                self.push_stack(result);
-                return Ok(());
-            }
+        if let (Value::Integer(n1), Value::Integer(n2)) = (value1, value2)
+            && let Some(result) = n1.checked_mul(n2)
+        {
+            self.push_stack(result);
+            return Ok(());
         }
         let value2 = value2.coerce_to_number(self)?;
         let value1 = value1.coerce_to_number(self)?;

--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -223,10 +223,10 @@ pub fn recursive_serialize<'gc>(
             if let Property::Method { .. } = prop {
                 continue;
             }
-            if let Property::Virtual { get, set } = prop {
-                if !(get.is_some() && set.is_some()) {
-                    continue;
-                }
+            if let Property::Virtual { get, set } = prop
+                && !(get.is_some() && set.is_some())
+            {
+                continue;
             }
             let value = Value::from(obj).get_public_property(name, activation)?;
             let name = name.to_utf8_lossy().to_string();
@@ -408,11 +408,11 @@ pub fn deserialize_value_impl<'gc>(
                     tracing::warn!(
                         "Ignoring error deserializing AMF property for field {name:?}: {e:?}"
                     );
-                    if let Some(e) = e.as_avm_error() {
-                        if let Some(e) = e.as_object().and_then(|o| o.as_error_object()) {
-                            // Flash player *traces* the error (without a stacktrace)
-                            activation.context.avm_trace(&e.display().to_string());
-                        }
+                    if let Some(e) = e.as_avm_error()
+                        && let Some(e) = e.as_object().and_then(|o| o.as_error_object())
+                    {
+                        // Flash player *traces* the error (without a stacktrace)
+                        activation.context.avm_trace(&e.display().to_string());
                     }
                 }
             }

--- a/core/src/avm2/array.rs
+++ b/core/src/avm2/array.rs
@@ -203,12 +203,12 @@ impl<'gc> ArrayStorage<'gc> {
                 storage,
                 occupied_count,
             } => {
-                if let Some(i) = storage.get_mut(item) {
-                    if i.is_some() {
-                        *i = None;
-                        *occupied_count -= 1;
-                        self.maybe_convert_to_sparse();
-                    }
+                if let Some(i) = storage.get_mut(item)
+                    && i.is_some()
+                {
+                    *i = None;
+                    *occupied_count -= 1;
+                    self.maybe_convert_to_sparse();
                 }
             }
             ArrayStorage::Sparse { storage, .. } => {
@@ -333,22 +333,22 @@ impl<'gc> ArrayStorage<'gc> {
             storage,
             occupied_count,
         } = self
+            && Self::should_convert_to_sparse(storage.len(), *occupied_count)
         {
-            if Self::should_convert_to_sparse(storage.len(), *occupied_count) {
-                self.convert_to_sparse();
-            }
+            self.convert_to_sparse();
         }
     }
 
     /// Convert the array to a dense representation if it meets the criteria.
     fn maybe_convert_to_dense(&mut self) {
-        if let ArrayStorage::Sparse { storage, length } = self {
-            if storage.is_empty() && *length == 0 {
-                *self = ArrayStorage::Dense {
-                    storage: Vec::new(),
-                    occupied_count: 0,
-                };
-            }
+        if let ArrayStorage::Sparse { storage, length } = self
+            && storage.is_empty()
+            && *length == 0
+        {
+            *self = ArrayStorage::Dense {
+                storage: Vec::new(),
+                occupied_count: 0,
+            };
         }
     }
 

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -205,11 +205,11 @@ impl<'gc> Domain<'gc> {
         self,
         multiname: &Multiname<'gc>,
     ) -> Option<(QName<'gc>, Script<'gc>)> {
-        if let Some(name) = multiname.local_name() {
-            if let Some((ns, script)) = self.cell().defs.get_with_ns_for_multiname(multiname) {
-                let qname = QName::new(ns, name);
-                return Some((qname, *script));
-            }
+        if let Some(name) = multiname.local_name()
+            && let Some((ns, script)) = self.cell().defs.get_with_ns_for_multiname(multiname)
+        {
+            let qname = QName::new(ns, name);
+            return Some((qname, *script));
         }
 
         if let Some(parent) = self.0.parent {
@@ -238,18 +238,19 @@ impl<'gc> Domain<'gc> {
     ) -> Option<Class<'gc>> {
         let class = self.get_class_inner(multiname);
 
-        if let Some(class) = class {
-            if let Some(param) = multiname.param() {
-                if let Some(param) = param {
-                    if let Some(resolved_param) = self.get_class(context, &param) {
-                        return Some(Class::with_type_param(context, class, Some(resolved_param)));
-                    }
-                    return None;
-                } else {
-                    return Some(Class::with_type_param(context, class, None));
+        if let Some(class) = class
+            && let Some(param) = multiname.param()
+        {
+            if let Some(param) = param {
+                if let Some(resolved_param) = self.get_class(context, &param) {
+                    return Some(Class::with_type_param(context, class, Some(resolved_param)));
                 }
+                return None;
+            } else {
+                return Some(Class::with_type_param(context, class, None));
             }
         }
+
         class
     }
 

--- a/core/src/avm2/dynamic_map.rs
+++ b/core/src/avm2/dynamic_map.rs
@@ -98,13 +98,13 @@ impl<K: Eq + Hash, V> DynamicMap<K, V> {
         let num_buckets = self.table.num_buckets();
 
         for i in 0..num_buckets {
-            if let Some((_, v)) = self.table.get_bucket(i) {
-                if v.enumerable {
-                    count += 1;
+            if let Some((_, v)) = self.table.get_bucket(i)
+                && v.enumerable
+            {
+                count += 1;
 
-                    if count >= index {
-                        return Some(i);
-                    }
+                if count >= index {
+                    return Some(i);
                 }
             }
         }
@@ -187,12 +187,12 @@ impl<K: Eq + Hash, V> DynamicMap<K, V> {
 
         if !self.table.is_empty() && real < num_buckets {
             for i in real..num_buckets {
-                if let Some((_, v)) = self.table.get_bucket(i) {
-                    if v.enumerable {
-                        self.real_index.set(i);
-                        self.public_index.set(self.public_index.get() + 1);
-                        return Some(self.public_index.get());
-                    }
+                if let Some((_, v)) = self.table.get_bucket(i)
+                    && v.enumerable
+                {
+                    self.real_index.set(i);
+                    self.public_index.set(self.public_index.get() + 1);
+                    return Some(self.public_index.get());
                 }
             }
         }

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -532,10 +532,10 @@ impl<'gc> E4XNode<'gc> {
         }
 
         // 4. If Type(V) is XML and (V is x or an ancestor of x) throw an Error exception
-        if let Some(xml) = value.as_object().and_then(|x| x.as_xml_object()) {
-            if self.ancestors().any(|x| E4XNode::ptr_eq(x, xml.node())) {
-                return Err(make_error_1118(activation));
-            }
+        if let Some(xml) = value.as_object().and_then(|x| x.as_xml_object())
+            && self.ancestors().any(|x| E4XNode::ptr_eq(x, xml.node()))
+        {
+            return Err(make_error_1118(activation));
         }
 
         // 10. If Type(V) is XMLList
@@ -771,14 +771,14 @@ impl<'gc> E4XNode<'gc> {
             Value::Null | Value::Undefined => istr!(""),
             // The docs claim that only String, Number or Boolean are accepted, but that's also a lie
             val => {
-                if let Some(obj) = val.as_object() {
-                    if obj.as_xml_object().is_some() || obj.as_xml_list_object().is_some() {
-                        value = val.call_public_property(
-                            istr!("toXMLString"),
-                            FunctionArgs::empty(),
-                            activation,
-                        )?;
-                    }
+                if let Some(obj) = val.as_object()
+                    && (obj.as_xml_object().is_some() || obj.as_xml_list_object().is_some())
+                {
+                    value = val.call_public_property(
+                        istr!("toXMLString"),
+                        FunctionArgs::empty(),
+                        activation,
+                    )?;
                 }
                 value.coerce_to_string(activation)?
             }
@@ -850,14 +850,14 @@ impl<'gc> E4XNode<'gc> {
                 Err(XmlError::IllFormed(IllFormedError::MismatchedEndTag { expected, found })) => {
                     // We must accept </a/>, </a />, and </a b="c">
                     // TODO: Reject </a bc>, </a//>, <a //> etc.
-                    if let Some(rest) = found.strip_prefix(&expected) {
-                        if rest.starts_with([' ', '\t', '/']) {
-                            let node = open_tags.pop().unwrap();
-                            if open_tags.is_empty() {
-                                top_level.push(node);
-                            }
-                            continue;
+                    if let Some(rest) = found.strip_prefix(&expected)
+                        && rest.starts_with([' ', '\t', '/'])
+                    {
+                        let node = open_tags.pop().unwrap();
+                        if open_tags.is_empty() {
+                            top_level.push(node);
                         }
+                        continue;
                     }
                     return Err(make_error_1085(activation, &expected));
                 }
@@ -1261,11 +1261,11 @@ impl<'gc> E4XNode<'gc> {
             let found_index = namespaces.iter().position(|ns| Some(prefix) == ns.prefix);
 
             // 2.d. If match is not null and match.uri is not equal to N.uri
-            if let Some(found_index) = found_index {
-                if namespaces[found_index].uri != namespace.uri {
-                    // 2.d.i. Remove match from x.[[InScopeNamespaces]]
-                    namespaces.remove(found_index);
-                }
+            if let Some(found_index) = found_index
+                && namespaces[found_index].uri != namespace.uri
+            {
+                // 2.d.i. Remove match from x.[[InScopeNamespaces]]
+                namespaces.remove(found_index);
             }
 
             // 2.e. Let x.[[InScopeNamespaces]] = x.[[InScopeNamespaces]] ∪ { N }
@@ -1559,16 +1559,17 @@ fn to_xml_string_inner<'gc>(
             .copied()
     };
 
-    if let Some(ns) = node.namespace() {
-        if get_namespace(&namespace_declarations, &ns).is_none() {
-            namespace_declarations.push(ns);
-        }
+    if let Some(ns) = node.namespace()
+        && get_namespace(&namespace_declarations, &ns).is_none()
+    {
+        namespace_declarations.push(ns);
     }
+
     for attribute in attributes {
-        if let Some(ns) = attribute.namespace() {
-            if get_namespace(&namespace_declarations, &ns).is_none() {
-                namespace_declarations.push(ns);
-            }
+        if let Some(ns) = attribute.namespace()
+            && get_namespace(&namespace_declarations, &ns).is_none()
+        {
+            namespace_declarations.push(ns);
         }
     }
 
@@ -1642,12 +1643,12 @@ fn to_xml_string_inner<'gc>(
         to_xml_string_inner(E4XOrXml::E4X(*child), buf, &all_namespaces, child_pretty);
     }
 
-    if let Some((indent_level, _)) = pretty {
-        if indent_children {
-            buf.push_char('\n');
-            for _ in 0..indent_level {
-                buf.push_char(' ');
-            }
+    if let Some((indent_level, _)) = pretty
+        && indent_children
+    {
+        buf.push_char('\n');
+        for _ in 0..indent_level {
+            buf.push_char(' ');
         }
     }
 
@@ -1721,14 +1722,14 @@ pub fn name_to_multiname<'gc>(
         return Err(make_error_1010(activation, None));
     }
 
-    if let Value::Object(o) = name {
-        if let Some(qname) = o.as_qname_object() {
-            let mut name = qname.name().clone();
-            if force_attribute {
-                name.set_is_attribute(true);
-            }
-            return Ok(name);
+    if let Value::Object(o) = name
+        && let Some(qname) = o.as_qname_object()
+    {
+        let mut name = qname.name().clone();
+        if force_attribute {
+            name.set_is_attribute(true);
         }
+        return Ok(name);
     }
 
     let name = name.coerce_to_string(activation)?;
@@ -1763,18 +1764,18 @@ pub fn maybe_escape_child<'gc>(
         }
     }
 
-    if activation.caller_movie_or_root().version() >= 21 {
-        if let Some(xml) = child.as_object().and_then(|x| x.as_xml_object()) {
-            let node = xml.node();
-            let parent = node.parent();
+    if activation.caller_movie_or_root().version() >= 21
+        && let Some(xml) = child.as_object().and_then(|x| x.as_xml_object())
+    {
+        let node = xml.node();
+        let parent = node.parent();
 
-            let index = node.child_index();
+        let index = node.child_index();
 
-            if let Some(parent) = parent {
-                if let Some(index) = index {
-                    parent.delete_by_index(index, activation);
-                }
-            }
+        if let Some(parent) = parent
+            && let Some(index) = index
+        {
+            parent.delete_by_index(index, activation);
         }
     }
 

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -340,12 +340,11 @@ impl Hash for EventHandler<'_> {
 /// to traverse. If no hierarchy is available, this returns `None`, as if the
 /// target had no parent.
 pub fn parent_of(target: Object<'_>) -> Option<Object<'_>> {
-    if let Some(dobj) = target.as_display_object() {
-        if let Some(dparent) = dobj.parent() {
-            if let Some(parent) = dparent.object2() {
-                return Some(parent.into());
-            }
-        }
+    if let Some(dobj) = target.as_display_object()
+        && let Some(dparent) = dobj.parent()
+        && let Some(parent) = dparent.object2()
+    {
+        return Some(parent.into());
     }
 
     None

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -330,15 +330,14 @@ fn avm2_to_color_matrix_filter<'gc>(
     if let Some(matrix_object) = object
         .get_slot(color_matrix_filter_slots::_MATRIX)
         .as_object()
+        && let Some(array) = matrix_object.as_array_storage()
     {
-        if let Some(array) = matrix_object.as_array_storage() {
-            for i in 0..matrix.len().min(array.length()) {
-                matrix[i] = array
-                    .get(i)
-                    .map(|v| v.coerce_to_number(activation))
-                    .transpose()?
-                    .unwrap_or_default() as f32;
-            }
+        for i in 0..matrix.len().min(array.length()) {
+            matrix[i] = array
+                .get(i)
+                .map(|v| v.coerce_to_number(activation))
+                .transpose()?
+                .unwrap_or_default() as f32;
         }
     }
     Ok(Filter::ColorMatrixFilter(ColorMatrixFilter { matrix }))
@@ -367,15 +366,14 @@ fn avm2_to_convolution_filter<'gc>(
     if let Some(matrix_object) = object
         .get_slot(convolution_filter_slots::MATRIX)
         .as_object()
+        && let Some(array) = matrix_object.as_array_storage()
     {
-        if let Some(array) = matrix_object.as_array_storage() {
-            for value in array.iter() {
-                matrix.push(
-                    value
-                        .unwrap_or(Value::Undefined)
-                        .coerce_to_number(activation)? as f32,
-                );
-            }
+        for value in array.iter() {
+            matrix.push(
+                value
+                    .unwrap_or(Value::Undefined)
+                    .coerce_to_number(activation)? as f32,
+            );
         }
     }
     let alpha = object

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -184,15 +184,15 @@ impl<'gc> Method<'gc> {
         }
 
         let mut native_info = None;
-        if txunit.domain().is_playerglobals_domain(activation.avm2()) {
-            if let Some(native_method) = activation.avm2().native_method_table[method_index] {
-                let fast_call = activation
-                    .avm2()
-                    .native_fast_call_list
-                    .contains(&method_index);
+        if txunit.domain().is_playerglobals_domain(activation.avm2())
+            && let Some(native_method) = activation.avm2().native_method_table[method_index]
+        {
+            let fast_call = activation
+                .avm2()
+                .native_fast_call_list
+                .contains(&method_index);
 
-                native_info = Some((native_method, fast_call));
-            }
+            native_info = Some((native_method, fast_call));
         };
 
         let method_kind = if let Some((native_method, fast_call)) = native_info {

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -97,10 +97,10 @@ impl<'gc> SoundChannelObject<'gc> {
         // The position is cached on read. This means that if the position isn't read until after
         // the sound has played, the position will be 0 (#9952).
         let sound_channel_data = self.0.sound_channel_data.borrow();
-        if let SoundChannelData::Loaded { sound_instance } = &*sound_channel_data {
-            if let Some(pos) = context.audio.get_sound_position(*sound_instance) {
-                self.0.position.set(pos);
-            }
+        if let SoundChannelData::Loaded { sound_instance } = &*sound_channel_data
+            && let Some(pos) = context.audio.get_sound_position(*sound_instance)
+        {
+            self.0.position.set(pos);
         }
 
         self.0.position.get()

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -588,14 +588,15 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
         // To be safe, we'll just perform exactly the same check that avmplus does.
         if matches!(method, Value::Undefined) {
             let prop = self.get_property_local(multiname, activation)?;
-            if let Some(list) = prop.as_object().and_then(|obj| obj.as_xml_list_object()) {
-                if list.length() == 0 && self.length() == 1 {
-                    let mut children = self.children_mut(activation.gc());
+            if let Some(list) = prop.as_object().and_then(|obj| obj.as_xml_list_object())
+                && list.length() == 0
+                && self.length() == 1
+            {
+                let mut children = self.children_mut(activation.gc());
 
-                    let child = children.first_mut().unwrap().get_or_create_xml(activation);
+                let child = children.first_mut().unwrap().get_or_create_xml(activation);
 
-                    return Value::from(child).call_property(multiname, arguments, activation);
-                }
+                return Value::from(child).call_property(multiname, arguments, activation);
             }
         }
 

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -353,16 +353,15 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
     ) -> Result<Value<'gc>, Error<'gc>> {
         // FIXME - implement everything from E4X spec (XMLObject::getMultinameProperty in avmplus)
 
-        if !name.has_explicit_namespace() {
-            if let Some(local_name) = name.local_name() {
-                // The only supported numerical index is 0
-                if let Ok(index) = local_name.parse::<usize>() {
-                    if index == 0 {
-                        return Ok(self.into());
-                    } else {
-                        return Ok(Value::Undefined);
-                    }
-                }
+        if !name.has_explicit_namespace()
+            && let Some(local_name) = name.local_name()
+            && let Ok(index) = local_name.parse::<usize>()
+        {
+            // The only supported numerical index is 0
+            if index == 0 {
+                return Ok(self.into());
+            } else {
+                return Ok(Value::Undefined);
             }
         }
 
@@ -390,12 +389,13 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
             // avmplus has this check, so we do it out of an abundance of caution.
             // Compare to the very similar case in XMLListObject::call_property_local
             let prop = self.get_property_local(multiname, activation)?;
-            if let Some(list) = prop.as_object().and_then(|obj| obj.as_xml_list_object()) {
-                if list.length() == 0 && self.node().has_simple_content() {
-                    let receiver = Value::String(self.node().xml_to_string(activation));
+            if let Some(list) = prop.as_object().and_then(|obj| obj.as_xml_list_object())
+                && list.length() == 0
+                && self.node().has_simple_content()
+            {
+                let receiver = Value::String(self.node().xml_to_string(activation));
 
-                    return receiver.call_property(multiname, arguments, activation);
-                }
+                return receiver.call_property(multiname, arguments, activation);
             }
         }
 

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -1294,38 +1294,36 @@ fn abstract_interpret_ops<'gc>(
                     }
 
                     // Then the outer scope stack
-                    if !stack_push_done {
-                        if let Some(info) =
+                    if !stack_push_done
+                        && let Some(info) =
                             outer_scope.get_entry_for_multiname(activation, &multiname)
-                        {
-                            if let Some((class, index)) = info {
-                                optimize_op_to!(Op::GetOuterScope { index });
+                    {
+                        if let Some((class, index)) = info {
+                            optimize_op_to!(Op::GetOuterScope { index });
 
-                                stack_push_done = true;
-                                stack.push_class_not_null(activation, class)?;
-                            } else {
-                                // If `get_entry_for_multiname` returned `Some(None)`, there was
-                                // a `with` scope in the outer ScopeChain- abort optimization.
-                                stack_push_done = true;
-                                stack.push_any(activation)?;
-                            }
+                            stack_push_done = true;
+                            stack.push_class_not_null(activation, class)?;
+                        } else {
+                            // If `get_entry_for_multiname` returned `Some(None)`, there was
+                            // a `with` scope in the outer ScopeChain- abort optimization.
+                            stack_push_done = true;
+                            stack.push_any(activation)?;
                         }
                     }
 
                     // Then check the domain
-                    if !stack_push_done {
-                        if let Some((_, script)) =
+                    if !stack_push_done
+                        && let Some((_, script)) =
                             outer_scope.domain().get_defining_script(&multiname)
-                        {
-                            // NOTE: avmplus rewrites this into a FindDef, and it caches
-                            // the results of that FindDef at runtime, rather than caching
-                            // the lookup here, in the verifier. However, this discrepancy
-                            // is unlikely to cause any real problems with SWFs.
-                            optimize_op_to!(Op::GetScriptGlobals { script });
+                    {
+                        // NOTE: avmplus rewrites this into a FindDef, and it caches
+                        // the results of that FindDef at runtime, rather than caching
+                        // the lookup here, in the verifier. However, this discrepancy
+                        // is unlikely to cause any real problems with SWFs.
+                        optimize_op_to!(Op::GetScriptGlobals { script });
 
-                            stack_push_done = true;
-                            stack.push_class_not_null(activation, script.global_class())?;
-                        }
+                        stack_push_done = true;
+                        stack.push_class_not_null(activation, script.global_class())?;
                     }
 
                     // Ignore global scope for now
@@ -1484,25 +1482,26 @@ fn abstract_interpret_ops<'gc>(
                     // `verify::translate_op`), so we need to check here again
                     let multiname_valid = multiname.valid_dynamic_name();
 
-                    if index_numeric && multiname_valid {
-                        if let Some(param) = param {
-                            // NOTE this is a bug in FP, in SWFv10 indexing
-                            // vectors with a numeric index is not actually
-                            // guaranteed to produce a result of the correct
-                            // type. For some reason, this special-case of
-                            // int/uint/number isn't version-gated.
-                            if param.is_builtin_int()
-                                || param.is_builtin_uint()
-                                || param.is_builtin_number()
-                            {
-                                stack_push_done = true;
-                                stack.push_class(activation, param)?;
-                            } else if activation.caller_movie_or_root().version() >= 14 {
-                                // The general case, meanwhile, *is* correctly
-                                // version-gated.
-                                stack_push_done = true;
-                                stack.push_class(activation, param)?;
-                            }
+                    if index_numeric
+                        && multiname_valid
+                        && let Some(param) = param
+                    {
+                        // NOTE this is a bug in FP, in SWFv10 indexing
+                        // vectors with a numeric index is not actually
+                        // guaranteed to produce a result of the correct
+                        // type. For some reason, this special-case of
+                        // int/uint/number isn't version-gated.
+                        if param.is_builtin_int()
+                            || param.is_builtin_uint()
+                            || param.is_builtin_number()
+                        {
+                            stack_push_done = true;
+                            stack.push_class(activation, param)?;
+                        } else if activation.caller_movie_or_root().version() >= 14 {
+                            // The general case, meanwhile, *is* correctly
+                            // version-gated.
+                            stack_push_done = true;
+                            stack.push_class(activation, param)?;
                         }
                     }
                 }
@@ -1528,54 +1527,53 @@ fn abstract_interpret_ops<'gc>(
 
                 stack.pop_for_multiname(activation, multiname)?;
                 let stack_value = stack.pop(activation)?;
-                if !multiname.has_lazy_component() {
-                    if let Some(vtable) = stack_value.vtable() {
-                        match vtable.get_trait(&multiname) {
-                            Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
-                                // If the set value's type is the same as the type of the slot,
-                                // a SetSlotNoCoerce can be emitted. Otherwise, emit a SetSlot.
-                                let mut value_class =
-                                    vtable.slot_class(slot_id).expect("Slot should exist");
-                                let resolved_value_class = value_class.get_class(activation)?;
+                if !multiname.has_lazy_component()
+                    && let Some(vtable) = stack_value.vtable()
+                {
+                    match vtable.get_trait(&multiname) {
+                        Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
+                            // If the set value's type is the same as the type of the slot,
+                            // a SetSlotNoCoerce can be emitted. Otherwise, emit a SetSlot.
+                            let mut value_class =
+                                vtable.slot_class(slot_id).expect("Slot should exist");
+                            let resolved_value_class = value_class.get_class(activation)?;
 
-                                vtable.set_slot_class(activation.gc(), slot_id, value_class);
+                            vtable.set_slot_class(activation.gc(), slot_id, value_class);
 
-                                if set_value.matches_type(resolved_value_class) {
-                                    optimize_op_to!(Op::SetSlotNoCoerce { index: slot_id });
-                                } else if resolved_value_class.is_some_and(|c| c.is_builtin_int()) {
-                                    // Special case for integer coercion, for performance
-                                    optimize_op_to!(Op::SetSlotCoerceI { index: slot_id });
-                                } else {
-                                    optimize_op_to!(Op::SetSlot { index: slot_id });
-                                }
+                            if set_value.matches_type(resolved_value_class) {
+                                optimize_op_to!(Op::SetSlotNoCoerce { index: slot_id });
+                            } else if resolved_value_class.is_some_and(|c| c.is_builtin_int()) {
+                                // Special case for integer coercion, for performance
+                                optimize_op_to!(Op::SetSlotCoerceI { index: slot_id });
+                            } else {
+                                optimize_op_to!(Op::SetSlot { index: slot_id });
                             }
-                            Some(Property::Virtual {
-                                set: Some(disp_id), ..
-                            }) => {
-                                let method =
-                                    vtable.get_method(disp_id).expect("Method should exist");
-
-                                let mut result_op = Op::CallMethod {
-                                    num_args: 1,
-                                    index: disp_id,
-                                    push_return_value: false,
-                                };
-
-                                // We can further optimize calling FastCall setters into a
-                                // static native method call
-                                maybe_optimize_static_call(
-                                    activation,
-                                    &mut result_op,
-                                    method,
-                                    stack_value,
-                                    &[set_value], // passed args
-                                    false,        // push_return_value
-                                )?;
-
-                                optimize_op_to!(result_op);
-                            }
-                            _ => {}
                         }
+                        Some(Property::Virtual {
+                            set: Some(disp_id), ..
+                        }) => {
+                            let method = vtable.get_method(disp_id).expect("Method should exist");
+
+                            let mut result_op = Op::CallMethod {
+                                num_args: 1,
+                                index: disp_id,
+                                push_return_value: false,
+                            };
+
+                            // We can further optimize calling FastCall setters into a
+                            // static native method call
+                            maybe_optimize_static_call(
+                                activation,
+                                &mut result_op,
+                                method,
+                                stack_value,
+                                &[set_value], // passed args
+                                false,        // push_return_value
+                            )?;
+
+                            optimize_op_to!(result_op);
+                        }
+                        _ => {}
                     }
                 }
                 // `stack_pop_multiname` handled lazy
@@ -1705,27 +1703,25 @@ fn abstract_interpret_ops<'gc>(
                 // Then receiver.
                 let stack_value = stack.pop(activation)?;
 
-                if !multiname.has_lazy_component() {
-                    if let Some(vtable) = stack_value.vtable()
-                        && let Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) =
-                            vtable.get_trait(&multiname)
+                if !multiname.has_lazy_component()
+                    && let Some(vtable) = stack_value.vtable()
+                    && let Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) =
+                        vtable.get_trait(&multiname)
+                {
+                    let mut value_class = vtable.slot_class(slot_id).expect("Slot should exist");
+                    let resolved_value_class = value_class.get_class(activation)?;
+
+                    if let Some(slot_class) = resolved_value_class
+                        && let Some(instance_class) = slot_class.i_class()
                     {
-                        let mut value_class =
-                            vtable.slot_class(slot_id).expect("Slot should exist");
-                        let resolved_value_class = value_class.get_class(activation)?;
+                        optimize_op_to!(Op::ConstructSlot {
+                            index: slot_id,
+                            num_args
+                        });
 
-                        if let Some(slot_class) = resolved_value_class
-                            && let Some(instance_class) = slot_class.i_class()
-                        {
-                            optimize_op_to!(Op::ConstructSlot {
-                                index: slot_id,
-                                num_args
-                            });
-
-                            // ConstructProp on a c_class will construct its i_class
-                            stack_push_done = true;
-                            stack.push_class_not_null(activation, instance_class)?;
-                        }
+                        // ConstructProp on a c_class will construct its i_class
+                        stack_push_done = true;
+                        stack.push_class_not_null(activation, instance_class)?;
                     }
                 }
 
@@ -2151,29 +2147,27 @@ fn maybe_optimize_static_call<'gc>(
 
     let declared_params = speculated_method.resolved_param_config();
 
-    if receiver.class.is_some_and(|c| c.is_final()) {
-        if let MethodKind::Native {
+    if receiver.class.is_some_and(|c| c.is_final())
+        && let MethodKind::Native {
             native_method,
             fast_call: true,
         } = speculated_method.method_kind()
-        {
-            if declared_params.len() == passed_args.len() {
-                let mut all_matches = true;
-                for (i, passed_arg) in passed_args.iter().enumerate() {
-                    let declared_param = &declared_params[i];
-                    if !passed_arg.matches_type(declared_param.param_type) {
-                        all_matches = false;
-                    }
-                }
-
-                if all_matches {
-                    *result_op = Op::CallNative {
-                        method: *native_method,
-                        num_args: passed_args.len() as u32,
-                        push_return_value,
-                    };
-                }
+        && declared_params.len() == passed_args.len()
+    {
+        let mut all_matches = true;
+        for (i, passed_arg) in passed_args.iter().enumerate() {
+            let declared_param = &declared_params[i];
+            if !passed_arg.matches_type(declared_param.param_type) {
+                all_matches = false;
             }
+        }
+
+        if all_matches {
+            *result_op = Op::CallNative {
+                method: *native_method,
+                num_args: passed_args.len() as u32,
+                push_return_value,
+            };
         }
     }
 

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -83,13 +83,12 @@ impl<'gc, V> PropertyMap<'gc, V> {
     }
 
     pub fn get_mut(&mut self, name: QName<'gc>) -> Option<&mut V> {
-        if let Some(bucket) = self.0.get_mut(&name.local_name()) {
-            if let Some((_, old_value)) = bucket
+        if let Some(bucket) = self.0.get_mut(&name.local_name())
+            && let Some((_, old_value)) = bucket
                 .iter_mut()
                 .find(|(n, _)| n.matches_ns(name.namespace()))
-            {
-                return Some(old_value);
-            }
+        {
+            return Some(old_value);
         }
 
         None

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -187,15 +187,15 @@ impl<'gc> RegExp<'gc> {
                         }
                         let mut grp_index = d_u;
                         let mut second_char = None;
-                        if let Some(&Ok(next_char)) = chars.peek() {
-                            if let Some(d1) = next_char.to_digit(10) {
-                                let d1_u = usize::try_from(d1).unwrap_or(0);
-                                let two_digit_index = d_u * 10 + d1_u;
-                                if two_digit_index <= m.captures.len() && two_digit_index != 0 {
-                                    chars.next();
-                                    grp_index = two_digit_index;
-                                    second_char = Some(next_char);
-                                }
+                        if let Some(&Ok(next_char)) = chars.peek()
+                            && let Some(d1) = next_char.to_digit(10)
+                        {
+                            let d1_u = usize::try_from(d1).unwrap_or(0);
+                            let two_digit_index = d_u * 10 + d1_u;
+                            if two_digit_index <= m.captures.len() && two_digit_index != 0 {
+                                chars.next();
+                                grp_index = two_digit_index;
+                                second_char = Some(next_char);
                             }
                         }
                         if grp_index == 0 {


### PR DESCRIPTION
Those are all mechanical changes. The temporary disabled lint is reenabled for AVM2.

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
