### PR TITLE
ci: Switch macOS GHA runner image from 15 to 26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,13 +132,13 @@ jobs:
 
           # Mac does two Rust builds to make a universal binary
           - build_name: macos-x86_64
-            os: macos-15
+            os: macos-26
             target: x86_64-apple-darwin
             MACOSX_DEPLOYMENT_TARGET: 10.7
             DESKTOP_FEATURES: sandbox,jpegxr,fontconfig-dlopen
 
           - build_name: macos-aarch64
-            os: macos-15
+            os: macos-26
             target: aarch64-apple-darwin
             MACOSX_DEPLOYMENT_TARGET: 11.0
             DESKTOP_FEATURES: sandbox,jpegxr,fontconfig-dlopen
@@ -257,7 +257,7 @@ jobs:
   build-mac-universal-binary:
     name: Build macOS universal binary
     needs: [create-release, build, build-web]
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       PACKAGE_FILE: ${{ needs.create-release.outputs.package_prefix }}-macos-universal.tar.gz
     steps:

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         rust_version: [stable]
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-26]
         include:
           - rust_version: nightly
             os: ubuntu-24.04
@@ -311,7 +311,7 @@ jobs:
     strategy:
       matrix:
         rust_version: [stable]
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-26]
         include:
           - rust_version: nightly
             os: ubuntu-24.04


### PR DESCRIPTION
## Description

Have to keep up with the times here too: https://github.com/actions/runner-images/issues/14167

Another thing to keep an eye on: https://github.com/actions/runner-images/issues/14017
But this will happen automatically for us, and _surely_ it won't break anything...

## Testing

Look for green checkmarks.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
