### PR TITLE
web/audio: Pin AudioContext to 44.1 kHz

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -67,7 +67,7 @@ features = ["audio", "mp3", "aac", "nellymoser", "default_compatibility_rules", 
 [dependencies.web-sys]
 workspace = true
 features = [
-    "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext",
+    "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext", "AudioContextOptions",
     "AudioDestinationNode", "AudioNode", "AudioParam", "Blob", "BlobPropertyBag",
     "ChannelMergerNode", "ChannelSplitterNode", "ClipboardEvent", "DataTransfer", "Element",
     "EventTarget", "GainNode", "Headers", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement",

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::Registry;
 use tracing_subscriber::layer::Layered;
 use tracing_wasm::WASMLayer;
 use wasm_bindgen::prelude::*;
-use web_sys::{AudioContext, AudioScheduledSourceNode};
+use web_sys::{AudioContext, AudioContextOptions, AudioScheduledSourceNode};
 
 pub struct WebAudioBackend {
     mixer: AudioMixer,
@@ -48,8 +48,19 @@ impl WebAudioBackend {
     const NORMAL_PROGRESS_RANGE_MAX: f64 = 0.75;
 
     pub fn new(log_subscriber: Arc<Layered<WASMLayer, Registry>>) -> Result<Self, JsError> {
-        let context = AudioContext::new().into_js_result()?;
+        // Pin the AudioContext to 44.1 kHz. SWF audio sources top out at 44.1 kHz, so
+        // there's no fidelity to gain from running our pipeline at the device rate, and
+        // running at the device rate caused stutter at startup on high-rate devices
+        // (e.g. 192/384 kHz cards) because each buffer expired faster than the JS event
+        // loop could refill it. Per Web Audio §1.2.1, the user agent MUST resample on
+        // output if the requested rate differs from the device rate.
+        // See: https://www.w3.org/TR/webaudio-1.1/#AudioContext-constructors
+        let opts = AudioContextOptions::new();
+        opts.set_sample_rate(44_100.0);
+
+        let context = AudioContext::new_with_context_options(&opts).into_js_result()?;
         let sample_rate = context.sample_rate();
+
         let mut audio = Self {
             context,
             mixer: AudioMixer::new(2, sample_rate as u32),


### PR DESCRIPTION
Fixes #23634

## Description
web/audio: Pin AudioContext to 44.1 kHz
SWF audio sources top out at 44.1 kHz, so running the Web Audio
pipeline at the device sample rate gains no fidelity and caused
stutter at startup on high-rate devices (e.g. 192/384 kHz sound
cards on Windows): each ping-pong buffer expired faster than the
JS event loop could refill it. Request a 44.1 kHz AudioContext
and let the browser resample to the device rate per Web Audio
§1.2.1, which mandates that user agents MUST resample on output
when contextOptions.sampleRate differs from the device rate.

## Testing

_How can we test this PR?_
  <details>
  <summary>Reproduction patch — forces <code>AudioContext</code> to 384 kHz</summary>

  Apply on top of this PR, build with `npm run build:debug`, open the demo in **Chrome** (Firefox caps `AudioContext` at 192 kHz). Without the fix you'll hear stutter at the start, with the fix, it's fine.

  ```diff
  --- a/web/Cargo.toml
  +++ b/web/Cargo.toml
  @@ -67,7 +67,7 @@
   [dependencies.web-sys]
   workspace = true
   features = [
  -    "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext",
  +    "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext", "AudioContextOptions",
       "AudioDestinationNode", "AudioNode", "AudioParam", "Blob", "BlobPropertyBag",
  --- a/web/src/audio.rs
  +++ b/web/src/audio.rs
  @@ -57,7 +57,9 @@
       const NORMAL_PROGRESS_RANGE_MAX: f64 = 0.75;

       pub fn new(log_subscriber: Arc<Layered<WASMLayer, Registry>>) -> Result<Self, JsError> {
  -        let context = AudioContext::new().into_js_result()?;
  +        let opts = web_sys::AudioContextOptions::new();
  +        opts.set_sample_rate(384_000.0);
  +        let context = AudioContext::new_with_context_options(&opts).into_js_result()?;
           let sample_rate = context.sample_rate();
  ```

  </details>

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
