### PR TITLE
🤖 web: Layout-independent clipboard shortcuts (Ctrl+V/C/X/A)

### DIFF
--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -263,13 +263,30 @@ fn map_key_location(location: u32) -> KeyLocation {
     }
 }
 
-/// Convert a web `KeyboardEvent.key` value to a Ruffle `TextControlCode`,
-/// given the states of the modifier keys. Return `None` if there is no match.
+/// Convert a web keyboard event to a Ruffle `TextControlCode`, given the
+/// states of the modifier keys. Return `None` if there is no match.
+///
+/// `key` is `KeyboardEvent.key` (the produced character — layout-dependent;
+/// e.g. on an Arabic keyboard the physical V key produces `ر`). `code` is
+/// `KeyboardEvent.code` (the physical key — always `"KeyV"` regardless of
+/// layout). For Ctrl-modified clipboard shortcuts we match on `code` first
+/// so paste/copy/cut/select-all work on every keyboard layout, matching
+/// Flash Player's layout-independent shortcut handling.
 pub fn web_to_ruffle_text_control(
     key: &str,
+    code: &str,
     ctrl_key: bool,
     shift_key: bool,
 ) -> Option<TextControlCode> {
+    if ctrl_key {
+        match code {
+            "KeyA" => return Some(TextControlCode::SelectAll),
+            "KeyC" => return Some(TextControlCode::Copy),
+            "KeyV" => return Some(TextControlCode::Paste),
+            "KeyX" => return Some(TextControlCode::Cut),
+            _ => {}
+        }
+    }
     let mut chars = key.chars();
     let (c1, c2) = (chars.next(), chars.next());
     if c2.is_none() {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -780,6 +780,7 @@ impl RuffleHandle {
 
                                 if let Some(control_code) = web_to_ruffle_text_control(
                                     &js_event.key(),
+                                    &js_event.code(),
                                     is_ctrl_cmd,
                                     js_event.shift_key(),
                                 ) {


### PR DESCRIPTION
## Description

Ctrl+V / Ctrl+C / Ctrl+X / Ctrl+A only worked on Latin-character keyboard layouts. Layouts that produce a non-Latin character on the V/C/X/A keys (Arabic, Hebrew, Cyrillic, Greek, Devanagari, etc.) reported `KeyboardEvent.key` as the localised character (e.g. `ر` on Arabic) and `web_to_ruffle_text_control`'s match-on-`key` silently dropped through to a no-op. Pressing Ctrl+V on an Arabic keyboard layout simply did nothing — no paste, no error.

Adobe Flash Player handled clipboard shortcuts on the physical key, layout-independent.

This change matches on `KeyboardEvent.code` first (`"KeyA"` / `"KeyC"` / `"KeyV"` / `"KeyX"` — always the physical key, regardless of layout) and falls back to the existing character-based match when `code` is empty (some on-screen / virtual keyboards report `code: ""`).

## Testing

Verified on Chrome with both English (US) and Arabic keyboard layouts:

1. Build the web extension (`cd web && npm run build`) and load `web/packages/extension/dist/ruffle_extension.zip` as an unpacked extension.
2. Switch keyboard layout to Arabic (Win+Space on Windows).
3. Click into any SWF text input, copy some Arabic text from another tab, press Ctrl+V — text pastes.
4. Repeat with English layout — paste still works exactly as before.
5. Same for Ctrl+C / Ctrl+X / Ctrl+A on selected text.

`cargo fmt --all` clean. `cargo clippy -p ruffle_web --target wasm32-unknown-unknown` produces zero warnings on this change.

No new automated test added — the existing keyboard-handling tests in `web/` are sparse and I didn't want to scope-creep. Happy to add one if reviewers prefer.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have made or updated tests where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
