### PR TITLE
chore: Bump copy-webpack-plugin to 14 in web/

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,7 +24,7 @@
                 "@wdio/static-server-service": "^9.27.1",
                 "chai": "^6.2.2",
                 "chai-html": "^3.2.0",
-                "copy-webpack-plugin": "^13.0.1",
+                "copy-webpack-plugin": "^14.0.0",
                 "cross-env": "^10.1.0",
                 "eslint": "^9.39.2",
                 "eslint-config-prettier": "^10.1.8",
@@ -6900,20 +6900,20 @@
             "license": "MIT"
         },
         "node_modules/copy-webpack-plugin": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-13.0.1.tgz",
-            "integrity": "sha512-J+YV3WfhY6W/Xf9h+J1znYuqTye2xkBUIGyTPWuBAT27qajBa5mR4f8WBmfDY3YjRftT2kqZZiLi1qf0H+UOFw==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
+            "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "glob-parent": "^6.0.1",
                 "normalize-path": "^3.0.0",
                 "schema-utils": "^4.2.0",
-                "serialize-javascript": "^6.0.2",
+                "serialize-javascript": "^7.0.3",
                 "tinyglobby": "^0.2.12"
             },
             "engines": {
-                "node": ">= 18.12.0"
+                "node": ">= 20.9.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -6921,6 +6921,16 @@
             },
             "peerDependencies": {
                 "webpack": "^5.1.0"
+            }
+        },
+        "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/core-util-is": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
         "@wdio/static-server-service": "^9.27.1",
         "chai": "^6.2.2",
         "chai-html": "^3.2.0",
-        "copy-webpack-plugin": "^13.0.1",
+        "copy-webpack-plugin": "^14.0.0",
         "cross-env": "^10.1.0",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
This should resolve one of the many security advisories: https://github.com/webpack/copy-webpack-plugin/blob/main/CHANGELOG.md#1400-2026-03-02