### PR TITLE
avm2: More minor crossbridge performance improvements

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -754,6 +754,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::ConvertO => self.op_convert_o(),
                 Op::ConvertS => self.op_convert_s(),
                 Op::Add => self.op_add(),
+                Op::AddIntegral => self.op_add_integral(),
                 Op::AddI => self.op_add_i(),
                 Op::BitAnd => self.op_bitand(),
                 Op::BitNot => self.op_bitnot(),
@@ -776,6 +777,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::NegateI => self.op_negate_i(),
                 Op::RShift => self.op_rshift(),
                 Op::Subtract => self.op_subtract(),
+                Op::SubtractIntegral => self.op_subtract_integral(),
                 Op::SubtractI => self.op_subtract_i(),
                 Op::Swap => self.op_swap(),
                 Op::URShift => self.op_urshift(),
@@ -2072,6 +2074,29 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(())
     }
 
+    fn op_add_integral(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        let sum_value: Value<'gc> = match (value1, value2) {
+            (Value::Integer(n1), Value::Integer(n2)) => {
+                if let Some(res) = n1.checked_add(n2) {
+                    res.into()
+                } else {
+                    ((n1 as i64 + n2 as i64) as f64).into()
+                }
+            }
+            (Value::Number(n1), Value::Number(n2)) => (n1 + n2).into(),
+            (Value::Integer(n1), Value::Number(n2)) => (n1 as f64 + n2).into(),
+            (Value::Number(n1), Value::Integer(n2)) => (n1 + n2 as f64).into(),
+            _ => unreachable!("Guaranteed by verifier"),
+        };
+
+        self.push_stack(sum_value);
+
+        Ok(())
+    }
+
     fn op_add_i(&mut self) -> Result<(), Error<'gc>> {
         let value2 = self.pop_stack();
         let value1 = self.pop_stack();
@@ -2290,6 +2315,29 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 let value1 = value1.coerce_to_number(self)?;
                 (value1 - value2).into()
             }
+        };
+
+        self.push_stack(sub_value);
+
+        Ok(())
+    }
+
+    fn op_subtract_integral(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        let sub_value: Value<'gc> = match (value1, value2) {
+            (Value::Integer(n1), Value::Integer(n2)) => {
+                if let Some(res) = n1.checked_sub(n2) {
+                    res.into()
+                } else {
+                    ((n1 as i64 - n2 as i64) as f64).into()
+                }
+            }
+            (Value::Number(n1), Value::Number(n2)) => (n1 - n2).into(),
+            (Value::Integer(n1), Value::Number(n2)) => (n1 as f64 - n2).into(),
+            (Value::Number(n1), Value::Integer(n2)) => (n1 - n2 as f64).into(),
+            _ => unreachable!("Guaranteed by verifier"),
         };
 
         self.push_stack(sub_value);

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2794,13 +2794,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Si8`
     fn op_si8(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_i32(self)?;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let val = self.pop_stack().coerce_to_i32(self)? as i8;
         let mut dm = self.domain_memory().storage_mut();
-
-        let Ok(address) = usize::try_from(address) else {
-            return Err(make_error_1506(self));
-        };
 
         if address >= dm.len() {
             return Err(make_error_1506(self));
@@ -2813,13 +2813,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Si16`
     fn op_si16(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_i32(self)?;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let val = self.pop_stack().coerce_to_i32(self)? as i16;
         let mut dm = self.domain_memory().storage_mut();
 
-        let Ok(address) = usize::try_from(address) else {
-            return Err(make_error_1506(self));
-        };
         if address > dm.len() - 2 {
             return Err(make_error_1506(self));
         }
@@ -2831,13 +2832,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Si32`
     fn op_si32(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_i32(self)?;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let val = self.pop_stack().coerce_to_i32(self)?;
         let mut dm = self.domain_memory().storage_mut();
 
-        let Ok(address) = usize::try_from(address) else {
-            return Err(make_error_1506(self));
-        };
         if address > dm.len() - 4 {
             return Err(make_error_1506(self));
         }
@@ -2849,13 +2851,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Sf32`
     fn op_sf32(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_i32(self)?;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let val = self.pop_stack().coerce_to_number(self)? as f32;
         let mut dm = self.domain_memory().storage_mut();
 
-        let Ok(address) = usize::try_from(address) else {
-            return Err(make_error_1506(self));
-        };
         if address > dm.len() - 4 {
             return Err(make_error_1506(self));
         }
@@ -2867,13 +2870,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Sf64`
     fn op_sf64(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_i32(self)?;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let val = self.pop_stack().coerce_to_number(self)?;
         let mut dm = self.domain_memory().storage_mut();
 
-        let Ok(address) = usize::try_from(address) else {
-            return Err(make_error_1506(self));
-        };
         if address > dm.len() - 8 {
             return Err(make_error_1506(self));
         }
@@ -2885,7 +2889,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Li8`
     fn op_li8(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_u32(self)? as usize;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let dm = self.domain_memory().storage();
 
         let val = dm.get(address);
@@ -2901,7 +2909,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Li16`
     fn op_li16(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_u32(self)? as usize;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let dm = self.domain_memory().storage();
 
         if address > dm.len() - 2 {
@@ -2916,7 +2928,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Li32`
     fn op_li32(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_u32(self)? as usize;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let dm = self.domain_memory().storage();
 
         if address > dm.len() - 4 {
@@ -2930,7 +2946,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Lf32`
     fn op_lf32(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_u32(self)? as usize;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let dm = self.domain_memory().storage();
 
         if address > dm.len() - 4 {
@@ -2945,7 +2965,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     /// Implements `Op::Lf64`
     fn op_lf64(&mut self) -> Result<(), Error<'gc>> {
-        let address = self.pop_stack().coerce_to_u32(self)? as usize;
+        // Negative addresses will be coerced to >i32::MAX, which is guaranteed
+        // to be out-of-bounds of the domain memory by a check in
+        // `Domain::set_domain_memory`.
+        let address = self.pop_stack().coerce_to_i32(self)? as usize;
+
         let dm = self.domain_memory().storage();
 
         if address > dm.len() - 8 {

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -379,6 +379,24 @@ impl<'gc> Domain<'gc> {
             if domain_memory.storage().len() < MIN_DOMAIN_MEMORY_LENGTH {
                 return Err(make_error_1504(activation));
             }
+
+            // We rely on negative indices into domain memory becoming positive
+            // indices greater than i32::MAX due to 2's complement. If the
+            // domain memory bytearray's length is never greater than i32::MAX,
+            // all such negative indices will always be out of bounds, allowing
+            // us to skip extra checks for indices being positive in the
+            // interpreter.
+
+            // However, this requires us to actually guarantee that all byte-
+            // arrays that are used as domain memory never have a length greater
+            // than i32::MAX.
+
+            // TODO: This check should be moved somewhere to bytearray code, and
+            // should throw Error #1000 from there instead of panicking.
+            if domain_memory.storage().len() > i32::MAX as usize {
+                panic!("Domain memory bytearray must not be larger than i32::MAX!");
+            }
+
             domain_memory
         } else {
             let memory = self.0.default_domain_memory.get();

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -12,6 +12,7 @@ use std::cell::Cell;
 #[collect(no_drop)]
 pub enum Op<'gc> {
     Add,
+    AddIntegral,
     AddI,
     ApplyType {
         num_types: u32,
@@ -327,6 +328,7 @@ pub enum Op<'gc> {
         index: u32,
     },
     Subtract,
+    SubtractIntegral,
     SubtractI,
     Swap,
     Sxi1,

--- a/core/src/avm2/optimizer/peephole.rs
+++ b/core/src/avm2/optimizer/peephole.rs
@@ -21,8 +21,8 @@ pub fn preprocess_peephole(ops: &[Cell<Op<'_>>]) {
 
 /// A peephole optimizer to run after type-aware optimizations. This should be
 /// called once on the entire code slice.
-pub fn postprocess_peephole(
-    ops: &[Cell<Op<'_>>],
+pub fn postprocess_peephole<'a>(
+    ops: &'a [Cell<Op<'_>>],
     jump_targets: &HashSet<usize>,
     has_exceptions: bool,
 ) {
@@ -58,7 +58,7 @@ pub fn postprocess_peephole(
         simple_scope_structure(ops, jump_targets).filter(|_| !has_exceptions);
 
     // Now actually run the peephole optimizer.
-    let mut last_op = None;
+    let mut last_op: Option<&'a Cell<Op<'_>>> = None;
 
     for (i, current_op) in ops.iter().enumerate() {
         if jump_targets.contains(&i) {
@@ -94,6 +94,42 @@ pub fn postprocess_peephole(
                     // SetLocal+GetLocal becomes Nop+StoreLocal
                     last_op.set(Op::Nop);
                     current_op.set(Op::StoreLocal { index: index1 });
+                }
+                (Op::AddIntegral, Op::CoerceI) => {
+                    // An integral addition that yields Number on overflow
+                    // followed by coerce-to-integer is equivalent to wrapping
+                    // integral addition
+                    last_op.set(Op::AddI);
+                    current_op.set(Op::Nop);
+                }
+                (Op::SubtractIntegral, Op::CoerceI) => {
+                    // The same is true for subtraction
+                    last_op.set(Op::SubtractI);
+                    current_op.set(Op::Nop);
+                }
+                (
+                    Op::AddIntegral,
+                    Op::Li8 | Op::Li16 | Op::Li32 | Op::Si8 | Op::Si16 | Op::Si32,
+                ) => {
+                    // See comments above
+                    last_op.set(Op::AddI);
+                }
+                (
+                    Op::SubtractIntegral,
+                    Op::Li8 | Op::Li16 | Op::Li32 | Op::Si8 | Op::Si16 | Op::Si32,
+                ) => {
+                    // The same is true for subtraction
+                    last_op.set(Op::SubtractI);
+                }
+                (Op::AddIntegral, Op::SetSlotCoerceI { index }) => {
+                    // See comments above
+                    last_op.set(Op::AddI);
+                    current_op.set(Op::SetSlotNoCoerce { index });
+                }
+                (Op::SubtractIntegral, Op::SetSlotCoerceI { index }) => {
+                    // The same is true for subtraction
+                    last_op.set(Op::SubtractI);
+                    current_op.set(Op::SetSlotNoCoerce { index });
                 }
                 _ => {}
             }

--- a/core/src/avm2/optimizer/peephole.rs
+++ b/core/src/avm2/optimizer/peephole.rs
@@ -66,44 +66,46 @@ pub fn postprocess_peephole(
             last_op = None;
         }
 
-        match (last_op, last_op.map(Cell::get), current_op.get()) {
-            (Some(last_op), Some(push_op), Op::Pop) if push_op.is_pure_push() => {
-                // Eliminate PushXXX+Pop and GetLocal+Pop
-                last_op.set(Op::Nop);
-                current_op.set(Op::Nop);
+        if let Some(last_op) = last_op {
+            // Optimizations on both the current and the last op
+            match (last_op.get(), current_op.get()) {
+                (push_op, Op::Pop) if push_op.is_pure_push() => {
+                    // Eliminate PushXXX+Pop and GetLocal+Pop
+                    last_op.set(Op::Nop);
+                    current_op.set(Op::Nop);
+                }
+                (push_op, Op::PopJump { offset }) if push_op.is_pure_push() => {
+                    // PushXXX+PopJump becomes Nop+Jump
+                    last_op.set(Op::Nop);
+                    current_op.set(Op::Jump { offset });
+                }
+                (Op::CoerceB, Op::IfTrue { .. } | Op::IfFalse { .. } | Op::Not) => {
+                    // Remove CoerceB before IfTrue, IfFalse, and Not
+                    last_op.set(Op::Nop);
+                }
+                (Op::Dup, Op::SetLocal { index }) => {
+                    // Dup+SetLocal becomes Nop+StoreLocal
+                    last_op.set(Op::Nop);
+                    current_op.set(Op::StoreLocal { index });
+                }
+                (Op::SetLocal { index: index1 }, Op::GetLocal { index: index2 })
+                    if index1 == index2 =>
+                {
+                    // SetLocal+GetLocal becomes Nop+StoreLocal
+                    last_op.set(Op::Nop);
+                    current_op.set(Op::StoreLocal { index: index1 });
+                }
+                _ => {}
             }
-            (Some(last_op), Some(push_op), Op::PopJump { offset }) if push_op.is_pure_push() => {
-                // PushXXX+PopJump becomes Nop+Jump
-                last_op.set(Op::Nop);
-                current_op.set(Op::Jump { offset });
-            }
-            (
-                Some(last_op),
-                Some(Op::CoerceB),
-                Op::IfTrue { .. } | Op::IfFalse { .. } | Op::Not,
-            ) => {
-                // Remove CoerceB before IfTrue, IfFalse, and Not
-                last_op.set(Op::Nop);
-            }
-            (_, _, Op::GetScopeObject { index: 0 })
+        }
+
+        // Optimizations on the current op
+        match current_op.get() {
+            Op::GetScopeObject { index: 0 }
                 if simple_scope_op_positions.is_some() && !sets_local_0 =>
             {
                 // Replace `getscopeobject 0` with `getlocal 0` if possible
                 current_op.set(Op::GetLocal { index: 0 })
-            }
-            (Some(last_op), Some(Op::Dup), Op::SetLocal { index }) => {
-                // Dup+SetLocal becomes Nop+StoreLocal
-                last_op.set(Op::Nop);
-                current_op.set(Op::StoreLocal { index });
-            }
-            (
-                Some(last_op),
-                Some(Op::SetLocal { index: index1 }),
-                Op::GetLocal { index: index2 },
-            ) if index1 == index2 => {
-                // SetLocal+GetLocal becomes Nop+StoreLocal
-                last_op.set(Op::Nop);
-                current_op.set(Op::StoreLocal { index: index1 });
             }
             _ => {}
         }

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -994,6 +994,11 @@ fn abstract_interpret_ops<'gc>(
             Op::Add => {
                 let value2 = stack.pop(activation)?;
                 let value1 = stack.pop(activation)?;
+
+                if value1.class == Some(types.int) && value2.class == Some(types.int) {
+                    optimize_op_to!(Op::AddIntegral);
+                }
+
                 if (value1.class == Some(types.int)
                     || value1.class == Some(types.uint)
                     || value1.class == Some(types.number))
@@ -1011,8 +1016,13 @@ fn abstract_interpret_ops<'gc>(
                 }
             }
             Op::Subtract => {
-                stack.pop(activation)?;
-                stack.pop(activation)?;
+                let value2 = stack.pop(activation)?;
+                let value1 = stack.pop(activation)?;
+
+                if value1.class == Some(types.int) && value2.class == Some(types.int) {
+                    optimize_op_to!(Op::SubtractIntegral);
+                }
+
                 stack.push_class(activation, types.number)?;
             }
             Op::Multiply => {
@@ -2123,7 +2133,8 @@ fn abstract_interpret_ops<'gc>(
                 return Ok(());
             }
 
-            Op::CallMethod { .. }
+            Op::AddIntegral
+            | Op::CallMethod { .. }
             | Op::CallNative { .. }
             | Op::CoerceSwapPop { .. }
             | Op::CoerceDSwapPop
@@ -2133,7 +2144,8 @@ fn abstract_interpret_ops<'gc>(
             | Op::GetScriptGlobals { .. }
             | Op::PopJump { .. }
             | Op::SetSlotCoerceI { .. }
-            | Op::SetSlotNoCoerce { .. } => unreachable!("Custom ops should not be encountered"),
+            | Op::SetSlotNoCoerce { .. }
+            | Op::SubtractIntegral => unreachable!("Custom ops should not be encountered"),
         }
     }
 


### PR DESCRIPTION
## Description

This PR speeds up the domain memory ops and implements peephole conversion of the `add` and `subtract` ops to `add_i` and `subtract_i` when possible.

## Testing

No changes were made that can be covered by SWF regression tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
