### PR TITLE
ci: Add support for release version bumps other than nightly

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -115,28 +115,51 @@ def gh_get_last_nightly_tag(repo):
 
 # ===== Commands ===========================================
 
-def bump():
+def bump(release_type):
     """
-    Bump the current version of Ruffle nightly.
+    Bump the current version of Ruffle.
     """
+
+    # Make sure the workspace is clean first.
+    try:
+        run_command(['git', 'diff', '--quiet'])
+        run_command(['git', 'diff', '--cached', '--quiet'])
+    except:
+        log('git workspace is not clean, refusing to bump')
+        raise
 
     current_version = cargo_get_version()
     log(f'Current version: {current_version}')
 
-    log('Bumping minor version to get the next planned version')
-    cargo_set_version(['--bump', 'minor'])
-    next_planned_version = cargo_get_version()
-    run_command(['git', 'reset', '--hard', 'HEAD'])
+    if release_type in ['major', 'minor', 'patch']:
+        # Those are standard bumps, we can just bump it.
+        cargo_set_version(['--bump', release_type])
 
-    log(f'Next planned version is {next_planned_version}')
+        version = cargo_get_version()
 
-    nightly_version = f'{next_planned_version}-nightly.{get_current_time_version()}'
-    log(f'Nightly version is {nightly_version}')
+        # Even for standard versions we have to add the day ID to version4,
+        # because otherwise a stable version would be older than a pre-release
+        # version (that's because in version4, 1.2.3 < 1.2.3.4).
+        version4 = f'{version}.{get_current_day_id()}'
+    elif release_type == 'nightly':
+        # Nightly is our custom pre-release version. We basically get the next
+        # minor version (by bumping it and resetting) and add suffix manually
+        # (https://semver.org/#spec-item-9).
 
-    cargo_set_version([nightly_version])
+        log('Bumping minor version to get the next planned version')
+        cargo_set_version(['--bump', 'minor'])
+        next_planned_version = cargo_get_version()
+        run_command(['git', 'reset', '--hard', 'HEAD'])
 
-    version = cargo_get_version()
-    version4 = f'{next_planned_version}.{get_current_day_id()}'
+        log(f'Next planned version is {next_planned_version}')
+
+        nightly_version = f'{next_planned_version}-nightly.{get_current_time_version()}'
+        cargo_set_version([nightly_version])
+
+        version = cargo_get_version()
+        version4 = f'{next_planned_version}.{get_current_day_id()}'
+    else:
+        raise Exception(f'Unsupported release type: {release_type}')
 
     npm_dir = f'{REPO_DIR}/web'
     run_command(['npm', 'install', 'workspace-version'], cwd=npm_dir)
@@ -212,7 +235,8 @@ def main():
     cmd = sys.argv[1]
     log(f'Running command {cmd}')
     if cmd == 'bump':
-        bump()
+        release_type = sys.argv[2]
+        bump(release_type)
     elif cmd == 'metainfo':
         metainfo()
     elif cmd == 'commit':

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -58,7 +58,7 @@ jobs:
         if: steps.activity.outputs.is_active == 'true'
         id: version
         run: |
-          $RELEASE_SCRIPT bump
+          $RELEASE_SCRIPT bump nightly
           # Ensure newlines at the end of file
           shopt -s globstar
           sed -i -e '$a\' **/package.json


### PR DESCRIPTION
## Description

This patch adds a param to the `bump` command of the release script, so that you can select how the version should be bumped. Currently it supports "major", "minor", "patch", and "nightly".

Additionally it prevents bumping when the workspace is not clean.

It shouldn't change anything in the current release process, just adding features required for stable releases.

## Testing

Tested locally by running the release script. CI changes are untested.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
