### PR TITLE
core: Respect scrollRect when picking AVM1/AVM2 children (close #23678)

### DIFF
--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -178,6 +178,14 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
         options.set(HitTestOptions::SKIP_MASK, self.maskee().is_none());
 
         if self.visible() {
+            // A scrollRect clips mouse events at the visible viewport, just like rendering.
+            if let Some(scroll_rect) = self.scroll_rect()
+                && let Some(local_matrix) = self.global_to_local_matrix()
+                && !scroll_rect.contains(local_matrix * point)
+            {
+                return Avm2MousePick::Miss;
+            }
+
             // A loader has at most one child.
             if let Some(child) = self.iter_render_list().next() {
                 if let Some(int) = child.as_interactive() {

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -174,6 +174,14 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
         options.set(HitTestOptions::SKIP_MASK, self.maskee().is_none());
 
         if self.visible() {
+            // A scrollRect clips mouse events at the visible viewport, just like rendering.
+            if let Some(scroll_rect) = self.scroll_rect()
+                && let Some(local_matrix) = self.global_to_local_matrix()
+                && !scroll_rect.contains(local_matrix * point)
+            {
+                return Avm2MousePick::Miss;
+            }
+
             // A loader has at most one child.
             if let Some(child) = self.iter_render_list().next() {
                 if let Some(int) = child.as_interactive() {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2992,6 +2992,15 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
                 }
             }
 
+            // A scrollRect clips mouse events at the container's visible viewport
+            // (in the same way it clips rendering). Children whose position falls
+            // outside the rect must not receive any mouse events.
+            if let Some(scroll_rect) = self.scroll_rect()
+                && !scroll_rect.contains(local_matrix * point)
+            {
+                return None;
+            }
+
             // In AVM2, mouse_enabled should only impact the ability to select the current clip
             // but it should still be possible to select any children where child.mouse_enabled() is
             // true.
@@ -3097,6 +3106,15 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
 
             if self.maskee().is_some() {
                 // If we're masking another object, we can't be hit.
+                return Avm2MousePick::Miss;
+            }
+
+            // A scrollRect clips mouse events at the container's visible viewport
+            // (in the same way it clips rendering). Children whose position falls
+            // outside the rect must not receive any mouse events.
+            if let Some(scroll_rect) = self.scroll_rect()
+                && !scroll_rect.contains(local_matrix * point)
+            {
                 return Avm2MousePick::Miss;
             }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3048,6 +3048,15 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
 
             let local_matrix = self.global_to_local_matrix()?;
 
+            // A scrollRect clips mouse events at the container's visible viewport
+            // (in the same way it clips rendering). Children whose position falls
+            // outside the rect must not receive any mouse events.
+            if let Some(scroll_rect) = self.scroll_rect()
+                && !scroll_rect.contains(local_matrix * point)
+            {
+                return None;
+            }
+
             // Maybe we could skip recursing down at all if !world_bounds.contains(point),
             // but a child button can have an invisible hit area outside the parent's bounds.
             let mut hit_depth = 0;
@@ -3134,6 +3143,15 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
 
             if self.maskee().is_some() {
                 // If we're masking another object, we can't be hit.
+                return Avm2MousePick::Miss;
+            }
+
+            // A scrollRect clips mouse events at the container's visible viewport
+            // (in the same way it clips rendering). Children whose position falls
+            // outside the rect must not receive any mouse events.
+            if let Some(scroll_rect) = self.scroll_rect()
+                && !scroll_rect.contains(local_matrix * point)
+            {
                 return Avm2MousePick::Miss;
             }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/ruffle-rs/ruffle/issues/23678

Cause
mouse_pick_avm2 / mouse_pick_avm1 on MovieClip and mouse_pick_avm2 on LoaderDisplay iterate over their children without ever consulting the container's own scrollRect. Rendering applies the rect as a stencil mask (see apply_standard_mask_and_scroll in core/src/display_object.rs), but the hit-testing path does not, so a child whose visual position falls outside the clipped viewport still receives mouse events. This breaks Flex/Spark containers that rely on clipAndEnableScrolling (e.g. VGroup, BorderContainer), where buttons remain clickable on portions hidden by the container edges.

Fix
Before recursing into children, if self.scroll_rect() is set, transform the incoming global point into the container's local coordinate space (local_matrix * point) and check it against the rect. If it is outside, return Avm2MousePick::Miss / None immediately. This is applied to:

MovieClip::mouse_pick_avm2 (core/src/display_object/movie_clip.rs)
MovieClip::mouse_pick_avm1 (core/src/display_object/movie_clip.rs)
LoaderDisplay::mouse_pick_avm2 (core/src/display_object/loader_display.rs)
Because the check runs at every recursion level, nested scrollRects are handled correctly. No changes to rendering or to the public API.

## Testing
See issue #23678 for testing application

## Checklist
- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
