### PR TITLE
chore: Fix a bunch of typos (mostly in comments)

### DIFF
--- a/core/common/src/utils.rs
+++ b/core/common/src/utils.rs
@@ -16,7 +16,7 @@ pub use ruffle_macros::HasPrefixField;
 /// # Safety
 /// - `Self` must have a field of type `Inner` at the start of its layout;
 /// - `Self` must not impose additional safety invariants on the `Inner` prefix;
-/// - The methods of this trait should not be overriden;
+/// - The methods of this trait should not be overridden;
 /// - Any layout constraints that can't be checked by the type-system should
 ///   be checked by assertions in the `ASSERT_PREFIX_FIELD` constant.
 pub unsafe trait HasPrefixField<Inner>: Sized {

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -40,7 +40,7 @@ enum SoundState<'gc> {
     /// Sound is loading, plays can be queued.
     Loading { queued_plays: Vec<QueuedPlay<'gc>> },
 
-    /// Sound is loaded, plays can be started immadiately.
+    /// Sound is loaded, plays can be started immediately.
     Loaded {
         /// The sound that is attached to this object.
         #[collect(require_static)]

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -25,7 +25,7 @@ pub struct SuperObject<'gc> {
     /// The prototype depth of the currently-executing method.
     depth: u8,
 
-    /// Adds a niche, so that enums contaning this type can use it for their discriminant.
+    /// Adds a niche, so that enums containing this type can use it for their discriminant.
     _niche: ruffle_common::utils::ZeroU8,
 }
 

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -115,7 +115,7 @@ pub fn get_qualified_definition_names<'gc>(
     let this = this.as_object().unwrap();
 
     if let Some(appdomain) = this.as_application_domain() {
-        // NOTE: According to the docs of 'getQualifiedDeinitionNames',
+        // NOTE: According to the docs of 'getQualifiedDefinitionNames',
         // it is able to throw a 'SecurityError' if "The definition belongs
         // to a domain to which the calling code does not have access."
         //

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -275,7 +275,7 @@ impl<'gc> EventObject<'gc> {
                 false.into(),
                 // bytesLoaded
                 (bytes_loaded as f64).into(),
-                // bytesToal
+                // bytesTotal
                 (bytes_total as f64).into(),
             ],
         )

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -231,7 +231,7 @@ pub struct UpdateContext<'gc> {
     pub notification_sender: Option<&'gc Sender<PlayerNotification>>,
 
     // Movie clips whose frame scripts were registered during frame script phase
-    // requires a seperate clean-up pass when running frame-scripts instead of executing them in place
+    // requires a separate clean-up pass when running frame-scripts instead of executing them in place
     pub frame_script_cleanup_queue: VecDeque<MovieClip<'gc>>,
 }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1378,7 +1378,7 @@ impl<'gc> EditText<'gc> {
     }
 
     /// Attempts to bind this text field to a property of a display object.
-    /// If we find a parent display object matching the given path, we register oursevles and a property name with it.
+    /// If we find a parent display object matching the given path, we register ourselves and a property name with it.
     /// `set_text` will be called by the stage object whenever the property changes.
     /// If we don't find a display object, we register ourselves on a list of pending unbound text fields.
     /// Whenever a display object is created, the unbound list is checked to see if the new object should be bound.

--- a/render/pixel_bender/assembly_tests/src/runner.rs
+++ b/render/pixel_bender/assembly_tests/src/runner.rs
@@ -19,7 +19,7 @@ const TEST_TOML_NAME: &str = "test.toml";
 enum TestType {
     Roundtrip,
     Assemble,
-    Dissassemble,
+    Disassemble,
 }
 
 impl TestType {
@@ -28,7 +28,7 @@ impl TestType {
     }
 
     fn performs_disassembly(self) -> bool {
-        matches!(self, TestType::Dissassemble | TestType::Roundtrip)
+        matches!(self, TestType::Disassemble | TestType::Roundtrip)
     }
 }
 

--- a/render/src/shape_utils.rs
+++ b/render/src/shape_utils.rs
@@ -1094,7 +1094,7 @@ fn winding_number_curve(
             }
         }
 
-        // Second subcurve is moving downard, include extrema point.
+        // Second subcurve is moving downward, include extrema point.
         if is_t1_valid && (y_min..y2).contains(&0.0) {
             let x = x0 + bx * t1 + ax * t1 * t1;
             if x > 0.0 {

--- a/tests/README.md
+++ b/tests/README.md
@@ -226,7 +226,7 @@ japanese_mincho = ["Test Font", "Test Font Fallback"]
 [subtests.SUBTEST_NAME]
 # ...
 
-# To make tests easier to maintain, we encourage programatic compilation of source files where possible.
+# To make tests easier to maintain, we encourage programmatic compilation of source files where possible.
 # This is currently limited to pure AVM1 code.
 # Multiple compiler steps can be included in a single test.
 [[compilers]]


### PR DESCRIPTION
Found by the `typos` crate.

## Description

Just a bit of spring cleanup.

## Testing

No functionality change intended.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
