### PR TITLE
tests: Trace warnings if enabled when executing tests

### DIFF
--- a/tests/src/execute.rs
+++ b/tests/src/execute.rs
@@ -56,7 +56,7 @@ pub fn main_execute(options: ExecuteOptions) {
     let tests = runner.find_tests();
     for (test_dir, test) in tests {
         let swf_path_real = test_dir.join(test.swf_path.as_str().trim_start_matches(['/']));
-        let environment = PlayerEnvironment::new();
+        let environment = PlayerEnvironment::new(test.options.log_warnings);
         let version = test
             .options
             .player_options

--- a/tests/src/flashplayer/environment/linux.rs
+++ b/tests/src/flashplayer/environment/linux.rs
@@ -10,10 +10,16 @@ pub struct PlayerEnvironment {
 }
 
 impl PlayerEnvironment {
-    pub fn new() -> Self {
+    pub fn new(log_warnings: bool) -> Self {
         let root = TempDir::new().unwrap();
         let log_file = root.child(".macromedia/Flash_Player/Logs/flashlog.txt");
-        fs::write(root.child("mm.cfg"), "TraceOutputFileEnable=1\n").unwrap();
+
+        let mut config = "TraceOutputFileEnable=1\n".to_string();
+        if log_warnings {
+            config.push_str("ErrorReportingEnable=1\n");
+        }
+
+        fs::write(root.child("mm.cfg"), config).unwrap();
         Self { root, log_file }
     }
 

--- a/tests/src/flashplayer/environment/unsupported.rs
+++ b/tests/src/flashplayer/environment/unsupported.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 pub struct PlayerEnvironment;
 
 impl PlayerEnvironment {
-    pub fn new() -> Self {
+    pub fn new(_log_warnings: bool) -> Self {
         panic!("Unsupported platform :( Feel free to add support and open a PR!");
     }
 


### PR DESCRIPTION

## Description

If log_warnings is true, we should trace warnings too.

## Testing

Ran a test that emits warnings, checked that they end up in output.txt

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
