### PR TITLE
core: Rework infrastructure around the FileDialogResult trait

### DIFF
--- a/core/src/avm1/globals/file_reference.rs
+++ b/core/src/avm1/globals/file_reference.rs
@@ -8,7 +8,7 @@ use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{DeclContext, StaticDeclarations, SystemClass};
 use crate::avm1::{NativeObject, Object, Value};
 use crate::avm1_stub;
-use crate::backend::ui::{FileDialogResult, FileFilter};
+use crate::backend::ui::{FileDialogSelection, FileFilter};
 use crate::string::AvmString;
 use gc_arena::barrier::unlock;
 use gc_arena::lock::Lock;
@@ -21,10 +21,10 @@ use url::Url;
 pub struct FileReferenceObject<'gc>(Gc<'gc, FileReferenceData<'gc>>);
 
 impl<'gc> FileReferenceObject<'gc> {
-    pub fn init_from_dialog_result(
+    pub fn init_from_file_selection(
         self,
         activation: &mut Activation<'_, 'gc>,
-        result: &dyn FileDialogResult,
+        result: &dyn FileDialogSelection,
     ) {
         let mc = activation.gc();
         let write = Gc::write(mc, self.0);
@@ -53,7 +53,7 @@ impl<'gc> FileReferenceObject<'gc> {
         let file_type = result.file_type().map(|s| AvmString::new_utf8(mc, s));
         unlock!(write, FileReferenceData, file_type).set(file_type);
 
-        let file_name = result.file_name().map(|s| AvmString::new_utf8(mc, s));
+        let file_name = Some(AvmString::new_utf8(mc, result.file_name()));
         unlock!(write, FileReferenceData, name).set(file_name);
 
         let creator = result.creator().map(|s| AvmString::new_utf8(mc, s));

--- a/core/src/avm2/globals/flash/net/file_reference.rs
+++ b/core/src/avm2/globals/flash/net/file_reference.rs
@@ -20,8 +20,8 @@ pub fn get_creation_date<'gc>(
 
     let creation_date = match *this.file_reference() {
         FileReference::None => return Err(make_error_2037(activation)),
-        FileReference::FileDialogResult(ref dialog_result) => {
-            if let Some(time) = dialog_result.creation_time() {
+        FileReference::FileDialogSelection(ref selection) => {
+            if let Some(time) = selection.creation_time() {
                 DateObject::from_date_time(activation.context, time).into()
             } else {
                 Value::Null
@@ -42,8 +42,8 @@ pub fn get_data<'gc>(
     let this = this.as_file_reference().unwrap();
 
     let bytearray = match *this.file_reference() {
-        FileReference::FileDialogResult(ref dialog_result) if this.loaded() => {
-            let bytes = dialog_result.contents();
+        FileReference::FileDialogSelection(ref selection) if this.loaded() => {
+            let bytes = selection.contents();
             let storage = ByteArrayStorage::from_vec(activation.context, bytes.to_vec());
             ByteArrayObject::from_storage(activation.context, storage)
         }
@@ -65,8 +65,8 @@ pub fn get_modification_date<'gc>(
 
     let modification_date = match *this.file_reference() {
         FileReference::None => return Err(make_error_2037(activation)),
-        FileReference::FileDialogResult(ref dialog_result) => {
-            if let Some(time) = dialog_result.modification_time() {
+        FileReference::FileDialogSelection(ref selection) => {
+            if let Some(time) = selection.modification_time() {
                 DateObject::from_date_time(activation.context, time).into()
             } else {
                 Value::Null
@@ -88,8 +88,8 @@ pub fn get_name<'gc>(
 
     let name = match *this.file_reference() {
         FileReference::None => return Err(make_error_2037(activation)),
-        FileReference::FileDialogResult(ref dialog_result) => {
-            let name = dialog_result.file_name().unwrap_or_default();
+        FileReference::FileDialogSelection(ref selection) => {
+            let name = selection.file_name();
             AvmString::new_utf8(activation.gc(), name).into()
         }
     };
@@ -108,7 +108,7 @@ pub fn get_size<'gc>(
 
     let size = match *this.file_reference() {
         FileReference::None => return Err(make_error_2037(activation)),
-        FileReference::FileDialogResult(ref dialog_result) => dialog_result.size().unwrap_or(0),
+        FileReference::FileDialogSelection(ref selection) => selection.size().unwrap_or(0),
     };
 
     Ok(Value::Number(size as f64))
@@ -125,8 +125,8 @@ pub fn get_type<'gc>(
 
     let type_ = match *this.file_reference() {
         FileReference::None => return Err(make_error_2037(activation)),
-        FileReference::FileDialogResult(ref dialog_result) => {
-            let type_ = dialog_result.file_type().unwrap_or_default();
+        FileReference::FileDialogSelection(ref selection) => {
+            let type_ = selection.file_type().unwrap_or_default();
             AvmString::new_utf8(activation.gc(), type_).into()
         }
     };
@@ -216,7 +216,7 @@ pub fn load<'gc>(
 
     let size = match *this.file_reference() {
         FileReference::None => return Err(make_error_2037(activation)),
-        FileReference::FileDialogResult(ref dialog_result) => dialog_result.size().unwrap_or(0),
+        FileReference::FileDialogSelection(ref selection) => selection.size().unwrap_or(0),
     };
 
     let size = size as usize;

--- a/core/src/avm2/object/file_reference_object.rs
+++ b/core/src/avm2/object/file_reference_object.rs
@@ -1,7 +1,7 @@
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, TObject};
 use crate::avm2::{Activation, Error};
-use crate::backend::ui::FileDialogResult;
+use crate::backend::ui::FileDialogSelection;
 use crate::context::UpdateContext;
 use gc_arena::{Collect, DynamicRoot, Gc, GcWeak, Rootable};
 use ruffle_common::utils::HasPrefixField;
@@ -53,10 +53,13 @@ impl<'gc> TObject<'gc> for FileReferenceObject<'gc> {
 }
 
 impl FileReferenceObject<'_> {
-    pub fn init_from_dialog_result(self, result: Box<dyn FileDialogResult>) -> FileReference {
+    pub fn init_from_file_selection(
+        self,
+        selection: Box<dyn FileDialogSelection>,
+    ) -> FileReference {
         self.0
             .reference
-            .replace(FileReference::FileDialogResult(result))
+            .replace(FileReference::FileDialogSelection(selection))
     }
 
     pub fn file_reference(&self) -> Ref<'_, FileReference> {
@@ -74,7 +77,7 @@ impl FileReferenceObject<'_> {
 
 pub enum FileReference {
     None,
-    FileDialogResult(Box<dyn FileDialogResult>),
+    FileDialogSelection(Box<dyn FileDialogSelection>),
 }
 
 #[derive(Collect, HasPrefixField)]

--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -63,13 +63,11 @@ impl FileFilter {
     }
 }
 
-/// A result of a file selection
-pub trait FileDialogResult: Any {
-    /// Was the file selection canceled by the user
-    fn is_cancelled(&self) -> bool;
+/// Data for a single selected file.
+pub trait FileDialogSelection: Any {
     fn creation_time(&self) -> Option<DateTime<Utc>>;
     fn modification_time(&self) -> Option<DateTime<Utc>>;
-    fn file_name(&self) -> Option<String>;
+    fn file_name(&self) -> String;
     fn size(&self) -> Option<u64>;
     fn file_type(&self) -> Option<String>;
     fn creator(&self) -> Option<String> {
@@ -77,13 +75,21 @@ pub trait FileDialogResult: Any {
     }
     fn contents(&self) -> &[u8];
     /// Write the given data to the chosen file and refresh any internal metadata.
-    /// Any future calls to other functions (such as [FileDialogResult::size]) will reflect
+    /// Any future calls to other functions (such as [FileDialogSelection::size]) will reflect
     /// the state at the time of the last refresh
     fn write_and_refresh(&mut self, data: &[u8]);
 }
 
+/// Result of a file dialog (open or save).
+pub enum FileDialogResult {
+    /// The user selected a file.
+    Selection(Box<dyn FileDialogSelection>),
+    /// The user canceled the dialog.
+    Canceled,
+}
+
 /// Future representing a file selection in process
-pub type DialogResultFuture = OwnedFuture<Box<dyn FileDialogResult>, DialogLoaderError>;
+pub type DialogResultFuture = OwnedFuture<FileDialogResult, DialogLoaderError>;
 
 pub trait UiBackend: Any {
     fn mouse_visible(&self) -> bool;
@@ -237,11 +243,7 @@ impl UiBackend for NullUiBackend {
         &mut self,
         _filters: Vec<FileFilter>,
     ) -> Option<DialogResultFuture> {
-        Some(Box::pin(async move {
-            let result: Result<Box<dyn FileDialogResult>, DialogLoaderError> =
-                Ok(Box::new(NullFileDialogResult::new()));
-            result
-        }))
+        Some(Box::pin(async move { Ok(FileDialogResult::Canceled) }))
     }
 
     fn close_file_dialog(&mut self) {}
@@ -259,45 +261,4 @@ impl Default for NullUiBackend {
     fn default() -> Self {
         NullUiBackend::new()
     }
-}
-
-pub struct NullFileDialogResult {}
-
-impl NullFileDialogResult {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Default for NullFileDialogResult {
-    fn default() -> Self {
-        NullFileDialogResult::new()
-    }
-}
-
-impl FileDialogResult for NullFileDialogResult {
-    fn is_cancelled(&self) -> bool {
-        true
-    }
-
-    fn creation_time(&self) -> Option<DateTime<Utc>> {
-        None
-    }
-    fn modification_time(&self) -> Option<DateTime<Utc>> {
-        None
-    }
-    fn file_name(&self) -> Option<String> {
-        None
-    }
-    fn size(&self) -> Option<u64> {
-        None
-    }
-    fn file_type(&self) -> Option<String> {
-        None
-    }
-    fn contents(&self) -> &[u8] {
-        &[]
-    }
-
-    fn write_and_refresh(&mut self, _data: &[u8]) {}
 }

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -20,7 +20,7 @@ use crate::avm2_stub_method_context;
 use crate::backend::navigator::{
     ErrorResponse, FetchReason, OwnedFuture, Request, SuccessResponse,
 };
-use crate::backend::ui::DialogResultFuture;
+use crate::backend::ui::{DialogResultFuture, FileDialogResult};
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::bitmap::bitmap_data::Color;
 use crate::context::{ActionQueue, ActionType, UpdateContext};
@@ -42,7 +42,6 @@ use indexmap::IndexMap;
 use ruffle_macros::istr;
 use ruffle_render::utils::{JpegTagFormat, determine_jpeg_tag_format};
 use slotmap::{SlotMap, new_key_type};
-use std::borrow::Borrow;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -2345,12 +2344,11 @@ fn run_file_dialog<D: 'static>(
         let dialog_result = dialog.await;
 
         // Dialog is done, allow opening new dialogs.
-        player.lock().unwrap().ui_mut().close_file_dialog();
+        let mut player = player.lock().unwrap();
 
-        player
-            .lock()
-            .unwrap()
-            .update(|uc| on_result(uc, dialog_result))
+        player.ui_mut().close_file_dialog();
+
+        player.update(|uc| on_result(uc, dialog_result))
     })
 }
 
@@ -2376,25 +2374,26 @@ pub fn select_file_dialog_avm1<'gc>(
         let mut activation = Activation::from_stub(uc, ActivationIdentifier::root("[File Dialog]"));
 
         match dialog_result {
-            Ok(dialog_result) => {
+            Ok(FileDialogResult::Selection(selection)) => {
                 use crate::avm1::globals::as_broadcaster;
 
-                if !dialog_result.is_cancelled() {
-                    file_ref.init_from_dialog_result(&mut activation, dialog_result.borrow());
-                    as_broadcaster::broadcast_internal(
-                        target_object,
-                        &[target_object.into()],
-                        istr!("onSelect"),
-                        &mut activation,
-                    )?;
-                } else {
-                    as_broadcaster::broadcast_internal(
-                        target_object,
-                        &[target_object.into()],
-                        istr!("onCancel"),
-                        &mut activation,
-                    )?;
-                }
+                file_ref.init_from_file_selection(&mut activation, &*selection);
+                as_broadcaster::broadcast_internal(
+                    target_object,
+                    &[target_object.into()],
+                    istr!("onSelect"),
+                    &mut activation,
+                )?;
+            }
+            Ok(FileDialogResult::Canceled) => {
+                use crate::avm1::globals::as_broadcaster;
+
+                as_broadcaster::broadcast_internal(
+                    target_object,
+                    &[target_object.into()],
+                    istr!("onCancel"),
+                    &mut activation,
+                )?;
             }
             Err(err) => {
                 tracing::warn!("Error on file dialog: {:?}", err);
@@ -2420,16 +2419,15 @@ pub fn select_file_dialog_avm2<'gc>(
         let target_object = handle.fetch(uc);
 
         match dialog_result {
-            Ok(dialog_result) => {
-                if !dialog_result.is_cancelled() {
-                    target_object.init_from_dialog_result(dialog_result);
+            Ok(FileDialogResult::Selection(selection)) => {
+                target_object.init_from_file_selection(selection);
 
-                    let select_event = Avm2EventObject::bare_default_event(uc, "select");
-                    Avm2::dispatch_event(uc, select_event, target_object.into());
-                } else {
-                    let cancel_event = Avm2EventObject::bare_default_event(uc, "cancel");
-                    Avm2::dispatch_event(uc, cancel_event, target_object.into());
-                }
+                let select_event = Avm2EventObject::bare_default_event(uc, "select");
+                Avm2::dispatch_event(uc, select_event, target_object.into());
+            }
+            Ok(FileDialogResult::Canceled) => {
+                let cancel_event = Avm2EventObject::bare_default_event(uc, "cancel");
+                Avm2::dispatch_event(uc, cancel_event, target_object.into());
             }
             Err(err) => {
                 tracing::warn!("Error on file dialog: {:?}", err);
@@ -2454,36 +2452,34 @@ pub fn save_file_dialog<'gc>(
         let target_object = handle.fetch(uc);
 
         match dialog_result {
-            Ok(mut dialog_result) => {
-                if !dialog_result.is_cancelled() {
-                    dialog_result.write_and_refresh(&data);
-                    target_object.init_from_dialog_result(dialog_result);
+            Ok(FileDialogResult::Selection(mut selection)) => {
+                selection.write_and_refresh(&data);
+                target_object.init_from_file_selection(selection);
 
-                    let mut activation = Avm2Activation::from_nothing(uc);
+                let mut activation = Avm2Activation::from_nothing(uc);
 
-                    let select_event =
-                        Avm2EventObject::bare_default_event(activation.context, "select");
-                    Avm2::dispatch_event(activation.context, select_event, target_object.into());
+                let select_event =
+                    Avm2EventObject::bare_default_event(activation.context, "select");
+                Avm2::dispatch_event(activation.context, select_event, target_object.into());
 
-                    let open_event =
-                        Avm2EventObject::bare_default_event(activation.context, "open");
-                    Avm2::dispatch_event(activation.context, open_event, target_object.into());
+                let open_event = Avm2EventObject::bare_default_event(activation.context, "open");
+                Avm2::dispatch_event(activation.context, open_event, target_object.into());
 
-                    let progress_evt = Avm2EventObject::progress_event(
-                        &mut activation,
-                        "progress",
-                        data.len(),
-                        data.len(),
-                    );
-                    Avm2::dispatch_event(activation.context, progress_evt, target_object.into());
+                let progress_evt = Avm2EventObject::progress_event(
+                    &mut activation,
+                    "progress",
+                    data.len(),
+                    data.len(),
+                );
+                Avm2::dispatch_event(activation.context, progress_evt, target_object.into());
 
-                    let complete_event =
-                        Avm2EventObject::bare_default_event(activation.context, "complete");
-                    Avm2::dispatch_event(activation.context, complete_event, target_object.into());
-                } else {
-                    let cancel_event = Avm2EventObject::bare_default_event(uc, "cancel");
-                    Avm2::dispatch_event(uc, cancel_event, target_object.into());
-                }
+                let complete_event =
+                    Avm2EventObject::bare_default_event(activation.context, "complete");
+                Avm2::dispatch_event(activation.context, complete_event, target_object.into());
+            }
+            Ok(FileDialogResult::Canceled) => {
+                let cancel_event = Avm2EventObject::bare_default_event(uc, "cancel");
+                Avm2::dispatch_event(uc, cancel_event, target_object.into());
             }
             Err(err) => {
                 tracing::warn!("Save dialog had an error {:?}", err);
@@ -2536,145 +2532,141 @@ pub fn download_file_dialog<'gc>(
             use crate::avm1::globals::as_broadcaster;
 
             match dialog_result {
-                Ok(mut dialog_result) => {
-                    if !dialog_result.is_cancelled() {
-                        // onSelect and onOpen should be called before the download begins
-                        // We simulate this by using the initial dialog result
-                        file_ref.init_from_dialog_result(&mut activation, dialog_result.borrow());
+                Ok(FileDialogResult::Selection(mut selection)) => {
+                    // onSelect and onOpen should be called before the download begins
+                    // We simulate this by using the initial dialog result
+                    file_ref.init_from_file_selection(&mut activation, &*selection);
 
-                        as_broadcaster::broadcast_internal(
-                            target_object,
-                            &[target_object.into()],
-                            istr!("onSelect"),
-                            &mut activation,
-                        )?;
+                    as_broadcaster::broadcast_internal(
+                        target_object,
+                        &[target_object.into()],
+                        istr!("onSelect"),
+                        &mut activation,
+                    )?;
 
-                        match download_res {
-                            Ok((body, _, _, _)) => {
-                                as_broadcaster::broadcast_internal(
-                                    target_object,
-                                    &[target_object.into()],
-                                    istr!("onOpen"),
-                                    &mut activation,
-                                )?;
+                    match download_res {
+                        Ok((body, _, _, _)) => {
+                            as_broadcaster::broadcast_internal(
+                                target_object,
+                                &[target_object.into()],
+                                istr!("onOpen"),
+                                &mut activation,
+                            )?;
 
-                                // onProgress and onComplete expect to receive the current state
-                                // of the file, as we simulate an instant 100% download from the
-                                // perspective of AS, we want to refresh the file_ref internal data
-                                // before invoking the callbacks
+                            // onProgress and onComplete expect to receive the current state
+                            // of the file, as we simulate an instant 100% download from the
+                            // perspective of AS, we want to refresh the file_ref internal data
+                            // before invoking the callbacks
 
-                                dialog_result.write_and_refresh(&body);
-                                file_ref.init_from_dialog_result(
-                                    &mut activation,
-                                    dialog_result.borrow(),
-                                );
+                            selection.write_and_refresh(&body);
+                            file_ref.init_from_file_selection(&mut activation, &*selection);
 
-                                let total_bytes = body.len();
+                            let total_bytes = body.len();
 
-                                as_broadcaster::broadcast_internal(
-                                    target_object,
-                                    &[
-                                        target_object.into(),
-                                        Value::from_usize_lossy(total_bytes),
-                                        Value::from_usize_lossy(total_bytes),
-                                    ],
-                                    istr!("onProgress"),
-                                    &mut activation,
-                                )?;
+                            as_broadcaster::broadcast_internal(
+                                target_object,
+                                &[
+                                    target_object.into(),
+                                    Value::from_usize_lossy(total_bytes),
+                                    Value::from_usize_lossy(total_bytes),
+                                ],
+                                istr!("onProgress"),
+                                &mut activation,
+                            )?;
 
-                                as_broadcaster::broadcast_internal(
-                                    target_object,
-                                    &[target_object.into()],
-                                    istr!("onComplete"),
-                                    &mut activation,
-                                )?;
-                            }
-                            Err(err) => {
-                                match err.error {
-                                    Error::InvalidDomain(_) => {
-                                        activation
-                                            .context
-                                            .avm_trace(&format!("Error opening URL '{url}'"));
+                            as_broadcaster::broadcast_internal(
+                                target_object,
+                                &[target_object.into()],
+                                istr!("onComplete"),
+                                &mut activation,
+                            )?;
+                        }
+                        Err(err) => {
+                            match err.error {
+                                Error::InvalidDomain(_) => {
+                                    activation
+                                        .context
+                                        .avm_trace(&format!("Error opening URL '{url}'"));
 
-                                        as_broadcaster::broadcast_internal(
-                                            target_object,
-                                            &[target_object.into()],
-                                            istr!("onIOError"),
-                                            &mut activation,
-                                        )?;
-                                    }
-                                    Error::HttpNotOk(_, _, _, body_len) => {
-                                        // If the error happens before the connection is
-                                        // established, then don't invoke onOpen
-                                        as_broadcaster::broadcast_internal(
-                                            target_object,
-                                            &[target_object.into()],
-                                            istr!("onOpen"),
-                                            &mut activation,
-                                        )?;
+                                    as_broadcaster::broadcast_internal(
+                                        target_object,
+                                        &[target_object.into()],
+                                        istr!("onIOError"),
+                                        &mut activation,
+                                    )?;
+                                }
+                                Error::HttpNotOk(_, _, _, body_len) => {
+                                    // If the error happens before the connection is
+                                    // established, then don't invoke onOpen
+                                    as_broadcaster::broadcast_internal(
+                                        target_object,
+                                        &[target_object.into()],
+                                        istr!("onOpen"),
+                                        &mut activation,
+                                    )?;
 
-                                        activation
-                                            .context
-                                            .avm_trace(&format!("Error opening URL '{url}'"));
+                                    activation
+                                        .context
+                                        .avm_trace(&format!("Error opening URL '{url}'"));
 
-                                        as_broadcaster::broadcast_internal(
-                                            target_object,
-                                            &[target_object.into()],
-                                            istr!("onIOError"),
-                                            &mut activation,
-                                        )?;
+                                    as_broadcaster::broadcast_internal(
+                                        target_object,
+                                        &[target_object.into()],
+                                        istr!("onIOError"),
+                                        &mut activation,
+                                    )?;
 
-                                        // Flash still executes the onProgress callback, even after an error
-                                        // However it should only be called if the error occurred after the connection was established
-                                        as_broadcaster::broadcast_internal(
-                                            target_object,
-                                            &[
-                                                target_object.into(),
-                                                Value::from_u64_lossy(body_len),
-                                                Value::from_u64_lossy(body_len),
-                                            ],
-                                            istr!("onProgress"),
-                                            &mut activation,
-                                        )?;
-                                    }
-                                    Error::FetchError(_) => {
-                                        // If the error happens before the connection is
-                                        // established, then don't invoke onOpen
-                                        as_broadcaster::broadcast_internal(
-                                            target_object,
-                                            &[target_object.into()],
-                                            istr!("onOpen"),
-                                            &mut activation,
-                                        )?;
+                                    // Flash still executes the onProgress callback, even after an error
+                                    // However it should only be called if the error occurred after the connection was established
+                                    as_broadcaster::broadcast_internal(
+                                        target_object,
+                                        &[
+                                            target_object.into(),
+                                            Value::from_u64_lossy(body_len),
+                                            Value::from_u64_lossy(body_len),
+                                        ],
+                                        istr!("onProgress"),
+                                        &mut activation,
+                                    )?;
+                                }
+                                Error::FetchError(_) => {
+                                    // If the error happens before the connection is
+                                    // established, then don't invoke onOpen
+                                    as_broadcaster::broadcast_internal(
+                                        target_object,
+                                        &[target_object.into()],
+                                        istr!("onOpen"),
+                                        &mut activation,
+                                    )?;
 
-                                        activation
-                                            .context
-                                            .avm_trace(&format!("Error opening URL '{url}'"));
+                                    activation
+                                        .context
+                                        .avm_trace(&format!("Error opening URL '{url}'"));
 
-                                        as_broadcaster::broadcast_internal(
-                                            target_object,
-                                            &[target_object.into()],
-                                            istr!("onIOError"),
-                                            &mut activation,
-                                        )?;
-                                    }
-                                    _ => {
-                                        tracing::warn!(
-                                            "Unhandled non-fetch error on download: {:?}",
-                                            err.error
-                                        );
-                                    }
+                                    as_broadcaster::broadcast_internal(
+                                        target_object,
+                                        &[target_object.into()],
+                                        istr!("onIOError"),
+                                        &mut activation,
+                                    )?;
+                                }
+                                _ => {
+                                    tracing::warn!(
+                                        "Unhandled non-fetch error on download: {:?}",
+                                        err.error
+                                    );
                                 }
                             }
                         }
-                    } else {
-                        as_broadcaster::broadcast_internal(
-                            target_object,
-                            &[target_object.into()],
-                            istr!("onCancel"),
-                            &mut activation,
-                        )?;
                     }
+                }
+                Ok(FileDialogResult::Canceled) => {
+                    as_broadcaster::broadcast_internal(
+                        target_object,
+                        &[target_object.into()],
+                        istr!("onCancel"),
+                        &mut activation,
+                    )?;
                 }
                 Err(err) => {
                     tracing::warn!("Download dialog had an error {:?}", err);

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -11,7 +11,7 @@ use rfd::{
     AsyncFileDialog, FileHandle, MessageButtons, MessageDialog, MessageDialogResult, MessageLevel,
 };
 use ruffle_core::backend::ui::{
-    DialogLoaderError, DialogResultFuture, FileDialogResult, FileFilter, FontDefinition,
+    DialogResultFuture, FileDialogResult, FileDialogSelection, FileFilter, FontDefinition,
     FullscreenError, LanguageIdentifier, MouseCursor, UiBackend,
 };
 use ruffle_core::font::{FontFileData, FontQuery};
@@ -25,15 +25,15 @@ use winit::event_loop::EventLoopProxy;
 use winit::raw_window_handle::HasDisplayHandle;
 use winit::window::{Fullscreen, Window};
 
-pub struct DesktopFileDialogResult {
-    handle: Option<FileHandle>,
+pub struct DesktopFileSelection {
+    handle: FileHandle,
     md: Option<std::fs::Metadata>,
     contents: Vec<u8>,
 }
 
-impl DesktopFileDialogResult {
-    /// Create a new [`DesktopFileDialogResult`] from a given file handle
-    pub async fn new(handle: Option<FileHandle>) -> Self {
+impl DesktopFileSelection {
+    /// Create a new [`DesktopFileSelection`] from a given file handle.
+    pub async fn new(handle: FileHandle) -> Self {
         async fn read_file(path: &Path) -> (Option<std::fs::Metadata>, Vec<u8>) {
             let file = match tokio::fs::File::open(path).await {
                 Ok(file) => file,
@@ -62,11 +62,7 @@ impl DesktopFileDialogResult {
             (metadata, contents)
         }
 
-        let (md, contents) = if let Some(ref handle) = handle {
-            read_file(handle.path()).await
-        } else {
-            (None, Vec::new())
-        };
+        let (md, contents) = read_file(handle.path()).await;
 
         Self {
             handle,
@@ -76,29 +72,23 @@ impl DesktopFileDialogResult {
     }
 }
 
-impl FileDialogResult for DesktopFileDialogResult {
-    fn is_cancelled(&self) -> bool {
-        self.handle.is_none()
-    }
-
+impl FileDialogSelection for DesktopFileSelection {
     fn creation_time(&self) -> Option<DateTime<Utc>> {
-        if let Some(md) = &self.md {
-            md.created().ok().map(DateTime::<Utc>::from)
-        } else {
-            None
-        }
+        self.md
+            .as_ref()
+            .and_then(|md| md.created().ok())
+            .map(DateTime::<Utc>::from)
     }
 
     fn modification_time(&self) -> Option<DateTime<Utc>> {
-        if let Some(md) = &self.md {
-            md.modified().ok().map(DateTime::<Utc>::from)
-        } else {
-            None
-        }
+        self.md
+            .as_ref()
+            .and_then(|md| md.modified().ok())
+            .map(DateTime::<Utc>::from)
     }
 
-    fn file_name(&self) -> Option<String> {
-        self.handle.as_ref().map(|handle| handle.file_name())
+    fn file_name(&self) -> String {
+        self.handle.file_name()
     }
 
     fn size(&self) -> Option<u64> {
@@ -106,15 +96,11 @@ impl FileDialogResult for DesktopFileDialogResult {
     }
 
     fn file_type(&self) -> Option<String> {
-        if let Some(handle) = &self.handle {
-            handle
-                .path()
-                .extension()
-                .and_then(|x| x.to_str())
-                .map(|x| ".".to_owned() + x)
-        } else {
-            None
-        }
+        self.handle
+            .path()
+            .extension()
+            .and_then(|x| x.to_str())
+            .map(|x| ".".to_owned() + x)
     }
 
     fn contents(&self) -> &[u8] {
@@ -122,25 +108,9 @@ impl FileDialogResult for DesktopFileDialogResult {
     }
 
     fn write_and_refresh(&mut self, data: &[u8]) {
-        // write
-        if let Some(handle) = &self.handle {
-            let _ = std::fs::write(handle.path(), data);
-        }
-
-        // refresh
-        let md = self
-            .handle
-            .as_ref()
-            .and_then(|x| std::fs::metadata(x.path()).ok());
-
-        let contents = if let Some(handle) = &self.handle {
-            std::fs::read(handle.path()).unwrap_or_default()
-        } else {
-            Vec::new()
-        };
-
-        self.md = md;
-        self.contents = contents;
+        let _ = std::fs::write(self.handle.path(), data);
+        self.md = std::fs::metadata(self.handle.path()).ok();
+        self.contents = std::fs::read(self.handle.path()).unwrap_or_default();
     }
 }
 
@@ -366,9 +336,11 @@ impl UiBackend for DesktopUiBackend {
         let result = self.file_picker.show_dialog(dialog, |d| d.pick_file())?;
 
         Some(Box::pin(async move {
-            let result: Result<Box<dyn FileDialogResult>, DialogLoaderError> =
-                Ok(Box::new(DesktopFileDialogResult::new(result.await).await));
-            result
+            Ok(if let Some(handle) = result.await {
+                FileDialogResult::Selection(Box::new(DesktopFileSelection::new(handle).await))
+            } else {
+                FileDialogResult::Canceled
+            })
         }))
     }
 
@@ -385,9 +357,11 @@ impl UiBackend for DesktopUiBackend {
         let result = self.file_picker.show_dialog(dialog, |d| d.save_file())?;
 
         Some(Box::pin(async move {
-            let result: Result<Box<dyn FileDialogResult>, DialogLoaderError> =
-                Ok(Box::new(DesktopFileDialogResult::new(result.await).await));
-            result
+            Ok(if let Some(handle) = result.await {
+                FileDialogResult::Selection(Box::new(DesktopFileSelection::new(handle).await))
+            } else {
+                FileDialogResult::Canceled
+            })
         }))
     }
 

--- a/tests/framework/src/backends/ui.rs
+++ b/tests/framework/src/backends/ui.rs
@@ -3,45 +3,28 @@ use std::collections::HashMap;
 use crate::test::Font;
 use chrono::{DateTime, Utc};
 use ruffle_core::backend::ui::{
-    DialogLoaderError, DialogResultFuture, FileDialogResult, FileFilter, FontDefinition,
+    DialogResultFuture, FileDialogResult, FileDialogSelection, FileFilter, FontDefinition,
     FullscreenError, LanguageIdentifier, MouseCursor, US_ENGLISH, UiBackend,
 };
 use ruffle_core::font::{FontFileData, FontQuery};
 use url::Url;
 
-/// A simulated file dialog response, for use in tests
-///
-/// Currently this can only simulate either a user cancellation result, or a successful file selection
-#[derive(Default)]
-pub struct TestFileDialogResult {
-    canceled: bool,
-    file_name: Option<String>,
+/// A simulated file selection, for use in tests.
+pub struct TestFileSelection {
+    file_name: String,
     contents: Vec<u8>,
 }
 
-impl TestFileDialogResult {
-    fn new_canceled() -> Self {
+impl TestFileSelection {
+    fn new(file_name: String) -> Self {
         Self {
-            canceled: true,
-            file_name: None,
-            contents: Vec::new(),
-        }
-    }
-
-    fn new_success(file_name: String) -> Self {
-        Self {
-            canceled: false,
-            file_name: Some(file_name),
+            file_name,
             contents: b"Hello, World!".to_vec(),
         }
     }
 }
 
-impl FileDialogResult for TestFileDialogResult {
-    fn is_cancelled(&self) -> bool {
-        self.canceled
-    }
-
+impl FileDialogSelection for TestFileSelection {
     fn creation_time(&self) -> Option<DateTime<Utc>> {
         None
     }
@@ -50,7 +33,7 @@ impl FileDialogResult for TestFileDialogResult {
         None
     }
 
-    fn file_name(&self) -> Option<String> {
+    fn file_name(&self) -> String {
         self.file_name.clone()
     }
 
@@ -59,7 +42,7 @@ impl FileDialogResult for TestFileDialogResult {
     }
 
     fn file_type(&self) -> Option<String> {
-        (!self.is_cancelled()).then(|| ".txt".to_string())
+        Some(".txt".to_string())
     }
 
     fn contents(&self) -> &[u8] {
@@ -165,19 +148,18 @@ impl UiBackend for TestUiBackend {
     fn display_file_open_dialog(&mut self, filters: Vec<FileFilter>) -> Option<DialogResultFuture> {
         Some(Box::pin(async move {
             // If filters has the magic debug-select-success filter, then return a fake file for testing
-
-            let result: Result<Box<dyn FileDialogResult>, DialogLoaderError> = if filters
-                .iter()
-                .any(|f| f.description == "debug-select-success")
-            {
-                Ok(Box::new(TestFileDialogResult::new_success(
-                    "test.txt".to_string(),
-                )))
-            } else {
-                Ok(Box::new(TestFileDialogResult::new_canceled()))
-            };
-
-            result
+            Ok(
+                if filters
+                    .iter()
+                    .any(|f| f.description == "debug-select-success")
+                {
+                    FileDialogResult::Selection(Box::new(TestFileSelection::new(
+                        "test.txt".to_string(),
+                    )))
+                } else {
+                    FileDialogResult::Canceled
+                },
+            )
         }))
     }
 
@@ -188,15 +170,11 @@ impl UiBackend for TestUiBackend {
     ) -> Option<DialogResultFuture> {
         Some(Box::pin(async move {
             // If file_name has the magic debug-success.txt value, then return a fake file for testing
-
-            let result: Result<Box<dyn FileDialogResult>, DialogLoaderError> =
-                if file_name == "debug-success.txt" {
-                    Ok(Box::new(TestFileDialogResult::new_success(file_name)))
-                } else {
-                    Ok(Box::new(TestFileDialogResult::new_canceled()))
-                };
-
-            result
+            Ok(if file_name == "debug-success.txt" {
+                FileDialogResult::Selection(Box::new(TestFileSelection::new(file_name)))
+            } else {
+                FileDialogResult::Canceled
+            })
         }))
     }
 

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -3,7 +3,7 @@ mod font_renderer;
 use super::JavascriptPlayer;
 use rfd::{AsyncFileDialog, FileHandle};
 use ruffle_core::backend::ui::{
-    DialogLoaderError, DialogResultFuture, FileDialogResult, FileFilter,
+    DialogResultFuture, FileDialogResult, FileDialogSelection, FileFilter,
 };
 use ruffle_core::backend::ui::{
     FontDefinition, FullscreenError, LanguageIdentifier, MouseCursor, US_ENGLISH, UiBackend,
@@ -21,39 +21,22 @@ use web_sys::{
 use chrono::{DateTime, Utc};
 use js_sys::{Array, Uint8Array};
 
-pub struct WebFileDialogResult {
-    canceled: bool,
-    file_name: Option<String>,
+pub struct WebFileSelection {
+    file_name: String,
     modification_time: Option<DateTime<Utc>>,
     contents: Vec<u8>,
 }
 
-impl WebFileDialogResult {
-    pub async fn new_pick(handle: Option<FileHandle>) -> Self {
-        let contents = if let Some(handle) = handle.as_ref() {
-            handle.read().await
-        } else {
-            Vec::new()
-        };
+impl WebFileSelection {
+    pub async fn new_pick(handle: FileHandle) -> Self {
+        let contents = handle.read().await;
 
-        #[cfg(not(target_arch = "wasm32"))]
-        let file_name = None;
-
-        #[cfg(target_arch = "wasm32")]
-        let file_name = handle.as_ref().map(|handle| handle.file_name());
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let modification_time = None;
-
-        #[cfg(target_arch = "wasm32")]
-        let modification_time = if let Some(ref handle) = handle {
-            DateTime::from_timestamp(handle.inner().last_modified() as i64, 0)
-        } else {
-            None
+        let (file_name, modification_time) = cfg_select! {
+            target_arch = "wasm32" => (handle.file_name(), DateTime::from_timestamp(handle.inner().last_modified() as i64, 0)),
+            _ => (String::new(), None)
         };
 
         Self {
-            canceled: handle.is_none(),
             file_name,
             modification_time,
             contents,
@@ -62,8 +45,7 @@ impl WebFileDialogResult {
 
     fn new_download(file_name: String) -> Self {
         Self {
-            canceled: false,
-            file_name: Some(file_name),
+            file_name,
             modification_time: None,
             contents: Vec::new(),
         }
@@ -94,11 +76,7 @@ fn download_as_file(filename: Option<&str>, data: &[u8]) -> Result<(), JsValue> 
     Ok(())
 }
 
-impl FileDialogResult for WebFileDialogResult {
-    fn is_cancelled(&self) -> bool {
-        self.canceled
-    }
-
+impl FileDialogSelection for WebFileSelection {
     fn creation_time(&self) -> Option<DateTime<Utc>> {
         // Creation time is not available in JS
         None
@@ -108,7 +86,7 @@ impl FileDialogResult for WebFileDialogResult {
         self.modification_time
     }
 
-    fn file_name(&self) -> Option<String> {
+    fn file_name(&self) -> String {
         self.file_name.clone()
     }
 
@@ -117,11 +95,7 @@ impl FileDialogResult for WebFileDialogResult {
     }
 
     fn file_type(&self) -> Option<String> {
-        if let Some(ref file_name) = self.file_name {
-            get_extension_from_filename(file_name)
-        } else {
-            None
-        }
+        get_extension_from_filename(&self.file_name)
     }
 
     fn contents(&self) -> &[u8] {
@@ -132,7 +106,7 @@ impl FileDialogResult for WebFileDialogResult {
         self.contents = data.to_vec();
         self.modification_time = Some(Utc::now());
 
-        if let Err(err) = download_as_file(self.file_name.as_deref(), &self.contents[..]) {
+        if let Err(err) = download_as_file(Some(&self.file_name), &self.contents[..]) {
             tracing::error!("Download failed: {:?}", err);
         }
     }
@@ -376,10 +350,11 @@ impl UiBackend for WebUiBackend {
                 dialog = dialog.add_filter(&filter.description, &extensions);
             }
 
-            let result: Result<Box<dyn FileDialogResult>, DialogLoaderError> = Ok(Box::new(
-                WebFileDialogResult::new_pick(dialog.pick_file().await).await,
-            ));
-            result
+            Ok(if let Some(handle) = dialog.pick_file().await {
+                FileDialogResult::Selection(Box::new(WebFileSelection::new_pick(handle).await))
+            } else {
+                FileDialogResult::Canceled
+            })
         }))
     }
 
@@ -399,9 +374,9 @@ impl UiBackend for WebUiBackend {
         self.dialog_open = true;
 
         Some(Box::pin(async move {
-            let result: Result<Box<dyn FileDialogResult>, DialogLoaderError> =
-                Ok(Box::new(WebFileDialogResult::new_download(file_name)));
-            result
+            Ok(FileDialogResult::Selection(Box::new(
+                WebFileSelection::new_download(file_name),
+            )))
         }))
     }
 }


### PR DESCRIPTION
## Description

Pure refactor of the `FileDialogResult` infrastructure in `core/src/backend/ui.rs` and all its consumers (`core`, `desktop`, `web`, test framework).

Before: `FileDialogResult` was a trait with an `is_cancelled()` method and nullable accessors (`file_name() -> Option<String>`). Each backend had to ship a separate `Null*FileDialogResult` type to represent cancellation, and call sites read cancellation via `if !result.is_cancelled() { ... }`.

After:

```rust
pub enum FileDialogResult {
    Selection(Box<dyn FileDialogSelection>),
    Canceled,
}

pub trait FileDialogSelection: Any {
    fn creation_time(&self) -> Option<DateTime<Utc>>;
    fn modification_time(&self) -> Option<DateTime<Utc>>;
    fn file_name(&self) -> String;
    fn size(&self) -> Option<u64>;
    fn file_type(&self) -> Option<String>;
    fn creator(&self) -> Option<String> { None }
    fn contents(&self) -> &[u8];
    fn write_and_refresh(&mut self, data: &[u8]);
}
```

Cancellation is now expressed at the type level. `file_name()` is no longer `Option<String>` because a selected file always has a name — the previous nullability only existed to support the cancellation sentinel. The `Null*FileDialogResult` boilerplate types are deleted from desktop, web and the test framework.

Motivation: prerequisite cleanup before adding multi-file dialog support (`FileReferenceList`). With this enum/trait split, a follow-up `MultiFileDialogResult { Selection(Vec<Box<dyn FileDialogSelection>>), Canceled }` reuses the same `FileDialogSelection` trait per file with no duplication. Submitting this alone first to keep the multi-file PR scoped to just the new functionality.

No behavior change — `FileReference.browse` / `FileReference.save` in AVM1 and AVM2 behave identically.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have made or updated tests where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
