### PR TITLE
avm1: Simplify nested ifs in xml_node

### DIFF
--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -67,15 +67,13 @@ fn append_child<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let (Some(xmlnode), Some(child_xmlnode)) = (
-        this.as_xml_node(),
-        args.get(0).and_then(|n| n.as_xml_node()),
-    ) {
-        if !xmlnode.has_child(child_xmlnode) {
-            let position = xmlnode.children_len();
-            xmlnode.insert_child(activation.gc(), position, child_xmlnode);
-            xmlnode.refresh_cached_child_nodes(activation)?;
-        }
+    if let Some(xmlnode) = this.as_xml_node()
+        && let Some(child_xmlnode) = args.get(0).and_then(|n| n.as_xml_node())
+        && !xmlnode.has_child(child_xmlnode)
+    {
+        let position = xmlnode.children_len();
+        xmlnode.insert_child(activation.gc(), position, child_xmlnode);
+        xmlnode.refresh_cached_child_nodes(activation)?;
     }
 
     Ok(Value::Undefined)
@@ -86,17 +84,14 @@ fn insert_before<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let (Some(xmlnode), Some(child_xmlnode), Some(insertpoint_xmlnode)) = (
-        this.as_xml_node(),
-        args.get(0).and_then(|n| n.as_xml_node()),
-        args.get(1).and_then(|n| n.as_xml_node()),
-    ) {
-        if !xmlnode.has_child(child_xmlnode) {
-            if let Some(position) = xmlnode.child_position(insertpoint_xmlnode) {
-                xmlnode.insert_child(activation.gc(), position, child_xmlnode);
-                xmlnode.refresh_cached_child_nodes(activation)?;
-            }
-        }
+    if let Some(xmlnode) = this.as_xml_node()
+        && let Some(child_xmlnode) = args.get(0).and_then(|n| n.as_xml_node())
+        && let Some(insertpoint_xmlnode) = args.get(1).and_then(|n| n.as_xml_node())
+        && !xmlnode.has_child(child_xmlnode)
+        && let Some(position) = xmlnode.child_position(insertpoint_xmlnode)
+    {
+        xmlnode.insert_child(activation.gc(), position, child_xmlnode);
+        xmlnode.refresh_cached_child_nodes(activation)?;
     }
 
     Ok(Value::Undefined)


### PR DESCRIPTION
This fixes clippy::collapsible_if, but is not a mechanical change.

It changes tuple matchers to let chains, but should be equivalent as tuples did not have side effects.

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
