### PR TITLE
core: Include `ruffle_render/jpegxr` in `jpegxr` feature

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -92,7 +92,7 @@ audio = ["dasp"]
 known_stubs = ["linkme", "serde"]
 default_compatibility_rules = []
 egui = ["dep:egui", "dep:egui_extras", "png"]
-jpegxr = ["dep:jpegxr", "lzma"]
+jpegxr = ["dep:jpegxr", "ruffle_render/jpegxr", "lzma"]
 default_font = []
 serde = ["serde/derive"]
 

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -81,7 +81,7 @@ OriginalFilename = "ruffle.exe"
 
 [features]
 default = ["software_video", "external_video", "lzma", "fontconfig"]
-jpegxr = ["ruffle_core/jpegxr", "ruffle_render/jpegxr"]
+jpegxr = ["ruffle_core/jpegxr"]
 
 # core features
 avm_debug = ["ruffle_core/avm_debug"]

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -38,5 +38,5 @@ clap = { workspace = true, optional = true }
 tempfile = { workspace = true }
 
 [features]
-jpegxr = ["ruffle_core/jpegxr", "ruffle_render/jpegxr"]
+jpegxr = ["ruffle_core/jpegxr"]
 lzma = ["ruffle_core/lzma"]


### PR DESCRIPTION
## Description

Moving it here allows us to not have to individually put it in the `desktop`, `tests/framework` and `web` features, the last of which was missed in https://github.com/ruffle-rs/ruffle/pull/23789, which caused the additions from that PR to not work on the web build.

## Testing

Not tested, but I'm 99% sure this was the cause of JPEGXR in the web build not working.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
