### PR TITLE
chore: Migrate to current Node.js 26 from 25 for testing

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["24", "25"]
+        node_version: ["24", "26"]
         os: [ubuntu-24.04, windows-2025]
 
     steps:
@@ -197,7 +197,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ["24", "25"]
+        node_version: ["24", "26"]
         os: [ubuntu-24.04, windows-2025]
 
     steps:

--- a/web/README.md
+++ b/web/README.md
@@ -57,7 +57,7 @@ should work. Additionally, headless JREs should also work.
 
 Follow the instructions to [install Node.js](https://nodejs.org/) on your machine.
 
-We recommend using the currently active LTS 24, but we do also run tests with current Node.js 25.
+We recommend using the currently active LTS 24, but we do also run tests with current Node.js 26.
 
 Note that npm 7 or newer is required. It should come bundled with Node.js 15 or newer, but can be upgraded with older Node.js versions using `npm install -g npm` as root/Administrator.
 


### PR DESCRIPTION
## Description

Node.js 25 is now in "maintenance" mode for a short time: https://nodejs.org/en/about/previous-releases#release-schedule
With Node.js 26 taking its place as "current": https://nodejs.org/en/blog/release/v26.0.0
In the spirit of https://github.com/ruffle-rs/ruffle/pull/21953. Similarly, this will need repo admin intervention to update the set or required GHA checks on PRs.

## Testing

See if CI turns up green, I guess.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
