### PR TITLE
chore: Bump browserstack-local in package-lock.json

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6234,17 +6234,16 @@
             }
         },
         "node_modules/browserstack-local": {
-            "version": "1.5.9",
-            "resolved": "https://registry.npmjs.org/browserstack-local/-/browserstack-local-1.5.9.tgz",
-            "integrity": "sha512-p8H3alMqUK9lq8JHhsDdZ4tpnSgbHyRyKnZu9U+9p7XzR/SpvTm/zkfsSJsnUZBoiYFe+B1VaGZ4cL5f2ya6mw==",
+            "version": "1.5.13",
+            "resolved": "https://registry.npmjs.org/browserstack-local/-/browserstack-local-1.5.13.tgz",
+            "integrity": "sha512-7helY+Ms3ss4BtIQZTIyshdAFZSvS9A7ZpEB9stRaobeZ9BM1BkJFTuMakQNTOj78llv0+/qDI5Ak+bkGWV1xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^6.0.2",
                 "https-proxy-agent": "^5.0.1",
                 "is-running": "^2.1.0",
-                "ps-tree": "=1.2.0",
-                "temp-fs": "^0.9.9"
+                "tree-kill": "^1.2.2"
             }
         },
         "node_modules/buffer": {
@@ -7845,13 +7844,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/duplexer": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -8588,22 +8580,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/event-stream": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-            "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "duplexer": "~0.1.1",
-                "from": "~0",
-                "map-stream": "~0.1.0",
-                "pause-stream": "0.0.11",
-                "split": "0.3",
-                "stream-combiner": "~0.0.4",
-                "through": "~2.3.1"
-            }
-        },
         "node_modules/event-target-shim": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -9333,13 +9309,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/from": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-            "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -11901,12 +11870,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/map-stream": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-            "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
-            "dev": true
-        },
         "node_modules/markdown-it": {
             "version": "14.1.1",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -12900,16 +12863,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -12957,19 +12910,6 @@
             "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/pause-stream": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-            "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-            "dev": true,
-            "license": [
-                "MIT",
-                "Apache2"
-            ],
-            "dependencies": {
-                "through": "~2.3"
-            }
         },
         "node_modules/pend": {
             "version": "1.2.0",
@@ -13912,22 +13852,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/ps-tree": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
-            "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "event-stream": "=3.3.4"
-            },
-            "bin": {
-                "ps-tree": "bin/ps-tree.js"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
         "node_modules/pump": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -14771,42 +14695,6 @@
             "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/rimraf": {
-            "version": "2.5.4",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-            "integrity": "sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.0.5"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/rimraf/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
         },
         "node_modules/rolldown": {
             "version": "1.0.0-rc.17",
@@ -15704,19 +15592,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/split": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-            "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "through": "2"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/split2": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -15768,16 +15643,6 @@
             "license": "Unlicense",
             "engines": {
                 "node": ">= 0.10.0"
-            }
-        },
-        "node_modules/stream-combiner": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-            "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "duplexer": "~0.1.1"
             }
         },
         "node_modules/streamx": {
@@ -16476,19 +16341,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/temp-fs": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/temp-fs/-/temp-fs-0.9.9.tgz",
-            "integrity": "sha512-WfecDCR1xC9b0nsrzSaxPf3ZuWeWLUWblW4vlDQAa1biQaKHiImHnJfeQocQe/hXKMcolRzgkcVX/7kK4zoWbw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "rimraf": "~2.5.2"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/terser": {
             "version": "5.46.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
@@ -16575,13 +16427,6 @@
             "peerDependencies": {
                 "tslib": "^2"
             }
-        },
-        "node_modules/through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/thunky": {
             "version": "1.1.0",
@@ -16713,6 +16558,16 @@
             },
             "peerDependencies": {
                 "tslib": "2"
+            }
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
             }
         },
         "node_modules/triple-beam": {


### PR DESCRIPTION
This drops a lot of old deps.

Similar to https://github.com/ruffle-rs/ruffle/pull/23654.

Ran `npm update browserstack-local`.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
