### PR TITLE
avm2: Print full error details when logging caught error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,7 @@ Additionally, if you build Ruffle with `--features avm_debug` then you will acti
 
 ### Logging caught exceptions
 
-Some SWFs may catch and suppress exceptions, which can hide the fact that the SWF is trying to use an unimplemented definition. To log call caught exceptions:
-
-1. Add `avm_caught=info` to your `RUST_LOG` environment variable (e.g. `RUST_LOG=warn,avm_caught=debug`)
-2. Build ruffle with `--features avm_debug`
+Some SWFs may catch and suppress exceptions, which can hide the fact that the SWF is trying to use an unimplemented definition. To log call caught exceptions, build ruffle with `--features avm_debug`.
 
 Caught exceptions will be logged as "Caught exception: <exception object>"
 Note that some SWFs throw and catch exceptions as part of their normal control flow, so a caught exception

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -682,7 +682,8 @@ impl<'gc> Avm2<'gc> {
         extra_info: &str,
     ) {
         // This will print the properly formatted error
-        error.log(activation, extra_info);
+        let stringified = error.to_string(activation);
+        tracing::error!("{}: {}", extra_info, stringified);
 
         // TODO: push the error onto `loaderInfo.uncaughtErrorEvents`
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -924,7 +924,10 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
                 if matches {
                     #[cfg(feature = "avm_debug")]
-                    original_error.log(self, "Caught exception");
+                    {
+                        let stringified = original_error.to_string(self);
+                        tracing::warn!("Caught exception: {}", stringified);
+                    }
 
                     self.reset_stack();
                     self.push_stack(error);

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -924,7 +924,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
                 if matches {
                     #[cfg(feature = "avm_debug")]
-                    tracing::info!(target: "avm_caught", "Caught exception: {:?}", original_error);
+                    original_error.log(self, "Caught exception");
 
                     self.reset_stack();
                     self.push_stack(error);

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -70,15 +70,13 @@ impl<'gc> Error<'gc> {
         }
     }
 
-    /// Print this error using `tracing::error`.
-    pub fn log(&self, activation: &mut Activation<'_, 'gc>, extra_info: &str) {
+    /// Return a stringified representation of the error, including its stack
+    /// trace if it has one.
+    pub fn to_string(&self, activation: &mut Activation<'_, 'gc>) -> String {
         let (error, call_stack) = match &*self.0 {
             ErrorData::AvmValue(value, call_stack) => (*value, call_stack),
             ErrorData::AvmError(error) => ((*error).into(), error.call_stack()),
-            ErrorData::RustError(error) => {
-                tracing::error!("{}: RustError({:?})", extra_info, error);
-                return;
-            }
+            ErrorData::RustError(error) => return format!("RustError({:?})", error),
         };
 
         // NOTE: When FP is writing to flashlog, it calls `stringify_error`
@@ -90,18 +88,16 @@ impl<'gc> Error<'gc> {
             Err(_) => {
                 // It's possible that trying to coerce the error to a string
                 // will also throw an error. In that case, print a dummy message
-                tracing::error!("{}: <failed to display AVM error>", extra_info);
-                return;
+                return "<failed to display AVM error>".to_string();
             }
         };
 
         let mut output = WString::new();
 
-        output.push_utf8(&format!("{}: ", extra_info));
         output.push_str(&stringified_error);
         call_stack.display(&mut output);
 
-        tracing::error!("{}", output);
+        format!("{}", output)
     }
 }
 


### PR DESCRIPTION
This should close #23687- @n-raine does this change work for you?