### PR TITLE
ci: Support creating non-nightly releases on GitHub 

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -213,29 +213,49 @@ def release(repo):
     Create a release of Ruffle on GitHub.
     """
 
-    now = datetime.now()
-    current_time_dashes = now.strftime('%Y-%m-%d')
-    current_time_underscores = now.strftime('%Y_%m_%d')
-
     version = cargo_get_version()
     tag_name = get_tag_name(version)
-    last_nightly_tag = gh_get_last_nightly_tag(repo)
-    release_name = f'Nightly {current_time_dashes}'
-    package_prefix = f'ruffle-nightly-{current_time_underscores}'
-    release_options = ['--generate-notes', '--prerelease']
 
-    if last_nightly_tag is not None:
-        log(f'Using {last_nightly_tag} as start tag for notes')
-        release_options += ['--notes-start-tag', last_nightly_tag]
-    else:
-        log('No start tag for notes found')
+    # When there's a "-" in version it's a pre-release version.
+    # (Except for versions with a build suffix, but we don't support those.)
+    is_pre_release = '-' in version
+
+    notes_start_tag = None
+    release_options = []
+    release_name = f'Release {version}'
+    package_prefix = f'ruffle-{version}'
+
+    if is_pre_release:
+        release_options += ['--prerelease']
+
+        if '-nightly.' in version:
+            # Nightly-specific stuff.
+            now = datetime.now()
+            current_time_dashes = now.strftime('%Y-%m-%d')
+            current_time_underscores = now.strftime('%Y_%m_%d')
+
+            # For nightly, we do detached tags, and we need to specify the start
+            # tag explicitly for generated notes to work.
+            notes_start_tag = gh_get_last_nightly_tag(repo)
+
+            release_name = f'Nightly {current_time_dashes}'
+            package_prefix = f'ruffle-nightly-{current_time_underscores}'
+            release_options += ['--generate-notes']
+    else: # Not a pre release.
+        # For stable release trust GitHub's generation tool.
+        release_options += ['--generate-notes']
+
+    if notes_start_tag is not None:
+        log(f'Using {notes_start_tag} as start tag for notes')
+        release_options += ['--notes-start-tag', notes_start_tag]
 
     run_command([
         'gh', 'release', 'create', tag_name,
         '--repo', repo,
         '--title', release_name,
         '--verify-tag',
-        *release_options])
+        *release_options,
+    ])
 
     github_output('tag_name', tag_name)
     github_output('package_prefix', package_prefix)


### PR DESCRIPTION
## Description

This adds support for creating for non-nightly releases: release names,
package prefixes, release options, notes. For nightly releases, the
behavior remains the same. For non-prereleases notes are generated
automatically by GitHub.

## Testing

Tested manually on my fork of Ruffle. Notes are generated properly for stable releases, emphasis on the following behavior:

* When it's the first stable release, it won't have any notes.
* When it's a major bump, it will have notes based on the last minor bump (so if after 1.47.0 there's 2.0.0, notes will be generated from 1.47.0..2.0.0).
* Notes skip all prereleases (which is desirable).

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
