### PR TITLE
ci: Generate release tag names based on version

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -29,7 +29,15 @@ def get_current_day_id():
     return f'{now.year - 2000}{day}'
 
 
-def get_tag_name():
+def get_tag_name(version):
+    if '-nightly.' in version:
+        # TODO Nightly versions use a different tag syntax, unify it.
+        return get_today_nightly_tag_name()
+
+    return f'v{version}'
+
+
+def get_today_nightly_tag_name():
     now = datetime.now()
     current_time_dashes = now.strftime('%Y-%m-%d')
     tag_name = f'nightly-{current_time_dashes}'
@@ -175,7 +183,7 @@ def metainfo():
     metainfo_path1 = f'{REPO_DIR}/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml'
     metainfo_path2 = f'{REPO_DIR}/desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml.in'
     version = cargo_get_version()
-    tag_name = get_tag_name()
+    tag_name = get_tag_name(version)
     add_release_to_metainfo(metainfo_path1, tag_name, version)
     add_release_to_metainfo(metainfo_path2, tag_name, version)
 
@@ -193,7 +201,8 @@ def commit():
 
 
 def tag_and_push(remote):
-    tag_name = get_tag_name()
+    version = cargo_get_version()
+    tag_name = get_tag_name(version)
     run_command(['git', 'tag', tag_name])
     run_command(['git', 'push', remote, 'tag', tag_name])
     github_output('tag_name', tag_name)
@@ -208,7 +217,8 @@ def release(repo):
     current_time_dashes = now.strftime('%Y-%m-%d')
     current_time_underscores = now.strftime('%Y_%m_%d')
 
-    tag_name = get_tag_name()
+    version = cargo_get_version()
+    tag_name = get_tag_name(version)
     last_nightly_tag = gh_get_last_nightly_tag(repo)
     release_name = f'Nightly {current_time_dashes}'
     package_prefix = f'ruffle-nightly-{current_time_underscores}'

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -192,10 +192,10 @@ def commit():
     ])
 
 
-def tag_and_push():
+def tag_and_push(remote):
     tag_name = get_tag_name()
     run_command(['git', 'tag', tag_name])
-    run_command(['git', 'push', 'origin', 'tag', tag_name])
+    run_command(['git', 'push', remote, 'tag', tag_name])
     github_output('tag_name', tag_name)
 
 
@@ -242,7 +242,8 @@ def main():
     elif cmd == 'commit':
         commit()
     elif cmd == 'tag-and-push':
-        tag_and_push()
+        remote = sys.argv[2]
+        tag_and_push(remote)
     elif cmd == 'release':
         repo = sys.argv[2]
         release(repo)

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -73,7 +73,7 @@ jobs:
         id: commit
         run: |
           $RELEASE_SCRIPT commit
-          $RELEASE_SCRIPT tag-and-push
+          $RELEASE_SCRIPT tag-and-push origin
 
       - name: Get current time with underscores
         uses: josStorer/get-current-time@v2.1.2


### PR DESCRIPTION
## Description

Nightly tag names remain the same for now (nightly-2026-05-04), but that
allows creating tag names for non-nightly versions, which is just a
version with a 'v' prefix, e.g. v1.0.0.

In the future we might want to unify the tag names for nightly releases
too, so that `nightly-2026-05-04` becomes `v0.2.0-nightly.2026.5.4`.

## Testing

Tested locally, CI changes untested.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
