### PR TITLE
tests: Add --skip-no-player to testutils execute

### DIFF
--- a/tests/src/execute.rs
+++ b/tests/src/execute.rs
@@ -28,6 +28,10 @@ pub struct ExecuteOptions {
     /// Whether tests should be compiled before running.
     #[arg(short, long)]
     compile: bool,
+
+    /// Skip tests which require a Flash Player version we don't have.
+    #[arg(long)]
+    skip_no_player: bool,
 }
 
 pub fn main_execute(options: ExecuteOptions) {
@@ -58,12 +62,22 @@ pub fn main_execute(options: ExecuteOptions) {
             .player_options
             .version()
             .unwrap_or(DEFAULT_PLAYER_VERSION);
-        let definition = config.get_player(version).unwrap_or_else(|| {
-            panic!(
-                "Could not find a Flash Player debug executable for version {} in .flash_players.toml",
-                version
-            )
-        });
+
+        let Some(definition) = config.get_player(version) else {
+            if options.skip_no_player {
+                eprintln!(
+                    "Skipping '{}' because it requires player {}, which was not found",
+                    test.name, version
+                );
+                continue;
+            } else {
+                panic!(
+                    "Could not find a Flash Player debug executable for version {} in .flash_players.toml",
+                    version
+                )
+            }
+        };
+
         let player = FlashPlayer::new(definition);
         test.compile(match options.compile {
             true => CompileMode::CompileSilently,


### PR DESCRIPTION
## Description

This filters out tests for which we do not have a player configured.

## Testing

I could execute tests and skip those without a player.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
