### PR TITLE
ci: Use correct npm dist-tag for nightly and stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -537,9 +537,27 @@ jobs:
         working-directory: web
         run: npm run docs
 
+      - name: Configure npm tag
+        id: npm_tag
+        env:
+          RELEASE_CHANNEL: ${{ needs.create-release.outputs.release_channel }}
+        run: |
+          if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
+            tag=latest
+          elif [[ "$RELEASE_CHANNEL" == "nightly" ]]; then
+            tag=nightly
+          else
+            echo "Unknown npm tag mapping, skipping npm publish"
+            tag=
+          fi
+          echo "tag=$tag" | tee -a $GITHUB_OUTPUT
+
       - name: Publish npm package
+        if: steps.npm_tag.outputs.tag != ''
+        env:
+          NPM_TAG: ${{ steps.npm_tag.outputs.tag }}
         # npm scoped packages are private by default, explicitly make public
-        run: npm publish --tag latest --access public --provenance
+        run: npm publish --tag "$NPM_TAG" --access public --provenance
         continue-on-error: true
         working-directory: web/packages/selfhosted/dist
 


### PR DESCRIPTION
## Description

Previously, all releases were published with `--tag latest`, causing nightly builds to overwrite the latest dist-tag. This maps stable releases to `latest`, nightly releases to `nightly`, and skips publishing for unknown channels.

## Testing

Not tested, but LLM reviewed.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
