### PR TITLE
tests: Change all ChainablePromiseElement params to WebdriverIO.Element

### DIFF
--- a/web/packages/selfhosted/test/integration_tests/context_menu/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/context_menu/test.ts
@@ -23,7 +23,7 @@ async function supportsClipboardReadText(): Promise<boolean> {
     });
 }
 
-async function focusFlashInput(player: ChainablePromiseElement) {
+async function focusFlashInput(player: WebdriverIO.Element) {
     await player.click({ x: 10 - 200, y: 110 - 200 });
     await expectTraceOutput(browser, player, ["onMouseDown()", "onMouseUp()"]);
 }
@@ -35,16 +35,16 @@ async function focusHtmlInput() {
     });
 }
 
-async function openContextMenu(player: ChainablePromiseElement) {
+async function openContextMenu(player: WebdriverIO.Element) {
     await player.click({ x: 10 - 200, y: 10 - 200, button: "right" });
 }
 
-async function openContextMenuOnInput(player: ChainablePromiseElement) {
+async function openContextMenuOnInput(player: WebdriverIO.Element) {
     await player.click({ x: 10 - 200, y: 110 - 200, button: "right" });
 }
 
 async function clickContextMenuEntry(
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
     text: string,
     button: ButtonNames = "left",
 ) {
@@ -57,7 +57,7 @@ describe("Context Menu", () => {
     it("load the test", async () => {
         await openTest(browser, "integration_tests/context_menu");
         await injectRuffleAndWait(browser);
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await playAndMonitor(browser, player, ["Loaded!"]);
 
         // Dismiss hardware acceleration modal in Chrome
@@ -70,7 +70,7 @@ describe("Context Menu", () => {
     });
 
     it("clicking out of context menu does not fire events", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         await player.click({ x: 10 - 200, y: 10 - 200 });
 
@@ -91,7 +91,7 @@ describe("Context Menu", () => {
     });
 
     it("left clicking a context menu entry works", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         await browser.keys("q");
 
@@ -106,7 +106,7 @@ describe("Context Menu", () => {
     });
 
     it("right clicking a context menu entry works", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         await browser.keys("q");
 
@@ -121,7 +121,7 @@ describe("Context Menu", () => {
     });
 
     it("copying text works", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         // Populate text input in Flash
         await browser.keys("t");
@@ -158,7 +158,7 @@ describe("Context Menu", () => {
     });
 
     it("cutting text works", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         await focusFlashInput(player);
 
@@ -192,7 +192,7 @@ describe("Context Menu", () => {
             this.skip();
         }
 
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         // Populate text input in HTML
         await browser.execute(() => {
@@ -222,7 +222,7 @@ describe("Context Menu", () => {
             this.skip();
         }
 
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         // Try pasting
         await focusFlashInput(player);
@@ -244,7 +244,7 @@ describe("Context Menu", () => {
     });
 
     it("no more traces", async function () {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
         assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/context_menu_escaping_body/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/context_menu_escaping_body/test.ts
@@ -19,7 +19,7 @@ describe("Context Menu", () => {
             "index_quirks.html",
         );
         await injectRuffleAndWait(browser);
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await playAndMonitor(browser, player, ["Loaded!"]);
 
         // Dismiss hardware acceleration modal in Chrome
@@ -28,7 +28,7 @@ describe("Context Menu", () => {
     });
 
     it("(quirks mode) open context menu", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         await player.click({ x: -150, y: -150, button: "right" });
 
@@ -48,7 +48,7 @@ describe("Context Menu", () => {
             "index_no_quirks.html",
         );
         await injectRuffleAndWait(browser);
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await playAndMonitor(browser, player, ["Loaded!"]);
 
         // Dismiss hardware acceleration modal in Chrome
@@ -71,7 +71,7 @@ describe("Context Menu", () => {
     });
 
     it("no more traces", async function () {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
         assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/context_menu_position/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/context_menu_position/test.ts
@@ -29,7 +29,7 @@ describe("Context Menu", () => {
     it("load the test", async () => {
         await openTest(browser, "integration_tests/context_menu_position");
         await injectRuffleAndWait(browser);
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await playAndMonitor(browser, player, ["Loaded!"]);
 
         // Dismiss hardware acceleration modal in Chrome
@@ -153,7 +153,7 @@ describe("Context Menu", () => {
     });
 
     it("no more traces", async function () {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
         assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/device_fonts_metrics/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/device_fonts_metrics/test.ts
@@ -25,13 +25,13 @@ describe("Device Fonts: Metrics", () => {
                 `index.html?deviceFontRenderer=${deviceFontRenderer}`,
             );
             await injectRuffleAndWait(browser);
-            const player = await browser.$("<ruffle-object>");
+            const player = await browser.$("<ruffle-object>").getElement();
             await playAndMonitor(browser, player, ["Loaded test!"]);
             await hideHardwareAccelerationModal(browser, player);
         });
 
         it("check metrics", async () => {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
 
             await expectTraceOutput(browser, player, [
                 "Displayed text metrics:",
@@ -70,7 +70,7 @@ describe("Device Fonts: Metrics", () => {
         });
 
         it("no more traces", async function () {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
             assertNoMoreTraceOutput(browser, player);
         });
     }

--- a/web/packages/selfhosted/test/integration_tests/device_fonts_rendering/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/device_fonts_rendering/test.ts
@@ -23,13 +23,13 @@ describe("Device Fonts: Rendering", () => {
                 `index.html?deviceFontRenderer=${deviceFontRenderer}`,
             );
             await injectRuffleAndWait(browser);
-            const player = await browser.$("<ruffle-object>");
+            const player = await browser.$("<ruffle-object>").getElement();
             await playAndMonitor(browser, player, ["Loaded test!"]);
             await hideHardwareAccelerationModal(browser, player);
         });
 
         it("check rendered image", async () => {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
 
             await expectTraceOutput(browser, player, ["Character bounds:"]);
 
@@ -112,7 +112,7 @@ describe("Device Fonts: Rendering", () => {
         });
 
         it("no more traces", async function () {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
             assertNoMoreTraceOutput(browser, player);
         });
     }

--- a/web/packages/selfhosted/test/integration_tests/external_interface/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/external_interface/test.ts
@@ -75,7 +75,7 @@ describe("ExternalInterface", () => {
     it("loads the test", async () => {
         await openTest(browser, "integration_tests/external_interface");
         await injectRuffleAndWait(browser);
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await playAndMonitor(browser, player, [
             "ExternalInterface.available: true",
             'ExternalInterface.objectID: "flash_name"',
@@ -109,7 +109,7 @@ describe("ExternalInterface", () => {
     });
 
     it("responds to 'log'", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await browser.execute(
             (player) =>
                 player.log("Hello world!", {
@@ -135,7 +135,7 @@ describe("ExternalInterface", () => {
     });
 
     it("returns a value with legacy API", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         const returned = await browser.execute(
             (player) => player.returnAValue(123.4),
             player,
@@ -152,7 +152,7 @@ describe("ExternalInterface", () => {
     });
 
     it("returns a value with V1 API", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         const returned = await browser.execute(
             (player) =>
                 player.ruffle().callExternalInterface("returnAValue", 123.4),
@@ -170,7 +170,7 @@ describe("ExternalInterface", () => {
     });
 
     it("calls a method with delay", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await browser.execute(
             (player) =>
                 player.callMethodWithDelay("window.RuffleTest.set", true),
@@ -192,7 +192,7 @@ describe("ExternalInterface", () => {
     // [NA] Broken on Ruffle at time of writing
     it.skip("calls a reentrant JS method", async () => {
         // JS -> Flash -> JS within one call
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         const actualValue = await browser.execute((player) => {
             player.callMethodImmediately("window.RuffleTest.set", {
                 nested: { object: { complex: true } },
@@ -222,7 +222,7 @@ describe("ExternalInterface", () => {
 
     it("calls a reentrant Flash method", async () => {
         // Flash -> JS -> Flash within one call
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await browser.execute((player) => {
             player.callMethodWithDelay("window.RuffleTest.log", "Reentrant!");
         }, player);
@@ -245,7 +245,7 @@ describe("ExternalInterface", () => {
     });
 
     it("supports a JS function as name", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await browser.execute((player) => {
             player.callMethodWithDelay(
                 "function(name){window.RuffleTest.set(name)}",
@@ -270,7 +270,7 @@ describe("ExternalInterface", () => {
     });
 
     it("supports calling a method that doesn't exist", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await browser.execute((player) => {
             player.callMethodWithDelay("does.not.exist");
         }, player);
@@ -288,7 +288,7 @@ describe("ExternalInterface", () => {
     });
 
     it("doesn't enforce Strict Mode", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await browser.execute((player) => {
             player.callMethodWithDelay(
                 "function(){return aPropertyThatDoesntExist = 'success!'}",
@@ -308,7 +308,7 @@ describe("ExternalInterface", () => {
     });
 
     it("allows overriding a Ruffle method", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await browser.execute((player) => {
             player.addAnotherCallback("isPlaying", "isPlaying from EI");
         }, player);
@@ -326,7 +326,7 @@ describe("ExternalInterface", () => {
     });
 
     it("allows redefining a method", async () => {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
 
         // First definition
         await browser.execute((player) => {
@@ -362,7 +362,7 @@ describe("ExternalInterface", () => {
     });
 
     it("no more traces", async function () {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/keyboard_input/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/keyboard_input/test.ts
@@ -13,7 +13,7 @@ describe("Key up and down events work", () => {
     loadJsAPI("/test/integration_tests/keyboard_input/test.swf");
 
     it("'a' key is recognised", async () => {
-        const player = await browser.$("<ruffle-player>");
+        const player = await browser.$("<ruffle-player>").getElement();
         await player.click();
         // Extra safety click in case there's a modal
         await player.click();
@@ -32,7 +32,7 @@ describe("Key up and down events work", () => {
     });
 
     it("enter key is recognised", async () => {
-        const player = await browser.$("<ruffle-player>");
+        const player = await browser.$("<ruffle-player>").getElement();
         await player.click();
 
         await browser.keys([Key.Enter]);
@@ -49,7 +49,7 @@ describe("Key up and down events work", () => {
     });
 
     it("no more traces", async function () {
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/missing_default_fonts/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/missing_default_fonts/test.ts
@@ -8,7 +8,7 @@ describe("Missing Default Fonts", () => {
     it("load the test", async () => {
         await openTest(browser, "integration_tests/missing_default_fonts");
         await injectRuffleAndWait(browser);
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await playAndMonitor(browser, player, ["Loaded!"]);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/mouse_wheel_avm2/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/mouse_wheel_avm2/test.ts
@@ -13,7 +13,7 @@ use(chaiHtml);
 
 async function scroll(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
     x: number,
     y: number,
     lines: number,
@@ -74,14 +74,14 @@ interface TestParams {
                 "index_" + testParams.name + ".html",
             );
             await injectRuffleAndWait(browser);
-            const player = await browser.$("<ruffle-object>");
+            const player = await browser.$("<ruffle-object>").getElement();
             await playAndMonitor(browser, player, ["Loaded!"]);
             await hideHardwareAccelerationModal(browser, player);
             // await new Promise(f => setTimeout(f, 10000000));
         });
 
         it("scroll the first clip", async () => {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
 
             expect(await scroll(browser, player, 100, 100, 1)).to.equal(
                 expectedScroll ?? false,
@@ -92,7 +92,7 @@ interface TestParams {
         });
 
         it("scroll the text field up", async () => {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
 
             expect(await scroll(browser, player, 300, 100, -1)).to.equal(
                 expectedScroll ?? true,
@@ -100,7 +100,7 @@ interface TestParams {
         });
 
         it("scroll the text field", async () => {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
 
             expect(await scroll(browser, player, 300, 100, 2)).to.equal(
                 expectedScroll ?? false,
@@ -108,7 +108,7 @@ interface TestParams {
         });
 
         it("scroll the text field back up", async () => {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
 
             expect(await scroll(browser, player, 300, 100, -1)).to.equal(
                 expectedScroll ?? false,
@@ -116,7 +116,7 @@ interface TestParams {
         });
 
         it("scroll the second clip", async () => {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
 
             expect(await scroll(browser, player, 500, 100, 1)).to.equal(
                 expectedScroll ?? false,
@@ -127,7 +127,7 @@ interface TestParams {
         });
 
         it("scroll non-interactive content", async () => {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
 
             expect(await scroll(browser, player, 700, 100, 1)).to.equal(
                 expectedScroll ?? true,
@@ -135,7 +135,7 @@ interface TestParams {
         });
 
         it("no more traces", async function () {
-            const player = await browser.$("#objectElement");
+            const player = await browser.$("#objectElement").getElement();
             assertNoMoreTraceOutput(browser, player);
         });
     });

--- a/web/packages/selfhosted/test/integration_tests/programmatic_events/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/programmatic_events/test.ts
@@ -10,7 +10,7 @@ import chaiHtml from "chai-html";
 
 use(chaiHtml);
 
-async function focusElement(element: ChainablePromiseElement) {
+async function focusElement(element: WebdriverIO.Element) {
     await browser.execute((el) => {
         el.focus();
     }, element);
@@ -30,15 +30,15 @@ describe("Programmatic Events", () => {
     it("load the test", async () => {
         await openTest(browser, "integration_tests/programmatic_events");
         await injectRuffleAndWait(browser);
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await playAndMonitor(browser, player, ["Loaded!"]);
     });
 
     // See https://github.com/ruffle-rs/ruffle/issues/6952#issuecomment-1133990189
     it("scenario: programmatic pointerdown on the player", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
-        await focusElement(await browser.$("#inputElement"));
+        await focusElement(await browser.$("#inputElement").getElement());
 
         await typeText("should be ignored");
 
@@ -70,13 +70,13 @@ describe("Programmatic Events", () => {
     // That has been possible since https://github.com/ruffle-rs/ruffle/pull/17158,
     // so ideally we want to preserve this behavior.
     it("scenario: programmatic focus on the container", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
-        await focusElement(await browser.$("#inputElement"));
+        await focusElement(await browser.$("#inputElement").getElement());
 
         await typeText("should be ignored");
 
-        await focusElement(await player.shadow$("#container"));
+        await focusElement(await player.shadow$("#container").getElement());
 
         await browser.execute((el) => {
             el.dispatchEvent(
@@ -101,9 +101,9 @@ describe("Programmatic Events", () => {
 
     // That's probably the most sane way of focusing Ruffle.
     it("scenario: programmatic focus on the player", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
-        await focusElement(await browser.$("#inputElement"));
+        await focusElement(await browser.$("#inputElement").getElement());
 
         await typeText("should be ignored");
 
@@ -131,10 +131,10 @@ describe("Programmatic Events", () => {
     });
 
     it("scenario: example input overlay", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
         const overlay = await browser.$("#overlay");
 
-        await focusElement(await browser.$("#inputElement"));
+        await focusElement(await browser.$("#inputElement").getElement());
 
         await typeText("should be ignored");
 
@@ -151,7 +151,7 @@ describe("Programmatic Events", () => {
     });
 
     it("no more traces", async function () {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
         assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/integration_tests/url_rewrite_rules/test.ts
+++ b/web/packages/selfhosted/test/integration_tests/url_rewrite_rules/test.ts
@@ -15,13 +15,13 @@ describe("URL Rewrite Rules", () => {
     it("load the test", async () => {
         await openTest(browser, "integration_tests/url_rewrite_rules");
         await injectRuffleAndWait(browser);
-        const player = await browser.$("<ruffle-object>");
+        const player = await browser.$("<ruffle-object>").getElement();
         await playAndMonitor(browser, player, ["Loaded test!"]);
         await hideHardwareAccelerationModal(browser, player);
     });
 
     it("rewrites URL of other1 to a relative one", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         await browser.execute((el) => {
             el.focus();
@@ -42,7 +42,7 @@ describe("URL Rewrite Rules", () => {
     });
 
     it("rewrites URL of other1 to an absolute one", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         await browser.execute((el) => {
             el.focus();
@@ -63,7 +63,7 @@ describe("URL Rewrite Rules", () => {
     });
 
     it("does not rewrite URL of other2", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         await browser.execute((el) => {
             el.focus();
@@ -81,7 +81,7 @@ describe("URL Rewrite Rules", () => {
     });
 
     it("rewrites URL of a clicked link", async () => {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
 
         player.click();
 
@@ -102,7 +102,7 @@ describe("URL Rewrite Rules", () => {
     });
 
     it("no more traces", async function () {
-        const player = await browser.$("#objectElement");
+        const player = await browser.$("#objectElement").getElement();
         assertNoMoreTraceOutput(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/js_api/load.ts
+++ b/web/packages/selfhosted/test/js_api/load.ts
@@ -9,7 +9,7 @@ describe("RufflePlayer.load", () => {
     loadJsAPI();
 
     it("loads and plays a URL", async () => {
-        const player = await browser.$("<ruffle-player>");
+        const player = await browser.$("<ruffle-player>").getElement();
         await browser.execute(async (playerElement) => {
             const player = playerElement as Player.PlayerElement;
             await player.ruffle().load("/test_assets/example.swf");

--- a/web/packages/selfhosted/test/polyfill/embed_default/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_default/test.ts
@@ -26,7 +26,10 @@ describe("Embed tag", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_insensitive/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_insensitive/test.ts
@@ -27,7 +27,10 @@ describe("Embed with case-insensitive MIME type", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_missing_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_type/test.ts
@@ -26,7 +26,10 @@ describe("Embed without type attribute", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_MIME_insensitive/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_MIME_insensitive/test.ts
@@ -27,7 +27,10 @@ describe("Object with case-insensitive MIME type", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_clsid_insensitive/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_insensitive/test.ts
@@ -27,7 +27,10 @@ describe("Object with case-insensitive clsid", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.ts
@@ -26,7 +26,10 @@ describe("Object with clsid and embed", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_data/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_data/test.ts
@@ -27,7 +27,10 @@ describe("Object with only data attribute", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_default/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_default/test.ts
@@ -26,7 +26,10 @@ describe("Object tag", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_double_object/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_double_object/test.ts
@@ -26,7 +26,10 @@ describe("Object with another object tag", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_double_object_classid/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_double_object_classid/test.ts
@@ -26,7 +26,10 @@ describe("Object using classid with another object tag without classid", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_flashvars/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars/test.ts
@@ -26,7 +26,10 @@ describe("Object tag", () => {
     it("Plays a movie with flashvars", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
             [
                 "// _level0.a",
                 "1",

--- a/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.ts
@@ -26,7 +26,10 @@ describe("Object tag", () => {
     it("Plays a movie with flashvars", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
             [
                 "// _level0.a",
                 "1",

--- a/web/packages/selfhosted/test/polyfill/object_ie_only/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_ie_only/test.ts
@@ -26,7 +26,10 @@ describe("Object for old IE must work everywhere", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type/test.ts
@@ -26,7 +26,10 @@ describe("Object without type attribute", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.ts
@@ -26,7 +26,10 @@ describe("Object without type and classid attributes", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.ts
@@ -26,7 +26,10 @@ describe("Object with unexpected string", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_wrong_type/test.ts
+++ b/web/packages/selfhosted/test/polyfill/object_wrong_type/test.ts
@@ -26,7 +26,10 @@ describe("Object with wrong type attribute value", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-embed />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-embed />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/swf_extension_insensitive/test.ts
+++ b/web/packages/selfhosted/test/polyfill/swf_extension_insensitive/test.ts
@@ -27,7 +27,10 @@ describe("SWF extension insensitive", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/swf_extension_with_fragment/test.ts
+++ b/web/packages/selfhosted/test/polyfill/swf_extension_with_fragment/test.ts
@@ -27,7 +27,10 @@ describe("SWF extension, file with fragment", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/swf_extension_with_get/test.ts
+++ b/web/packages/selfhosted/test/polyfill/swf_extension_with_get/test.ts
@@ -27,7 +27,10 @@ describe("SWF extension, file with GET parameter", () => {
     it("Plays a movie", async () => {
         await playAndMonitor(
             browser,
-            await browser.$("#test-container").$("<ruffle-object />"),
+            await browser
+                .$("#test-container")
+                .$("<ruffle-object />")
+                .getElement(),
         );
     });
 });

--- a/web/packages/selfhosted/test/utils.ts
+++ b/web/packages/selfhosted/test/utils.ts
@@ -24,14 +24,14 @@ export async function isRuffleLoaded(browser: WebdriverIO.Browser) {
 
 export async function isRufflePlayerLoaded(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
 ) {
     return (
         (await browser.execute(
             (player) =>
                 // TODO: How can we import ReadyState enum?
                 (player as Player.PlayerElement).ruffle().readyState,
-            await player,
+            player,
         )) === 2
     );
 }
@@ -85,48 +85,42 @@ export async function injectRuffle(browser: WebdriverIO.Browser) {
 
 export async function playAndMonitor(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
     expectedOutput: string[] = ["Hello from Flash!"],
 ) {
     await throwIfError(browser);
-    await waitForPlayerToLoad(browser, await player);
-    await setupAndPlay(browser, await player);
+    await waitForPlayerToLoad(browser, player);
+    await setupAndPlay(browser, player);
 
     await expectTraceOutput(browser, player, expectedOutput);
 }
 
 export async function setupAndPlay(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
 ) {
-    await browser.execute(
-        (playerElement) => {
-            const player = playerElement as Player.PlayerElement;
-            player.__ruffle_log__ = [];
-            player.ruffle().traceObserver = (msg) => {
-                player.__ruffle_log__.push(msg);
-                console.log(`[trace] ${msg}`);
-            };
-            player.ruffle().resume();
-        },
-        await player,
-    );
+    await browser.execute((playerElement) => {
+        const player = playerElement as Player.PlayerElement;
+        player.__ruffle_log__ = [];
+        player.ruffle().traceObserver = (msg) => {
+            player.__ruffle_log__.push(msg);
+            console.log(`[trace] ${msg}`);
+        };
+        player.ruffle().resume();
+    }, player);
 }
 
 export async function getTraceOutput(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
     messageCount: number = 1,
 ): Promise<string[]> {
     // Await trace output
     await browser.waitUntil(
         async () => {
-            const log = await browser.execute(
-                (player) => {
-                    return (player as Player.PlayerElement).__ruffle_log__;
-                },
-                await player,
-            );
+            const log = await browser.execute((player) => {
+                return (player as Player.PlayerElement).__ruffle_log__;
+            }, player);
             return log.length >= messageCount;
         },
         {
@@ -148,7 +142,7 @@ export async function getTraceOutput(
 
 export async function expectTraceOutput(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
     messages: string[],
 ) {
     expect(
@@ -158,7 +152,7 @@ export async function expectTraceOutput(
 
 export async function clearTraceOutput(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
 ) {
     await browser.execute((playerElement) => {
         const player = playerElement as Player.PlayerElement;
@@ -168,7 +162,7 @@ export async function clearTraceOutput(
 
 export async function assertNoMoreTraceOutput(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
 ) {
     await browser.execute((playerElement) => {
         const player = playerElement as Player.PlayerElement;
@@ -186,7 +180,7 @@ export async function injectRuffleAndWait(browser: WebdriverIO.Browser) {
 
 export async function waitForPlayerToLoad(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
 ) {
     await browser.waitUntil(
         async () => await isRufflePlayerLoaded(browser, player),
@@ -221,7 +215,7 @@ export function loadJsAPI(swf?: string) {
             container!.appendChild(player);
         });
 
-        const player = await $("#ruffle-player");
+        const player = await $("#ruffle-player").getElement();
 
         if (swf) {
             await browser.execute(async (swf) => {
@@ -235,7 +229,7 @@ export function loadJsAPI(swf?: string) {
 
 export async function closeAllModals(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
 ) {
     const modals = await player.$$(".modal:not(.hidden)");
     await browser.execute((modals) => {
@@ -248,7 +242,7 @@ export async function closeAllModals(
 
 export async function hideHardwareAccelerationModal(
     browser: WebdriverIO.Browser,
-    player: ChainablePromiseElement,
+    player: WebdriverIO.Element,
 ) {
     // Trigger it if not triggered yet
     await player.moveTo();


### PR DESCRIPTION
## Description

Made all functions take WebdriverIO.Element params instead of ChainablePromiseElement for uniformity. Added `getElement` spam to allow for that.

## Testing

Run `npm run wdio --workspaces --if-present -- --headless --parallel`

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
