### PR TITLE
text: Prevent measuring text twice during layout

### DIFF
--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -682,10 +682,10 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
         let metrics = font_set.metrics();
         let ascent = metrics.ascent(params.height());
         let descent = metrics.descent(params.height());
-        let text_width = font_set.measure(text, params);
         let box_origin = self.cursor - (Twips::ZERO, ascent).into();
 
         let mut new_box = LayoutBox::from_text(text, start, end, font_set, span);
+        let text_width = new_box.text_width();
         new_box.bounds = BoxBounds::from_position_and_size(
             box_origin,
             Size::from((text_width, ascent + descent)),
@@ -1386,6 +1386,15 @@ impl<'gc> LayoutBox<'gc> {
 
     pub fn text_range(&self) -> Range<usize> {
         self.start()..self.end()
+    }
+
+    pub fn text_width(&self) -> Twips {
+        match &self.content {
+            LayoutContent::Text { char_end_pos, .. } => {
+                char_end_pos.last().copied().unwrap_or_default()
+            }
+            _ => Twips::ZERO,
+        }
     }
 
     /// Return x-axis char bounds of the given char relative to the whole layout.


### PR DESCRIPTION
## Description

Measuring text (evaluating a font) is very costly. In the case of append_text_fragment() we were doing it twice.

Now, append_text_fragment() uses LayoutBox to get text measurement instead of performing the measurement beforehand.

## Testing

It's well tested already.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
