### PR TITLE
ci: Use RuffleBuild for pushing and creating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RUFFLE_BUILD_TOKEN }}
 
       - name: Configure release
         id: configure
@@ -108,7 +110,7 @@ jobs:
         if: steps.configure.outputs.enabled == 'true'
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RUFFLE_BUILD_TOKEN }}
         run: |
           $RELEASE_SCRIPT release ${{ github.repository }}
 


### PR DESCRIPTION
## Description

Ruffle has protections and it doesn't look like we can allow GitHub actions to bypass them, but we can configure RuffleBuild to do so.

## Testing

Tested manually on my fork by adding a ruleset and checking whether it works with and without bypass. Tested using my personal token.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
