### PR TITLE
ci: Generate AVM2 report only for nightlies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,7 +357,7 @@ jobs:
   build-stub-report:
     name: Build AVM2 stub repository
     needs: create-release
-    if: needs.create-release.outputs.enabled == 'true'
+    if: needs.create-release.outputs.enabled == 'true' && needs.create-release.outputs.release_channel == 'nightly'
     runs-on: ubuntu-24.04
     steps:
       - name: Clone Ruffle repo


### PR DESCRIPTION
## Description

The website reads the report from nightlies only, no need to attach it to regular releases.

## Testing

Not tested, reviewed by an LLM.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
