### PR TITLE
Revert "core: Cleanup some `SwfSlice/buffer::Slice` code"

### DIFF
--- a/core/common/src/buffer.rs
+++ b/core/common/src/buffer.rs
@@ -163,6 +163,30 @@ impl Slice {
         }
     }
 
+    /// Create a subslice of this buffer slice, without bounds checking.
+    ///
+    /// The parameter `slice` must be derived from the same buffer this slice
+    /// was, otherwise the returned slice will be empty
+    ///
+    /// This emulates "unbounded reads" in file formats that don't bounds-check
+    /// things properly.
+    pub fn to_unbounded_subslice(&self, slice: &[u8]) -> Self {
+        let self_guard = self.buf.0.read().expect("unlock read");
+        let self_pval = self_guard.as_ptr() as usize;
+        let self_len = self.buf.len();
+        let slice_pval = slice.as_ptr() as usize;
+
+        if self_pval <= slice_pval && slice_pval < (self_pval + self_len) {
+            Slice {
+                buf: self.buf.clone(),
+                start: slice_pval - self_pval,
+                end: (slice_pval - self_pval) + slice.len(),
+            }
+        } else {
+            self.buf.to_empty_slice()
+        }
+    }
+
     /// Construct a new Slice from a start and an end.
     ///
     /// The start and end values will be relative to the current slice.
@@ -186,7 +210,8 @@ impl Slice {
 
     /// Get a subslice of this slice.
     ///
-    /// Normal subslicing bounds rules will be respected.
+    /// Normal subslicing bounds rules will be respected. If you want to get a
+    /// slice outside the bounds of this one, use `to_unbounded_subslice`.
     pub fn get<T: RangeBounds<usize>>(&self, range: T) -> Option<Slice> {
         let s = self.buf.0.read().expect("unlock read");
 

--- a/core/common/src/buffer.rs
+++ b/core/common/src/buffer.rs
@@ -242,13 +242,13 @@ impl Slice {
     pub fn buffer(&self) -> &Buffer {
         &self.buf
     }
-}
 
-impl Read for Slice {
-    fn read(&mut self, data: &mut [u8]) -> IoResult<usize> {
-        let len = <&[u8] as Read>::read(&mut self.data().as_ref(), data)?;
-        self.start += len;
-        Ok(len)
+    /// Create a readable cursor into the `Slice`.
+    pub fn as_cursor(&self) -> SliceCursor {
+        SliceCursor {
+            slice: self.clone(),
+            pos: 0,
+        }
     }
 }
 
@@ -261,6 +261,27 @@ impl LowerHex for Slice {
 impl UpperHex for Slice {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         UpperHex::fmt(&self.data(), f)
+    }
+}
+
+/// A readable cursor into a buffer slice.
+pub struct SliceCursor {
+    slice: Slice,
+    pos: usize,
+}
+
+impl Read for SliceCursor {
+    fn read(&mut self, data: &mut [u8]) -> IoResult<usize> {
+        let copy_count = min(data.len(), self.slice.len() - self.pos);
+        let slice = self
+            .slice
+            .get(self.pos..self.pos + copy_count)
+            .expect("Slice offsets are always valid");
+        let slice_data = slice.data();
+
+        data[..copy_count].copy_from_slice(&slice_data);
+        self.pos += copy_count;
+        Ok(copy_count)
     }
 }
 
@@ -558,12 +579,12 @@ mod test {
     }
 
     #[test]
-    fn slice_read() {
+    fn slice_cursor_read() {
         let buf = Buffer::from(vec![
             38, 26, 99, 1, 1, 1, 1, 38, 12, 14, 1, 1, 93, 86, 1, 88,
         ]);
         let slice = buf.to_full_slice();
-        let mut cursor = slice.clone();
+        let mut cursor = slice.as_cursor();
         let refdata = slice.data();
 
         let mut data = vec![0; 1];
@@ -576,12 +597,12 @@ mod test {
     }
 
     #[test]
-    fn slice_read_all() {
+    fn slice_cursor_read_all() {
         let buf = Buffer::from(vec![
             38, 26, 99, 1, 1, 1, 1, 38, 12, 14, 1, 1, 93, 86, 1, 88,
         ]);
         let slice = buf.to_full_slice();
-        let mut cursor = slice.clone();
+        let mut cursor = slice.as_cursor();
         let refdata = slice.data();
 
         let mut data = vec![0; slice.len() + 32];

--- a/core/common/src/buffer.rs
+++ b/core/common/src/buffer.rs
@@ -293,6 +293,18 @@ impl Substream {
         self.chunks.read().unwrap().len()
     }
 
+    /// Create a readable cursor into the `Substream`.
+    ///
+    /// The returned cursor clones the `Substream` and thus shares a chunk list
+    /// with it.
+    pub fn as_cursor(&self) -> SubstreamCursor {
+        SubstreamCursor {
+            substream: self.clone(),
+            chunk_pos: 0,
+            bytes_pos: 0,
+        }
+    }
+
     /// Calculate the number of bytes in the `Substream`.
     pub fn len(&self) -> usize {
         let mut tally = 0;
@@ -501,7 +513,7 @@ impl UpperHex for SliceRef<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::buffer::Buffer;
+    use crate::buffer::{Buffer, Substream};
     use std::io::Read;
 
     #[test]
@@ -556,5 +568,64 @@ mod test {
         let result = cursor.read(&mut data);
         assert_eq!(result.unwrap(), slice.len());
         assert_eq!(&data[..slice.len()], &refdata[..]);
+    }
+
+    #[test]
+    fn substream_cursor_read_inside() {
+        let buf = Buffer::from(vec![
+            38, 26, 99, 1, 1, 1, 1, 38, 12, 14, 1, 1, 93, 86, 1, 88,
+        ]);
+        let mut substream = Substream::new(buf.clone());
+
+        substream.append(buf.get(3..7).unwrap()).unwrap();
+        substream.append(buf.get(10..12).unwrap()).unwrap();
+        substream.append(buf.get(14..15).unwrap()).unwrap();
+
+        let mut cursor = substream.as_cursor();
+        let mut data = vec![0; 7];
+        let result = cursor.read(&mut data);
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(data, vec![1; 7]);
+    }
+
+    #[test]
+    fn substream_cursor_read_outside() {
+        let buf = Buffer::from(vec![
+            38, 26, 99, 1, 1, 1, 1, 38, 12, 14, 1, 1, 93, 86, 1, 88,
+        ]);
+        let mut substream = Substream::new(buf.clone());
+
+        substream.append(buf.get(0..3).unwrap()).unwrap();
+        substream.append(buf.get(7..10).unwrap()).unwrap();
+        substream.append(buf.get(12..14).unwrap()).unwrap();
+        substream.append(buf.get(15..).unwrap()).unwrap();
+
+        let mut cursor = substream.as_cursor();
+        let mut data = vec![0; 7];
+        let result = cursor.read(&mut data);
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(data, vec![38, 26, 99, 38, 12, 14, 93]);
+
+        let mut data = vec![0; 2];
+        let result = cursor.read(&mut data);
+        assert_eq!(result.unwrap(), 2);
+        assert_eq!(data, vec![86, 88]);
+
+        let mut cursor = substream.as_cursor();
+        let mut data = vec![0; 8];
+        let result = cursor.read(&mut data);
+        assert_eq!(result.unwrap(), 8);
+        assert_eq!(data, vec![38, 26, 99, 38, 12, 14, 93, 86]);
+
+        let mut data = vec![0; 1];
+        let result = cursor.read(&mut data);
+        assert_eq!(result.unwrap(), 1);
+        assert_eq!(data, vec![88]);
+
+        let mut cursor = substream.as_cursor();
+        let mut data = vec![0; 9];
+        let result = cursor.read(&mut data);
+        assert_eq!(result.unwrap(), 9);
+        assert_eq!(data, vec![38, 26, 99, 38, 12, 14, 93, 86, 88]);
     }
 }

--- a/core/common/src/buffer.rs
+++ b/core/common/src/buffer.rs
@@ -163,6 +163,27 @@ impl Slice {
         }
     }
 
+    /// Construct a new Slice from a start and an end.
+    ///
+    /// The start and end values will be relative to the current slice.
+    /// Furthermore, this function will yield an empty slice if the calculated
+    /// slice would be invalid (e.g. negative length) or would extend past the
+    /// end of the current slice.
+    pub fn to_start_and_end(&self, start: usize, end: usize) -> Self {
+        let new_start = self.start + start;
+        let new_end = self.start + end;
+
+        if new_start <= new_end && new_end <= self.end {
+            if let Some(result) = self.buf.get(new_start..new_end) {
+                result
+            } else {
+                self.buf.to_empty_slice()
+            }
+        } else {
+            self.buf.to_empty_slice()
+        }
+    }
+
     /// Get a subslice of this slice.
     ///
     /// Normal subslicing bounds rules will be respected.

--- a/core/common/src/tag_utils.rs
+++ b/core/common/src/tag_utils.rs
@@ -412,16 +412,40 @@ impl SwfSlice {
         }
     }
 
-    /// Construct a new SwfSlice from a SwfStream.
+    /// Construct a new SwfSlice from a Reader and a size.
     ///
     /// This is intended to allow constructing references to the contents of a
-    /// given SWF tag.
+    /// given SWF tag. You just need the current reader and the size of the tag
+    /// you want to reference.
     ///
-    /// If the reader references a slice outside the bounds of the current
-    /// slice, or the given reader refers to a different underlying movie, this
+    /// The returned slice may or may not be a subslice of the current slice.
+    /// If the resulting slice would be outside the bounds of the underlying
+    /// movie, or the given reader refers to a different underlying movie, this
     /// function returns an empty slice.
-    pub fn resize_to_reader(&self, reader: &SwfStream<'_>) -> Self {
-        self.to_subslice(reader.get_ref())
+    pub fn resize_to_reader(&self, reader: &mut SwfStream<'_>, size: usize) -> Self {
+        if self.movie.data().as_ptr() as usize <= reader.get_ref().as_ptr() as usize
+            && (reader.get_ref().as_ptr() as usize)
+                < self.movie.data().as_ptr() as usize + self.movie.data().len()
+        {
+            let outer_offset =
+                reader.get_ref().as_ptr() as usize - self.movie.data().as_ptr() as usize;
+            let new_start = outer_offset;
+            let new_end = outer_offset + size;
+
+            let len = self.movie.data().len();
+
+            if new_start < len && new_end < len {
+                Self {
+                    movie: self.movie.clone(),
+                    start: new_start,
+                    end: new_end,
+                }
+            } else {
+                self.copy_empty()
+            }
+        } else {
+            self.copy_empty()
+        }
     }
 
     /// Construct a new SwfSlice from a start and an end.

--- a/core/common/src/tag_utils.rs
+++ b/core/common/src/tag_utils.rs
@@ -424,6 +424,27 @@ impl SwfSlice {
         self.to_subslice(reader.get_ref())
     }
 
+    /// Construct a new SwfSlice from a start and an end.
+    ///
+    /// The start and end values will be relative to the current slice.
+    /// Furthermore, this function will yield an empty slice if the calculated slice
+    /// would be invalid (e.g. negative length) or would extend past the end of
+    /// the current slice.
+    pub fn to_start_and_end(&self, start: usize, end: usize) -> Self {
+        let new_start = self.start + start;
+        let new_end = self.start + end;
+
+        if new_start <= new_end {
+            if let Some(result) = self.movie.data().get(new_start..new_end) {
+                self.to_subslice(result)
+            } else {
+                self.copy_empty()
+            }
+        } else {
+            self.copy_empty()
+        }
+    }
+
     /// Convert the SwfSlice into a standard data slice.
     pub fn data(&self) -> &[u8] {
         &self.movie.data()[self.start..self.end]

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -833,7 +833,7 @@ pub fn load_playerglobal<'gc>(context: &mut UpdateContext<'gc>, domain: Domain<'
 
     let mut reader = slice.read_from(0);
 
-    let tag_callback = |reader: &mut SwfStream<'_>, tag_code| {
+    let tag_callback = |reader: &mut SwfStream<'_>, tag_code, _tag_len| {
         if tag_code == TagCode::DoAbc2 {
             let do_abc = reader
                 .read_do_abc_2()

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -301,43 +301,47 @@ impl Iterator for StreamTagReader {
     type Item = SwfSlice;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let audio_data = &mut self.current_audio_data;
         let compression = self.compression;
         let mut found = false;
 
         let swf_data = &self.swf_data;
         loop {
-            let mut reader = self.swf_data.read_from(self.pos as u64);
-            let _ = crate::tag_utils::decode_tags(&mut reader, |reader, tag_code| match tag_code {
-                TagCode::SoundStreamBlock if !found => {
-                    found = true;
-                    let mut audio_block = reader.get_ref();
-                    // MP3 audio blocks start with a header indicating sample count + seek offset (SWF19 p.184).
-                    if compression == AudioCompression::Mp3
-                        && let [b0, b1, _, _, ref block_data @ ..] = *audio_block
-                    {
-                        // MP3s deliver audio in frames of 576 samples, which means we may have SoundStreamBlocks with
-                        // lots of extra samples, followed by a block with 0 samples. Worse, there may be frames without
-                        // blocks at all despite SWF19 saying this shouldn't happen. This may or may not indicate a gap
-                        // in the audio depending on the number of empty frames.
-                        // Keep a tally of the # of samples we've seen compared to the number of samples that will be
-                        // played in each timeline frame. Only stop an MP3 sound if we've exhausted all of the samples.
-                        // RESEARCHME: How does Flash Player actually determine when there is an audio gap or not?
-                        // If an MP3 audio track has gaps, Flash Player will often play it out of sync (too early).
-                        // Seems closely related to `stream_info.num_samples_per_block`.
-                        let num_samples = u16::from_le_bytes([b0, b1]);
-                        self.mp3_samples_buffered += i32::from(num_samples);
-                        audio_block = block_data;
+            let tag_callback =
+                |reader: &mut swf::read::Reader<'_>, tag_code, tag_len| match tag_code {
+                    TagCode::SoundStreamBlock if !found => {
+                        found = true;
+                        let mut audio_block = &reader.get_ref()[..tag_len];
+                        // MP3 audio blocks start with a header indicating sample count + seek offset (SWF19 p.184).
+                        if compression == AudioCompression::Mp3 && audio_block.len() >= 4 {
+                            // MP3s deliver audio in frames of 576 samples, which means we may have SoundStreamBlocks with
+                            // lots of extra samples, followed by a block with 0 samples. Worse, there may be frames without
+                            // blocks at all despite SWF19 saying this shouldn't happen. This may or may not indicate a gap
+                            // in the audio depending on the number of empty frames.
+                            // Keep a tally of the # of samples we've seen compared to the number of samples that will be
+                            // played in each timeline frame. Only stop an MP3 sound if we've exhausted all of the samples.
+                            // RESEARCHME: How does Flash Player actually determine when there is an audio gap or not?
+                            // If an MP3 audio track has gaps, Flash Player will often play it out of sync (too early).
+                            // Seems closely related to `stream_info.num_samples_per_block`.
+                            let num_samples = u16::from_le_bytes(
+                                audio_block[..2].try_into().expect("2 bytes fit into a u16"),
+                            );
+                            self.mp3_samples_buffered += i32::from(num_samples);
+                            audio_block = &audio_block[4..];
+                        }
+                        *audio_data = swf_data.to_subslice(audio_block);
+                        Ok(ControlFlow::Continue)
                     }
-                    self.current_audio_data = swf_data.to_subslice(audio_block);
-                    Ok(ControlFlow::Continue)
-                }
-                TagCode::ShowFrame if compression == AudioCompression::Mp3 => {
-                    self.mp3_samples_buffered -= i32::from(self.mp3_samples_per_block);
-                    Ok(ControlFlow::Exit)
-                }
-                TagCode::ShowFrame => Ok(ControlFlow::Exit),
-                _ => Ok(ControlFlow::Continue),
-            });
+                    TagCode::ShowFrame if compression == AudioCompression::Mp3 => {
+                        self.mp3_samples_buffered -= i32::from(self.mp3_samples_per_block);
+                        Ok(ControlFlow::Exit)
+                    }
+                    TagCode::ShowFrame => Ok(ControlFlow::Exit),
+                    _ => Ok(ControlFlow::Continue),
+                };
+
+            let mut reader = self.swf_data.read_from(self.pos as u64);
+            let _ = crate::tag_utils::decode_tags(&mut reader, tag_callback);
             self.pos = reader.get_ref().as_ptr() as usize - swf_data.as_ref().as_ptr() as usize;
 
             // If we hit a SoundStreamBlock within this frame, return it. Otherwise, the stream should end.

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -474,9 +474,15 @@ impl Read for SubstreamTagReader {
             return Ok(0);
         }
 
-        //At this point, current_audio_data should be full
         let chunk = self.current_audio_data.as_mut().unwrap();
-        let len = chunk.read(buf)?;
+        let data = chunk.data();
+
+        //At this point, current_audio_data should be full
+        let len = std::cmp::min(buf.len(), data.len());
+        buf[..len].copy_from_slice(&data[..len]);
+
+        drop(data);
+        *chunk = chunk.to_start_and_end(len, chunk.len());
 
         if chunk.is_empty() {
             self.current_audio_data = None;

--- a/core/src/backend/audio/decoders/adpcm.rs
+++ b/core/src/backend/audio/decoders/adpcm.rs
@@ -1,6 +1,6 @@
 use super::{Decoder, SeekableDecoder, SoundStreamInfo, Substream, SubstreamTagReader};
 use bitstream_io::{BigEndian, BitRead, BitReader};
-use ruffle_common::buffer::Slice;
+use ruffle_common::buffer::SliceCursor;
 use std::io::{Cursor, Read};
 use swf::SoundFormat;
 use thiserror::Error;
@@ -191,7 +191,7 @@ impl<R: AsRef<[u8]> + Default + Send + Sync> SeekableDecoder for AdpcmDecoder<Cu
 pub struct AdpcmSubstreamDecoder {
     format: SoundFormat,
     tag_reader: SubstreamTagReader,
-    decoder: AdpcmDecoder<Slice>,
+    decoder: AdpcmDecoder<SliceCursor>,
 }
 
 impl AdpcmSubstreamDecoder {
@@ -200,7 +200,7 @@ impl AdpcmSubstreamDecoder {
         let mut tag_reader = SubstreamTagReader::new(stream_info, data_stream);
         let audio_data = tag_reader.next().unwrap_or(empty_buffer);
         let decoder = AdpcmDecoder::new(
-            audio_data,
+            audio_data.as_cursor(),
             stream_info.stream_format.is_stereo,
             stream_info.stream_format.sample_rate,
         )?;
@@ -234,9 +234,12 @@ impl Iterator for AdpcmSubstreamDecoder {
             // We've reached the end of the sound stream block tag, so
             // read the next one and recreate the decoder.
             // `AdpcmDecoder` read the ADPCM header when it is created.
-            self.decoder =
-                AdpcmDecoder::new(audio_data, self.format.is_stereo, self.format.sample_rate)
-                    .ok()?;
+            self.decoder = AdpcmDecoder::new(
+                audio_data.as_cursor(),
+                self.format.is_stereo,
+                self.format.sample_rate,
+            )
+            .ok()?;
             self.decoder.next()
         } else {
             // No more SoundStreamBlock tags.

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -68,7 +68,7 @@ impl<'gc> Avm1Button<'gc> {
             .actions
             .iter()
             .map(|action| ButtonAction {
-                action_data: source_movie.to_subslice(action.action_data),
+                action_data: source_movie.to_unbounded_subslice(action.action_data),
                 conditions: action.conditions,
             })
             .collect();

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -549,16 +549,16 @@ impl<'gc> MovieClip<'gc> {
                 TagCode::DefineSound => shared.define_sound(context, reader),
                 TagCode::DefineVideoStream => shared.define_video_stream(context, reader),
                 TagCode::DefineSprite => {
-                    return shared.define_sprite(context, reader, chunk_limit);
+                    return shared.define_sprite(context, reader, tag_len, chunk_limit);
                 }
                 TagCode::DefineText => shared.define_text(context, reader, 1),
                 TagCode::DefineText2 => shared.define_text(context, reader, 2),
-                TagCode::DoInitAction => self.do_init_action(context, reader),
+                TagCode::DoInitAction => self.do_init_action(context, reader, tag_len),
                 TagCode::DefineSceneAndFrameLabelData => shared.scene_and_frame_labels(reader),
                 TagCode::ExportAssets => shared.export_assets(context, reader),
                 TagCode::FrameLabel => shared.frame_label(reader),
                 TagCode::JpegTables => shared.jpeg_tables(context, reader),
-                TagCode::ShowFrame => shared.show_frame(reader),
+                TagCode::ShowFrame => shared.show_frame(reader, tag_len),
                 TagCode::ScriptLimits => shared.script_limits(reader, context.avm1),
                 TagCode::SoundStreamHead => shared.sound_stream_head(reader, 1),
                 TagCode::SoundStreamHead2 => shared.sound_stream_head(reader, 2),
@@ -603,7 +603,7 @@ impl<'gc> MovieClip<'gc> {
             if progress.cur_preload_frame.get() == 1 {
                 // If this clip did not have any show frame tags,
                 // treat the end-of-clip as a ShowFrame
-                shared.show_frame(reader).unwrap();
+                shared.show_frame(reader, 0).unwrap();
             }
             // Flag the movie as fully preloaded when we hit the end of the tag stream.
             progress.next_preload_chunk.set(u64::MAX);
@@ -630,6 +630,7 @@ impl<'gc> MovieClip<'gc> {
         self,
         context: &mut UpdateContext<'gc>,
         reader: &mut SwfStream<'_>,
+        tag_len: usize,
     ) -> Result<(), Error> {
         let mut target = self;
         loop {
@@ -647,14 +648,22 @@ impl<'gc> MovieClip<'gc> {
             target = parent;
         }
 
+        let start = reader.as_slice();
+
         // TODO: Init actions are supposed to be executed once, and it gives a
         // sprite ID... how does that work?
         // TODO: what happens with `DoInitAction` blocks nested in a `DefineSprite`?
         // The SWF spec forbids this, but Ruffle will currently execute them in the context
         // of the character itself, which is probably nonsense.
         let _sprite_id = reader.read_u16()?;
+        let num_read = reader.pos(start);
 
-        let slice = self.0.shared.get().swf.resize_to_reader(reader);
+        let slice = self
+            .0
+            .shared
+            .get()
+            .swf
+            .resize_to_reader(reader, tag_len - num_read);
 
         if !slice.is_empty() {
             Avm1::run_stack_frame_for_init_action(target.into(), slice, context);
@@ -1304,7 +1313,7 @@ impl<'gc> MovieClip<'gc> {
                         }
                         TagCode::DoAction if cur_frame == frame => {
                             // On the target frame, add any DoAction tags to the array.
-                            let slice = shared.swf.resize_to_reader(reader);
+                            let slice = shared.swf.resize_to_reader(reader, reader.get_ref().len());
                             if !slice.is_empty() {
                                 actions.push(slice);
                             }
@@ -1373,7 +1382,7 @@ impl<'gc> MovieClip<'gc> {
 
         let tag_callback = |reader: &mut SwfStream<'_>, tag_code| {
             match tag_code {
-                TagCode::DoAction => self.do_action(context, reader),
+                TagCode::DoAction => self.do_action(context, reader, reader.get_ref().len()),
                 TagCode::PlaceObject if run_display_actions && !is_action_script_3 => {
                     self.place_object(context, reader, 1)
                 }
@@ -3843,15 +3852,18 @@ impl<'gc, 'a> MovieClipShared<'gc> {
         &self,
         context: &mut UpdateContext<'gc>,
         reader: &mut SwfStream<'a>,
+        tag_len: usize,
         chunk_limit: &mut ExecutionLimit,
     ) -> Result<ControlFlow, Error> {
+        let start = reader.as_slice();
         let id = reader.read_character_id()?;
         let num_frames = reader.read_u16()?;
+        let num_read = reader.pos(start);
 
         let movie_clip = MovieClip::new_with_data(
             context.gc(),
             id,
-            self.swf.resize_to_reader(reader),
+            self.swf.resize_to_reader(reader, tag_len - num_read),
             num_frames,
         );
 
@@ -4102,24 +4114,31 @@ impl<'gc, 'a> MovieClipShared<'gc> {
     }
 
     #[inline]
-    fn show_frame(&self, #[allow(unused)] reader: &mut SwfStream<'a>) -> Result<(), Error> {
+    fn show_frame(
+        &self,
+        #[allow(unused)] reader: &mut SwfStream<'a>,
+        #[allow(unused)] tag_len: usize,
+    ) -> Result<(), Error> {
         let progress = &self.preload_progress;
 
         #[cfg(feature = "timeline_debug")]
         {
-            let tag_stream_start = self.swf.as_ref().as_ptr().addr();
-            // We grab the *end* of the SomeFrame tag. Strictly speaking ShowFrame should not have
-            // tag data, but who *knows* what weird obfuscation hacks people have done with it.
-            let tag_show_end = reader.get_ref().as_ptr_range().end.addr();
-            let end_pos = (tag_show_end - tag_stream_start) as u64;
+            let tag_stream_start = self.swf.as_ref().as_ptr() as u64;
+            let end_pos = reader.get_ref().as_ptr() as u64 - tag_stream_start;
 
+            // We add tag_len because the reader position doesn't take it into
+            // account. Strictly speaking ShowFrame should not have tag data, but
+            // who *knows* what weird obfuscation hacks people have done with it.
             self.cell.borrow_mut().tag_frame_boundaries.insert(
                 progress.cur_preload_frame.get(),
-                (progress.start_pos.replace(end_pos), end_pos),
+                (progress.start_pos.get(), end_pos + tag_len as u64),
             );
+
+            progress.start_pos.set(end_pos);
         }
 
-        progress.cur_preload_frame.update(|f| f + 1);
+        let cur = &progress.cur_preload_frame;
+        cur.set(cur.get() + 1);
 
         Ok(())
     }
@@ -4143,7 +4162,9 @@ impl<'gc, 'a> MovieClipShared<'gc> {
 
         let cur_frame = self.preload_progress.cur_preload_frame.get() - 1;
         let abc = match tag_code {
-            TagCode::DoAbc | TagCode::DoAbc2 => self.swf.resize_to_reader(reader),
+            TagCode::DoAbc | TagCode::DoAbc2 => {
+                self.swf.resize_to_reader(reader, reader.as_slice().len())
+            }
             _ => unreachable!(),
         };
 
@@ -4186,6 +4207,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         self,
         context: &mut UpdateContext<'gc>,
         reader: &mut SwfStream<'a>,
+        tag_len: usize,
     ) -> Result<(), Error> {
         if self.movie().is_declared_action_script_3() {
             tracing::warn!("DoAction tag in AVM2 movie");
@@ -4193,7 +4215,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         }
 
         // Queue the actions.
-        let slice = self.0.shared.get().swf.resize_to_reader(reader);
+        let slice = self.0.shared.get().swf.resize_to_reader(reader, tag_len);
         if !slice.is_empty() {
             context.action_queue.queue_action(
                 self.into(),

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -520,8 +520,7 @@ impl<'gc> MovieClip<'gc> {
         }
 
         let mut end_tag_found = false;
-        let tag_callback = |reader: &mut SwfStream<'_>, tag_code| {
-            let tag_len = reader.get_ref().len();
+        let tag_callback = |reader: &mut SwfStream<'_>, tag_code, tag_len| {
             match tag_code {
                 TagCode::CsmTextSettings => shared.csm_text_settings(context, reader),
                 TagCode::DefineBits => shared.define_bits(context, reader),
@@ -1305,7 +1304,7 @@ impl<'gc> MovieClip<'gc> {
             let shared = self.0.shared.get();
             let mut reader = shared.swf.read_from(0);
             while cur_frame <= frame && !reader.get_ref().is_empty() {
-                let tag_callback = |reader: &mut Reader<'_>, tag_code| {
+                let tag_callback = |reader: &mut Reader<'_>, tag_code, tag_len| {
                     match tag_code {
                         TagCode::ShowFrame => {
                             cur_frame += 1;
@@ -1313,7 +1312,7 @@ impl<'gc> MovieClip<'gc> {
                         }
                         TagCode::DoAction if cur_frame == frame => {
                             // On the target frame, add any DoAction tags to the array.
-                            let slice = shared.swf.resize_to_reader(reader, reader.get_ref().len());
+                            let slice = shared.swf.resize_to_reader(reader, tag_len);
                             if !slice.is_empty() {
                                 actions.push(slice);
                             }
@@ -1380,9 +1379,9 @@ impl<'gc> MovieClip<'gc> {
         let data = shared.swf.clone();
         let mut reader = data.read_from(self.0.tag_stream_pos.get());
 
-        let tag_callback = |reader: &mut SwfStream<'_>, tag_code| {
+        let tag_callback = |reader: &mut SwfStream<'_>, tag_code, tag_len| {
             match tag_code {
-                TagCode::DoAction => self.do_action(context, reader, reader.get_ref().len()),
+                TagCode::DoAction => self.do_action(context, reader, tag_len),
                 TagCode::PlaceObject if run_display_actions && !is_action_script_3 => {
                     self.place_object(context, reader, 1)
                 }
@@ -1690,7 +1689,7 @@ impl<'gc> MovieClip<'gc> {
             self.0.increment_current_frame();
             frame_pos = reader.get_ref().as_ptr() as u64 - tag_stream_start;
 
-            let tag_callback = |reader: &mut _, tag_code| {
+            let tag_callback = |reader: &mut _, tag_code, _tag_len| {
                 enum Action {
                     Place(u8),
                     Remove(u8),

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -4502,8 +4502,10 @@ impl<'gc, 'a> MovieClip<'gc> {
             let read = self.0.shared_cell();
             if let (Some(stream_info), None) = (&read.audio_stream_info, self.0.audio_stream.get())
             {
-                let mut slice = self.0.shared.get().swf.clone();
-                slice.start = self.0.tag_stream_pos.get() as usize;
+                let slice = self.0.shared.get().swf.to_start_and_end(
+                    self.0.tag_stream_pos.get() as usize,
+                    self.0.tag_stream_len(),
+                );
                 Some(context.start_stream(self, self.0.current_frame(), slice, stream_info))
             } else {
                 None

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -4969,10 +4969,11 @@ impl ClipEventHandler {
         } else {
             ButtonKeyCode::Unknown
         };
+        let action_data = SwfSlice::from(movie).to_unbounded_subslice(other.action_data);
         Self {
             events: other.events,
             key_code,
-            action_data: SwfSlice::from(movie).to_subslice(other.action_data),
+            action_data,
         }
     }
 }

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -211,7 +211,7 @@ impl<'gc> Video<'gc> {
 
         match self.0.source.get() {
             VideoSource::Swf(swf_source) => {
-                let subslice = SwfSlice::from(movie).to_subslice(tag.data);
+                let subslice = SwfSlice::from(movie).to_unbounded_subslice(tag.data);
                 let mut frames = swf_source.frames.borrow_mut();
 
                 if frames.contains_key(&tag.frame_num.into()) {

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -56,7 +56,7 @@ pub enum ControlFlow {
 /// irregular decoding will be signalled by returning false.
 pub fn decode_tags<'a, F>(reader: &mut SwfStream<'a>, mut tag_callback: F) -> Result<bool, Error>
 where
-    F: for<'b> FnMut(&'b mut SwfStream<'a>, TagCode) -> Result<ControlFlow, Error>,
+    F: for<'b> FnMut(&'b mut SwfStream<'a>, TagCode, usize) -> Result<ControlFlow, Error>,
 {
     loop {
         let (tag_code, tag_len) = reader.read_tag_code_and_length()?;
@@ -70,7 +70,7 @@ where
         let end_slice = &reader.get_ref()[tag_len..];
         if let Some(tag) = TagCode::from_u16(tag_code) {
             *reader.get_mut() = tag_slice;
-            let result = tag_callback(reader, tag);
+            let result = tag_callback(reader, tag, tag_len);
 
             match result {
                 Err(e) => {


### PR DESCRIPTION
Reverts ruffle-rs/ruffle#23124

Reason: caused audio-related regressions

Fixes https://github.com/ruffle-rs/ruffle/issues/23588