### PR TITLE
chore: Change h1 to h2 headers in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
-# Description
+## Description
 
 _Please explain the changes made within this PR.
 Why did you make this change; does it add a feature, or fix a bug?
 Be sure to link to any content or issues that it affects!
 Please also remember that each commit message should describe its own changes too._
 
-# Testing
+## Testing
 
 _How can we test this PR?_
 
@@ -13,7 +13,7 @@ _If you're able to, please follow our [test guidelines](https://github.com/ruffl
 
 _If you need help with making tests, or do not believe this change is easily automatically testable, please describe how we can verify the changes ourselves. If there is real world content that we can test on, that helps a lot!_
 
-# Checklist
+## Checklist
 
 <!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->
 


### PR DESCRIPTION
There should be only one h1 header (the PR title). The rest should be h2–h5.

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
