### PR TITLE
tests: add `known_failure` support to audio assertions

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -181,6 +181,10 @@ max_amplitude = 0.5
 # The max is calculated per frame.
 min_max_amplitude = 0.4
 
+# If true, this audio assertion is known to fail and the test runner will expect it to fail.
+# When the assertion passes in the future, it'll fail and alert that it now passes.
+known_failure = false
+
 # A single device font provided for this test.
 [fonts.FONT_NAME] # FONT_NAME is a name of this particular font
 

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -79,6 +79,8 @@ pub struct AudioAssertion {
     pub frames: FrameSelection,
     pub max_amplitude: Option<f32>,
     pub min_max_amplitude: Option<f32>,
+    #[serde(default)]
+    pub known_failure: bool,
 }
 
 #[derive(Clone, Deserialize)]

--- a/tests/framework/src/runner.rs
+++ b/tests/framework/src/runner.rs
@@ -304,7 +304,7 @@ impl TestRunner {
             return Err(anyhow!("Audio assertions require audio"));
         };
 
-        for assertion in self.audio_assertions.values() {
+        for (assertion_name, assertion) in &self.audio_assertions {
             if !assertion.frames.includes_frame(self.current_iteration) {
                 continue;
             }
@@ -315,27 +315,34 @@ impl TestRunner {
                 .map(|&v| v.abs())
                 .reduce(|a, b| a.max(b))
                 .expect("buffer should not be empty");
+            let frame = self.current_iteration;
 
-            if let Some(max_amplitude) = assertion.max_amplitude
+            let result = if let Some(max_amplitude) = assertion.max_amplitude
                 && current_max > max_amplitude
             {
-                return Err(anyhow!(
-                    "Expected max audio amplitude to be {}, was {} at frame {}",
-                    max_amplitude,
-                    current_max,
-                    self.current_iteration
-                ));
-            }
-
-            if let Some(min_max_amplitude) = assertion.min_max_amplitude
+                Err(anyhow!(
+                    "Audio assertion '{assertion_name}': expected max audio amplitude to be {max_amplitude}, was {current_max} at frame {frame}"
+                ))
+            } else if let Some(min_max_amplitude) = assertion.min_max_amplitude
                 && current_max < min_max_amplitude
             {
-                return Err(anyhow!(
-                    "Expected max audio amplitude to be at least {}, was {} at frame {}",
-                    min_max_amplitude,
-                    current_max,
-                    self.current_iteration
-                ));
+                Err(anyhow!(
+                    "Audio assertion '{assertion_name}': expected max audio amplitude to be at least {min_max_amplitude}, was {current_max} at frame {frame}",
+                ))
+            } else {
+                Ok(())
+            };
+
+            match result {
+                Err(err) if !assertion.known_failure => return Err(err),
+                Ok(()) if assertion.known_failure => {
+                    // TODO: should we allow known_failure assertions to succeed on *some* frames as long as they fail at least once?
+                    return Err(anyhow!(
+                        "Audio assertion '{assertion_name}': check was known to be failing (at frame {frame}) but now passes successfully. \
+                        Please update the test and remove `known_failure = true`",
+                    ));
+                }
+                _ => (),
             }
         }
 


### PR DESCRIPTION
## Description

Allow marking expected audio assertion failures with `known_failure = true`, like trace outputs or image comparisons.

## Testing

An test using this feature has been added to PR #23676.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
