### PR TITLE
refactor: Remove mut references where not needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ used_underscore_items = "deny"
 dbg_macro = "warn"
 enum_glob_use = "deny"
 branches_sharing_code = "warn"
+needless_pass_by_ref_mut = "warn"
 
 # TODO Enable used_underscore_binding when false positives get fixed.
 

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -201,7 +201,7 @@ impl GuiController {
         }
     }
 
-    pub fn reconfigure_surface(&mut self) {
+    pub fn reconfigure_surface(&self) {
         self.surface.configure(
             &self.descriptors.device,
             &wgpu::SurfaceConfiguration {

--- a/desktop/src/gui/dialogs/export_bundle_dialog.rs
+++ b/desktop/src/gui/dialogs/export_bundle_dialog.rs
@@ -214,18 +214,13 @@ impl ExportBundleDialog {
         should_close
     }
 
-    fn render_info(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) {
+    fn render_info(&self, locale: &LanguageIdentifier, ui: &mut Ui) {
         ui.collapsing(text(locale, "export-bundle-dialog-info-title"), |ui| {
             ui.label(text(locale, "export-bundle-dialog-info-description"));
         });
     }
 
-    fn render_status(
-        &mut self,
-        export_status: ExportStatus,
-        locale: &LanguageIdentifier,
-        ui: &mut Ui,
-    ) {
+    fn render_status(&self, export_status: ExportStatus, locale: &LanguageIdentifier, ui: &mut Ui) {
         let error_message = match export_status {
             ExportStatus::Idle | ExportStatus::Success => return,
             ExportStatus::Exporting => {
@@ -286,7 +281,7 @@ impl ExportBundleDialog {
         });
     }
 
-    fn trigger_export(&mut self) -> ExportStatus {
+    fn trigger_export(&self) -> ExportStatus {
         let dialog = rfd::AsyncFileDialog::new().set_file_name(self.bundle_name.clone() + ".ruf");
         let selected_file = self.picker.show_dialog(dialog, |d| d.save_file());
         let Some(selected_file) = selected_file else {

--- a/desktop/src/gui/dialogs/message_dialog.rs
+++ b/desktop/src/gui/dialogs/message_dialog.rs
@@ -22,7 +22,7 @@ impl MessageDialog {
         Self { config }
     }
 
-    pub fn show(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) -> bool {
+    pub fn show(&self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) -> bool {
         let mut keep_open = true;
         let mut should_close = false;
 
@@ -40,7 +40,7 @@ impl MessageDialog {
         keep_open && !should_close
     }
 
-    pub fn render_window_contents(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) -> bool {
+    pub fn render_window_contents(&self, locale: &LanguageIdentifier, ui: &mut Ui) -> bool {
         let mut should_close = false;
 
         ui.vertical_centered(|ui| {

--- a/desktop/src/gui/dialogs/open_url_dialog.rs
+++ b/desktop/src/gui/dialogs/open_url_dialog.rs
@@ -12,7 +12,7 @@ impl OpenUrlDialog {
         Self { url }
     }
 
-    pub fn show(&mut self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) -> bool {
+    pub fn show(&self, locale: &LanguageIdentifier, egui_ctx: &egui::Context) -> bool {
         let mut keep_open = true;
         let mut should_close = false;
 
@@ -30,7 +30,7 @@ impl OpenUrlDialog {
         keep_open && !should_close
     }
 
-    pub fn render_window_contents(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) -> bool {
+    pub fn render_window_contents(&self, locale: &LanguageIdentifier, ui: &mut Ui) -> bool {
         let mut should_close = false;
 
         ui.label(text(locale, "open-url-dialog-message"));

--- a/desktop/src/gui/dialogs/preferences_dialog.rs
+++ b/desktop/src/gui/dialogs/preferences_dialog.rs
@@ -565,7 +565,7 @@ impl PreferencesDialog {
         ui.end_row()
     }
 
-    fn save(&mut self) {
+    fn save(&self) {
         if let Err(e) = self.preferences.write_preferences(|preferences| {
             if self.graphics_backend_changed {
                 preferences.set_graphics_backend(self.graphics_backend);

--- a/desktop/src/gui/menu_bar.rs
+++ b/desktop/src/gui/menu_bar.rs
@@ -48,7 +48,7 @@ impl MenuBar {
     }
 
     pub fn consume_shortcuts(
-        &mut self,
+        &self,
         egui_ctx: &egui::Context,
         dialogs: &mut Dialogs,
         mut player: Option<&mut Player>,
@@ -322,7 +322,7 @@ impl MenuBar {
     }
 
     fn view_menu(
-        &mut self,
+        &self,
         locale: &LanguageIdentifier,
         ui: &mut egui::Ui,
         player: &mut Option<&mut Player>,
@@ -444,7 +444,7 @@ impl MenuBar {
     }
 
     fn controls_menu(
-        &mut self,
+        &self,
         locale: &LanguageIdentifier,
         ui: &mut egui::Ui,
         dialogs: &mut Dialogs,
@@ -492,20 +492,20 @@ impl MenuBar {
         });
     }
 
-    fn browse_and_open(&mut self, open_type: OpenType) {
+    fn browse_and_open(&self, open_type: OpenType) {
         let _ = self.event_loop.send_event(RuffleEvent::BrowseAndOpen(
             Box::new(self.default_launch_options.clone()),
             open_type,
         ));
     }
 
-    fn close_movie(&mut self, ui: &mut egui::Ui) {
+    fn close_movie(&mut self, ui: &egui::Ui) {
         let _ = self.event_loop.send_event(RuffleEvent::CloseFile);
         self.currently_opened = None;
         ui.close();
     }
 
-    fn reload_movie(&mut self, ui: &mut egui::Ui) {
+    fn reload_movie(&mut self, ui: &egui::Ui) {
         let _ = self.event_loop.send_event(RuffleEvent::CloseFile);
         if let Some((movie_url, opts)) = self.currently_opened.take() {
             let _ = self
@@ -515,16 +515,16 @@ impl MenuBar {
         ui.close();
     }
 
-    fn request_exit(&mut self) {
+    fn request_exit(&self) {
         let _ = self.event_loop.send_event(RuffleEvent::ExitRequested);
     }
 
-    fn launch_website(&mut self, ui: &mut egui::Ui, url: &str) {
+    fn launch_website(&self, ui: &egui::Ui, url: &str) {
         let _ = webbrowser::open(url);
         ui.close();
     }
 
-    fn export_bundle(&mut self, ui: &mut egui::Ui) {
+    fn export_bundle(&self, ui: &egui::Ui) {
         let _ = self.event_loop.send_event(RuffleEvent::ExportBundle);
         ui.close();
     }

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -322,7 +322,7 @@ impl WebCanvasRenderBackend {
     }
 
     #[inline]
-    fn set_transform(&mut self, matrix: &Matrix) {
+    fn set_transform(&self, matrix: &Matrix) {
         self.context
             .set_transform(
                 matrix.a.into(),
@@ -386,7 +386,7 @@ impl WebCanvasRenderBackend {
         ));
     }
 
-    fn apply_blend_mode(&mut self, blend: RenderBlendMode) {
+    fn apply_blend_mode(&self, blend: RenderBlendMode) {
         // TODO: Objects with a blend mode need to be rendered to an intermediate buffer first,
         // but for now we render each child directly to the canvas. This should look reasonable for most
         // common cases.
@@ -454,7 +454,7 @@ impl WebCanvasRenderBackend {
         }
     }
 
-    fn draw_lines(&mut self, color: Color, mut matrix: Matrix, rect: bool) {
+    fn draw_lines(&self, color: Color, mut matrix: Matrix, rect: bool) {
         matrix.tx += Twips::HALF_PX;
         matrix.ty += Twips::HALF_PX;
         let dom_matrix = matrix.to_dom_matrix();

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -727,7 +727,7 @@ impl WebGlRenderBackend {
         };
     }
 
-    fn set_stencil_state(&mut self) {
+    fn set_stencil_state(&self) {
         // Set stencil state for masking, if necessary.
         if self.mask_state_dirty {
             match self.mask_state {
@@ -758,7 +758,7 @@ impl WebGlRenderBackend {
         }
     }
 
-    fn apply_blend_mode(&mut self, mode: RenderBlendMode) {
+    fn apply_blend_mode(&self, mode: RenderBlendMode) {
         let (blend_op, src_rgb, dst_rgb) = match mode {
             RenderBlendMode::Builtin(BlendMode::Normal) => {
                 // src + (1-a)
@@ -815,7 +815,7 @@ impl WebGlRenderBackend {
         self.gl.clear(Gl::COLOR_BUFFER_BIT | Gl::STENCIL_BUFFER_BIT);
     }
 
-    fn end_frame(&mut self) {
+    fn end_frame(&self) {
         // Resolve MSAA, if we're using it (WebGL2).
         if let (Some(gl), Some(msaa_buffers)) = (&self.gl2, &self.msaa_buffers) {
             // Disable any remaining masking state.

--- a/tests/framework/src/runner.rs
+++ b/tests/framework/src/runner.rs
@@ -293,7 +293,7 @@ impl TestRunner {
         Ok(())
     }
 
-    fn test_audio(&mut self) -> Result<()> {
+    fn test_audio(&self) -> Result<()> {
         if self.audio_assertions.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION
This fixes instances of clippy::needless_pass_by_ref_mut and enables the lint. The lint itself is pretty useful as it makes sure we don't use mut references where not necessary.

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
