### PR TITLE
core: Fix LoaderInfo.width/height returning 0 for loaded raster images

### DIFF
--- a/core/common/src/tag_utils.rs
+++ b/core/common/src/tag_utils.rs
@@ -177,8 +177,11 @@ impl SwfMovie {
     }
 
     /// Construct a movie based on a loaded image (JPEG, GIF or PNG).
-    pub fn from_loaded_image(url: String, length: usize) -> Self {
-        let header = HeaderExt::default_with_uncompressed_len(length as i32);
+    pub fn from_loaded_image(url: String, length: usize, width: u32, height: u32) -> Self {
+        let stage_size = Rectangle::ZERO
+            .with_width(Twips::from_pixels_i32(width as i32))
+            .with_height(Twips::from_pixels_i32(height as i32));
+        let header = HeaderExt::default_with_uncompressed_len(length as i32, stage_size);
         let sandbox_type = SandboxType::infer(url.as_str(), &header);
         let mut movie = Self {
             header,

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1625,7 +1625,15 @@ impl<'gc> MovieLoader<'gc> {
                 Arc::new(movie)
             }
             ContentType::Gif | ContentType::Jpeg | ContentType::Png => {
-                Arc::new(SwfMovie::from_loaded_image(url.clone(), length))
+                let (width, height) =
+                    ruffle_render::utils::decode_define_bits_jpeg_dimensions(data)
+                        .unwrap_or((0, 0));
+                Arc::new(SwfMovie::from_loaded_image(
+                    url.clone(),
+                    length,
+                    width,
+                    height,
+                ))
             }
             ContentType::Unknown => Arc::new(SwfMovie::error_movie(url.clone())),
         };

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -126,11 +126,11 @@ impl HeaderExt {
     }
 
     /// Returns the header for a loaded image (JPEG, GIF or PNG).
-    pub fn default_with_uncompressed_len(length: i32) -> Self {
+    pub fn default_with_uncompressed_len(length: i32, stage_size: Rectangle<Twips>) -> Self {
         let header = Header {
             compression: Compression::None,
             version: 0,
-            stage_size: Default::default(),
+            stage_size,
             frame_rate: Fixed8::ONE,
             num_frames: 1,
         };

--- a/tests/tests/swfs/from_shumway/as3-loader/loaderinfo/loaded-content-properties/output.ruffle.txt
+++ b/tests/tests/swfs/from_shumway/as3-loader/loaderinfo/loaded-content-properties/output.ruffle.txt
@@ -33,7 +33,7 @@ childSandboxBridge: null
 content: [object Bitmap]
 contentType: image/jpeg
 frameRate: 1
-height: 0
+height: 140
 isURLInaccessible: false
 loader: [object Loader]
 loaderURL: alf.jpg
@@ -45,4 +45,4 @@ sharedEvents: [object EventDispatcher]
 swfVersion: 0
 uncaughtErrorEvents: [object UncaughtErrorEvents]
 url: alf.jpg
-width: 0
+width: 140


### PR DESCRIPTION
## Description

LoaderInfo.width/height returned 0 for raster images loaded via flash.display.Loader. 
Cause: SwfMovie built by from_loaded_image is constructed before the bytes are decoded, so its placeholder header had a 0x0 stage size, and that movie ends up in the final LoaderStream::Swf, which is what the getters read.

Fixes #19769

## Testing

I've updated the loaded-content-properties test, which now correctly returns width and height. 

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [X] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
