### PR TITLE
web: Enable BackgroundExecutionMode.MainThread by default

### DIFF
--- a/web/packages/core/src/public/config/default.ts
+++ b/web/packages/core/src/public/config/default.ts
@@ -59,5 +59,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     urlRewriteRules: [],
     scrollingBehavior: ScrollingBehavior.Smart,
     deviceFontRenderer: DeviceFontRenderer.Embedded,
-    backgroundExecutionMode: BackgroundExecutionMode.None,
+    backgroundExecutionMode: BackgroundExecutionMode.MainThread,
 };

--- a/web/packages/core/src/public/config/load-options.ts
+++ b/web/packages/core/src/public/config/load-options.ts
@@ -308,7 +308,7 @@ export enum DeviceFontRenderer {
 }
 
 /**
- * Represents the various background execution behaviours that are supported.
+ * Represents the various background execution behaviors that are supported.
  */
 export enum BackgroundExecutionMode {
     /**
@@ -809,7 +809,7 @@ export interface BaseLoadOptions {
     /**
      * Controls how Ruffle behaves when the browser tab is hidden.
      *
-     * @default BackgroundExecutionMode.None
+     * @default BackgroundExecutionMode.MainThread
      */
     backgroundExecutionMode?: BackgroundExecutionMode;
 }


### PR DESCRIPTION
* Fixes https://github.com/ruffle-rs/ruffle/issues/7289
* Fixes https://github.com/ruffle-rs/ruffle/issues/10527

## Description

It's been 2 weeks and we received positive feedback about this change. I've been testing it personally too and I didn't see any issues, so this patch enabled background execution on main thread by default.

Thanks @robinmiau again for implementing this feature!

## Testing

Tested myself and received positive feedback from testers.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
