### PR TITLE
🤖 core: Render Arabic / RTL text in TextField

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arabic_reshaper"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb963411bc62b3888e69ad0d821ac03a3176ec7d74c2096bb5555a4cc419545b"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4591,6 +4597,7 @@ dependencies = [
 name = "ruffle_core"
 version = "0.1.0"
 dependencies = [
+ "arabic_reshaper",
  "async-channel",
  "bitflags 2.11.1",
  "bitstream-io 4.10.0",
@@ -4649,6 +4656,7 @@ dependencies = [
  "tracing",
  "tracy-client",
  "ttf-parser",
+ "unicode-bidi",
  "unicode-segmentation",
  "url",
  "wasm-bindgen-futures",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -66,6 +66,8 @@ enum-map = { workspace = true }
 ttf-parser = "0.25"
 num-bigint = "0.4"
 unicode-segmentation = "1.13.2"
+unicode-bidi = "0.3.18"
+arabic_reshaper = "0.4.2"
 id3 = "1.16.4"
 either = "1.15.0"
 chardetng = "0.1.17"

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -2,7 +2,7 @@ use crate::context::RenderContext;
 use crate::drawing::Drawing;
 use crate::html::TextSpan;
 use crate::prelude::*;
-use crate::string::WStr;
+use crate::string::{WStr, WString};
 use gc_arena::{Collect, Gc, Mutation};
 use ruffle_render::backend::null::NullBitmapSource;
 use ruffle_render::backend::{RenderBackend, ShapeHandle};
@@ -107,6 +107,97 @@ impl DefaultFont {
 
 fn round_to_pixel(t: Twips) -> Twips {
     Twips::from_pixels(t.to_pixels().round())
+}
+
+/// Mirror paired ASCII punctuation when it appears inside an RTL run.
+fn mirror_char(c: char) -> char {
+    match c {
+        '(' => ')',
+        ')' => '(',
+        '[' => ']',
+        ']' => '[',
+        '{' => '}',
+        '}' => '{',
+        '<' => '>',
+        '>' => '<',
+        _ => c,
+    }
+}
+
+/// Arabic base blocks — letters that need joining into Presentation Forms.
+fn is_arabic_base(c: u32) -> bool {
+    (0x0600..=0x06FF).contains(&c)
+        || (0x0750..=0x077F).contains(&c)
+        || (0x08A0..=0x08FF).contains(&c)
+}
+
+/// Arabic Presentation Forms-A and -B — text that is already shaped.
+fn is_arabic_presentation_form(c: u32) -> bool {
+    (0xFB50..=0xFDFF).contains(&c) || (0xFE70..=0xFEFF).contains(&c)
+}
+
+/// RTL scripts other than Arabic that need bidi reordering but no shaping.
+fn is_other_rtl(c: u32) -> bool {
+    (0x0590..=0x05FF).contains(&c)        // Hebrew
+        || (0x0700..=0x074F).contains(&c) // Syriac
+        || (0x0780..=0x07BF).contains(&c) // Thaana
+        || (0x07C0..=0x07FF).contains(&c) // N'Ko
+        || (0x0800..=0x083F).contains(&c) // Samaritan
+        || (0x0840..=0x085F).contains(&c) // Mandaic
+}
+
+/// Reshape Arabic to Presentation Forms and reorder RTL runs into visual
+/// order, so the cmap-only lookup in `evaluate` can resolve them. Returns
+/// `None` (fast path) if the text has no RTL codepoints, or if the font is
+/// embedded — embedded SWF fonts typically lack Presentation Forms.
+fn maybe_reshape_rtl(text: &WStr, font_type: FontType) -> Option<WString> {
+    if !font_type.is_device() {
+        return None;
+    }
+
+    let mut has_arabic_base = false;
+    let mut has_presentation_forms = false;
+    let mut has_other_rtl = false;
+    for u in text.iter() {
+        let c = u as u32;
+        if is_arabic_base(c) {
+            has_arabic_base = true;
+        } else if is_arabic_presentation_form(c) {
+            has_presentation_forms = true;
+        } else if is_other_rtl(c) {
+            has_other_rtl = true;
+        }
+    }
+    if !has_arabic_base && !has_presentation_forms && !has_other_rtl {
+        return None;
+    }
+
+    let logical: String = text.to_utf8_lossy().into_owned();
+    let shaped = if has_arabic_base {
+        arabic_reshaper::arabic_reshape(&logical)
+    } else {
+        logical
+    };
+
+    let bidi = unicode_bidi::BidiInfo::new(&shaped, None);
+    let visual = if !unicode_bidi::level::has_rtl(&bidi.levels) {
+        shaped
+    } else {
+        let mut out = String::with_capacity(shaped.len());
+        for para in &bidi.paragraphs {
+            let (levels, runs) = bidi.visual_runs(para, para.range.clone());
+            for run in runs {
+                if levels[run.start].is_rtl() {
+                    out.extend(shaped[run].chars().rev().map(mirror_char));
+                } else {
+                    out.push_str(&shaped[run]);
+                }
+            }
+        }
+        out
+    };
+
+    Some(WString::from_utf8(&visual))
 }
 
 /// Parameters necessary to evaluate a font.
@@ -877,6 +968,9 @@ pub trait FontLike<'gc> {
         glyph_func: &mut dyn FnMut(usize, &Transform, GlyphRef, Twips, Twips),
     ) {
         let baseline = self.metrics().ascent(params.height);
+
+        let shaped_text = maybe_reshape_rtl(text, self.font_type());
+        let text: &WStr = shaped_text.as_deref().unwrap_or(text);
 
         // TODO [KJ] I'm not sure whether we should iterate over characters here or over code units.
         //   I suspect Flash Player does not support full UTF-16 when displaying and laying out text.

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -498,25 +498,32 @@ impl<'gc> Library<'gc> {
             return cache.clone();
         }
 
+        // Collect every font in the configured chain so a glyph miss on the
+        // first font falls through to the next. The chain is turned into a
+        // FontSet downstream where index 0 is the main font and the rest are
+        // fallbacks; previously this stopped after the first match, so the
+        // fallbacks were never reachable even when the caller configured a
+        // multi-font chain via `set_default_font(_, vec![a, b, ...])`.
         let mut result = vec![];
-        // First try to find any exactly matching fonts.
+        // First pass: prefer fonts that match the requested name exactly.
         for name in self.default_font_names.entry(name).or_default().clone() {
             let query = FontQuery::new(FontType::Device, name, is_bold, is_italic);
             if let Some(font) = self.get_or_load_exact_device_font(&query, ui, renderer, gc_context)
             {
                 result.push(font);
-                break; // TODO: Return multiple fonts when it's needed.
             }
         }
 
-        // Nothing found, try a compatible font.
-        if result.is_empty() {
-            for name in self.default_font_names.entry(name).or_default().clone() {
-                let query = FontQuery::new(FontType::Device, name, is_bold, is_italic);
-                if let Some(font) = self.device_fonts.find(&query) {
-                    result.push(font);
-                    break; // TODO: Return multiple fonts when it's needed.
-                }
+        // Second pass: for any names without an exact match, fall back to the
+        // closest available font under that name. Deduplicate against the
+        // exact-match pass by FontDescriptor so the same font isn't listed
+        // twice in the chain.
+        for name in self.default_font_names.entry(name).or_default().clone() {
+            let query = FontQuery::new(FontType::Device, name, is_bold, is_italic);
+            if let Some(font) = self.device_fonts.find(&query)
+                && !result.iter().any(|f| f.descriptor() == font.descriptor())
+            {
+                result.push(font);
             }
         }
 


### PR DESCRIPTION
## Description

Arabic in any path that flows through `font::FontLike::evaluate` (plain `TextField`, `EditText`, FTE `TextLine` since `text_block::create_text_line` synthesises an `EditText`, and TLF since it uses FTE) is unreadable today:

- `font::evaluate` walks codepoints one by one through `ttf_parser`'s raw cmap lookup, with no GSUB shaping. Even when a font ships isolated forms in cmap (Tahoma, Segoe UI, etc.) the text appeared as detached letters in logical (LTR) order.
- Hebrew, Syriac, Thaana, N'Ko etc. don't need shaping but suffer the same logical-order problem.

This is a pragmatic fix that does not introduce a full shaping engine. Modern Arabic-aware fonts carry the Arabic Presentation Forms-A and -B blocks in their cmap as a compatibility encoding for exactly this case — the joined initial/medial/final/isolated shapes are addressable directly by codepoint. Reshaping base Arabic letters into Presentation Forms makes them resolvable through the existing cmap-only lookup.

### Two commits, both load-bearing

1. **`core: Collect every font in the default_font fallback chain`** — `Library::default_font` had a stale `// TODO: Return multiple fonts when it's needed.` `break;` that returned at most one font per chain. The downstream `FontSet` treats element 0 as the main font and the rest as fallbacks, so discarding the rest meant glyph misses on the primary font had nowhere to fall through to even when the caller had configured a multi-name chain via `set_default_font(_, vec![a, b, ...])`. Single-element chains behave identically to before — no caller that configured one font per default sees a behavior change. This is a real latent bug independent of the Arabic work but the Arabic work needs it (so a host page's Arabic font becomes a real fallback).

2. **`core: Reshape Arabic and reorder RTL runs in font::evaluate`** — the rendering fix. New `maybe_reshape_rtl` in `core/src/font.rs` runs from `evaluate` before the per-codepoint loop. For text without RTL codepoints it's a single linear scan that returns `None` and the existing fast path runs unchanged. For RTL text it reshapes Arabic via `arabic_reshaper`, runs `unicode_bidi`, mirrors paired ASCII punctuation in RTL runs. Returns `None` for `FontType::Embedded` — embedded SWF fonts typically ship only the base Arabic block, so substituting Presentation Forms there would resolve to nothing. Skips re-running the joiner on text already in Presentation Forms. Adds `arabic_reshaper = "0.4.2"` and `unicode-bidi = "0.3.18"` to `core/Cargo.toml` (unicode-bidi was already an indirect dependency).

### Where Arabic-bearing glyphs come from

- **Desktop:** OS device fonts (Tahoma / Segoe UI on Windows; macOS / Linux equivalents) carry the Arabic Presentation Forms in their cmap, so the shaping is enough.
- **Web:** host pages register their own Arabic font (e.g. fetch Noto Sans Arabic and pass to Ruffle's `addFont` + `setDefaultFont` JS APIs). The `library.rs` chain fix above is what makes a multi-name default chain actually fall through on glyph misses.

This PR does **not** bundle a font itself — that would inflate the universal fallback for every user. (An earlier revision of this PR did bundle Noto Sans Arabic as a separate `FALLBACK_DEVICE_FONT_ARABIC` const; dropped on review.)

### Out of scope (deliberate)

- **No real OpenType shaper** (rustybuzz). The right long-term answer but requires reworking `Glyph`/`GlyphSource` to be keyed by glyph ID rather than `char` — much larger change.
- **No GPOS positioning of combining marks (harakat).** Vowel marks still get positive advance and lay out as separate spacing characters.
- **No RTL paragraph alignment.** Lines of Arabic now read correctly but a default-aligned (`left`) paragraph stays left-anchored. That's a layout-engine concern (`core/src/html/layout.rs`), not a font concern.
- **`pos` no longer round-trips for shaped runs.** The `pos` argument `evaluate` passes to its glyph callback is the byte offset into the *reshaped* `WString`, not the source `WStr`. Cursor positioning, hit testing and selection highlighting in `display_object::edit_text` will be off for Arabic spans. Editing Arabic in a `TextField` is rare in practice; preserving correctness here would need a source↔shaped position map that `arabic-reshaper` doesn't expose.

### Transparency for non-RTL content

The `evaluate` change is two lines:

```rust
let shaped_text = maybe_reshape_rtl(text, self.font_type());
let text: &WStr = shaped_text.as_deref().unwrap_or(text);
```

`maybe_reshape_rtl` returns `None` for any text without RTL codepoints, and the rest of `evaluate` runs against the original `text`. So English/Latin/CJK content goes through one extra `O(n)` codepoint scan and otherwise hits the existing path identically.

## Testing

Verified against `safari2025.swf` from cdn.safariislandsgame.com (Cocolani), which uses TLF with `Direction.RTL` and feeds raw logical-order Arabic from a runtime `Language` table. Before: empty rectangles where Arabic should be. After: correctly joined, right-to-left Arabic on desktop (using OS Tahoma/Segoe UI) and on web with a host-page-supplied Arabic font.

`cargo fmt --all` clean. `cargo clippy -p ruffle_core --features default_font --tests` produces zero warnings.

I have not added an automated visual regression test in `tests/tests/swfs/`. Happy to add one if reviewers point me at an existing visual-text fixture I can adapt.

## Notes for reviewers

- **Why `arabic_reshaper` over rolling our own joining table?** The crate is a Python-port and weighs trivially in the WASM (~30 KB). The alternative (in-tree joining table) would duplicate Unicode property data we'd then need to keep current.

- **The `break;` in `library.rs::default_font` is a real latent bug**, not just a fix in service of this PR. Anyone who configures `set_default_font` with a multi-name chain on `master` today is silently losing every name after the first. The TODO comment from the original author suggests this was planned work; this PR is the smallest patch that does it.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have made or updated tests where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
