### PR TITLE
ci: Add stable releases

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -29,6 +29,12 @@ def get_current_day_id():
     return f'{now.year - 2000}{day}'
 
 
+def get_max_day_id():
+    max_year = 2999
+    max_day = 999
+    return f'{max_year - 2000}{max_day}'
+
+
 def get_tag_name(version):
     if '-nightly.' in version:
         # TODO Nightly versions use a different tag syntax, unify it.
@@ -148,7 +154,7 @@ def bump(release_type):
         # Even for standard versions we have to add the day ID to version4,
         # because otherwise a stable version would be older than a pre-release
         # version (that's because in version4, 1.2.3 < 1.2.3.4).
-        version4 = f'{version}.{get_current_day_id()}'
+        version4 = f'{version}.{get_max_day_id()}'
     elif release_type == 'nightly':
         # Nightly is our custom pre-release version. We basically get the next
         # minor version (by bumping it and resetting) and add suffix manually

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,15 @@ on:
 
   # Allow for manual dispatch on GitHub
   workflow_dispatch:
+    inputs:
+      release_type:
+        type: choice
+        description: Choose release type
+        options:
+          - nightly
+          - minor
+          - patch
+          - major
 
 env:
   RELEASE_SCRIPT: ./.github/scripts/release.py
@@ -33,16 +42,23 @@ jobs:
       - name: Configure release
         id: configure
         run: |
-          # Skip activity check when manually triggered.
-          if [ "${{ github.event_name }}" == "repository_dispatch" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            enabled=true
-          elif [ "$(git rev-list --after="24 hours" ${{ github.sha }})" ]; then
-            enabled=true
+          enabled=true
+          if [[ "${{ github.event.inputs.release_type }}" == "nightly" ]]; then
+            release_channel=nightly
+            release_type=nightly
+          elif [[ -n "${{ github.event.inputs.release_type }}" ]]; then
+            release_channel=stable
+            release_type="${{ github.event.inputs.release_type }}"
+          elif [[ "${{ github.event.schedule }}" == '0 0 * * *' && "$(git rev-list --after="24 hours" ${{ github.sha }})" ]]; then
+            release_channel=nightly
+            release_type=nightly
           else
             enabled=false
+            release_channel=
           fi
           echo "enabled=$enabled" | tee -a $GITHUB_OUTPUT
-          echo "release_channel=nightly" | tee -a $GITHUB_OUTPUT
+          echo "release_channel=$release_channel" | tee -a $GITHUB_OUTPUT
+          echo "release_type=$release_type" | tee -a $GITHUB_OUTPUT
 
       - name: Install cargo-edit
         uses: baptiste0928/cargo-install@v3
@@ -60,7 +76,7 @@ jobs:
         if: steps.configure.outputs.enabled == 'true'
         id: version
         run: |
-          $RELEASE_SCRIPT bump nightly
+          $RELEASE_SCRIPT bump "${{ steps.configure.outputs.release_type }}"
           # Ensure newlines at the end of file
           shopt -s globstar
           sed -i -e '$a\' **/package.json
@@ -76,6 +92,11 @@ jobs:
         run: |
           $RELEASE_SCRIPT commit
           $RELEASE_SCRIPT tag-and-push origin
+
+      - name: Update branch
+        if: steps.configure.outputs.enabled == 'true' && steps.configure.outputs.release_type != 'nightly'
+        run: |
+          git push
 
       - name: Get current time with underscores
         uses: josStorer/get-current-time@v2.1.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       package_prefix: ${{ steps.create_release.outputs.package_prefix }}
       tag_name: ${{ steps.commit.outputs.tag_name }}
       version4: ${{ steps.version.outputs.version4 }}
+      release_channel: ${{ steps.configure.outputs.release_channel }}
 
     # Only run the scheduled workflows on the main repo.
     if: github.repository == 'ruffle-rs/ruffle' || github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
@@ -41,6 +42,7 @@ jobs:
             enabled=false
           fi
           echo "enabled=$enabled" | tee -a $GITHUB_OUTPUT
+          echo "release_channel=nightly" | tee -a $GITHUB_OUTPUT
 
       - name: Install cargo-edit
         uses: baptiste0928/cargo-install@v3
@@ -163,7 +165,7 @@ jobs:
       - name: Cargo build
         run: cargo build --locked --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
-          CFG_RELEASE_CHANNEL: nightly
+          CFG_RELEASE_CHANNEL: ${{ needs.create-release.outputs.release_channel }}
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
 
@@ -213,7 +215,7 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo build --locked --package ruffle_web_safari --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
-          CFG_RELEASE_CHANNEL: nightly
+          CFG_RELEASE_CHANNEL: ${{ needs.create-release.outputs.release_channel }}
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
 
@@ -408,7 +410,7 @@ jobs:
         shell: bash -l {0}
         working-directory: web
         env:
-          CFG_RELEASE_CHANNEL: nightly
+          CFG_RELEASE_CHANNEL: ${{ needs.create-release.outputs.release_channel }}
           VERSION4: ${{ needs.create-release.outputs.version4 }}
           ENABLE_VERSION_SEAL: "true"
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
@@ -416,7 +418,7 @@ jobs:
 
       - name: Build web
         env:
-          CFG_RELEASE_CHANNEL: nightly
+          CFG_RELEASE_CHANNEL: ${{ needs.create-release.outputs.release_channel }}
           VERSION4: ${{ needs.create-release.outputs.version4 }}
           # NOTE: In the future, we might want to enable some features (like `webgpu`) only in
           # the demo build, for limited testing (like a Chrome origin trial) on ruffle.rs.
@@ -469,7 +471,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Chrome extension
-        if: env.CHROME_EXTENSION_ID != ''
+        if: env.CHROME_EXTENSION_ID != '' && needs.create-release.outputs.release_channel == 'nightly'
         id: publish-chrome-extension
         continue-on-error: true
         env:
@@ -483,7 +485,7 @@ jobs:
           file-path: ./web/packages/extension/dist/ruffle_extension.zip
 
       - name: Publish Edge extension
-        if: env.EDGE_PRODUCT_ID != ''
+        if: env.EDGE_PRODUCT_ID != '' && needs.create-release.outputs.release_channel == 'nightly'
         id: publish-edge-extension
         continue-on-error: true
         env:
@@ -496,7 +498,7 @@ jobs:
           api-key: ${{ secrets.EDGE_API_KEY }}
 
       - name: Publish Firefox extension
-        if: env.FIREFOX_EXTENSION_ID != ''
+        if: env.FIREFOX_EXTENSION_ID != '' && needs.create-release.outputs.release_channel == 'nightly'
         id: publish-firefox-extension
         continue-on-error: true
         env:
@@ -533,6 +535,7 @@ jobs:
 
       - name: Clone JS docs
         uses: actions/checkout@v6
+        if: needs.create-release.outputs.release_channel == 'nightly'
         with:
           repository: ruffle-rs/js-docs
           path: js-docs
@@ -541,6 +544,7 @@ jobs:
           persist-credentials: false # Needed to allow commit via RUFFLE_BUILD_TOKEN below
 
       - name: Update JS docs
+        if: needs.create-release.outputs.release_channel == 'nightly'
         run: |
           # Delete the old docs
           rm -rf master/
@@ -556,7 +560,7 @@ jobs:
         working-directory: js-docs
 
       - name: Push JS docs
-        if: github.repository == 'ruffle-rs/ruffle'
+        if: github.repository == 'ruffle-rs/ruffle' && needs.create-release.outputs.release_channel == 'nightly'
         uses: ad-m/github-push-action@master
         with:
           repository: ruffle-rs/js-docs
@@ -566,6 +570,7 @@ jobs:
 
       - name: Clone web demo
         uses: actions/checkout@v6
+        if: needs.create-release.outputs.release_channel == 'nightly'
         with:
           repository: ruffle-rs/demo
           path: demo
@@ -574,6 +579,7 @@ jobs:
           persist-credentials: false # Needed to allow commit via RUFFLE_BUILD_TOKEN below
 
       - name: Update web demo
+        if: needs.create-release.outputs.release_channel == 'nightly'
         run: |
           # Delete the old build.
           rm -fr *
@@ -592,7 +598,7 @@ jobs:
         working-directory: demo
 
       - name: Push web demo
-        if: github.repository == 'ruffle-rs/ruffle'
+        if: github.repository == 'ruffle-rs/ruffle' && needs.create-release.outputs.release_channel == 'nightly'
         uses: ad-m/github-push-action@master
         with:
           repository: ruffle-rs/demo
@@ -604,7 +610,7 @@ jobs:
     name: Publish AUR package
     needs: [create-release, build]
     runs-on: ubuntu-24.04
-    if: github.repository == 'ruffle-rs/ruffle'
+    if: github.repository == 'ruffle-rs/ruffle' && needs.create-release.outputs.release_channel == 'nightly'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Description

This is a retake of https://github.com/ruffle-rs/ruffle/pull/17193.

The majority of code has already been merged, this adds the remaining pieces so that we can do stable releases.

Specifically:
* fix version4 for stable releases so it's date-independent,
* accept `release_type` input param which allows selecting what release should be performed,
* set release channel based on release type (`nightly`/`stable`),
* for non-nightly releases, push the release commit to the branch.

Stuff like publishing extensions, the AUR package, demo, or JS docs are constrained to nightly releases for now. The npm package is published for all versions (according to my knowledge it should work OOTB).

## Testing

It has been tested on my fork, did three releases:
1. `0.2.0`,
2. a nightly release,
3. `1.0.0`.

Resulting commits: https://github.com/kjarosh/ruffle/commits/102c8082d0c0db747432bc034b2c841c81e3a5b7

Resulting releases: https://github.com/kjarosh/ruffle/releases

Jobs:
* https://github.com/kjarosh/ruffle/actions/runs/25454216414
* https://github.com/kjarosh/ruffle/actions/runs/25454288235
* https://github.com/kjarosh/ruffle/actions/runs/25454381457

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
