### PR TITLE
avm1: Fix remaining clippy::collapsible_if and reenable lint

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1,6 +1,4 @@
-// Temporarily allow this to ease migration to Rust 2024 edition.
-// TODO: Remove this once all instances are fixed.
-#![allow(clippy::collapsible_if)]
+//! ActionScript Virtual Machine 1 (AS1 & AS2) support.
 
 #[cfg(test)]
 #[macro_use]

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -730,15 +730,15 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         } else {
             // An optional path to a MovieClip and a frame #/label, such as "/clip:framelabel".
             let frame_path = arg.coerce_to_string(self)?;
-            if let Some((clip, frame)) = self.resolve_variable_path(target, &frame_path)? {
-                if let Some(clip) = clip.as_display_object().and_then(|o| o.as_movie_clip()) {
-                    if let Ok(frame) = frame.parse().map(f64_to_wrapping_u32) {
-                        // First try to parse as a frame number.
-                        call_frame = Some((clip, frame));
-                    } else if let Some(frame) = clip.frame_label_to_number(frame, self.context) {
-                        // Otherwise, it's a frame label.
-                        call_frame = Some((clip, frame.into()));
-                    }
+            if let Some((clip, frame)) = self.resolve_variable_path(target, &frame_path)?
+                && let Some(clip) = clip.as_display_object().and_then(|o| o.as_movie_clip())
+            {
+                if let Ok(frame) = frame.parse().map(f64_to_wrapping_u32) {
+                    // First try to parse as a frame number.
+                    call_frame = Some((clip, frame));
+                } else if let Some(frame) = clip.frame_label_to_number(frame, self.context) {
+                    // Otherwise, it's a frame label.
+                    call_frame = Some((clip, frame.into()));
                 }
             }
         };
@@ -2174,43 +2174,39 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         let mut result = self.run_actions(parent_data.to_unbounded_subslice(action.try_body));
 
-        if let Some((catch_vars, actions)) = &action.catch_body {
-            if let Err(Error::ThrownValue(value)) = &result {
-                let mut activation = Activation::from_action(
-                    self.context,
-                    self.id.child("[Catch]"),
-                    self.swf_version(),
-                    self.scope,
-                    self.constant_pool,
-                    self.base_clip,
-                    self.this,
-                    self.callee,
-                    &[],
-                );
+        if let Some((catch_vars, actions)) = &action.catch_body
+            && let Err(Error::ThrownValue(value)) = &result
+        {
+            let mut activation = Activation::from_action(
+                self.context,
+                self.id.child("[Catch]"),
+                self.swf_version(),
+                self.scope,
+                self.constant_pool,
+                self.base_clip,
+                self.this,
+                self.callee,
+                &[],
+            );
 
-                activation.local_registers = self.local_registers;
+            activation.local_registers = self.local_registers;
 
-                match catch_vars {
-                    CatchVar::Var(name) => {
-                        let name =
-                            AvmString::new(activation.gc(), name.decode(activation.encoding()));
-                        activation.set_variable(name, value.to_owned())?
-                    }
-                    CatchVar::Register(id) => {
-                        activation.set_current_register(*id, value.to_owned())
-                    }
+            match catch_vars {
+                CatchVar::Var(name) => {
+                    let name = AvmString::new(activation.gc(), name.decode(activation.encoding()));
+                    activation.set_variable(name, value.to_owned())?
                 }
-
-                result = activation.run_actions(parent_data.to_unbounded_subslice(actions));
+                CatchVar::Register(id) => activation.set_current_register(*id, value.to_owned()),
             }
+
+            result = activation.run_actions(parent_data.to_unbounded_subslice(actions));
         }
 
-        if let Some(actions) = action.finally_body {
-            if let ReturnType::Explicit(value) =
+        if let Some(actions) = action.finally_body
+            && let ReturnType::Explicit(value) =
                 self.run_actions(parent_data.to_unbounded_subslice(actions))?
-            {
-                return Ok(FrameControl::Return(ReturnType::Explicit(value)));
-            }
+        {
+            return Ok(FrameControl::Return(ReturnType::Explicit(value)));
         }
 
         match result? {
@@ -2358,10 +2354,10 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     ///
     /// If a given register does not exist, this function does nothing.
     pub fn set_current_register(&mut self, id: u8, value: Value<'gc>) {
-        if !self.set_local_register(id, value) {
-            if let Some(reg) = self.context.avm1.get_register_mut(id as usize) {
-                *reg = value;
-            }
+        if !self.set_local_register(id, value)
+            && let Some(reg) = self.context.avm1.get_register_mut(id as usize)
+        {
+            *reg = value;
         }
     }
 

--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -32,22 +32,22 @@ impl<'gc> FileReferenceObject<'gc> {
         self.0.is_initialised.set(true);
 
         let date_proto = activation.prototypes().date_constructor;
-        if let Some(creation_time) = result.creation_time() {
-            if let Ok(Value::Object(obj)) = date_proto.construct(
+        if let Some(creation_time) = result.creation_time()
+            && let Ok(Value::Object(obj)) = date_proto.construct(
                 activation,
                 &[(creation_time.timestamp_millis() as f64).into()],
-            ) {
-                unlock!(write, FileReferenceData, creation_date).set(Some(obj));
-            }
+            )
+        {
+            unlock!(write, FileReferenceData, creation_date).set(Some(obj));
         }
 
-        if let Some(modification_time) = result.modification_time() {
-            if let Ok(Value::Object(obj)) = date_proto.construct(
+        if let Some(modification_time) = result.modification_time()
+            && let Ok(Value::Object(obj)) = date_proto.construct(
                 activation,
                 &[(modification_time.timestamp_millis() as f64).into()],
-            ) {
-                unlock!(write, FileReferenceData, modification_date).set(Some(obj));
-            }
+            )
+        {
+            unlock!(write, FileReferenceData, modification_date).set(Some(obj));
         }
 
         let file_type = result.file_type().map(|s| AvmString::new_utf8(mc, s));

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1129,17 +1129,14 @@ pub fn goto_frame<'gc>(
             let frame_path = val.coerce_to_string(activation)?;
             if let Some((clip, frame)) =
                 activation.resolve_variable_path(movie_clip.into(), &frame_path)?
+                && let Some(clip) = clip.as_display_object().and_then(|o| o.as_movie_clip())
             {
-                if let Some(clip) = clip.as_display_object().and_then(|o| o.as_movie_clip()) {
-                    if let Ok(frame) = frame.parse().map(f64_to_wrapping_i32) {
-                        // First try to parse as a frame number.
-                        call_frame = Some((clip, frame));
-                    } else if let Some(frame) =
-                        clip.frame_label_to_number(frame, activation.context)
-                    {
-                        // Otherwise, it's a frame label.
-                        call_frame = Some((clip, frame as i32));
-                    }
+                if let Ok(frame) = frame.parse().map(f64_to_wrapping_i32) {
+                    // First try to parse as a frame number.
+                    call_frame = Some((clip, frame));
+                } else if let Some(frame) = clip.frame_label_to_number(frame, activation.context) {
+                    // Otherwise, it's a frame label.
+                    call_frame = Some((clip, frame as i32));
                 }
             }
         }

--- a/core/src/avm1/globals/netconnection.rs
+++ b/core/src/avm1/globals/netconnection.rs
@@ -306,10 +306,10 @@ fn close<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(net_connection) = NetConnection::cast(this.into()) {
-        if let Some(previous_handle) = net_connection.set_handle(None) {
-            NetConnections::close(activation.context, previous_handle, true);
-        }
+    if let Some(net_connection) = NetConnection::cast(this.into())
+        && let Some(previous_handle) = net_connection.set_handle(None)
+    {
+        NetConnections::close(activation.context, previous_handle, true);
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/style_sheet.rs
+++ b/core/src/avm1/globals/style_sheet.rs
@@ -271,13 +271,13 @@ fn transform<'gc>(
             }
         }
 
-        if let Some(family) = get_style(style_object, "fontFamily", activation) {
-            if family.as_bool(activation.swf_version()) {
-                let font_list =
-                    crate::html::parse_font_list(family.coerce_to_string(activation)?.as_wstr());
-                let font_list = AvmString::new(activation.gc(), font_list);
-                text_format.font = Some(font_list.as_wstr().to_owned());
-            }
+        if let Some(family) = get_style(style_object, "fontFamily", activation)
+            && family.as_bool(activation.swf_version())
+        {
+            let font_list =
+                crate::html::parse_font_list(family.coerce_to_string(activation)?.as_wstr());
+            let font_list = AvmString::new(activation.gc(), font_list);
+            text_format.font = Some(font_list.as_wstr().to_owned());
         }
 
         if let Some(size) = get_style(style_object, "fontSize", activation) {
@@ -313,32 +313,32 @@ fn transform<'gc>(
             text_format.kerning = Some(kerning);
         }
 
-        if let Some(leading) = get_style(style_object, "leading", activation) {
-            if leading.as_bool(activation.swf_version()) {
-                let leading = parse_suffixed_number_i32(activation, &leading)?;
-                text_format.leading = Some(leading as f64);
-            }
+        if let Some(leading) = get_style(style_object, "leading", activation)
+            && leading.as_bool(activation.swf_version())
+        {
+            let leading = parse_suffixed_number_i32(activation, &leading)?;
+            text_format.leading = Some(leading as f64);
         }
 
-        if let Some(letter_spacing) = get_style(style_object, "letterSpacing", activation) {
-            if letter_spacing.as_bool(activation.swf_version()) {
-                let letter_spacing = parse_suffixed_number_f64(activation, &letter_spacing)?;
-                text_format.letter_spacing = Some(letter_spacing);
-            }
+        if let Some(letter_spacing) = get_style(style_object, "letterSpacing", activation)
+            && letter_spacing.as_bool(activation.swf_version())
+        {
+            let letter_spacing = parse_suffixed_number_f64(activation, &letter_spacing)?;
+            text_format.letter_spacing = Some(letter_spacing);
         }
 
-        if let Some(left_margin) = get_style(style_object, "marginLeft", activation) {
-            if left_margin.as_bool(activation.swf_version()) {
-                let left_margin = parse_suffixed_number_i32(activation, &left_margin)?;
-                text_format.left_margin = Some(left_margin.max(0) as f64);
-            }
+        if let Some(left_margin) = get_style(style_object, "marginLeft", activation)
+            && left_margin.as_bool(activation.swf_version())
+        {
+            let left_margin = parse_suffixed_number_i32(activation, &left_margin)?;
+            text_format.left_margin = Some(left_margin.max(0) as f64);
         }
 
-        if let Some(right_margin) = get_style(style_object, "marginRight", activation) {
-            if right_margin.as_bool(activation.swf_version()) {
-                let right_margin = parse_suffixed_number_i32(activation, &right_margin)?;
-                text_format.right_margin = Some(right_margin.max(0) as f64);
-            }
+        if let Some(right_margin) = get_style(style_object, "marginRight", activation)
+            && right_margin.as_bool(activation.swf_version())
+        {
+            let right_margin = parse_suffixed_number_i32(activation, &right_margin)?;
+            text_format.right_margin = Some(right_margin.max(0) as f64);
         }
 
         if let Some(align) = get_style(style_object, "textAlign", activation) {
@@ -363,11 +363,11 @@ fn transform<'gc>(
             }
         }
 
-        if let Some(indent) = get_style(style_object, "textIndent", activation) {
-            if indent.as_bool(activation.swf_version()) {
-                let indent = parse_suffixed_number_i32(activation, &indent)?;
-                text_format.indent = Some(indent as f64);
-            }
+        if let Some(indent) = get_style(style_object, "textIndent", activation)
+            && indent.as_bool(activation.swf_version())
+        {
+            let indent = parse_suffixed_number_i32(activation, &indent)?;
+            text_format.indent = Some(indent as f64);
         }
     }
 

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -144,13 +144,13 @@ fn get_prefix_for_namespace<'gc>(
             // is returned.
             for (key, value) in ancestor.attributes().own_properties() {
                 let value = value.coerce_to_string(activation)?;
-                if value == uri {
-                    if let Some(prefix) = key.strip_prefix(WStr::from_units(b"xmlns")) {
-                        if let Some(prefix) = prefix.strip_prefix(b':') {
-                            return Ok(AvmString::new(activation.gc(), prefix).into());
-                        } else {
-                            return Ok(istr!("").into());
-                        }
+                if value == uri
+                    && let Some(prefix) = key.strip_prefix(WStr::from_units(b"xmlns"))
+                {
+                    if let Some(prefix) = prefix.strip_prefix(b':') {
+                        return Ok(AvmString::new(activation.gc(), prefix).into());
+                    } else {
+                        return Ok(istr!("").into());
                     }
                 }
             }

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -279,15 +279,14 @@ impl<'gc> Object<'gc> {
                     stage_object::notify_property_change(dobj, name, value, activation)?;
                     // 'magic' display object properties (such as _x, _y, etc) take
                     // priority over properties in prototypes.
-                    if !self.has_own_property(activation, name) {
-                        if let Some(property) = activation
+                    if !self.has_own_property(activation, name)
+                        && let Some(property) = activation
                             .context
                             .avm1
                             .display_properties()
                             .get_by_name(name)
-                        {
-                            return property.set(activation, dobj, value);
-                        }
+                    {
+                        return property.set(activation, dobj, value);
                     }
                 }
             }
@@ -300,20 +299,19 @@ impl<'gc> Object<'gc> {
             .get(name, activation.is_case_sensitive())
             .and_then(|v| v.setter());
 
-        if let Some(setter) = setter {
-            if let Some(exec) = setter.as_function() {
-                if let Err(Error::ThrownValue(e)) = exec.exec(
-                    ExecutionName::Static("[Setter]"),
-                    activation,
-                    this.into(),
-                    1,
-                    &[value],
-                    ExecutionReason::Special,
-                    setter,
-                ) {
-                    return Err(Error::ThrownValue(e));
-                }
-            }
+        if let Some(setter) = setter
+            && let Some(exec) = setter.as_function()
+            && let Err(Error::ThrownValue(e)) = exec.exec(
+                ExecutionName::Static("[Setter]"),
+                activation,
+                this.into(),
+                1,
+                &[value],
+                ExecutionReason::Special,
+                setter,
+            )
+        {
+            return Err(Error::ThrownValue(e));
         }
 
         match self


### PR DESCRIPTION
This contains only mechanical changes (with the exception of the avm1 doc comment). All instances of clippy::collapsible_if in AVM1 are fixed and the lint is reenabled.

* Requires https://github.com/ruffle-rs/ruffle/pull/23572

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
