### PR TITLE
🤖 avm2: Send Accept: */* from URLRequest (#9395)

### DIFF
--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -148,7 +148,17 @@ pub fn request_from_url_request<'gc>(
         .get_slot(url_request_slots::_REQUEST_HEADERS)
         .as_object();
 
+    // Send `Accept: */*` by default, matching Flash Player's URLLoader /
+    // Loader behavior.  Inserted before the user-headers loop so a
+    // user-supplied entry wins per the existing last-write-wins semantics.
+    // `reqwest` does not auto-add an `Accept` header on desktop, so this
+    // makes the wire-level request match Flash; on web platforms the
+    // browser's own Accept value flows through unless overridden.  Closes
+    // the Accept piece of #9395; Accept-Encoding remains as a follow-up
+    // pending reqwest gzip/deflate feature enablement.
     let mut string_headers = IndexMap::default();
+    string_headers.insert("Accept".into(), "*/*".into());
+
     if let Some(headers) = headers {
         let headers = headers.as_array_storage().unwrap();
 

--- a/tests/tests/swfs/avm2/loader_load/output.txt
+++ b/tests/tests/swfs/avm2/loader_load/output.txt
@@ -14,6 +14,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+Accept: */*
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3
@@ -39,6 +40,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+Accept: */*
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3
@@ -64,6 +66,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+Accept: */*
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3
@@ -89,6 +92,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+Accept: */*
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3
@@ -114,6 +118,7 @@ Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
   Headers:
+Accept: */*
 MyHeader1: MyDuplicateVal
 MyHeader2: MyVal2
 MyHeader3: MyVal3

--- a/tests/tests/swfs/avm2/loader_method/output.txt
+++ b/tests/tests/swfs/avm2/loader_method/output.txt
@@ -13,6 +13,8 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: GET
+  Headers:
+Accept: */*
 
 Test 1
 // request.url
@@ -29,6 +31,8 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: POST
+  Headers:
+Accept: */*
   Mime-Type: application/x-www-form-urlencoded
   Body: [object Object]
 
@@ -47,6 +51,8 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: GET
+  Headers:
+Accept: */*
 
 Test 3
 // request.url
@@ -63,6 +69,8 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: GET
+  Headers:
+Accept: */*
 
 Test 4
 // request.url
@@ -79,5 +87,7 @@ undefined
 Navigator::fetch:
   URL: http://localhost:8000
   Method: GET
+  Headers:
+Accept: */*
 
 Test 5


### PR DESCRIPTION
  **Description**

  Addresses the Accept-header piece of #9395.

  Flash Player sent Accept: */* as its default Accept header on URLLoader /
  Loader / URLStream fetches. Ruffle currently sends nothing on the desktop
  build (reqwest doesn't auto-add Accept), so servers see no Accept header at
  all; on the web build the browser's default flows through.

  The fix mirrors the X-Flash-Version (#23754) and User-Agent (#23769) PRs
  already open against this issue: request_from_url_request in
  flash.display.Loader inserts an Accept entry into string_headers before the
  user-headers loop, so the per-request header is transmitted while still
  letting URLRequest.requestHeaders win for users who supply their own.

  **Accept value**

  Accept: */*

  Real Flash Player varied the Accept value slightly for specialized loads
  (image loads sometimes had MIME priorities), but the URLLoader / Loader
  umbrella case was always */*. Reviewers can ask for per-context variants in
  follow-up.

  **Test updates**

  tests/tests/swfs/avm2/loader_load/output.txt and
  tests/tests/swfs/avm2/loader_method/output.txt updated to include the new
  Accept: */* line. These were the only log_fetch=true fixtures whose output.txt
   exercises a URLRequest path.

  **Remaining #9395 scope**

  After this lands, the only remaining header from the original umbrella is
  Accept-Encoding. That one is non-trivial because Ruffle's reqwest client is
  configured without the gzip / deflate decompression features, so we'd either
  need to enable those features (changes desktop runtime behavior) or send
  Accept-Encoding: identity (diverges from Flash). Holding that as a separate
  follow-up.

  **Verification**

```
  - cargo fmt --all --check
  - cargo clippy -p ruffle_core --tests --lib
  - cargo test --package tests (url_*, netconnection_*, loader_*: all green)
```
