### PR TITLE
wstr: Remove unsafe usage from str_eq

### DIFF
--- a/wstr/src/ops.rs
+++ b/wstr/src/ops.rs
@@ -113,10 +113,7 @@ pub fn str_eq(left: &WStr, right: &WStr) -> bool {
         return false;
     }
 
-    (0..bytes.len()).all(|i| {
-        // SAFETY: Both slices have the same length.
-        unsafe { *bytes.get_unchecked(i) as u16 == *wide.get_unchecked(i) }
-    })
+    core::iter::zip(bytes.iter(), wide.iter()).all(|(&b, &w)| b as u16 == w)
 }
 
 pub fn str_eq_ignore_case(left: &WStr, right: &WStr) -> bool {

--- a/wstr/src/tests.rs
+++ b/wstr/src/tests.rs
@@ -55,11 +55,39 @@ fn eq() {
 
 #[test]
 #[rustfmt::skip]
+fn eq_common_prefix() {
+    let a1 = bstr!(b"hello");
+    let b1 = bstr!(b"hello!");
+    let a2 = wstr!('h''e''l''l''o');
+    let b2 = wstr!('h''e''l''l''o''!');
+
+    assert_eq!(a1, a1); assert_eq!(a2, a1); assert_ne!(b1, a1); assert_ne!(b2, a1);
+    assert_eq!(a1, a2); assert_eq!(a2, a2); assert_ne!(b1, a2); assert_ne!(b2, a2);
+    assert_ne!(a1, b1); assert_ne!(a2, b1); assert_eq!(b1, b1); assert_eq!(b2, b1);
+    assert_ne!(a1, b2); assert_ne!(a2, b2); assert_eq!(b1, b2); assert_eq!(b2, b2);
+}
+
+#[test]
+#[rustfmt::skip]
 fn cmp() {
     let a1 = bstr!(b"hello");
     let b1 = bstr!(b"world");
     let a2 = wstr!('h''e''l''l''o');
     let b2 = wstr!('w''o''r''l''d');
+
+    assert!(a1 == a1); assert!(a2 == a1); assert!(b1 >  a1); assert!(b2 >  a1);
+    assert!(a1 == a2); assert!(a2 == a2); assert!(b1 >  a2); assert!(b2 >  a2);
+    assert!(a1 <  b1); assert!(a2 <  b1); assert!(b1 == b1); assert!(b2 == b1);
+    assert!(a1 <  b2); assert!(a2 <  b2); assert!(b1 == b2); assert!(b2 == b2);
+}
+
+#[test]
+#[rustfmt::skip]
+fn cmp_common_prefix() {
+    let a1 = bstr!(b"hello");
+    let b1 = bstr!(b"hello!");
+    let a2 = wstr!('h''e''l''l''o');
+    let b2 = wstr!('h''e''l''l''o''!');
 
     assert!(a1 == a1); assert!(a2 == a1); assert!(b1 >  a1); assert!(b2 >  a1);
     assert!(a1 == a2); assert!(a2 == a2); assert!(b1 >  a2); assert!(b2 >  a2);


### PR DESCRIPTION
## Description

It's not needed as there's a safe zero cost abstraction.

## Testing

We have unit tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
