### PR TITLE
avm1: Do not trace an error on with(undefined)/with(null)

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2309,13 +2309,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value = self.context.avm1.pop();
         match value {
             // Undefined/null with is ignored.
-            Value::Undefined | Value::Null => {
-                // Mimic Flash's error output.
-                self.context.avm_trace(
-                    "Error: A 'with' action failed because the specified object did not exist.\n",
-                );
-                Ok(FrameControl::Continue)
-            }
+            Value::Undefined | Value::Null => Ok(FrameControl::Continue),
 
             value => {
                 // Note that primitives get boxed at this point.

--- a/tests/tests/swfs/avm1/with/output.txt
+++ b/tests/tests/swfs/avm1/with/output.txt
@@ -42,10 +42,6 @@ object
 root
 
 // with(undefined)
-Error: A 'with' action failed because the specified object did not exist.
-
 
 // with(null)
-Error: A 'with' action failed because the specified object did not exist.
-
 

--- a/tests/tests/swfs/from_gnash/actionscript.all/with-v5/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/with-v5/output.ruffle.txt
@@ -19,26 +19,12 @@ PASSED: b == 2 [./with.as:65]
 PASSED: found7 == 1 [./with.as:81]
 PASSED: get_name() == "timeline" [./with.as:115]
 PASSED: get_name() == "obj1" [./with.as:118]
-Error: A 'with' action failed because the specified object did not exist.
-
 PASSED: checkpoint == 1 [./with.as:135]
-Error: A 'with' action failed because the specified object did not exist.
-
 PASSED: checkpoint == 1 [./with.as:138]
 PASSED: checkpoint == 3 [./with.as:141]
 PASSED: Number.prototype.checkpoint == 'three' [./with.as:142]
 PASSED: checkpoint == 4 [./with.as:145]
 PASSED: String.prototype.checkpoint == 'four' [./with.as:146]
-Error: A 'with' action failed because the specified object did not exist.
-
-Error: A 'with' action failed because the specified object did not exist.
-
-Error: A 'with' action failed because the specified object did not exist.
-
-Error: A 'with' action failed because the specified object did not exist.
-
-Error: A 'with' action failed because the specified object did not exist.
-
 PASSED: this == objA [./with.as:234]
 PASSED: this == objA [./with.as:237]
 PASSED: a == 4 [./with.as:424]

--- a/tests/tests/swfs/from_gnash/actionscript.all/with-v6/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/with-v6/output.ruffle.txt
@@ -21,11 +21,7 @@ PASSED: obj.a == 1 [./with.as:88]
 PASSED: found8 == 1 [./with.as:91]
 PASSED: get_name() == "timeline" [./with.as:115]
 PASSED: get_name() == "obj1" [./with.as:118]
-Error: A 'with' action failed because the specified object did not exist.
-
 PASSED: checkpoint == 1 [./with.as:135]
-Error: A 'with' action failed because the specified object did not exist.
-
 PASSED: checkpoint == 1 [./with.as:138]
 PASSED: checkpoint == 3 [./with.as:141]
 PASSED: Number.prototype.checkpoint == 'three' [./with.as:142]

--- a/tests/tests/swfs/from_gnash/actionscript.all/with-v7/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/with-v7/output.ruffle.txt
@@ -21,11 +21,7 @@ PASSED: obj.a == 1 [./with.as:88]
 PASSED: found8 == 1 [./with.as:91]
 PASSED: get_name() == "timeline" [./with.as:115]
 PASSED: get_name() == "obj1" [./with.as:118]
-Error: A 'with' action failed because the specified object did not exist.
-
 PASSED: checkpoint == 1 [./with.as:135]
-Error: A 'with' action failed because the specified object did not exist.
-
 PASSED: checkpoint == 1 [./with.as:138]
 PASSED: checkpoint == 3 [./with.as:141]
 PASSED: Number.prototype.checkpoint == 'three' [./with.as:142]

--- a/tests/tests/swfs/from_gnash/actionscript.all/with-v8/output.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/with-v8/output.ruffle.txt
@@ -21,11 +21,7 @@ PASSED: obj.a == 1 [./with.as:88]
 PASSED: found8 == 1 [./with.as:91]
 PASSED: get_name() == "timeline" [./with.as:115]
 PASSED: get_name() == "obj1" [./with.as:118]
-Error: A 'with' action failed because the specified object did not exist.
-
 PASSED: checkpoint == 1 [./with.as:135]
-Error: A 'with' action failed because the specified object did not exist.
-
 PASSED: checkpoint == 1 [./with.as:138]
 PASSED: checkpoint == 3 [./with.as:141]
 PASSED: Number.prototype.checkpoint == 'three' [./with.as:142]


### PR DESCRIPTION
## Description
It was introduced in https://github.com/ruffle-rs/ruffle/pull/803, however I wasn't able to reproduce it with FP 32 and 9. It's possible this could be traced under some conditions.

## Testing

Covered by tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
