### PR TITLE
🤖 avm2: Send Shockwave-Flash-branded User-Agent from URLRequest (#9395)

### DIFF
--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -148,7 +148,24 @@ pub fn request_from_url_request<'gc>(
         .get_slot(url_request_slots::_REQUEST_HEADERS)
         .as_object();
 
+    // Send a Shockwave-Flash-branded `User-Agent` by default, matching real
+    // Flash Player.  Inserted before the user-headers loop so a user-supplied
+    // entry wins per the existing last-write-wins semantics.  Web platforms
+    // silently drop user-supplied `User-Agent` on `fetch()` per browser
+    // security restrictions, so this only takes effect on desktop, but that
+    // already overrides the `Ruffle/<version>` `reqwest` default which leaks
+    // the runtime name to Flash-aware servers.  Closes #9395 for the
+    // User-Agent piece; broader header parity (Content-Type, Accept,
+    // Accept-Encoding) tracked separately.
     let mut string_headers = IndexMap::default();
+    string_headers.insert(
+        "User-Agent".into(),
+        format!(
+            "Mozilla/5.0 (compatible; Shockwave Flash {}.0.0.0)",
+            activation.avm2().player_version
+        ),
+    );
+
     if let Some(headers) = headers {
         let headers = headers.as_array_storage().unwrap();
 

--- a/tests/tests/swfs/avm2/loader_load/output.txt
+++ b/tests/tests/swfs/avm2/loader_load/output.txt
@@ -14,6 +14,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3
@@ -39,6 +40,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3
@@ -64,6 +66,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3
@@ -89,6 +92,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3
@@ -114,6 +118,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3

--- a/tests/tests/swfs/avm2/loader_method/output.txt
+++ b/tests/tests/swfs/avm2/loader_method/output.txt
@@ -13,6 +13,8 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: GET
+  Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
 
 Test 1
 // request.url
@@ -29,6 +31,8 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
+  Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
   Mime-Type: application/x-www-form-urlencoded
   Body: [object Object]
 
@@ -47,6 +51,8 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: GET
+  Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
 
 Test 3
 // request.url
@@ -63,6 +69,8 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: GET
+  Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
 
 Test 4
 // request.url
@@ -79,5 +87,7 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: GET
+  Headers:
+User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0)
 
 Test 5


### PR DESCRIPTION
  **Description**

  Addresses the User-Agent piece of #9395.

  Flash Player sent a Shockwave-Flash-branded User-Agent on
  URLLoader/Loader/URLStream fetches.  Ruffle currently sends Ruffle/<version>
  (https://ruffle.rs) (the default reqwest client-level User-Agent on desktop,
  set at frontend-utils/src/backends/navigator.rs:86), or the browser's
  User-Agent on the web build.  Flash-aware services that filter or branch on
  User-Agent see "Ruffle" today and treat the request as non-Flash.

  The fix mirrors the recently-landed X-Flash-Version pattern:
  request_from_url_request in flash.display.Loader inserts a User-Agent entry
  into string_headers before the user-headers loop, so the per-request header
  overrides the reqwest client default while still letting
  URLRequest.requestHeaders win for users who supply their own.

  **User-Agent value**

  Mozilla/5.0 (compatible; Shockwave Flash {player_version}.0.0.0)

  For example, with player_version = 32: Mozilla/5.0 (compatible; Shockwave
  Flash 32.0.0.0).

  I picked a clearly-Flash-branded string rather than the IE-spoofing UA real
  Flash Player 32 sent (Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0;
  rv:11.0) like Gecko) because:

  1. The IE-spoofing form is OS-specific (different strings on Win/Mac/Linux)
  and ties us to the IE 11 UA's expiry date.
  2. "Shockwave Flash" is the recognized brand for Flash-aware UA filtering
  historically.
  3. Reviewers can ask for the IE-spoofing variant in follow-up if compatibility
   with a specific service requires it.

  **Web-platform caveat**

  fetch() in modern browsers silently drops user-supplied User-Agent headers per
   security restrictions, so this fix only takes effect on the desktop build.
  On the web build the browser's own UA flows through unchanged.

  **Test updates**

  tests/tests/swfs/avm2/loader_load/output.txt and
  tests/tests/swfs/avm2/loader_method/output.txt updated to include the new
  User-Agent: Mozilla/5.0 (compatible; Shockwave Flash 32.0.0.0) line in the
  captured fetch headers.  These were the only log_fetch=true fixtures whose
  output.txt exercised a URLRequest path.

  **Remaining #9395 scope**

  Content-Type was implicitly fixed when URLRequest.contentType was wired up
  after the 2023 report (both backends transmit it via body.1 mime-type today).
   Accept and Accept-Encoding remain unimplemented and would be separate
  follow-up PRs.
  - cargo test --package tests (url_*, netconnection_*, loader_*: all green, 59
  tests)