### PR TITLE
Make FsTestRunner less dependent on libtest_mimic

### DIFF
--- a/exporter/integration_tests/src/runner.rs
+++ b/exporter/integration_tests/src/runner.rs
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
         .with_test_loader(Box::new(|params, register_trial| {
             register_trial(load_test(params))
         }))
-        .with_sorter(Box::new(|a, b| a.name().cmp(b.name())));
+        .sorted_by_name();
 
     runner.run().exit()
 }

--- a/exporter/integration_tests/src/runner.rs
+++ b/exporter/integration_tests/src/runner.rs
@@ -88,7 +88,8 @@ fn main() -> Result<()> {
         .with_descriptor_name(Cow::Borrowed(TEST_TOML_NAME))
         .with_test_loader(Box::new(|params, register_trial| {
             register_trial(load_test(params))
-        }));
+        }))
+        .with_sorter(Box::new(|a, b| a.name().cmp(b.name())));
 
     runner.run().exit()
 }

--- a/exporter/integration_tests/src/runner.rs
+++ b/exporter/integration_tests/src/runner.rs
@@ -83,6 +83,7 @@ fn main() -> Result<()> {
     let mut runner = FsTestsRunner::new();
 
     runner
+        .with_args_from_libtest_mimic()
         // We're switching directories, so we cannot use relative paths.
         .with_canonicalize_paths(true)
         .with_descriptor_name(Cow::Borrowed(TEST_TOML_NAME))

--- a/render/pixel_bender/assembly_tests/src/runner.rs
+++ b/render/pixel_bender/assembly_tests/src/runner.rs
@@ -78,7 +78,8 @@ fn main() {
         .with_descriptor_name(Cow::Borrowed(TEST_TOML_NAME))
         .with_test_loader(Box::new(|params, register_trial| {
             register_trial(load_test(params))
-        }));
+        }))
+        .with_sorter(Box::new(|a, b| a.name().cmp(b.name())));
 
     runner.run().exit()
 }

--- a/render/pixel_bender/assembly_tests/src/runner.rs
+++ b/render/pixel_bender/assembly_tests/src/runner.rs
@@ -80,7 +80,7 @@ fn main() {
         .with_test_loader(Box::new(|params, register_trial| {
             register_trial(load_test(params))
         }))
-        .with_sorter(Box::new(|a, b| a.name().cmp(b.name())));
+        .sorted_by_name();
 
     runner.run().exit()
 }

--- a/render/pixel_bender/assembly_tests/src/runner.rs
+++ b/render/pixel_bender/assembly_tests/src/runner.rs
@@ -75,6 +75,7 @@ fn main() {
     let mut runner = FsTestsRunner::new();
 
     runner
+        .with_args_from_libtest_mimic()
         .with_descriptor_name(Cow::Borrowed(TEST_TOML_NAME))
         .with_test_loader(Box::new(|params, register_trial| {
             register_trial(load_test(params))

--- a/tests/fs-tests-runner/src/lib.rs
+++ b/tests/fs-tests-runner/src/lib.rs
@@ -33,19 +33,19 @@ fn filter_to_test_name(filter: &str) -> String {
         .to_string()
 }
 
-fn is_candidate(args: &Arguments, test_name: &str) -> bool {
-    if let Some(filter) = &args.filter {
+fn is_candidate(test_name: &str, filter: Option<&str>, exact: bool, skip: &[String]) -> bool {
+    if let Some(filter) = filter {
         let expected_test_name = filter_to_test_name(filter);
-        match args.exact {
+        match exact {
             true if test_name != expected_test_name => return false,
             false if !test_name.contains(&expected_test_name) => return false,
             _ => {}
         };
     }
 
-    for skip_filter in &args.skip {
+    for skip_filter in skip {
         let skipped_test_name = filter_to_test_name(skip_filter);
-        match args.exact {
+        match exact {
             true if test_name == skipped_test_name => return false,
             false if test_name.contains(&skipped_test_name) => return false,
             _ => {}
@@ -71,6 +71,9 @@ pub struct FsTestsRunner {
     test_loader: Option<TestLoader>,
     canonicalize_paths: bool,
     sorter: Option<TestSorter>,
+    exact: bool,
+    filter: Option<String>,
+    skip: Vec<String>,
 }
 
 impl Default for FsTestsRunner {
@@ -88,7 +91,33 @@ impl FsTestsRunner {
             test_loader: None,
             canonicalize_paths: false,
             sorter: None,
+            exact: false,
+            filter: None,
+            skip: Vec::new(),
         }
+    }
+
+    pub fn with_args_from_libtest_mimic(&mut self) -> &mut Self {
+        let arguments = Arguments::from_args();
+        self.exact = arguments.exact;
+        self.filter = arguments.filter;
+        self.skip = arguments.skip;
+        self
+    }
+
+    pub fn with_exact(&mut self, exact: bool) -> &mut Self {
+        self.exact = exact;
+        self
+    }
+
+    pub fn with_filter(&mut self, filter: Option<String>) -> &mut Self {
+        self.filter = filter;
+        self
+    }
+
+    pub fn with_skip(&mut self, skip: Vec<String>) -> &mut Self {
+        self.skip = skip;
+        self
     }
 
     pub fn with_root_dir(&mut self, root_dir: PathBuf) -> &mut Self {
@@ -124,19 +153,17 @@ impl FsTestsRunner {
     pub fn run(mut self) -> Conclusion {
         self.ensure_root_dir_exists();
 
-        let args = Arguments::from_args();
-
         // When this is true, we are looking for one specific test.
         // This is an important optimization for nextest,
         // as it executes tests one by one.
-        let filter_exact = args.exact && args.filter.is_some();
+        let filter_exact = self.exact && self.filter.is_some();
 
         let root = &self.root_dir;
         let mut tests = Vec::new();
 
         if filter_exact {
             // Ignore "errors" here.
-            let _ = self.look_up_test(&args, &mut tests);
+            let _ = self.look_up_test(&mut tests);
         } else {
             let walk = walkdir::WalkDir::new(root)
                 .into_iter()
@@ -156,7 +183,7 @@ impl FsTestsRunner {
                     .unwrap()
                     .to_string_lossy()
                     .replace('\\', "/");
-                if is_candidate(&args, &name) {
+                if is_candidate(&name, self.filter.as_deref(), self.exact, &self.skip) {
                     self.load_test(file.path(), &name, &mut tests)
                 }
             }
@@ -168,6 +195,10 @@ impl FsTestsRunner {
             tests.sort_unstable_by(sorter);
         }
 
+        let mut args = Arguments::from_args();
+        args.exact = self.exact;
+        args.filter = self.filter.clone();
+        args.skip = self.skip.clone();
         libtest_mimic::run(&args, tests)
     }
 
@@ -178,10 +209,10 @@ impl FsTestsRunner {
         }
     }
 
-    fn look_up_test(&self, args: &Arguments, out: &mut Vec<Trial>) -> anyhow::Result<()> {
+    fn look_up_test(&self, out: &mut Vec<Trial>) -> anyhow::Result<()> {
         let root = &self.root_dir;
 
-        let name = filter_to_test_name(args.filter.as_ref().unwrap());
+        let name = filter_to_test_name(self.filter.as_ref().unwrap());
         let absolute_root = std::fs::canonicalize(root).unwrap();
         let path = absolute_root
             .join(&name)

--- a/tests/fs-tests-runner/src/lib.rs
+++ b/tests/fs-tests-runner/src/lib.rs
@@ -252,6 +252,10 @@ impl FsTestsRunner<Trial> {
         self
     }
 
+    pub fn sorted_by_name(&mut self) -> &mut Self {
+        self.with_sorter(Box::new(|a, b| a.name().cmp(b.name())))
+    }
+
     pub fn run(self) -> Conclusion {
         let mut args = Arguments::from_args();
         args.exact = self.exact;

--- a/tests/fs-tests-runner/src/lib.rs
+++ b/tests/fs-tests-runner/src/lib.rs
@@ -150,7 +150,7 @@ impl FsTestsRunner {
         self
     }
 
-    pub fn run(mut self) -> Conclusion {
+    pub fn find_tests(mut self) -> Vec<Trial> {
         self.ensure_root_dir_exists();
 
         // When this is true, we are looking for one specific test.
@@ -195,10 +195,15 @@ impl FsTestsRunner {
             tests.sort_unstable_by(sorter);
         }
 
+        tests
+    }
+
+    pub fn run(self) -> Conclusion {
         let mut args = Arguments::from_args();
         args.exact = self.exact;
         args.filter = self.filter.clone();
         args.skip = self.skip.clone();
+        let tests = self.find_tests();
         libtest_mimic::run(&args, tests)
     }
 

--- a/tests/fs-tests-runner/src/lib.rs
+++ b/tests/fs-tests-runner/src/lib.rs
@@ -61,28 +61,28 @@ pub struct TestLoaderParams<'a> {
     pub test_name: &'a str,
 }
 
-pub type TestLoader = Box<dyn Fn(TestLoaderParams, &mut dyn FnMut(Trial))>;
-pub type TestSorter = Box<dyn FnMut(&Trial, &Trial) -> Ordering>;
+pub type TestLoader<T> = Box<dyn Fn(TestLoaderParams, &mut dyn FnMut(T))>;
+pub type TestSorter<T> = Box<dyn FnMut(&T, &T) -> Ordering>;
 
-pub struct FsTestsRunner {
+pub struct FsTestsRunner<T> {
     root_dir: PathBuf,
     descriptor_name: Cow<'static, str>,
-    additional_tests: Vec<Trial>,
-    test_loader: Option<TestLoader>,
+    additional_tests: Vec<T>,
+    test_loader: Option<TestLoader<T>>,
     canonicalize_paths: bool,
-    sorter: Option<TestSorter>,
+    sorter: Option<TestSorter<T>>,
     exact: bool,
     filter: Option<String>,
     skip: Vec<String>,
 }
 
-impl Default for FsTestsRunner {
+impl<T> Default for FsTestsRunner<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl FsTestsRunner {
+impl<T> FsTestsRunner<T> {
     pub fn new() -> Self {
         Self {
             root_dir: PathBuf::from("tests"),
@@ -95,14 +95,6 @@ impl FsTestsRunner {
             filter: None,
             skip: Vec::new(),
         }
-    }
-
-    pub fn with_args_from_libtest_mimic(&mut self) -> &mut Self {
-        let arguments = Arguments::from_args();
-        self.exact = arguments.exact;
-        self.filter = arguments.filter;
-        self.skip = arguments.skip;
-        self
     }
 
     pub fn with_exact(&mut self, exact: bool) -> &mut Self {
@@ -130,12 +122,12 @@ impl FsTestsRunner {
         self
     }
 
-    pub fn with_additional_test(&mut self, test: Trial) -> &mut Self {
+    pub fn with_additional_test(&mut self, test: T) -> &mut Self {
         self.additional_tests.push(test);
         self
     }
 
-    pub fn with_test_loader(&mut self, test_loader: TestLoader) -> &mut Self {
+    pub fn with_test_loader(&mut self, test_loader: TestLoader<T>) -> &mut Self {
         self.test_loader = Some(test_loader);
         self
     }
@@ -145,12 +137,12 @@ impl FsTestsRunner {
         self
     }
 
-    pub fn with_sorter(&mut self, sorter: TestSorter) -> &mut Self {
+    pub fn with_sorter(&mut self, sorter: TestSorter<T>) -> &mut Self {
         self.sorter = Some(sorter);
         self
     }
 
-    pub fn find_tests(mut self) -> Vec<Trial> {
+    pub fn find_tests(mut self) -> Vec<T> {
         self.ensure_root_dir_exists();
 
         // When this is true, we are looking for one specific test.
@@ -198,15 +190,6 @@ impl FsTestsRunner {
         tests
     }
 
-    pub fn run(self) -> Conclusion {
-        let mut args = Arguments::from_args();
-        args.exact = self.exact;
-        args.filter = self.filter.clone();
-        args.skip = self.skip.clone();
-        let tests = self.find_tests();
-        libtest_mimic::run(&args, tests)
-    }
-
     fn ensure_root_dir_exists(&self) {
         if !self.root_dir.is_dir() {
             let root_dir = self.root_dir.to_string_lossy();
@@ -214,7 +197,7 @@ impl FsTestsRunner {
         }
     }
 
-    fn look_up_test(&self, out: &mut Vec<Trial>) -> anyhow::Result<()> {
+    fn look_up_test(&self, out: &mut Vec<T>) -> anyhow::Result<()> {
         let root = &self.root_dir;
 
         let name = filter_to_test_name(self.filter.as_ref().unwrap());
@@ -238,7 +221,7 @@ impl FsTestsRunner {
         Ok(())
     }
 
-    fn load_test(&self, file: &Path, name: &str, out: &mut Vec<Trial>) {
+    fn load_test(&self, file: &Path, name: &str, out: &mut Vec<T>) {
         let Some(test_loader) = self.test_loader.as_ref() else {
             return;
         };
@@ -257,5 +240,24 @@ impl FsTestsRunner {
             test_name: name,
         };
         test_loader(params, &mut |trial| out.push(trial));
+    }
+}
+
+impl FsTestsRunner<Trial> {
+    pub fn with_args_from_libtest_mimic(&mut self) -> &mut Self {
+        let arguments = Arguments::from_args();
+        self.exact = arguments.exact;
+        self.filter = arguments.filter;
+        self.skip = arguments.skip;
+        self
+    }
+
+    pub fn run(self) -> Conclusion {
+        let mut args = Arguments::from_args();
+        args.exact = self.exact;
+        args.filter = self.filter.clone();
+        args.skip = self.skip.clone();
+        let tests = self.find_tests();
+        libtest_mimic::run(&args, tests)
     }
 }

--- a/tests/fs-tests-runner/src/lib.rs
+++ b/tests/fs-tests-runner/src/lib.rs
@@ -56,7 +56,6 @@ fn is_candidate(args: &Arguments, test_name: &str) -> bool {
 }
 
 pub struct TestLoaderParams<'a> {
-    pub args: &'a Arguments,
     pub test_dir: VfsPath,
     pub test_dir_real: Cow<'a, Path>,
     pub test_name: &'a str,
@@ -158,7 +157,7 @@ impl FsTestsRunner {
                     .to_string_lossy()
                     .replace('\\', "/");
                 if is_candidate(&args, &name) {
-                    self.load_test(&args, file.path(), &name, &mut tests)
+                    self.load_test(file.path(), &name, &mut tests)
                 }
             }
         };
@@ -198,12 +197,12 @@ impl FsTestsRunner {
         }
 
         if path.is_file() {
-            self.load_test(args, &path, &name, out)
+            self.load_test(&path, &name, out)
         }
         Ok(())
     }
 
-    fn load_test(&self, args: &Arguments, file: &Path, name: &str, out: &mut Vec<Trial>) {
+    fn load_test(&self, file: &Path, name: &str, out: &mut Vec<Trial>) {
         let Some(test_loader) = self.test_loader.as_ref() else {
             return;
         };
@@ -217,7 +216,6 @@ impl FsTestsRunner {
         }
         let test_dir = VfsPath::new(PhysicalFS::new(&test_dir_real));
         let params = TestLoaderParams {
-            args,
             test_dir,
             test_dir_real,
             test_name: name,

--- a/tests/fs-tests-runner/src/lib.rs
+++ b/tests/fs-tests-runner/src/lib.rs
@@ -10,6 +10,7 @@ pub use libtest_mimic::Conclusion;
 use libtest_mimic::{Arguments, Trial};
 use regex::Regex;
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::path::Path;
 use std::path::PathBuf;
 use vfs::PhysicalFS;
@@ -62,6 +63,7 @@ pub struct TestLoaderParams<'a> {
 }
 
 pub type TestLoader = Box<dyn Fn(TestLoaderParams, &mut dyn FnMut(Trial))>;
+pub type TestSorter = Box<dyn FnMut(&Trial, &Trial) -> Ordering>;
 
 pub struct FsTestsRunner {
     root_dir: PathBuf,
@@ -69,6 +71,7 @@ pub struct FsTestsRunner {
     additional_tests: Vec<Trial>,
     test_loader: Option<TestLoader>,
     canonicalize_paths: bool,
+    sorter: Option<TestSorter>,
 }
 
 impl Default for FsTestsRunner {
@@ -85,6 +88,7 @@ impl FsTestsRunner {
             additional_tests: Vec::new(),
             test_loader: None,
             canonicalize_paths: false,
+            sorter: None,
         }
     }
 
@@ -110,6 +114,11 @@ impl FsTestsRunner {
 
     pub fn with_canonicalize_paths(&mut self, canonicalize_paths: bool) -> &mut Self {
         self.canonicalize_paths = canonicalize_paths;
+        self
+    }
+
+    pub fn with_sorter(&mut self, sorter: TestSorter) -> &mut Self {
+        self.sorter = Some(sorter);
         self
     }
 
@@ -156,7 +165,9 @@ impl FsTestsRunner {
 
         tests.append(&mut self.additional_tests);
 
-        tests.sort_unstable_by(|a, b| a.name().cmp(b.name()));
+        if let Some(sorter) = &mut self.sorter {
+            tests.sort_unstable_by(sorter);
+        }
 
         libtest_mimic::run(&args, tests)
     }

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -7,7 +7,7 @@ use crate::external_interface::tests::{external_interface_avm1, external_interfa
 use crate::shared_object::{shared_object_avm1, shared_object_avm2, shared_object_self_ref_avm1};
 use anyhow::Context;
 use clap::Parser;
-use libtest_mimic::Trial;
+use libtest_mimic::{Arguments, Trial};
 use ruffle_fs_tests_runner::FsTestsRunner;
 use ruffle_test_framework::environment::CompileMode;
 use ruffle_test_framework::options::TestOptions;
@@ -66,6 +66,7 @@ fn main() {
     let env = Arc::new(NativeEnvironment::new(ruffle_test_opts.compile_mode));
 
     let mut runner = FsTestsRunner::new();
+    let is_listing_only = Arguments::from_args().list;
 
     let env_clone = env.clone();
     runner
@@ -73,7 +74,7 @@ fn main() {
         .with_root_dir(PathBuf::from("tests/swfs"))
         .with_test_loader(Box::new(move |params, register_trial| {
             for test in load_test_dir(&params.test_dir, params.test_name) {
-                let trial = trial_for_test(&env_clone, &ruffle_test_opts, test, params.args.list);
+                let trial = trial_for_test(&env_clone, &ruffle_test_opts, test, is_listing_only);
                 register_trial(trial);
             }
         }))

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -70,6 +70,7 @@ fn main() {
 
     let env_clone = env.clone();
     runner
+        .with_args_from_libtest_mimic()
         .with_descriptor_name(Cow::Borrowed(TEST_TOML_NAME))
         .with_root_dir(PathBuf::from("tests/swfs"))
         .with_test_loader(Box::new(move |params, register_trial| {

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -79,7 +79,7 @@ fn main() {
                 register_trial(trial);
             }
         }))
-        .with_sorter(Box::new(|a, b| a.name().cmp(b.name())));
+        .sorted_by_name();
 
     // Manual tests here, since #[test] doesn't work once we use our own test harness
     let env_clone = env.clone();

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -76,7 +76,8 @@ fn main() {
                 let trial = trial_for_test(&env_clone, &ruffle_test_opts, test, params.args.list);
                 register_trial(trial);
             }
-        }));
+        }))
+        .with_sorter(Box::new(|a, b| a.name().cmp(b.name())));
 
     // Manual tests here, since #[test] doesn't work once we use our own test harness
     let env_clone = env.clone();


### PR DESCRIPTION
## Description

This is all of the necessary changes to the test framework to create a CLI that can navigate tests reusing the same infrastructure as our test runner - minus the actual CLI tool itself.

## Testing

Well, it passes all the existing tests :D CLI that uses it will be in a separate PR, depends on #23513

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
