### PR TITLE
ci: Enable full LTO for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
 
     env:
       PACKAGE_FILE: ${{ needs.create-release.outputs.package_prefix }}-${{ matrix.build_name }}.${{ startsWith(matrix.build_name, 'win') && 'zip' || 'tar.gz' }}
-      CARGO_BUILD_DIR: target/${{ matrix.target }}/release
+      CARGO_BUILD_DIR: target/${{ matrix.target }}/dist
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -188,7 +188,7 @@ jobs:
           wix extension add -g WixToolset.Util.wixext/5.0.2
 
       - name: Cargo build
-        run: cargo build --locked --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
+        run: cargo build --locked --package ruffle_desktop --profile dist ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
           CFG_RELEASE_CHANNEL: ${{ needs.create-release.outputs.release_channel }}
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
@@ -206,7 +206,7 @@ jobs:
           wix build ruffle.wxs -ext WixToolset.UI.wixext -ext WixToolset.Util.wixext -arch ${{ matrix.MSI_ARCH }} -o ../../../../package/setup.msi -pdbtype none
         env:
           RUFFLE_VERSION: ${{ needs.create-release.outputs.version4 }}
-          CARGO_BUILD_DIR: ../../../../target/${{ matrix.target }}/release
+          CARGO_BUILD_DIR: ../../../../target/${{ matrix.target }}/dist
         if: runner.os == 'Windows'
 
       - name: Package Windows
@@ -238,7 +238,7 @@ jobs:
 
       - name: Build Safari Web Extension stub binary
         if: runner.os == 'macOS'
-        run: cargo build --locked --package ruffle_web_safari --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
+        run: cargo build --locked --package ruffle_web_safari --profile dist ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
           CFG_RELEASE_CHANNEL: ${{ needs.create-release.outputs.release_channel }}
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
@@ -283,13 +283,13 @@ jobs:
 
       - name: Make universal desktop binary
         run: |
-          lipo -create -output package/ruffle target/x86_64-apple-darwin/release/ruffle_desktop target/aarch64-apple-darwin/release/ruffle_desktop
+          lipo -create -output package/ruffle target/x86_64-apple-darwin/dist/ruffle_desktop target/aarch64-apple-darwin/dist/ruffle_desktop
           chmod +x package/ruffle
 
       - name: Make universal Safari stub binary
         continue-on-error: true
         run: |
-          lipo -create -output package/ruffle_web_safari target/x86_64-apple-darwin/release/ruffle_web_safari target/aarch64-apple-darwin/release/ruffle_web_safari
+          lipo -create -output package/ruffle_web_safari target/x86_64-apple-darwin/dist/ruffle_web_safari target/aarch64-apple-darwin/dist/ruffle_web_safari
           chmod +x package/ruffle_web_safari
 
       - name: Create app bundle

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,11 @@ panic = "unwind"
 [profile.release]
 panic = "abort"
 
+[profile.dist]
+inherits = "release"
+lto = true
+codegen-units = 1
+
 [profile.dev.package.h263-rs]
 opt-level = 3
 


### PR DESCRIPTION

## Description

Full LTO takes a long time, but can reduce binary size and produce better optimized code.

This patch adds a dist profile for distributing Ruffle, which inherits from the release profile and enables full LTO.

Local tests show the following improvements:

- Binary size improvement of 18.5% (39 vs 32 MB)
- Compressed binary size improvement of 13.3% (15 vs 13 MB)
- Bench2d: perf improvement of 9.5% ± 4.9% (n = 4)
- Bench2dNape: perf improvement of 7.4% ± 2.6% (n = 4)
- crypto-bench: perf improvement of 8% ± 5% (n = 1)


## Testing

Performance tested locally, CI stuff is untested, but LLM-reviewed.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
