### PR TITLE
chore: Follow ".swf" to "SWF" string change with some translations

### DIFF
--- a/web/packages/core/texts/bs-BA/context_menu.ftl
+++ b/web/packages/core/texts/bs-BA/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Preuzmite .swf datoteku
+context-menu-download-swf = Preuzmite SWF datoteku
 context-menu-copy-debug-info = Kopiraj informacije o otklanjanju grešaka
 context-menu-open-save-manager = Otvori upravitelj spremanja
 context-menu-about-ruffle =

--- a/web/packages/core/texts/ca-ES/context_menu.ftl
+++ b/web/packages/core/texts/ca-ES/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Baixa el fitxer .swf
+context-menu-download-swf = Baixa el fitxer SWF
 context-menu-copy-debug-info = Copia la informació de depuració
 context-menu-open-save-manager = Obre el gestor d'emmagatzematge
 context-menu-about-ruffle =

--- a/web/packages/core/texts/cs-CZ/context_menu.ftl
+++ b/web/packages/core/texts/cs-CZ/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Stáhnout .swf
+context-menu-download-swf = Stáhnout SWF
 context-menu-copy-debug-info = Zkopírovat debug info
 context-menu-open-save-manager = Otevřít správce uložení
 context-menu-about-ruffle =

--- a/web/packages/core/texts/de-DE/context_menu.ftl
+++ b/web/packages/core/texts/de-DE/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = .swf herunterladen
+context-menu-download-swf = SWF herunterladen
 context-menu-copy-debug-info = Debug-Info kopieren
 context-menu-open-save-manager = Dateimanager öffnen
 context-menu-about-ruffle =

--- a/web/packages/core/texts/es-ES/context_menu.ftl
+++ b/web/packages/core/texts/es-ES/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Descargar .swf
+context-menu-download-swf = Descargar SWF
 context-menu-copy-debug-info = Copiar Información de depuración
 context-menu-open-save-manager = Abrir gestor de guardado
 context-menu-about-ruffle =

--- a/web/packages/core/texts/fi-FI/context_menu.ftl
+++ b/web/packages/core/texts/fi-FI/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Lataa .swf
+context-menu-download-swf = Lataa SWF
 context-menu-copy-debug-info = Kopioi vianjäljitystiedot
 context-menu-about-ruffle =
     { $flavor ->

--- a/web/packages/core/texts/fr-FR/context_menu.ftl
+++ b/web/packages/core/texts/fr-FR/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Télécharger en tant que .swf
+context-menu-download-swf = Télécharger en tant que SWF
 context-menu-copy-debug-info = Copier les infos de débogage
 context-menu-open-save-manager = Ouvrir le gestionnaire de stockage
 context-menu-about-ruffle =

--- a/web/packages/core/texts/he-IL/context_menu.ftl
+++ b/web/packages/core/texts/he-IL/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = הורדת קובץ הswf.
+context-menu-download-swf = הורדת קובץ הSWF
 context-menu-copy-debug-info = העתקת נתוני ניפוי שגיאות
 context-menu-open-save-manager = פתח את מנהל השמירות
 context-menu-about-ruffle =

--- a/web/packages/core/texts/hr-HR/context_menu.ftl
+++ b/web/packages/core/texts/hr-HR/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Preuzmi .swf datoteku
+context-menu-download-swf = Preuzmi SWF datoteku
 context-menu-copy-debug-info = Kopiraj informacije o otklanjanju pogrešaka
 context-menu-open-save-manager = Otvori Upravitelj spremanja
 context-menu-about-ruffle =

--- a/web/packages/core/texts/hu-HU/context_menu.ftl
+++ b/web/packages/core/texts/hu-HU/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = .swf fájl letöltése
+context-menu-download-swf = SWF fájl letöltése
 context-menu-copy-debug-info = Hibakeresési információk másolása
 context-menu-open-save-manager = Mentéskezelő megnyitása
 context-menu-about-ruffle =

--- a/web/packages/core/texts/id-ID/context_menu.ftl
+++ b/web/packages/core/texts/id-ID/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Unduh .swf
+context-menu-download-swf = Unduh SWF
 context-menu-copy-debug-info = Salin info debug
 context-menu-open-save-manager = Buka Manager Save
 context-menu-about-ruffle =

--- a/web/packages/core/texts/it-IT/context_menu.ftl
+++ b/web/packages/core/texts/it-IT/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Scarica .swf
+context-menu-download-swf = Scarica SWF
 context-menu-copy-debug-info = Copia informazioni di debug
 context-menu-open-save-manager = Apri gestione salvataggi
 context-menu-about-ruffle =

--- a/web/packages/core/texts/ko-KR/context_menu.ftl
+++ b/web/packages/core/texts/ko-KR/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = .swf 다운로드
+context-menu-download-swf = SWF 다운로드
 context-menu-copy-debug-info = 디버그 정보 복사
 context-menu-open-save-manager = 저장 관리자 열기
 context-menu-about-ruffle =

--- a/web/packages/core/texts/nb-NO/context_menu.ftl
+++ b/web/packages/core/texts/nb-NO/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Last ned .swf
+context-menu-download-swf = Last ned SWF
 context-menu-copy-debug-info = Kopier feilsøkningsinfo
 context-menu-open-save-manager = Åpne lagringsadministrasjon
 context-menu-about-ruffle =

--- a/web/packages/core/texts/pl-PL/context_menu.ftl
+++ b/web/packages/core/texts/pl-PL/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Pobierz .swf
+context-menu-download-swf = Pobierz SWF
 context-menu-copy-debug-info = Kopiuj informacje debugowania
 context-menu-open-save-manager = Otwórz menadżer zapisów
 context-menu-about-ruffle =

--- a/web/packages/core/texts/pt-BR/context_menu.ftl
+++ b/web/packages/core/texts/pt-BR/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Baixar .swf
+context-menu-download-swf = Baixar SWF
 context-menu-copy-debug-info = Copiar informação de depuração
 context-menu-open-save-manager = Abrir o gerenciador de salvamento
 context-menu-about-ruffle =

--- a/web/packages/core/texts/sk-SK/context_menu.ftl
+++ b/web/packages/core/texts/sk-SK/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Stiahnuť .swf
+context-menu-download-swf = Stiahnuť SWF
 context-menu-copy-debug-info = Skopírovať debug info
 context-menu-open-save-manager = Otvoriť správcu uložení
 context-menu-about-ruffle =

--- a/web/packages/core/texts/sl-SI/context_menu.ftl
+++ b/web/packages/core/texts/sl-SI/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Prenesi .swf
+context-menu-download-swf = Prenesi SWF
 context-menu-copy-debug-info = Kopiraj informacije o odpravljanju napak
 context-menu-open-save-manager = Odpri upravitelja shranjevanja
 context-menu-about-ruffle =

--- a/web/packages/core/texts/sv-SE/context_menu.ftl
+++ b/web/packages/core/texts/sv-SE/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Ladda ner .swf
+context-menu-download-swf = Ladda ner SWF
 context-menu-copy-debug-info = Kopiera felsökningsinfo
 context-menu-open-save-manager = Öppna Sparhanteraren
 context-menu-about-ruffle =

--- a/web/packages/core/texts/tt-RU/context_menu.ftl
+++ b/web/packages/core/texts/tt-RU/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = .swf файлны йөкләү
+context-menu-download-swf = SWF файлны йөкләү
 context-menu-copy-debug-info = Дебаг мәгълүматын күчерү
 context-menu-open-save-manager = Саклау менеджерын ачу
 context-menu-about-ruffle =

--- a/web/packages/core/texts/uk-UA/context_menu.ftl
+++ b/web/packages/core/texts/uk-UA/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Завантажити .swf
+context-menu-download-swf = Завантажити SWF
 context-menu-copy-debug-info = Копіювати інформацію про налагодження
 context-menu-open-save-manager = Відкрити менеджер збереження
 context-menu-about-ruffle =

--- a/web/packages/core/texts/vi-VN/context_menu.ftl
+++ b/web/packages/core/texts/vi-VN/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = Tải về file .swf
+context-menu-download-swf = Tải về file SWF
 context-menu-copy-debug-info = Sao chép thông tin gỡ lỗi
 context-menu-open-save-manager = Mở trình quản lý lưu file
 context-menu-about-ruffle =

--- a/web/packages/core/texts/zh-CN/context_menu.ftl
+++ b/web/packages/core/texts/zh-CN/context_menu.ftl
@@ -1,4 +1,4 @@
-context-menu-download-swf = 下载 .swf
+context-menu-download-swf = 下载 SWF
 context-menu-copy-debug-info = 复制调试信息
 context-menu-open-save-manager = 打开存档管理器
 context-menu-about-ruffle =


### PR DESCRIPTION
Following up https://github.com/ruffle-rs/ruffle/pull/23599.
Picked the really trivial ones out of https://github.com/ruffle-rs/ruffle/pull/21671 - just to shorten the diff. _It's a psychological thing..._
I even left out https://github.com/ruffle-rs/ruffle/pull/21671/changes#diff-b0804e3989471b174c4e9cbcfe74dd40450559ebda09acc53ab3b7824737ed71 (`.swf downloaden` -> `Download SWF` for Dutch) because it could be up for debate.