### PR TITLE
ci: Enable fontconfig-dlopen in the macOS Rust tester job

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -90,6 +90,12 @@ jobs:
         shell: bash
         run: echo FEATURES=${FEATURES},imgtests | tee -a $GITHUB_ENV
 
+        # TODO: Remove this once https://github.com/actions/runner-images/issues/14176 is fixed.
+      - name: Enable fontconfig-dlopen on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: echo FEATURES=${FEATURES},fontconfig-dlopen | tee -a $GITHUB_ENV
+
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Description

With this image update, our checks started failing:
https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260527.0100

( https://github.com/ruffle-rs/ruffle/actions/runs/26542164479/job/78185949310#step:1:17 -> https://github.com/ruffle-rs/ruffle/actions/runs/26667171366/job/78612116493?pr=23762#step:1:17 )

~~Perhaps `fontconfig` was "accidentally installed" on the previous image version, as an indirect dependency of something.~~
~~And now even if it prints a warning like "already installed", that apparently doesn't mean that installing it is a no-op, as it may not be "linked into" the active system properly (whatever that means).~~
~~So we could use `brew reinstall` or `brew link` instead, but I feel like a plain `brew install` may be more universal and future-proof, regardless of the warning.~~

~~It was also decided that instead of enabling `fontconfig-dlopen`, like on the release builder workflows, we'd rather test both build configs by not enabling it here.~~

This would also have been necessary for: https://github.com/ruffle-rs/ruffle/pull/23842

EDIT: The above didn't work, let's enable `fontconfig-dlopen` instead. :neutral_face:

## Testing

_How can we test this PR?_

Wait for the GHA job to finish.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
