### PR TITLE
chore: Bump enumset to 1.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96a4a12fe60ac746ae295a1a4ecb5bb02debc20856506c8635288065f142de"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
 dependencies = [
  "enumset_derive",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -48,7 +48,7 @@ flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "998f47
 lzma-rs = { workspace = true, optional = true }
 dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.5", default-features = false, optional = true }
-enumset = "1.1.12"
+enumset = "1.1.13"
 bytemuck = { workspace = true, features = ["derive"] }
 clap = { workspace = true, optional=true }
 realfft = "3.5.0"

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1068,7 +1068,7 @@ impl Player {
         let changed_mouse_buttons = self
             .input
             .get_mouse_down_buttons()
-            .symmetrical_difference(prev_mouse_buttons);
+            .symmetric_difference(prev_mouse_buttons);
 
         if cfg!(feature = "avm_debug") {
             match event {


### PR DESCRIPTION
Extracted from https://github.com/ruffle-rs/ruffle/pull/23750, with a manual fix to follow up https://github.com/Lymia/enumset/commit/2bc3757fa104e13ce8388de93d48795a6f2be44b.