### PR TITLE
chore: Fix and reenable clippy::needless_pass_by_ref_mut in some places

### DIFF
--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -319,7 +319,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
         }
     }
 
-    fn clamp_bitmap(&mut self, bitmap: &mut Bitmap) -> bool {
+    fn clamp_bitmap(&self, bitmap: &mut Bitmap) -> bool {
         let max_size = self.descriptors.limits.max_texture_dimension_2d;
         if bitmap.width() > max_size || bitmap.height() > max_size {
             let image =
@@ -519,7 +519,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
 
         for entry in cache_entries {
             let texture = as_texture(&entry.handle);
-            let mut surface = Surface::new(
+            let surface = Surface::new(
                 &self.descriptors,
                 self.surface.quality(),
                 texture.texture.width(),
@@ -752,7 +752,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
             .get_next_texture()
             .expect("TextureTargetFrame.get_next_texture is infallible");
 
-        let mut surface = Surface::new(
+        let surface = Surface::new(
             &self.descriptors,
             quality,
             texture.texture.width(),

--- a/render/wgpu/src/context3d/current_pipeline.rs
+++ b/render/wgpu/src/context3d/current_pipeline.rs
@@ -223,7 +223,7 @@ impl CurrentPipeline {
         }
     }
 
-    pub fn update_vertex_buffer_at(&mut self, _index: usize) {
+    pub fn update_vertex_buffer_at(&self, _index: usize) {
         // FIXME - check if it's the same, so we can skip rebuilding the pipeline
         self.dirty.set(true);
     }

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -165,7 +165,7 @@ impl WgpuContext3D {
         }
     }
 
-    fn create_depth_texture(&mut self, width: u32, height: u32, sample_count: u32) -> TextureView {
+    fn create_depth_texture(&self, width: u32, height: u32, sample_count: u32) -> TextureView {
         self.descriptors
             .device
             .create_texture(&wgpu::TextureDescriptor {

--- a/render/wgpu/src/filters/blur.rs
+++ b/render/wgpu/src/filters/blur.rs
@@ -283,7 +283,7 @@ impl BlurFilter {
                     descriptors,
                     draw_encoder,
                     pipeline,
-                    &mut flop,
+                    &flop,
                     previous_view,
                     previous_vertices,
                 );
@@ -305,7 +305,7 @@ impl BlurFilter {
         descriptors: &Descriptors,
         draw_encoder: &mut CommandEncoder,
         pipeline: &RenderPipeline,
-        destination: &mut CommandTarget,
+        destination: &CommandTarget,
         source: &TextureView,
         vertices: BufferSlice,
     ) {

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -1,8 +1,5 @@
 // Remove this when we decide on how to handle multithreaded rendering (especially on wasm)
 #![allow(clippy::arc_with_non_send_sync)]
-// This lint is helpful, but right now we have too many instances of it.
-// TODO: Remove this once all instances are fixed.
-#![allow(clippy::needless_pass_by_ref_mut)]
 
 use crate::backend::ActiveFrame;
 use crate::bitmaps::BitmapSamplers;

--- a/render/wgpu/src/pixel_bender.rs
+++ b/render/wgpu/src/pixel_bender.rs
@@ -336,7 +336,7 @@ fn image_input_as_texture<'a>(
 
 impl<T: RenderTarget> WgpuRenderBackend<T> {
     pub(super) fn compile_pixelbender_shader_impl(
-        &mut self,
+        &self,
         shader: PixelBenderShader,
     ) -> Result<PixelBenderShaderHandle, BitmapError> {
         let handle = PixelBenderWgpuShader::new(&self.descriptors, shader);

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -68,7 +68,7 @@ impl Surface {
     #[expect(clippy::too_many_arguments)]
     #[instrument(level = "debug", skip_all)]
     pub fn draw_commands_and_copy_to<'frame, 'global: 'frame>(
-        &mut self,
+        &self,
         frame_view: &wgpu::TextureView,
         render_target_mode: RenderTargetMode,
         descriptors: &'global Descriptors,
@@ -108,7 +108,7 @@ impl Surface {
     #[expect(clippy::too_many_arguments)]
     #[instrument(level = "debug", skip_all)]
     pub fn draw_commands<'frame, 'global: 'frame>(
-        &mut self,
+        &self,
         render_target_mode: RenderTargetMode,
         descriptors: &'global Descriptors,
         meshes: &'global Vec<Mesh>,

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -675,7 +675,7 @@ impl<'a> WgpuCommandHandler<'a> {
 
 impl CommandHandler for WgpuCommandHandler<'_> {
     fn blend(&mut self, commands: CommandList, blend_mode: RenderBlendMode) {
-        let mut surface = Surface::new(
+        let surface = Surface::new(
             self.descriptors,
             self.quality,
             self.width,
@@ -908,7 +908,7 @@ impl CommandHandler for WgpuCommandHandler<'_> {
     }
 
     fn render_alpha_mask(&mut self, maskee_commands: CommandList, mask_commands: CommandList) {
-        let mut surface = Surface::new(
+        let surface = Surface::new(
             self.descriptors,
             self.quality,
             self.width,

--- a/tests/tests/external_interface/mod.rs
+++ b/tests/tests/external_interface/mod.rs
@@ -1,7 +1,3 @@
-// This lint is helpful, but right now we have too many instances of it.
-// TODO: Remove this once all instances are fixed.
-#![allow(clippy::needless_pass_by_ref_mut)]
-
 use ruffle_core::context::UpdateContext;
 use ruffle_core::external::ExternalInterfaceProvider;
 use ruffle_core::external::{Value as ExternalValue, Value};
@@ -17,12 +13,12 @@ impl ExternalInterfaceTestProvider {
     }
 }
 
-fn do_trace(context: &mut UpdateContext<'_>, args: &[ExternalValue]) -> ExternalValue {
+fn do_trace(context: &UpdateContext<'_>, args: &[ExternalValue]) -> ExternalValue {
     context.avm_trace(&format!("[ExternalInterface] trace: {args:?}"));
     "Traced!".into()
 }
 
-fn do_ping(context: &mut UpdateContext<'_>, _args: &[ExternalValue]) -> ExternalValue {
+fn do_ping(context: &UpdateContext<'_>, _args: &[ExternalValue]) -> ExternalValue {
     context.avm_trace("[ExternalInterface] ping");
     "Pong!".into()
 }


### PR DESCRIPTION
This lint is useful and in those places there are only few instances, so fix them all and reenable the lint.

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
