### PR TITLE
web: Fix MVP wasm build by explicitly disabling post-MVP features

### DIFF
--- a/web/packages/core/tools/build_wasm.ts
+++ b/web/packages/core/tools/build_wasm.ts
@@ -77,13 +77,27 @@ function cargoBuild({
     if (process.env["CARGO_FLAGS"]) {
         args = args.concat(process.env["CARGO_FLAGS"].split(" "));
     }
-    execFileSync("cargo", args, {
-        env: Object.assign(Object.assign({}, process.env), {
-            RUSTFLAGS: totalRustFlags,
-            RUSTC_BOOTSTRAP: extensions ? "0" : "1",
-        }),
-        stdio: "inherit",
-    });
+    const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        RUSTFLAGS: totalRustFlags,
+        RUSTC_BOOTSTRAP: extensions ? "0" : "1",
+    };
+
+    if (!extensions) {
+        // C dependencies (e.g. jpegxr's jxrlib) are compiled by cc-rs/clang,
+        // whose default wasm32 target enables post-MVP features like
+        // reference-types and multivalue. Those bits end up in the linked
+        // module's target_features section, which makes wasm-bindgen attempt
+        // externref transforms and then fail with "failed to find the
+        // __wbindgen_externref_table_dealloc function". Force clang to MVP too.
+        // See: https://github.com/ruffle-rs/ruffle/issues/23751
+        // and: https://github.com/wasm-bindgen/wasm-bindgen/issues/4654
+        env["CFLAGS_wasm32_unknown_unknown"] ??= "";
+        env["CFLAGS_wasm32_unknown_unknown"] +=
+            " -mno-reference-types -mno-multivalue";
+    }
+
+    execFileSync("cargo", args, { env, stdio: "inherit" });
 }
 function buildWasm(
     profile: string,


### PR DESCRIPTION
## Description

Fixes #23751

`-C target-cpu=mvp` alone no longer keeps the produced wasm strictly
MVP. Two separate paths leak post-MVP target features back in:

1. Rust 1.82+ enables `reference-types` and `multivalue` by default
   for `wasm32-unknown-unknown`; `target-cpu=mvp` does not unset them.
2. C dependencies compiled by cc-rs/clang (e.g. jpegxr's jxrlib)
   produce object files whose `target_features` section carries
   `+reference-types`/`+multivalue` regardless of the Rust flags.

  Either path leaves `+reference-types` in the final module's
  `target_features`. wasm-bindgen 0.2.94+ then auto-enables externref
  transforms and fails with `failed to find the
  __wbindgen_externref_table_dealloc function`, because the
  build-std'd MVP code lacks the runtime helper.

  Explicitly pass `-C target-feature=-reference-types,-multivalue`
  to rustc and `-mno-reference-types -mno-multivalue` to clang via
  `CFLAGS_wasm32_unknown_unknown` for the MVP profile only.

## Testing

Prereqs:
- Rust 1.82+
- rustup component add rust-src (for -Z build-std)
- wasm-bindgen-cli 0.2.120 matching lockfile (cargo install wasm-bindgen-cli --version 0.2.120)
- Node + clang/LLVM for jpegxr's bindgen

Reproduce the bug on master:
cd web
npm ci
CARGO_FEATURES=jpegxr BUILD_WASM_MVP=true npm run build

expect: error: failed to find the `__wbindgen_externref_table_dealloc` function

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
