### PR TITLE
avm2: Don't double-dispatch rollOver/rollOut during drag (close #23801)

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1631,7 +1631,23 @@ impl Player {
                 // and fires "drag" events.
                 if context.input.is_mouse_down(MouseButton::Left) {
                     context.mouse_data.hovered = new_over_object;
-                    if let Some(down_object) = context.mouse_data.pressed {
+                    // DragOut/DragOver on the pressed object are AVM1-only:
+                    // in AVM1 they map to `onDragOut`/`onDragOver`, which are
+                    // distinct from `onRollOut`/`onRollOver`. In AVM2 both
+                    // `DragOut` and `RollOut` are translated to the same
+                    // `rollOut`/`mouseOut` events (see `interactive.rs`), so
+                    // emitting `DragOut` here when `pressed == cur_over_object`
+                    // (or `DragOver` when `pressed == new_over_object`) would
+                    // double-dispatch the event to the pressed object. The
+                    // duplicate `rollOut` then drives `mx.controls.Button` from
+                    // `phase=DOWN` to `OVER` and immediately to `UP` (instead
+                    // of staying at `OVER`), and the analogous duplicate
+                    // `rollOver` at re-entry is short-circuited by mx Button's
+                    // `if (event.buttonDown) return;` guard, leaving the
+                    // button visually stuck in the `UP` state.
+                    if let Some(down_object) = context.mouse_data.pressed
+                        && !down_object.as_displayobject().movie().is_action_script_3()
+                    {
                         if InteractiveObject::option_ptr_eq(
                             context.mouse_data.pressed,
                             cur_over_object,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1667,7 +1667,23 @@ impl Player {
                 // and fires "drag" events.
                 if context.input.is_mouse_down(MouseButton::Left) {
                     context.mouse_data.hovered = new_over_object;
-                    if let Some(down_object) = context.mouse_data.pressed {
+                    // DragOut/DragOver on the pressed object are AVM1-only:
+                    // in AVM1 they map to `onDragOut`/`onDragOver`, which are
+                    // distinct from `onRollOut`/`onRollOver`. In AVM2 both
+                    // `DragOut` and `RollOut` are translated to the same
+                    // `rollOut`/`mouseOut` events (see `interactive.rs`), so
+                    // emitting `DragOut` here when `pressed == cur_over_object`
+                    // (or `DragOver` when `pressed == new_over_object`) would
+                    // double-dispatch the event to the pressed object. The
+                    // duplicate `rollOut` then drives `mx.controls.Button` from
+                    // `phase=DOWN` to `OVER` and immediately to `UP` (instead
+                    // of staying at `OVER`), and the analogous duplicate
+                    // `rollOver` at re-entry is short-circuited by mx Button's
+                    // `if (event.buttonDown) return;` guard, leaving the
+                    // button visually stuck in the `UP` state.
+                    if let Some(down_object) = context.mouse_data.pressed
+                        && !down_object.as_displayobject().movie().is_action_script_3()
+                    {
                         if InteractiveObject::option_ptr_eq(
                             context.mouse_data.pressed,
                             cur_over_object,


### PR DESCRIPTION
## Summary

Fixes https://github.com/ruffle-rs/ruffle/issues/23801 — in AVM2, when an `mx.controls.Button` was pressed 
and the pointer was dragged outside, the button's visual phase jumped 
straight to `UP` (white) instead of going to `OVER` (greyed). Once in `UP`, 
re-entering the button did **not** restore the `DOWN` look — the button 
stayed visually idle even though the mouse was still held down. Flash Player
keeps the `OVER` phase across the drag and switches back to `DOWN` on
re-entry.

## Root cause

While the mouse is down, `Player::handle_event`
(`core/src/player.rs`, around line 1634) queues four events on a
boundary crossing:

| Event | Queued on | Purpose |
| --- | --- | --- |
| `DragOut` | `pressed` (when `pressed == cur_over`) | AVM1 `onDragOut` |
| `DragOver` | `pressed` (when `pressed == new_over`) | AVM1 `onDragOver` |
| `RollOut` | `cur_over` (always, for AVM2) | AVM2 `rollOut`/`mouseOut` |
| `RollOver` | `new_over` (always, for AVM2) | AVM2 `rollOver`/`mouseOver` |

For **AVM2**, `interactive.rs` translates both `RollOut` and `DragOut`
to the same bubbling `mouseOut` plus the cascading `rollOut` event
(same for the `Over` pair):

```rust
ClipEvent::RollOut { to } | ClipEvent::DragOut { to } => {
    // dispatch "mouseOut" (bubbling) + cascade "rollOut" on ancestors
}
```

So whenever the user drags **out of** the pressed object,
`pressed == cur_over_object` and both `DragOut` and `RollOut` end up
dispatching `rollOut` to the same target. Same on re-entry, where
`pressed == new_over_object` and `DragOver` + `RollOver` both
dispatch `rollOver` twice.

`mx.controls.Button.rollOutHandler` is a state machine that doesn't
tolerate the duplicate (excerpt from Apache Flex SDK 4.6,
`mx/controls/Button.as`):

```as
protected function rollOutHandler(event:MouseEvent):void {
    if (phase == ButtonPhase.OVER) {
        phase = ButtonPhase.UP;          // 2nd call drops the button to UP
    }
    else if (phase == ButtonPhase.DOWN && !stickyHighlighting) {
        phase = ButtonPhase.OVER;        // 1st call demotes DOWN -> OVER
    }
}

protected function rollOverHandler(event:MouseEvent):void {
    if (phase == ButtonPhase.UP) {
        if (event.buttonDown) return;    // re-entry while held: no-op!
        phase = ButtonPhase.OVER;
    }
    else if (phase == ButtonPhase.OVER) {
        phase = ButtonPhase.DOWN;
    }
}
```

After a drag-out, mx Button is in `phase=UP` instead of `OVER`. On
re-entry the `if (event.buttonDown) return;` guard prevents the
phase from leaving `UP`, so the button never gets back to `DOWN`.

## Fix

Gate the `DragOut`/`DragOver` push on AVM1, matching what
`interactive.rs` and the sibling block at `player.rs:1678/1703`
already imply: in AVM2 the `RollOut`/`RollOver` paths are the only
ones that should fire `rollOut`/`rollOver`, since they map to the
same AVM2 event anyway. AVM1 behaviour is unchanged (the `onDragOut`/
`onDragOver` callbacks keep firing).

## Compatibility

- **AVM1**: unchanged — the block runs as before, both `onDragOut`/
  `onDragOver` (on the pressed) and `onRollOut`/`onRollOver` (on
  `cur_over`/`new_over`) are dispatched.
- **AVM2**: the pressed object now receives `rollOut`/`rollOver`
  (and the bubbling `mouseOut`/`mouseOver`) exactly once per
  boundary crossing during a drag, matching Flash Player.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
