### PR TITLE
ci: Temporarily disable browser tests on Chrome

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -159,7 +159,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: ["chrome", "firefox", "edge"]
+        browser: ["firefox", "edge"]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Description

https://github.com/actions/runner-images/issues/14169. Edge is "close enough" for now, until that issue is resolved. This PR is meant to be reverted later.

## Testing

N/A

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
