### PR TITLE
desktop: Remove fontconfig from Windows and add fontconfig-dlopen 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,24 +124,24 @@ jobs:
         include:
           - build_name: linux-x86_64
             os: ubuntu-24.04
-            DESKTOP_FEATURES: jpegxr
+            DESKTOP_FEATURES: jpegxr,fontconfig-dlopen
 
           - build_name: linux-aarch64
             os: ubuntu-24.04-arm
-            DESKTOP_FEATURES: jpegxr
+            DESKTOP_FEATURES: jpegxr,fontconfig-dlopen
 
           # Mac does two Rust builds to make a universal binary
           - build_name: macos-x86_64
             os: macos-15
             target: x86_64-apple-darwin
             MACOSX_DEPLOYMENT_TARGET: 10.7
-            DESKTOP_FEATURES: sandbox,jpegxr
+            DESKTOP_FEATURES: sandbox,jpegxr,fontconfig-dlopen
 
           - build_name: macos-aarch64
             os: macos-15
             target: aarch64-apple-darwin
             MACOSX_DEPLOYMENT_TARGET: 11.0
-            DESKTOP_FEATURES: sandbox,jpegxr
+            DESKTOP_FEATURES: sandbox,jpegxr,fontconfig-dlopen
 
           - build_name: windows-x86_32
             os: windows-2025

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -16,7 +16,7 @@ env:
   LLVM_COV_OPTS: --branch --profile ci
   LLVM_COV_TEST_OPTS: ${LLVM_COV_OPTS} ${TEST_OPTS} --features ${FEATURES},imgtests
 
-  LINUX_DEPENDENCIES: libasound2-dev mesa-vulkan-drivers libudev-dev
+  LINUX_DEPENDENCIES: libasound2-dev mesa-vulkan-drivers libudev-dev libfontconfig-dev
 
   # This is to counteract the disabling by rust-cache.
   # See: https://github.com/Swatinem/rust-cache/issues/43

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ The following are typical dependencies for Linux:
 
 * Ubuntu/Debian:
   ```shell
-  sudo apt install pkg-config libasound2-dev libudev-dev default-jre-headless g++
+  sudo apt install pkg-config libasound2-dev libudev-dev libfontconfig-dev default-jre-headless g++
   ```
 
 * Fedora/RHEL:
   ```shell
-  sudo dnf install pkgconf-pkg-config alsa-lib-devel systemd-devel java-latest-openjdk-headless gcc-c++
+  sudo dnf install pkgconf-pkg-config alsa-lib-devel systemd-devel fontconfig-devel java-latest-openjdk-headless gcc-c++
   ```
 
 ### Desktop

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -51,10 +51,12 @@ rand = "0.9.1"
 thiserror.workspace = true
 async-channel.workspace = true
 unicode-bidi = "0.3.18"
-fontconfig = { version = "0.10.2", optional = true, features = ["dlopen"]}
 memmap2.workspace = true
 walkdir.workspace = true
 async-task = "4.7.1"
+
+[target.'cfg(unix)'.dependencies]
+fontconfig = { version = "0.10.2", optional = true, features = ["dlopen"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = "0.12.1"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -56,7 +56,7 @@ walkdir.workspace = true
 async-task = "4.7.1"
 
 [target.'cfg(unix)'.dependencies]
-fontconfig = { version = "0.10.2", optional = true, features = ["dlopen"] }
+fontconfig = { version = "0.10.2", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = "0.12.1"
@@ -90,6 +90,7 @@ software_video = ["ruffle_video_software"]
 external_video = ["ruffle_video_external"]
 tracy = ["tracing-tracy", "ruffle_render_wgpu/profile-with-tracy"]
 fontconfig = ["dep:fontconfig"]
+fontconfig-dlopen = ["fontconfig", "fontconfig/dlopen"]
 
 # wgpu features
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -335,11 +335,14 @@ impl UiBackend for DesktopUiBackend {
         query: &FontQuery,
         register: &mut dyn FnMut(FontDefinition),
     ) -> Vec<FontQuery> {
-        #[cfg(feature = "fontconfig")]
-        return fontconfig_sort_device_fonts(query, register);
-
-        #[cfg(not(feature = "fontconfig"))]
-        return Vec::new();
+        cfg_select! {
+            all(unix, feature = "fontconfig") => {
+                fontconfig_sort_device_fonts(query, register)
+            }
+            _ => {
+                Vec::new()
+            }
+        }
     }
 
     // Unused on desktop
@@ -440,7 +443,7 @@ fn load_fontdb_font(name: String, face: &FaceInfo) -> Result<FontDefinition<'sta
     }
 }
 
-#[cfg(feature = "fontconfig")]
+#[cfg(all(unix, feature = "fontconfig"))]
 fn fontconfig_sort_device_fonts(
     query: &FontQuery,
     register: &mut dyn FnMut(FontDefinition),


### PR DESCRIPTION
## Description

fontconfig is a unix dependency, while it can be theoretically installed on Windows, no one does that and it only takes space unnecessarily in the executable.

fontconfig-dlopen allows compiling Ruffle without fontconfig/dlopen which is usually desirable for downstream.

## Testing

Locally works without `dlopen`, release not tested.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
