### PR TITLE
Add testutils CLI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,6 +16,7 @@ linker = "rust-lld.exe"
 # Otherwise some tests overflow the stack.
 RUST_MIN_STACK = "8388608"
 LOCAL_RUFFLE_TESTS_SWFS_DIR = { value = "tests/tests/swfs", relative = true }
+FLASH_PLAYERS_TEST_CONFIG = { value = ".flash_players.toml", relative = true }
 
 [alias]
 testutils = "run --package tests --"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,3 +15,4 @@ linker = "rust-lld.exe"
 # Set the minimum stack size for tests to 8 MiB.
 # Otherwise some tests overflow the stack.
 RUST_MIN_STACK = "8388608"
+LOCAL_RUFFLE_TESTS_SWFS_DIR = { value = "tests/tests/swfs", relative = true }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,3 +16,6 @@ linker = "rust-lld.exe"
 # Otherwise some tests overflow the stack.
 RUST_MIN_STACK = "8388608"
 LOCAL_RUFFLE_TESTS_SWFS_DIR = { value = "tests/tests/swfs", relative = true }
+
+[alias]
+testutils = "run --package tests --"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ RECOVER_*.fla
 
 # Mac junk
 .DS_Store
+
+# A developers local Flash Player harness config
+.flash_players.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,8 @@ swf_version = 15
 
 Then, whenever you run the tests it'll automatically build `test.swf` (version 15) with the source code of `test.as`. Consult the [full documentation](tests/README.md) for more details about this format.
 
+There is also the ability to only compile the test and not run it - use `cargo testutils compile` to compile all swfs (which takes the same filters as tests does, e.g. `cargo testutils compile avm1/movieclip_lockroot`).
+
 ### Flash authoring tool
 
 Create a new ActionScript project. Save the `.fla` file and export an `.swf` (File -> Export -> Export Movie...).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,13 @@ Then, whenever you run the tests it'll automatically build `test.swf` (version 1
 
 There is also the ability to only compile the test and not run it - use `cargo testutils compile` to compile all swfs (which takes the same filters as tests does, e.g. `cargo testutils compile avm1/movieclip_lockroot`).
 
+If you want to conveniently run the test that you create in Flash Player, we also have a `cargo testutils execute` command - this only works on Linux currently, and you must configure the Flash Player paths in a `.flash_players.toml` file which looks something like:
+```toml
+[[players]]
+version = 32
+path = "/path/to/flashplayerdebugger"
+```
+
 ### Flash authoring tool
 
 Create a new ActionScript project. Save the `.fla` file and export an `.swf` (File -> Export -> Export Movie...).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5675,6 +5675,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "temp-dir"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ef9739649996fcc983b9c588fe3d557cf216d4d98503ce1b057ab5a66d689"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5720,6 +5726,9 @@ dependencies = [
  "ruffle_fs_tests_runner",
  "ruffle_render_wgpu",
  "ruffle_test_framework",
+ "serde",
+ "temp-dir",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -28,6 +28,10 @@ ruffle_fs_tests_runner = { path = "fs-tests-runner" }
 ruffle_test_framework = { path = "framework", features = ["clap"] }
 clap = { workspace = true }
 anyhow = { workspace = true }
+serde = { workspace = true }
+toml = { workspace = true }
+temp-dir = "0.2.0"
+ruffle_core = { path = "../core" }
 
 [dev-dependencies]
 ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "aac", "default_font"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -24,19 +24,19 @@ lzma = ["ruffle_test_framework/lzma"]
 
 [dependencies]
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
+ruffle_fs_tests_runner = { path = "fs-tests-runner" }
+ruffle_test_framework = { path = "framework", features = ["clap"] }
+clap = { workspace = true }
+anyhow = { workspace = true }
 
 [dev-dependencies]
 ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "aac", "default_font"] }
-ruffle_test_framework = { path = "framework", features = ["clap"] }
-ruffle_fs_tests_runner = { path = "fs-tests-runner" }
 libtest-mimic = { workspace = true }
-anyhow = { workspace = true }
 image = { workspace = true, features = ["png"] }
 futures = { workspace = true }
 env_logger = "0.11.10"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-clap = { workspace = true }
 
 [[test]]
 name = "tests"

--- a/tests/framework/src/options/player.rs
+++ b/tests/framework/src/options/player.rs
@@ -102,4 +102,8 @@ impl PlayerOptions {
             None
         }
     }
+
+    pub fn version(&self) -> Option<u8> {
+        self.version
+    }
 }

--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -47,6 +47,10 @@ impl Test {
         })
     }
 
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     pub fn create_test_runner(&self, environment: &impl Environment) -> Result<TestRunner> {
         let movie = self.movie()?;
         let viewport_dimensions = self.options.player_options.viewport_dimensions(&movie);
@@ -159,7 +163,7 @@ impl Test {
         self.options.can_run(check_renderer, environment)
     }
 
-    fn compile(&self, compile_mode: CompileMode) -> Result<()> {
+    pub fn compile(&self, compile_mode: CompileMode) -> Result<()> {
         let verify_if_changed = match compile_mode {
             CompileMode::CompileSilently => false,
             CompileMode::CompileAndVerify => true,

--- a/tests/src/compile.rs
+++ b/tests/src/compile.rs
@@ -1,0 +1,31 @@
+use crate::{find_root_dir, load_test_dir};
+use clap::Args;
+use ruffle_fs_tests_runner::FsTestsRunner;
+use ruffle_test_framework::environment::CompileMode;
+
+#[derive(Args)]
+pub struct CompileOptions {}
+
+pub fn main_compile(_compile_options: CompileOptions) {
+    let mut runner = FsTestsRunner::new();
+    runner
+        .with_root_dir(find_root_dir())
+        .with_test_loader(Box::new(move |params, register_trial| {
+            for test in load_test_dir(&params.test_dir, params.test_name) {
+                if !test.options.compilers.is_empty() {
+                    register_trial(test);
+                }
+            }
+        }))
+        .with_sorter(Box::new(|a, b| a.name().cmp(b.name())));
+    let tests = runner.find_tests();
+    for test in tests {
+        if let Some(subtest) = &test.options.subtest_name {
+            println!("Compiling {} ([{}])", test.name(), subtest);
+        } else {
+            println!("Compiling {}", test.name());
+        }
+        test.compile(CompileMode::CompileSilently).unwrap();
+    }
+    println!("Done!");
+}

--- a/tests/src/compile.rs
+++ b/tests/src/compile.rs
@@ -1,13 +1,17 @@
-use crate::{find_root_dir, load_test_dir};
+use crate::{TestFilterOptions, find_root_dir, load_test_dir};
 use clap::Args;
 use ruffle_fs_tests_runner::FsTestsRunner;
 use ruffle_test_framework::environment::CompileMode;
 
 #[derive(Args)]
-pub struct CompileOptions {}
+pub struct CompileOptions {
+    #[command(flatten)]
+    filter: TestFilterOptions,
+}
 
-pub fn main_compile(_compile_options: CompileOptions) {
+pub fn main_compile(compile_options: CompileOptions) {
     let mut runner = FsTestsRunner::new();
+    compile_options.filter.apply(&mut runner);
     runner
         .with_root_dir(find_root_dir())
         .with_test_loader(Box::new(move |params, register_trial| {

--- a/tests/src/execute.rs
+++ b/tests/src/execute.rs
@@ -1,0 +1,64 @@
+use crate::flashplayer::FlashPlayer;
+use crate::flashplayer::config::FlashHarnessConfig;
+use crate::flashplayer::environment::PlayerEnvironment;
+use crate::{TestFilterOptions, find_root_dir, load_test_dir};
+use clap::Args;
+use ruffle_core::DEFAULT_PLAYER_VERSION;
+use ruffle_fs_tests_runner::FsTestsRunner;
+use std::path::Path;
+use std::time::Duration;
+
+#[derive(Args)]
+pub struct ExecuteOptions {
+    #[command(flatten)]
+    filter: TestFilterOptions,
+
+    /// Forcefully quit the test after the given amount of seconds.
+    #[arg(long, default_value_t = 3)]
+    max_duration: u32,
+}
+
+pub fn main_execute(options: ExecuteOptions) {
+    if options.filter.is_empty() {
+        panic!(
+            "Running `execute` on every single test is inadvisable. Please specify any kind of filter."
+        );
+    }
+
+    let config = FlashHarnessConfig::load().unwrap();
+    let mut runner = FsTestsRunner::new();
+    options.filter.apply(&mut runner);
+    runner
+        .with_root_dir(find_root_dir())
+        .with_canonicalize_paths(true)
+        .with_test_loader(Box::new(move |params, register_trial| {
+            for test in load_test_dir(&params.test_dir, params.test_name) {
+                register_trial((params.test_dir_real.clone().into_owned(), test));
+            }
+        }))
+        .with_sorter(Box::new(|a, b| a.1.name().cmp(b.1.name())));
+    let tests = runner.find_tests();
+    for (test_dir, test) in tests {
+        let swf_path_real = test_dir.join(test.swf_path.as_str().trim_start_matches(['/']));
+        let swf_path_real_str = swf_path_real.to_string_lossy();
+        let environment = PlayerEnvironment::new();
+        let version = test
+            .options
+            .player_options
+            .version()
+            .unwrap_or(DEFAULT_PLAYER_VERSION);
+        let definition = config.get_player(version).unwrap_or_else(|| {
+            panic!(
+                "Could not find a Flash Player debug executable for version {} in .flash_players.toml",
+                version
+            )
+        });
+        let player = FlashPlayer::new(definition);
+        let output = player.run(
+            &environment,
+            Path::new(swf_path_real_str.as_ref()),
+            Duration::from_secs(options.max_duration as u64),
+        );
+        println!("Test output:\n{}", output);
+    }
+}

--- a/tests/src/execute.rs
+++ b/tests/src/execute.rs
@@ -5,7 +5,6 @@ use crate::{TestFilterOptions, find_root_dir, load_test_dir};
 use clap::Args;
 use ruffle_core::DEFAULT_PLAYER_VERSION;
 use ruffle_fs_tests_runner::FsTestsRunner;
-use std::path::Path;
 use std::time::Duration;
 
 #[derive(Args)]
@@ -20,6 +19,10 @@ pub struct ExecuteOptions {
     /// Forcefully quit the test after the given amount of seconds of inactivity (no log output).
     #[arg(long, default_value_t = 0.5)]
     max_idle: f32,
+
+    /// Save the output to the test's "expected output" file.
+    #[arg(short, long)]
+    save_output: bool,
 }
 
 pub fn main_execute(options: ExecuteOptions) {
@@ -44,7 +47,6 @@ pub fn main_execute(options: ExecuteOptions) {
     let tests = runner.find_tests();
     for (test_dir, test) in tests {
         let swf_path_real = test_dir.join(test.swf_path.as_str().trim_start_matches(['/']));
-        let swf_path_real_str = swf_path_real.to_string_lossy();
         let environment = PlayerEnvironment::new();
         let version = test
             .options
@@ -60,10 +62,14 @@ pub fn main_execute(options: ExecuteOptions) {
         let player = FlashPlayer::new(definition);
         let output = player.run(
             &environment,
-            Path::new(swf_path_real_str.as_ref()),
+            &swf_path_real,
             Duration::from_secs_f32(options.max_duration),
             Duration::from_secs_f32(options.max_idle),
         );
+        if options.save_output {
+            let output_path = test_dir.join(test.output_path.as_str().trim_start_matches(['/']));
+            std::fs::write(output_path, &output).unwrap();
+        }
         println!("Test output:\n{}", output);
     }
 }

--- a/tests/src/execute.rs
+++ b/tests/src/execute.rs
@@ -5,6 +5,7 @@ use crate::{TestFilterOptions, find_root_dir, load_test_dir};
 use clap::Args;
 use ruffle_core::DEFAULT_PLAYER_VERSION;
 use ruffle_fs_tests_runner::FsTestsRunner;
+use ruffle_test_framework::environment::CompileMode;
 use std::time::Duration;
 
 #[derive(Args)]
@@ -23,6 +24,10 @@ pub struct ExecuteOptions {
     /// Save the output to the test's "expected output" file.
     #[arg(short, long)]
     save_output: bool,
+
+    /// Whether tests should be compiled before running.
+    #[arg(short, long)]
+    compile: bool,
 }
 
 pub fn main_execute(options: ExecuteOptions) {
@@ -60,6 +65,11 @@ pub fn main_execute(options: ExecuteOptions) {
             )
         });
         let player = FlashPlayer::new(definition);
+        test.compile(match options.compile {
+            true => CompileMode::CompileSilently,
+            false => CompileMode::UsePrecompiled,
+        })
+        .unwrap();
         let output = player.run(
             &environment,
             &swf_path_real,

--- a/tests/src/execute.rs
+++ b/tests/src/execute.rs
@@ -13,9 +13,13 @@ pub struct ExecuteOptions {
     #[command(flatten)]
     filter: TestFilterOptions,
 
-    /// Forcefully quit the test after the given amount of seconds.
-    #[arg(long, default_value_t = 3)]
-    max_duration: u32,
+    /// Forcefully quit the test after the given amount of seconds has elapsed.
+    #[arg(long, default_value_t = 3.0)]
+    max_duration: f32,
+
+    /// Forcefully quit the test after the given amount of seconds of inactivity (no log output).
+    #[arg(long, default_value_t = 0.5)]
+    max_idle: f32,
 }
 
 pub fn main_execute(options: ExecuteOptions) {
@@ -57,7 +61,8 @@ pub fn main_execute(options: ExecuteOptions) {
         let output = player.run(
             &environment,
             Path::new(swf_path_real_str.as_ref()),
-            Duration::from_secs(options.max_duration as u64),
+            Duration::from_secs_f32(options.max_duration),
+            Duration::from_secs_f32(options.max_idle),
         );
         println!("Test output:\n{}", output);
     }

--- a/tests/src/flashplayer.rs
+++ b/tests/src/flashplayer.rs
@@ -1,0 +1,43 @@
+use crate::flashplayer::config::FlashPlayerDefinition;
+use crate::flashplayer::environment::PlayerEnvironment;
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+pub mod config;
+pub mod environment;
+
+pub struct FlashPlayer<'a> {
+    player_definition: &'a FlashPlayerDefinition,
+}
+
+impl<'a> FlashPlayer<'a> {
+    pub fn new(player_definition: &'a FlashPlayerDefinition) -> Self {
+        Self { player_definition }
+    }
+
+    pub fn run(
+        &self,
+        environment: &PlayerEnvironment,
+        swf: &Path,
+        max_duration: Duration,
+    ) -> String {
+        let mut command = Command::new(self.player_definition.path.clone());
+        environment.configure(&mut command);
+        let mut child = command
+            .arg(swf)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        let start = Instant::now();
+        while child.try_wait().unwrap().is_none() {
+            std::thread::sleep(Duration::from_millis(200));
+            if start.elapsed() > max_duration {
+                child.kill().unwrap();
+                break;
+            }
+        }
+        environment.read_log()
+    }
+}

--- a/tests/src/flashplayer.rs
+++ b/tests/src/flashplayer.rs
@@ -21,6 +21,7 @@ impl<'a> FlashPlayer<'a> {
         environment: &PlayerEnvironment,
         swf: &Path,
         max_duration: Duration,
+        max_idle: Duration,
     ) -> String {
         let mut command = Command::new(self.player_definition.path.clone());
         environment.configure(&mut command);
@@ -31,9 +32,16 @@ impl<'a> FlashPlayer<'a> {
             .spawn()
             .unwrap();
         let start = Instant::now();
+        let mut last_activity = Instant::now();
+        let mut last_log_time = None;
         while child.try_wait().unwrap().is_none() {
-            std::thread::sleep(Duration::from_millis(200));
-            if start.elapsed() > max_duration {
+            std::thread::sleep(Duration::from_millis(100));
+            let log_time = environment.log_file_last_modified();
+            if log_time != last_log_time {
+                last_log_time = log_time;
+                last_activity = Instant::now();
+            }
+            if start.elapsed() > max_duration || last_activity.elapsed() > max_idle {
                 child.kill().unwrap();
                 break;
             }

--- a/tests/src/flashplayer/config.rs
+++ b/tests/src/flashplayer/config.rs
@@ -1,0 +1,49 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Deserialize, Debug, Default)]
+pub struct FlashPlayerDefinition {
+    pub version: u8,
+    pub path: PathBuf,
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(default)]
+pub struct FlashHarnessConfig {
+    pub players: Vec<FlashPlayerDefinition>,
+}
+
+static CONFIG_TEMPLATE: &str = r#"# To use `cargo testutils` to execute tests within Flash Player, download some flash players (ensure it's the debug version!) and list them below as shown in the commented out examples.
+# (hint: there's a whole bunch on archive.org, e.g. https://archive.org/details/Adobe_Flash_Player_Complete_Collection)
+
+# [[players]]
+# version = 32
+# path = "/path/to/a/flashplayer/debugger"
+
+# [[players]]
+# version = 15
+# path = "/path/to/another/flashplayer"
+"#;
+
+impl FlashHarnessConfig {
+    pub fn load() -> anyhow::Result<Self> {
+        let path: PathBuf = std::env::var("FLASH_PLAYERS_TEST_CONFIG")
+            .expect("FLASH_PLAYERS_TEST_CONFIG environment variable must be set")
+            .into();
+        if !path.is_file() {
+            std::fs::write(path.clone(), CONFIG_TEMPLATE)?;
+        }
+        let config: Self = toml::from_str(&std::fs::read_to_string(&path)?)?;
+        if config.players.is_empty() {
+            return Err(anyhow::anyhow!(
+                "No Flash Player executables have been configured (please edit {})",
+                path.display()
+            ));
+        }
+        Ok(config)
+    }
+
+    pub fn get_player(&self, version: u8) -> Option<&FlashPlayerDefinition> {
+        self.players.iter().find(|player| player.version == version)
+    }
+}

--- a/tests/src/flashplayer/environment.rs
+++ b/tests/src/flashplayer/environment.rs
@@ -1,0 +1,10 @@
+cfg_select! {
+    target_os = "linux" => {
+        mod linux;
+        pub use linux::*;
+    }
+    _ => {
+        mod unsupported;
+        pub use unsupported::*;
+    }
+}

--- a/tests/src/flashplayer/environment/linux.rs
+++ b/tests/src/flashplayer/environment/linux.rs
@@ -1,0 +1,27 @@
+use std::fs;
+use std::path::PathBuf;
+use temp_dir::TempDir;
+
+#[derive(Debug)]
+pub struct PlayerEnvironment {
+    root: TempDir,
+    log_file: PathBuf,
+}
+
+impl PlayerEnvironment {
+    pub fn new() -> Self {
+        let root = TempDir::new().unwrap();
+        let log_file = root.child(".macromedia/Flash_Player/Logs/flashlog.txt");
+        fs::write(root.child("mm.cfg"), "TraceOutputFileEnable=1\n").unwrap();
+        Self { root, log_file }
+    }
+
+    pub fn read_log(&self) -> String {
+        fs::read_to_string(self.log_file.clone()).unwrap()
+    }
+
+    pub fn configure(&self, command: &mut std::process::Command) {
+        command.env("HOME", self.root.path().to_str().unwrap());
+        command.env("LC_ALL", "C");
+    }
+}

--- a/tests/src/flashplayer/environment/linux.rs
+++ b/tests/src/flashplayer/environment/linux.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
+use std::time::SystemTime;
 use temp_dir::TempDir;
 
 #[derive(Debug)]
@@ -18,6 +19,10 @@ impl PlayerEnvironment {
 
     pub fn read_log(&self) -> String {
         fs::read_to_string(self.log_file.clone()).unwrap()
+    }
+
+    pub fn log_file_last_modified(&self) -> Option<SystemTime> {
+        self.log_file.metadata().and_then(|m| m.modified()).ok()
     }
 
     pub fn configure(&self, command: &mut std::process::Command) {

--- a/tests/src/flashplayer/environment/unsupported.rs
+++ b/tests/src/flashplayer/environment/unsupported.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 #[derive(Debug)]
 pub struct PlayerEnvironment;
 
@@ -8,6 +10,10 @@ impl PlayerEnvironment {
 
     pub fn read_log(&self) -> String {
         panic!("Unsupported platform :( Feel free to add support and open a PR!");
+    }
+
+    pub fn log_file_last_modified(&self) -> Option<SystemTime> {
+        None
     }
 
     pub fn configure(&self, _command: &mut std::process::Command) {

--- a/tests/src/flashplayer/environment/unsupported.rs
+++ b/tests/src/flashplayer/environment/unsupported.rs
@@ -1,0 +1,16 @@
+#[derive(Debug)]
+pub struct PlayerEnvironment;
+
+impl PlayerEnvironment {
+    pub fn new() -> Self {
+        panic!("Unsupported platform :( Feel free to add support and open a PR!");
+    }
+
+    pub fn read_log(&self) -> String {
+        panic!("Unsupported platform :( Feel free to add support and open a PR!");
+    }
+
+    pub fn configure(&self, _command: &mut std::process::Command) {
+        panic!("Unsupported platform :( Feel free to add support and open a PR!");
+    }
+}

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -1,6 +1,9 @@
 mod compile;
+mod execute;
+mod flashplayer;
 
 use crate::compile::{CompileOptions, main_compile};
+use crate::execute::{ExecuteOptions, main_execute};
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
 use ruffle_fs_tests_runner::FsTestsRunner;
@@ -51,12 +54,20 @@ impl TestFilterOptions {
         runner.with_skip(self.skip.clone());
         runner.with_exact(self.exact);
     }
+
+    fn is_empty(&self) -> bool {
+        self.filter.is_none() && self.skip.is_empty()
+    }
 }
 
 #[derive(Subcommand)]
 enum Commands {
     /// Compile test assets from their source files.
     Compile(CompileOptions),
+
+    /// Executes a test using Flash Player. This is not the same as running the test, and has many limitations.
+    /// This is currently only supported on Linux.
+    Execute(ExecuteOptions),
 }
 
 fn main() {
@@ -65,6 +76,9 @@ fn main() {
     match opt.command {
         Commands::Compile(compile_options) => {
             main_compile(compile_options);
+        }
+        Commands::Execute(execute_options) => {
+            main_execute(execute_options);
         }
     }
 }

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -2,7 +2,8 @@ mod compile;
 
 use crate::compile::{CompileOptions, main_compile};
 use anyhow::Context;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
+use ruffle_fs_tests_runner::FsTestsRunner;
 use ruffle_test_framework::options::TestOptions;
 use ruffle_test_framework::test::Test;
 use ruffle_test_framework::vfs::VfsPath;
@@ -14,6 +15,42 @@ use std::path::PathBuf;
 struct Opt {
     #[command(subcommand)]
     command: Commands,
+}
+
+// Copied out of libtest_mimic to be similar enough that you can hop between actual tests & this util CLI.
+#[derive(Args)]
+struct TestFilterOptions {
+    /// If set, filters are matched exactly rather than by substring.
+    #[arg(
+        long = "exact",
+        help = "Exactly match filters rather than by substring."
+    )]
+    pub exact: bool,
+
+    /// A list of filters. Tests whose names contain parts of any of these
+    /// filters are skipped.
+    #[arg(
+        long = "skip",
+        value_name = "FILTER",
+        help = "Skip tests whose names contain FILTER (this flag can be used multiple times)."
+    )]
+    pub skip: Vec<String>,
+
+    /// Filter string. Only tests which contain this string are run.
+    #[arg(
+        value_name = "FILTER",
+        help = "The FILTER string is tested against the name of all tests, and only those tests \
+                 whose names contain the filter are run."
+    )]
+    pub filter: Option<String>,
+}
+
+impl TestFilterOptions {
+    pub fn apply<T>(&self, runner: &mut FsTestsRunner<T>) {
+        runner.with_filter(self.filter.clone());
+        runner.with_skip(self.skip.clone());
+        runner.with_exact(self.exact);
+    }
 }
 
 #[derive(Subcommand)]

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -1,0 +1,54 @@
+mod compile;
+
+use crate::compile::{CompileOptions, main_compile};
+use anyhow::Context;
+use clap::{Parser, Subcommand};
+use ruffle_test_framework::options::TestOptions;
+use ruffle_test_framework::test::Test;
+use ruffle_test_framework::vfs::VfsPath;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+#[command(propagate_version = true)]
+struct Opt {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Compile test assets from their source files.
+    Compile(CompileOptions),
+}
+
+fn main() {
+    let opt = Opt::parse();
+
+    match opt.command {
+        Commands::Compile(compile_options) => {
+            main_compile(compile_options);
+        }
+    }
+}
+
+pub fn load_test_dir<'a>(test_dir: &'a VfsPath, name: &'a str) -> impl Iterator<Item = Test> + 'a {
+    let options = TestOptions::read_with_subtests(&test_dir.join("test.toml").unwrap())
+        .with_context(|| format!("Couldn't load test options for test {name}"))
+        .unwrap();
+    options.into_iter().map(move |opts| {
+        Test::from_options(opts, test_dir.to_owned(), name.to_owned())
+            .with_context(|| format!("Couldn't create test {name}"))
+            .unwrap()
+    })
+}
+
+pub fn find_root_dir() -> PathBuf {
+    let path: PathBuf = std::env::var_os("LOCAL_RUFFLE_TESTS_SWFS_DIR")
+        .expect("LOCAL_RUFFLE_TESTS_SWFS_DIR not set")
+        .into();
+    if !path.is_dir() {
+        panic!("LOCAL_RUFFLE_TESTS_SWFS_DIR is not a directory!");
+    }
+    path
+}


### PR DESCRIPTION
## Description

This adds `cargo testutils` as a utility tool for working with tests. Currently, it has two subcommands:

`cargo testutils compile` can be used to compile tests easily, without needing to actually run our tests (useful when developing tests and you don't have the right output yet; the test would always fail in Ruffle).

`cargo testutils execute` can be used to execute tests in Flash Player (and compile them if needed). **This only works on Linux right now**, future OS support is pending someone who cares enough to make those work. This allows for extremely fast iteration on Linux for "basic" tests, at the cost of having a fair few limitations:
- Only Linux
- You need to configure a list of all Flash Player executables that you have
- It does not control the test environment in any way (no sandboxing, no "only run for one frame", etc)

However, if you accept those limitations, it does make the authoring of tests _incredibly convenient_.

Both commands accept the same kind of filtering as our standard test framework (either nextest or regular `cargo test`), for convenience in switching back & forth.

## Testing

Try changing a test (e.g. `movieclip_lockroot`) and see the swf change if you run `cargo testutils compile`.

To test `cargo testutils execute`, make sure you create a `.flash_players.toml` file that looks something like this:
```toml
[[players]]
version = 32
path = "/path/to/flashplayerdebugger"
```

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
