### PR TITLE
avm2: Don't fire click on mouse release outside pressed (close #23798)

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1786,9 +1786,16 @@ impl Player {
                         context.mouse_data.pressed(button),
                         context.mouse_data.hovered,
                     );
+                    // The structural equality check below exists to handle AVM1 buttons
+                    // that get re-instantiated by a `gotoAndPlay` while held down (see
+                    // `check_display_object_equality`). It must not run for AVM2, where
+                    // dynamically-created display objects share `depth() == 0` and
+                    // `id() == 0`, which would otherwise make every release look "inside"
+                    // and incorrectly dispatch a `click` event when releasing outside.
                     if let Some(down) = context.mouse_data.pressed(button)
                         && let Some(over) = context.mouse_data.hovered
                         && !released_inside
+                        && !down.as_displayobject().movie().is_action_script_3()
                     {
                         released_inside = Self::check_display_object_equality(
                             down.as_displayobject(),

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1827,9 +1827,16 @@ impl Player {
                         context.mouse_data.pressed(button),
                         context.mouse_data.hovered,
                     );
+                    // The structural equality check below exists to handle AVM1 buttons
+                    // that get re-instantiated by a `gotoAndPlay` while held down (see
+                    // `check_display_object_equality`). It must not run for AVM2, where
+                    // dynamically-created display objects share `depth() == 0` and
+                    // `id() == 0`, which would otherwise make every release look "inside"
+                    // and incorrectly dispatch a `click` event when releasing outside.
                     if let Some(down) = context.mouse_data.pressed(button)
                         && let Some(over) = context.mouse_data.hovered
                         && !released_inside
+                        && !down.as_displayobject().movie().is_action_script_3()
                     {
                         released_inside = Self::check_display_object_equality(
                             down.as_displayobject(),


### PR DESCRIPTION
### Summary

Fixes #23798 — in AVM2, a `MouseEvent.CLICK` was dispatched on the pressed
object even when the mouse was released outside that object. Any Flex
`mx:Button` / `s:Button` (and in general any AS3 button-like sprite)
would still trigger its `click` handler if the user pressed it, dragged
out, and released outside.

### Root cause

In `Player::handle_event`, the decision "is this release inside the
pressed object?" goes through two checks
(`core/src/player.rs`, around line 1785):

```rust
let mut released_inside = InteractiveObject::option_ptr_eq(
    context.mouse_data.pressed(button),
    context.mouse_data.hovered,
);
if let Some(down) = context.mouse_data.pressed(button)
    && let Some(over) = context.mouse_data.hovered
    && !released_inside
{
    released_inside = Self::check_display_object_equality(
        down.as_displayobject(),
        over.as_displayobject(),
    );
}
```

The fallback check_display_object_equality was introduced in
[8141e7b54](https://github.com/ruffle-rs/ruffle/commit/8141e7b54)
("avm1: fix buttons that were not clickable after a goto"). Its purpose
is purely AVM1: when an AVM1 button is held down across a gotoAndPlay,
the Flash re-instantiated object has a different pointer identity but
the same depth(), id(), and origin movie, and we want the click to
fire on the new instance.

For AVM2, the check is unsound:

addChild in AVM2 does not assign a depth to the child (see
ChildContainer::insert_at_id in core/src/display_object/container.rs).
Dynamic children keep the default depth() == 0.
Runtime-created display objects (new Sprite(), new MovieClip(),
every Flex skin part) have id() == 0 because no SWF character
defines them.
As a result, the structural fallback returns true for any pair of
dynamic AS3 objects in the same movie, and every release-outside is
classified as a release-inside, dispatching a spurious click.

The sibling use of the same helper at player.rs:1556 already gates on
!is_action_script_3(). This commit applies the same gate to the
release path.

### Fix
Single-condition change: add `&& !down.as_displayobject().movie().is_action_script_3()`
to the `if let` guarding the fallback. AVM1 behaviour is unchanged.
A code comment explains why the gate is necessary.

### Compatibility
- **AVM1**: unchanged (gate evaluates to `true` for AVM1-rooted movies,
  the fallback still runs as before).
- **AVM2**: when pointer equality (`option_ptr_eq`) returns `false`,
  `released_inside` now stays `false` and `ClipEvent::ReleaseOutside`
  is dispatched in place of `ClipEvent::Release`. This is what Flash
  Player does for AS3.

### Checklist
- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
