### PR TITLE
avm2: Minor performance improvements

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2073,10 +2073,20 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     }
 
     fn op_add_i(&mut self) -> Result<(), Error<'gc>> {
-        let value2 = self.pop_stack().coerce_to_i32(self)?;
-        let value1 = self.pop_stack().coerce_to_i32(self)?;
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
 
-        self.push_stack(value1.wrapping_add(value2));
+        let sum_value = match (value1, value2) {
+            (Value::Integer(n1), Value::Integer(n2)) => n1.wrapping_add(n2),
+            (value1, value2) => {
+                let value1 = value1.coerce_to_i32(self)?;
+                let value2 = value2.coerce_to_i32(self)?;
+
+                value1.wrapping_add(value2)
+            }
+        };
+
+        self.push_stack(sum_value);
 
         Ok(())
     }
@@ -2288,10 +2298,20 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     }
 
     fn op_subtract_i(&mut self) -> Result<(), Error<'gc>> {
-        let value2 = self.pop_stack().coerce_to_i32(self)?;
-        let value1 = self.pop_stack().coerce_to_i32(self)?;
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
 
-        self.push_stack(value1.wrapping_sub(value2));
+        let sum_value = match (value1, value2) {
+            (Value::Integer(n1), Value::Integer(n2)) => n1.wrapping_sub(n2),
+            (value1, value2) => {
+                let value1 = value1.coerce_to_i32(self)?;
+                let value2 = value2.coerce_to_i32(self)?;
+
+                value1.wrapping_sub(value2)
+            }
+        };
+
+        self.push_stack(sum_value);
 
         Ok(())
     }

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -382,11 +382,15 @@ impl Op<'_> {
 
     pub fn is_nop(&self) -> bool {
         if cfg!(feature = "avm_debug") {
-            matches!(self, Op::Nop)
+            matches!(self, Op::Nop | Op::CoerceA)
         } else {
             matches!(
                 self,
-                Op::Nop | Op::Debug { .. } | Op::DebugFile { .. } | Op::DebugLine { .. }
+                Op::Nop
+                    | Op::CoerceA
+                    | Op::Debug { .. }
+                    | Op::DebugFile { .. }
+                    | Op::DebugLine { .. }
             )
         }
     }

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -118,7 +118,11 @@ impl<'gc> OptValue<'gc> {
         }
     }
 
-    pub fn merged_with(self, other: OptValue<'gc>) -> OptValue<'gc> {
+    pub fn merged_with(
+        self,
+        activation: &mut Activation<'_, 'gc>,
+        other: OptValue<'gc>,
+    ) -> OptValue<'gc> {
         let mut created_value = OptValue::any();
 
         if self.class == other.class {
@@ -139,22 +143,35 @@ impl<'gc> OptValue<'gc> {
                 created_value.class = other.class;
             }
         } else if let (Some(self_class), Some(other_class)) = (self.class, other.class) {
-            // Check for a common superclass.
-            // FIXME: Make this faster?
-            let mut other_class = Some(other_class);
-            'outer: while let Some(current_other_class) = other_class {
-                let mut self_class = Some(self_class);
-                while let Some(current_self_class) = self_class {
-                    if current_other_class == current_self_class {
-                        // Found a common superclass; we're done
-                        created_value.class = Some(current_self_class);
-                        break 'outer;
+            let self_is_numeric = self_class.is_builtin_int()
+                || self_class.is_builtin_uint()
+                || self_class.is_builtin_number();
+
+            let other_is_numeric = other_class.is_builtin_int()
+                || other_class.is_builtin_uint()
+                || other_class.is_builtin_number();
+
+            if self_is_numeric && other_is_numeric {
+                // int/uint/Number merged with int/uint/Number becomes Number
+                created_value.class = Some(activation.avm2().class_defs().number);
+            } else {
+                // Check for a common superclass.
+                // FIXME: Make this faster?
+                let mut other_class = Some(other_class);
+                'outer: while let Some(current_other_class) = other_class {
+                    let mut self_class = Some(self_class);
+                    while let Some(current_self_class) = self_class {
+                        if current_other_class == current_self_class {
+                            // Found a common superclass; we're done
+                            created_value.class = Some(current_self_class);
+                            break 'outer;
+                        }
+
+                        self_class = current_self_class.super_class();
                     }
 
-                    self_class = current_self_class.super_class();
+                    other_class = current_other_class.super_class();
                 }
-
-                other_class = current_other_class.super_class();
             }
         }
 
@@ -512,7 +529,7 @@ impl<'gc> AbstractState<'gc> {
             let our_local = self.locals.at(i);
             let other_local = other.locals.at(i);
 
-            let merged = our_local.merged_with(other_local);
+            let merged = our_local.merged_with(activation, other_local);
             self.locals.set(i, merged);
             if merged != our_local {
                 changed = true;
@@ -532,7 +549,7 @@ impl<'gc> AbstractState<'gc> {
             let our_entry = self.stack.at(i);
             let other_entry = other.stack.at(i);
 
-            let merged = our_entry.merged_with(other_entry);
+            let merged = our_entry.merged_with(activation, other_entry);
             self.stack.set(i, merged);
             if merged != our_entry {
                 changed = true;
@@ -556,7 +573,7 @@ impl<'gc> AbstractState<'gc> {
                 return Err(make_error_1068(activation));
             }
 
-            let merged = our_scope.0.merged_with(other_scope.0);
+            let merged = our_scope.0.merged_with(activation, other_scope.0);
             self.scope_stack.set(i, merged, our_scope.1);
             if merged != our_scope.0 {
                 changed = true;


### PR DESCRIPTION
## Description

Tiny improvements to AVM2 performance.

With this PR, the `AddI` op is slightly (~5-10%) faster than the `Add` op. Previously, `AddI` was significantly (~30-60%) slower than `Add`. In a future PR I'll add optimizations to convert `Add` ops to `AddI` when possible.

## Testing

No SWF-observable changes were made in this PR.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
