### PR TITLE
(poc) avm2: Int interpreter

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -56,6 +56,7 @@ mod filters;
 mod flv;
 mod function;
 pub mod globals;
+mod int_interpreter;
 mod metadata;
 mod method;
 mod multiname;

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -785,9 +785,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::StrictEquals => self.op_strict_equals(),
                 Op::Equals => self.op_equals(),
                 Op::GreaterEquals => self.op_greater_equals(),
+                Op::GreaterEqualsIntegral => self.op_greater_equals_integral(),
                 Op::GreaterThan => self.op_greater_than(),
+                Op::GreaterThanIntegral => self.op_greater_than_integral(),
                 Op::LessEquals => self.op_less_equals(),
+                Op::LessEqualsIntegral => self.op_less_equals_integral(),
                 Op::LessThan => self.op_less_than(),
+                Op::LessThanIntegral => self.op_less_than_integral(),
                 Op::Nop => Ok(()),
                 Op::Not => self.op_not(),
                 Op::HasNext => self.op_has_next(),
@@ -2434,11 +2438,33 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(())
     }
 
+    fn op_greater_equals_integral(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack().as_i32();
+        let value1 = self.pop_stack().as_i32();
+
+        let result = value1 >= value2;
+
+        self.push_stack(result);
+
+        Ok(())
+    }
+
     fn op_greater_than(&mut self) -> Result<(), Error<'gc>> {
         let value2 = self.pop_stack();
         let value1 = self.pop_stack();
 
         let result = value2.abstract_lt(&value1, self)?.unwrap_or(false);
+
+        self.push_stack(result);
+
+        Ok(())
+    }
+
+    fn op_greater_than_integral(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack().as_i32();
+        let value1 = self.pop_stack().as_i32();
+
+        let result = value1 > value2;
 
         self.push_stack(result);
 
@@ -2456,11 +2482,33 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(())
     }
 
+    fn op_less_equals_integral(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack().as_i32();
+        let value1 = self.pop_stack().as_i32();
+
+        let result = value1 <= value2;
+
+        self.push_stack(result);
+
+        Ok(())
+    }
+
     fn op_less_than(&mut self) -> Result<(), Error<'gc>> {
         let value2 = self.pop_stack();
         let value1 = self.pop_stack();
 
         let result = value1.abstract_lt(&value2, self)?.unwrap_or(false);
+
+        self.push_stack(result);
+
+        Ok(())
+    }
+
+    fn op_less_than_integral(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack().as_i32();
+        let value1 = self.pop_stack().as_i32();
+
+        let result = value1 < value2;
 
         self.push_stack(result);
 
@@ -3121,8 +3169,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         // Synchronize all the int locals in this interpreter to the int
         // interpreter
-        for (i, is_int) in info.input_locals.iter().enumerate() {
-            if is_int {
+        for (i, is_read) in info.synchronize_locals.iter().enumerate() {
+            if is_read {
                 // This local might be read from the code run in the int
                 // interpreter, so pass it to it properly.
                 interpreter.push_stack(self.local_register(i as u32).as_i32());
@@ -3139,8 +3187,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // exception handlers to which that state is observable to (this method
         // will simply immediately return to its caller with the error).
         let result = interpreter.run(&info.ops);
-        let new_ip = match result {
-            Ok(new_ip) => new_ip,
+        let (new_ip, final_stack_height) = match result {
+            Ok(info) => info,
             Err(_) => {
                 // The only exception that can happen from the int interpreter is
                 // an out-of-bounds domain memory read/write.
@@ -3150,8 +3198,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         // Synchronize all the int locals in the int interpreter to this
         // interpreter
-        for (i, is_int) in info.output_locals.iter().enumerate() {
-            if is_int {
+        for (i, is_read) in info.synchronize_locals.iter().enumerate() {
+            if is_read {
                 // This local might have been written to by the code run in the
                 // int interpreter, so synchronize it back to us.
                 self.set_local_register(i as u32, interpreter.frame_at(i as u32));
@@ -3160,8 +3208,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         // Finally, synchronize the stack from the int interpreter to this
         // interpreter.
-        let num_locals = info.input_locals.len();
-        for i in num_locals..num_locals + info.final_stack_height {
+        let num_locals = info.synchronize_locals.len();
+        for i in num_locals..num_locals + final_stack_height {
             self.push_stack(interpreter.frame_at(i as u32));
         }
 

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -3259,7 +3259,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // exception handlers to which that state is observable to (this method
         // will simply immediately return to its caller with the error).
         let result = interpreter.run(&*ops);
-        let (new_ip, final_stack_height) = match result {
+        let new_ip = match result {
             Ok(info) => info,
             Err(_) => {
                 // The only exception that can happen from the int interpreter is
@@ -3281,7 +3281,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // Finally, synchronize the stack from the int interpreter to this
         // interpreter.
         let num_locals = info.synchronize_locals.len();
-        for i in num_locals..num_locals + final_stack_height {
+        for i in num_locals..interpreter.stack_pointer() {
             self.push_stack(interpreter.frame_at(i as u32));
         }
 

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -3219,6 +3219,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Err(Error::from_value(self, error_val))
     }
 
+    #[inline(never)]
     fn run_int_interpreter(&mut self, info: &IntInterpreterInfo) -> Result<usize, Error<'gc>> {
         // Code run in the int interpreter does not have the ability to borrow
         // or swap out the domain memory, so borrow it here. This means that

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -3250,12 +3250,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             }
         }
 
+        let ops = info.ops.borrow();
+
         // NOTE: Int interpreter promotion is never done if this method has
         // exception handlers. This means that it's fine to not synchronize
         // correct state of locals once this throws an error, as there are no
         // exception handlers to which that state is observable to (this method
         // will simply immediately return to its caller with the error).
-        let result = interpreter.run(&info.ops);
+        let result = interpreter.run(&*ops);
         let (new_ip, final_stack_height) = match result {
             Ok(info) => info,
             Err(_) => {

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -842,9 +842,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                     // exception handler; we can simply throw it from here (as
                     // there are no exception handlers in this method that could
                     // handle the error).
-                    self.run_int_interpreter(info)?;
+                    let new_ip = self.run_int_interpreter(info)?;
 
-                    ip = info.exit_offset.get();
+                    ip = new_ip;
 
                     continue;
                 }
@@ -3110,7 +3110,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Err(Error::from_value(self, error_val))
     }
 
-    fn run_int_interpreter(&mut self, info: &IntInterpreterInfo) -> Result<(), Error<'gc>> {
+    fn run_int_interpreter(&mut self, info: &IntInterpreterInfo) -> Result<usize, Error<'gc>> {
         // Code run in the int interpreter does not have the ability to borrow
         // or swap out the domain memory, so borrow it here. This means that
         // domain memory ops run in the int interpreter can just access the
@@ -3139,11 +3139,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // exception handlers to which that state is observable to (this method
         // will simply immediately return to its caller with the error).
         let result = interpreter.run(&info.ops);
-        if result.is_err() {
-            // The only exception that can happen from the int interpreter is
-            // an out-of-bounds domain memory read/write.
-            return Err(make_error_1506(self));
-        }
+        let new_ip = match result {
+            Ok(new_ip) => new_ip,
+            Err(_) => {
+                // The only exception that can happen from the int interpreter is
+                // an out-of-bounds domain memory read/write.
+                return Err(make_error_1506(self));
+            }
+        };
 
         // Synchronize all the int locals in the int interpreter to this
         // interpreter
@@ -3162,6 +3165,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             self.push_stack(interpreter.frame_at(i as u32));
         }
 
-        Ok(())
+        Ok(new_ip)
     }
 }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -12,13 +12,14 @@ use crate::avm2::error::{
     make_null_or_undefined_error,
 };
 use crate::avm2::function::FunctionArgs;
+use crate::avm2::int_interpreter::IntInterpreter;
 use crate::avm2::method::{Method, NativeMethodImpl, ResolvedParamConfig};
 use crate::avm2::object::TObject;
 use crate::avm2::object::{
     ArrayObject, ByteArrayObject, ClassObject, FunctionObject, NamespaceObject, ScriptObject,
     XmlListObject,
 };
-use crate::avm2::op::{LookupSwitch, Op};
+use crate::avm2::op::{IntInterpreterInfo, LookupSwitch, Op};
 use crate::avm2::scope::{Scope, ScopeChain, search_scope_stack};
 use crate::avm2::script::Script;
 use crate::avm2::stack::StackFrame;
@@ -833,6 +834,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::Sxi8 => self.op_sxi8(),
                 Op::Sxi16 => self.op_sxi16(),
                 Op::Throw => self.op_throw(),
+
+                Op::RunIntInterpreter(info) => {
+                    self.run_int_interpreter(info);
+
+                    ip = info.exit_offset.get();
+
+                    continue;
+                }
 
                 // Branch ops
                 Op::Jump { offset } => {
@@ -3093,5 +3102,42 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     fn op_throw(&mut self) -> Result<(), Error<'gc>> {
         let error_val = self.pop_stack();
         Err(Error::from_value(self, error_val))
+    }
+
+    fn run_int_interpreter(&mut self, info: &IntInterpreterInfo) {
+        let mut interpreter = IntInterpreter::new();
+
+        // Synchronize all the int locals in this interpreter to the int
+        // interpreter
+        for (i, is_int) in info.input_locals.iter().enumerate() {
+            if is_int {
+                // This local might be read from the code run in the int
+                // interpreter, so pass it to it properly.
+                interpreter.push_stack(self.local_register(i as u32).as_i32());
+            } else {
+                // This local won't be read from by the code run in the int
+                // interpreter, so we can just pass nothing.
+                interpreter.push_stack(0);
+            }
+        }
+
+        interpreter.run(&info.ops);
+
+        // Synchronize all the int locals in the int interpreter to this
+        // interpreter
+        for (i, is_int) in info.output_locals.iter().enumerate() {
+            if is_int {
+                // This local might have been written to by the code run in the
+                // int interpreter, so synchronize it back to us.
+                self.set_local_register(i as u32, interpreter.frame_at(i as u32));
+            }
+        }
+
+        // Finally, synchronize the stack from the int interpreter to this
+        // interpreter.
+        let num_locals = info.input_locals.len();
+        for i in num_locals..num_locals + info.final_stack_height {
+            self.push_stack(interpreter.frame_at(i as u32));
+        }
     }
 }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2825,7 +2825,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
         dm.write_at_nongrowing(&val.to_le_bytes(), address)
-            .map_err(|e| e.to_avm(self))?;
+            .expect("Just checked that the address was valid");
 
         Ok(())
     }
@@ -2844,7 +2844,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
         dm.write_at_nongrowing(&val.to_le_bytes(), address)
-            .map_err(|e| e.to_avm(self))?;
+            .expect("Just checked that the address was valid");
 
         Ok(())
     }
@@ -2863,7 +2863,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
         dm.write_at_nongrowing(&val.to_le_bytes(), address)
-            .map_err(|e| e.to_avm(self))?;
+            .expect("Just checked that the address was valid");
 
         Ok(())
     }
@@ -2882,7 +2882,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
         dm.write_at_nongrowing(&val.to_le_bytes(), address)
-            .map_err(|e| e.to_avm(self))?;
+            .expect("Just checked that the address was valid");
 
         Ok(())
     }
@@ -2920,7 +2920,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
 
-        let val = dm.read_at(2, address).map_err(|e| e.to_avm(self))?;
+        let val = dm
+            .read_at(2, address)
+            .expect("Just checked that the address was valid");
         self.push_stack(u16::from_le_bytes(val.try_into().unwrap()));
 
         Ok(())
@@ -2939,7 +2941,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
 
-        let val = dm.read_at(4, address).map_err(|e| e.to_avm(self))?;
+        let val = dm
+            .read_at(4, address)
+            .expect("Just checked that the address was valid");
         self.push_stack(i32::from_le_bytes(val.try_into().unwrap()));
         Ok(())
     }
@@ -2957,7 +2961,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
 
-        let val = dm.read_at(4, address).map_err(|e| e.to_avm(self))?;
+        let val = dm
+            .read_at(4, address)
+            .expect("Just checked that the address was valid");
         self.push_stack(f32::from_le_bytes(val.try_into().unwrap()));
 
         Ok(())
@@ -2976,7 +2982,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
 
-        let val = dm.read_at(8, address).map_err(|e| e.to_avm(self))?;
+        let val = dm
+            .read_at(8, address)
+            .expect("Just checked that the address was valid");
         self.push_stack(f64::from_le_bytes(val.try_into().unwrap()));
         Ok(())
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -12,7 +12,7 @@ use crate::avm2::error::{
     make_null_or_undefined_error,
 };
 use crate::avm2::function::FunctionArgs;
-use crate::avm2::int_interpreter::IntInterpreter;
+use crate::avm2::int_interpreter::{IntInterpreter, ObjectType};
 use crate::avm2::method::{Method, NativeMethodImpl, ResolvedParamConfig};
 use crate::avm2::object::TObject;
 use crate::avm2::object::{
@@ -28,6 +28,7 @@ use crate::avm2::{Avm2, Error};
 use crate::context::UpdateContext;
 use crate::string::{AvmAtom, AvmString, HasStringContext, StringContext};
 use crate::tag_utils::SwfMovie;
+use enum_map::EnumMap;
 use gc_arena::Gc;
 use ruffle_macros::istr;
 use std::cell::Cell;
@@ -3177,7 +3178,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // stored domain memory bytearray.
         let domain_memory = self.domain_memory().storage_mut();
 
-        let mut interpreter = IntInterpreter::new(domain_memory);
+        let topmost_outer_scope = self.outer().get(0).and_then(|o| o.values().as_object());
+
+        let objects = EnumMap::from_fn(|t| match t {
+            ObjectType::TopOuterScope => topmost_outer_scope,
+        });
+
+        let mut interpreter = IntInterpreter::new(domain_memory, objects);
 
         // Synchronize all the int locals in this interpreter to the int
         // interpreter

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -836,7 +836,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::Throw => self.op_throw(),
 
                 Op::RunIntInterpreter(info) => {
-                    self.run_int_interpreter(info);
+                    // NOTE: Int interpreter promotion is never done if this
+                    // method has exception handlers. This means that we don't
+                    // need to worry about this error not making it to an
+                    // exception handler; we can simply throw it from here (as
+                    // there are no exception handlers in this method that could
+                    // handle the error).
+                    self.run_int_interpreter(info)?;
 
                     ip = info.exit_offset.get();
 
@@ -3104,8 +3110,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Err(Error::from_value(self, error_val))
     }
 
-    fn run_int_interpreter(&mut self, info: &IntInterpreterInfo) {
-        let mut interpreter = IntInterpreter::new();
+    fn run_int_interpreter(&mut self, info: &IntInterpreterInfo) -> Result<(), Error<'gc>> {
+        // Code run in the int interpreter does not have the ability to borrow
+        // or swap out the domain memory, so borrow it here. This means that
+        // domain memory ops run in the int interpreter can just access the
+        // stored domain memory bytearray.
+        let domain_memory = self.domain_memory().storage_mut();
+
+        let mut interpreter = IntInterpreter::new(domain_memory);
 
         // Synchronize all the int locals in this interpreter to the int
         // interpreter
@@ -3121,7 +3133,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             }
         }
 
-        interpreter.run(&info.ops);
+        // NOTE: Int interpreter promotion is never done if this method has
+        // exception handlers. This means that it's fine to not synchronize
+        // correct state of locals once this throws an error, as there are no
+        // exception handlers to which that state is observable to (this method
+        // will simply immediately return to its caller with the error).
+        let result = interpreter.run(&info.ops);
+        if result.is_err() {
+            // The only exception that can happen from the int interpreter is
+            // an out-of-bounds domain memory read/write.
+            return Err(make_error_1506(self));
+        }
 
         // Synchronize all the int locals in the int interpreter to this
         // interpreter
@@ -3139,5 +3161,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         for i in num_locals..num_locals + info.final_stack_height {
             self.push_stack(interpreter.frame_at(i as u32));
         }
+
+        Ok(())
     }
 }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -784,6 +784,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::URShift => self.op_urshift(),
                 Op::StrictEquals => self.op_strict_equals(),
                 Op::Equals => self.op_equals(),
+                Op::EqualsIntegral => self.op_equals_integral(),
                 Op::GreaterEquals => self.op_greater_equals(),
                 Op::GreaterEqualsIntegral => self.op_greater_equals_integral(),
                 Op::GreaterThan => self.op_greater_than(),
@@ -2421,6 +2422,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value1 = self.pop_stack();
 
         let result = value1.abstract_eq(&value2, self)?;
+
+        self.push_stack(result);
+
+        Ok(())
+    }
+
+    fn op_equals_integral(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack().as_i32();
+        let value1 = self.pop_stack().as_i32();
+
+        let result = value1 == value2;
 
         self.push_stack(result);
 

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -3179,12 +3179,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let domain_memory = self.domain_memory().storage_mut();
 
         let topmost_outer_scope = self.outer().get(0).and_then(|o| o.values().as_object());
+        let receiver = self.local_register(0).as_object();
 
         let objects = EnumMap::from_fn(|t| match t {
             ObjectType::TopOuterScope => topmost_outer_scope,
+            ObjectType::Receiver => receiver,
         });
 
-        let mut interpreter = IntInterpreter::new(domain_memory, objects);
+        let mut interpreter = IntInterpreter::new(self.gc(), domain_memory, objects);
 
         // Synchronize all the int locals in this interpreter to the int
         // interpreter

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -774,7 +774,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::LShift => self.op_lshift(),
                 Op::Modulo => self.op_modulo(),
                 Op::Multiply => self.op_multiply(),
+                Op::MultiplyIntegral => self.op_multiply_integral(),
                 Op::MultiplyI => self.op_multiply_i(),
+                Op::MultiplyIntegralI => self.op_multiply_integral_i(),
                 Op::Negate => self.op_negate(),
                 Op::NegateI => self.op_negate_i(),
                 Op::RShift => self.op_rshift(),
@@ -783,6 +785,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::SubtractI => self.op_subtract_i(),
                 Op::Swap => self.op_swap(),
                 Op::URShift => self.op_urshift(),
+                Op::URShiftI => self.op_urshift_i(),
                 Op::StrictEquals => self.op_strict_equals(),
                 Op::Equals => self.op_equals(),
                 Op::EqualsIntegral => self.op_equals_integral(),
@@ -2284,11 +2287,47 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(())
     }
 
+    fn op_multiply_integral(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        if let (Value::Integer(n1), Value::Integer(n2)) = (value1, value2)
+            && let Some(result) = n1.checked_mul(n2)
+        {
+            self.push_stack(result);
+            return Ok(());
+        }
+        let value2 = value2.as_f64();
+        let value1 = value1.as_f64();
+        self.push_stack(value1 * value2);
+
+        Ok(())
+    }
+
     fn op_multiply_i(&mut self) -> Result<(), Error<'gc>> {
         let value2 = self.pop_stack().coerce_to_i32(self)?;
         let value1 = self.pop_stack().coerce_to_i32(self)?;
 
         self.push_stack(value1.wrapping_mul(value2));
+
+        Ok(())
+    }
+
+    fn op_multiply_integral_i(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        if let (Value::Integer(n1), Value::Integer(n2)) = (value1, value2)
+            && let Some(result) = n1.checked_mul(n2)
+        {
+            self.push_stack(result);
+            return Ok(());
+        }
+        let value2 = value2.as_f64();
+        let value1 = value1.as_f64();
+        self.push_stack(crate::ecma_conversions::f64_to_wrapping_i32(
+            value1 * value2,
+        ));
 
         Ok(())
     }
@@ -2400,6 +2439,15 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value1 = self.pop_stack().coerce_to_u32(self)?;
 
         self.push_stack(value1 >> (value2 & 0x1F));
+
+        Ok(())
+    }
+
+    fn op_urshift_i(&mut self) -> Result<(), Error<'gc>> {
+        let value2 = self.pop_stack().coerce_to_u32(self)?;
+        let value1 = self.pop_stack().coerce_to_u32(self)?;
+
+        self.push_stack((value1 >> (value2 & 0x1F)) as i32);
 
         Ok(())
     }

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -12,7 +12,7 @@ use std::cell::RefMut;
 /// store. NOTE(uqers): Synchronizing a large number of locals/stack from the
 /// int interpreter to the normal interpreter can have high performance costs!
 /// Increasing this may result in worse overall performance in some SWFs.
-pub const MAX_INT_INTERPRETER_FRAME: usize = 20;
+pub const MAX_INT_INTERPRETER_FRAME: usize = 36;
 
 #[derive(Clone, Copy, Debug, Enum, FromPrimitive, PartialEq)]
 pub enum ObjectType {

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -103,6 +103,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                 IntOp::Li32 => self.op_li32()?,
                 IntOp::Li8 => self.op_li8()?,
                 IntOp::LShift => self.op_lshift(),
+                IntOp::MultiplyNumbers => self.op_multiply_numbers(),
                 IntOp::Nop => {}
                 IntOp::Not => self.op_not(),
                 IntOp::Pop => self.op_pop(),
@@ -119,6 +120,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                 IntOp::Swap => self.op_swap(),
                 IntOp::Sxi16 => self.op_sxi16(),
                 IntOp::Sxi8 => self.op_sxi8(),
+                IntOp::URShift => self.op_urshift(),
 
                 IntOp::IfFalse { offset } => {
                     if self.pop_stack() == 0 {
@@ -324,6 +326,19 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
         self.push_stack(value1 << (value2 & 0x1F));
     }
 
+    fn op_multiply_numbers(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        let result = if let Some(result) = value1.checked_mul(value2) {
+            result
+        } else {
+            crate::ecma_conversions::f64_to_wrapping_i32(value1 as f64 * value2 as f64)
+        };
+
+        self.push_stack(result);
+    }
+
     fn op_not(&mut self) {
         let value = self.pop_stack();
 
@@ -452,5 +467,12 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
         let val = (val.wrapping_shl(23).wrapping_shr(23) & 0xFF) as i8 as i32;
 
         self.push_stack(val);
+    }
+
+    fn op_urshift(&mut self) {
+        let value2 = self.pop_stack() as u32;
+        let value1 = self.pop_stack() as u32;
+
+        self.push_stack((value1 >> (value2 & 0x1F)) as i32);
     }
 }

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -53,6 +53,10 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
         }
     }
 
+    pub fn stack_pointer(&self) -> usize {
+        self.stack_pointer
+    }
+
     pub fn push_stack(&mut self, value: i32) {
         self.frame[self.stack_pointer] = value;
         self.stack_pointer += 1;
@@ -76,7 +80,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
     }
 
     #[inline(never)]
-    pub fn run(&mut self, opcodes: &[IntOp]) -> Result<(usize, usize), DomainMemoryError> {
+    pub fn run(&mut self, opcodes: &[IntOp]) -> Result<usize, DomainMemoryError> {
         let mut ip = 0;
 
         loop {
@@ -127,13 +131,10 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                         ip = *offset as usize;
                     }
                 }
-                IntOp::IfFalseExternal {
-                    offset,
-                    final_stack_height,
-                } => {
+                IntOp::IfFalseExternal { offset } => {
                     if self.pop_stack() == 0 {
                         // Jump back into the normal interpreter
-                        return Ok((*offset as usize, *final_stack_height as usize));
+                        return Ok(*offset as usize);
                     }
                 }
                 IntOp::IfTrue { offset } => {
@@ -141,24 +142,18 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                         ip = *offset as usize;
                     }
                 }
-                IntOp::IfTrueExternal {
-                    offset,
-                    final_stack_height,
-                } => {
+                IntOp::IfTrueExternal { offset } => {
                     if self.pop_stack() != 0 {
                         // Jump back into the normal interpreter
-                        return Ok((*offset as usize, *final_stack_height as usize));
+                        return Ok(*offset as usize);
                     }
                 }
                 IntOp::Jump { offset } => {
                     ip = *offset as usize;
                 }
-                IntOp::JumpExternal {
-                    offset,
-                    final_stack_height,
-                } => {
+                IntOp::JumpExternal { offset } => {
                     // Jump back into the normal interpreter
-                    return Ok((*offset as usize, *final_stack_height as usize));
+                    return Ok(*offset as usize);
                 }
             }
         }

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -49,6 +49,7 @@ impl<'a> IntInterpreter<'a> {
         self.frame[index as usize] = value;
     }
 
+    #[inline(never)]
     pub fn run(&mut self, opcodes: &[IntOp]) -> Result<(), DomainMemoryError> {
         let mut ip = 0;
 

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -1,30 +1,45 @@
 use crate::avm2::bytearray::ByteArrayStorage;
+use crate::avm2::object::{Object, TObject};
 use crate::avm2::op::IntOp;
 
+use enum_map::{Enum, EnumMap};
+use num_traits::FromPrimitive;
 use std::cell::RefMut;
 
 /// The maximum number of items on the interpreter frame. This value should be
 /// able to fit in a `u8`, as there is logic in the optimizer that depends on it.
 pub const MAX_INT_INTERPRETER_FRAME: usize = 16;
 
+#[derive(Clone, Copy, Debug, Enum, FromPrimitive)]
+pub enum ObjectType {
+    TopOuterScope = 0,
+}
+
 pub struct DomainMemoryError;
 
-pub struct IntInterpreter<'a> {
+pub struct IntInterpreter<'a, 'gc: 'a> {
     /// The frame, which stores both the locals and the stack.
     frame: [i32; MAX_INT_INTERPRETER_FRAME],
 
     /// The current stack pointer.
     stack_pointer: usize,
 
+    /// Objects that code from the int interpreter can use.
+    objects: EnumMap<ObjectType, Option<Object<'gc>>>,
+
     /// The domain memory, pre-borrowed for speed.
     domain_memory: RefMut<'a, ByteArrayStorage>,
 }
 
-impl<'a> IntInterpreter<'a> {
-    pub fn new(domain_memory: RefMut<'a, ByteArrayStorage>) -> Self {
+impl<'a, 'gc> IntInterpreter<'a, 'gc> {
+    pub fn new(
+        domain_memory: RefMut<'a, ByteArrayStorage>,
+        objects: EnumMap<ObjectType, Option<Object<'gc>>>,
+    ) -> Self {
         Self {
             frame: [0; MAX_INT_INTERPRETER_FRAME],
             stack_pointer: 0,
+            objects,
             domain_memory,
         }
     }
@@ -69,6 +84,7 @@ impl<'a> IntInterpreter<'a> {
                 IntOp::Dup => self.op_dup(),
                 IntOp::Equals => self.op_equals(),
                 IntOp::GetLocal { index } => self.op_get_local(*index),
+                IntOp::GetSlot { index } => self.op_get_slot(*index),
                 IntOp::GreaterEquals => self.op_greater_equals(),
                 IntOp::GreaterThan => self.op_greater_than(),
                 IntOp::IncLocal { index } => self.op_inc_local(*index),
@@ -81,6 +97,7 @@ impl<'a> IntInterpreter<'a> {
                 IntOp::Not => self.op_not(),
                 IntOp::Pop => self.op_pop(),
                 IntOp::PushInt { value } => self.op_push_int(*value),
+                IntOp::PushObject { value } => self.op_push_int(*value as i32),
                 IntOp::RShift => self.op_rshift(),
                 IntOp::SetLocal { index } => self.op_set_local(*index),
                 IntOp::Si32 => self.op_si32()?,
@@ -181,6 +198,18 @@ impl<'a> IntInterpreter<'a> {
     fn op_get_local(&mut self, index: u32) {
         let value = self.frame_at(index);
         self.push_stack(value);
+    }
+
+    fn op_get_slot(&mut self, index: u32) {
+        let object_type = self.pop_stack();
+        let object_type = ObjectType::from_i32(object_type).expect("Is a valid object type");
+
+        let object =
+            self.objects[object_type].expect("Guaranteed by int interpreter promotion analysis");
+
+        let value = object.get_slot(index as usize);
+
+        self.push_stack(value.as_i32());
     }
 
     fn op_greater_equals(&mut self) {

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -3,6 +3,7 @@ use crate::avm2::object::{Object, TObject};
 use crate::avm2::op::IntOp;
 
 use enum_map::{Enum, EnumMap};
+use gc_arena::Mutation;
 use num_traits::FromPrimitive;
 use std::cell::RefMut;
 
@@ -13,6 +14,7 @@ pub const MAX_INT_INTERPRETER_FRAME: usize = 16;
 #[derive(Clone, Copy, Debug, Enum, FromPrimitive)]
 pub enum ObjectType {
     TopOuterScope = 0,
+    Receiver = 1,
 }
 
 pub struct DomainMemoryError;
@@ -29,10 +31,13 @@ pub struct IntInterpreter<'a, 'gc: 'a> {
 
     /// The domain memory, pre-borrowed for speed.
     domain_memory: RefMut<'a, ByteArrayStorage>,
+
+    mc: &'gc Mutation<'gc>,
 }
 
 impl<'a, 'gc> IntInterpreter<'a, 'gc> {
     pub fn new(
+        mc: &'gc Mutation<'gc>,
         domain_memory: RefMut<'a, ByteArrayStorage>,
         objects: EnumMap<ObjectType, Option<Object<'gc>>>,
     ) -> Self {
@@ -41,6 +46,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
             stack_pointer: 0,
             objects,
             domain_memory,
+            mc,
         }
     }
 
@@ -101,6 +107,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                 IntOp::PushObject { value } => self.op_push_int(*value as i32),
                 IntOp::RShift => self.op_rshift(),
                 IntOp::SetLocal { index } => self.op_set_local(*index),
+                IntOp::SetSlot { index } => self.op_set_slot(*index),
                 IntOp::Si16 => self.op_si16()?,
                 IntOp::Si32 => self.op_si32()?,
                 IntOp::Si8 => self.op_si8()?,
@@ -339,6 +346,18 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
     fn op_set_local(&mut self, index: u32) {
         let value = self.pop_stack();
         self.set_frame_at(index, value);
+    }
+
+    fn op_set_slot(&mut self, index: u32) {
+        let value = self.pop_stack();
+
+        let object_type = self.pop_stack();
+        let object_type = ObjectType::from_i32(object_type).expect("Is a valid object type");
+
+        let object =
+            self.objects[object_type].expect("Guaranteed by int interpreter promotion analysis");
+
+        object.set_slot_no_coerce(index as usize, value.into(), self.mc);
     }
 
     fn op_si16(&mut self) -> Result<(), DomainMemoryError> {

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -8,8 +8,11 @@ use num_traits::FromPrimitive;
 use std::cell::RefMut;
 
 /// The maximum number of items on the interpreter frame. This value should be
-/// able to fit in a `u8`, as there is logic in the optimizer that depends on it.
-pub const MAX_INT_INTERPRETER_FRAME: usize = 16;
+/// less than the number of bits that `avm2::optimizer::utils::SmallBitSet` can
+/// store. NOTE(uqers): Synchronizing a large number of locals/stack from the
+/// int interpreter to the normal interpreter can have high performance costs!
+/// Increasing this may result in worse overall performance in some SWFs.
+pub const MAX_INT_INTERPRETER_FRAME: usize = 20;
 
 #[derive(Clone, Copy, Debug, Enum, FromPrimitive)]
 pub enum ObjectType {

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -133,7 +133,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                 } => {
                     if self.pop_stack() == 0 {
                         // Jump back into the normal interpreter
-                        return Ok((offset.get() as usize, *final_stack_height as usize));
+                        return Ok((*offset as usize, *final_stack_height as usize));
                     }
                 }
                 IntOp::IfTrue { offset } => {
@@ -147,7 +147,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                 } => {
                     if self.pop_stack() != 0 {
                         // Jump back into the normal interpreter
-                        return Ok((offset.get() as usize, *final_stack_height as usize));
+                        return Ok((*offset as usize, *final_stack_height as usize));
                     }
                 }
                 IntOp::Jump { offset } => {
@@ -158,7 +158,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                     final_stack_height,
                 } => {
                     // Jump back into the normal interpreter
-                    return Ok((offset.get() as usize, *final_stack_height as usize));
+                    return Ok((*offset as usize, *final_stack_height as usize));
                 }
             }
         }

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -50,7 +50,7 @@ impl<'a> IntInterpreter<'a> {
     }
 
     #[inline(never)]
-    pub fn run(&mut self, opcodes: &[IntOp]) -> Result<(), DomainMemoryError> {
+    pub fn run(&mut self, opcodes: &[IntOp]) -> Result<usize, DomainMemoryError> {
         let mut ip = 0;
 
         loop {
@@ -77,13 +77,12 @@ impl<'a> IntInterpreter<'a> {
                 IntOp::StoreLocal { index } => self.op_store_local(*index),
                 IntOp::Subtract => self.op_subtract(),
 
-                IntOp::End => {
-                    break;
+                IntOp::ExternalJump { offset } => {
+                    // Jump back into the normal interpreter
+                    return Ok(offset.get() as usize);
                 }
             }
         }
-
-        Ok(())
     }
 
     fn op_add(&mut self) {

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -3,6 +3,8 @@ use crate::avm2::op::IntOp;
 
 use std::cell::RefMut;
 
+/// The maximum number of items on the interpreter frame. This value should be
+/// able to fit in a `u8`, as there is logic in the optimizer that depends on it.
 pub const MAX_INT_INTERPRETER_FRAME: usize = 16;
 
 pub struct DomainMemoryError;
@@ -50,7 +52,7 @@ impl<'a> IntInterpreter<'a> {
     }
 
     #[inline(never)]
-    pub fn run(&mut self, opcodes: &[IntOp]) -> Result<usize, DomainMemoryError> {
+    pub fn run(&mut self, opcodes: &[IntOp]) -> Result<(usize, usize), DomainMemoryError> {
         let mut ip = 0;
 
         loop {
@@ -66,10 +68,16 @@ impl<'a> IntInterpreter<'a> {
                 IntOp::DecLocal { index } => self.op_dec_local(*index),
                 IntOp::Dup => self.op_dup(),
                 IntOp::GetLocal { index } => self.op_get_local(*index),
+                IntOp::GreaterEquals => self.op_greater_equals(),
+                IntOp::GreaterThan => self.op_greater_than(),
                 IntOp::IncLocal { index } => self.op_inc_local(*index),
+                IntOp::LessEquals => self.op_less_equals(),
+                IntOp::LessThan => self.op_less_than(),
                 IntOp::Li32 => self.op_li32()?,
                 IntOp::Li8 => self.op_li8()?,
                 IntOp::Nop => {}
+                IntOp::Not => self.op_not(),
+                IntOp::Pop => self.op_pop(),
                 IntOp::PushInt { value } => self.op_push_int(*value),
                 IntOp::SetLocal { index } => self.op_set_local(*index),
                 IntOp::Si32 => self.op_si32()?,
@@ -77,9 +85,43 @@ impl<'a> IntInterpreter<'a> {
                 IntOp::StoreLocal { index } => self.op_store_local(*index),
                 IntOp::Subtract => self.op_subtract(),
 
-                IntOp::ExternalJump { offset } => {
+                IntOp::IfFalse { offset } => {
+                    if self.pop_stack() == 0 {
+                        ip = *offset as usize;
+                    }
+                }
+                IntOp::IfFalseExternal {
+                    offset,
+                    final_stack_height,
+                } => {
+                    if self.pop_stack() == 0 {
+                        // Jump back into the normal interpreter
+                        return Ok((offset.get() as usize, *final_stack_height as usize));
+                    }
+                }
+                IntOp::IfTrue { offset } => {
+                    if self.pop_stack() != 0 {
+                        ip = *offset as usize;
+                    }
+                }
+                IntOp::IfTrueExternal {
+                    offset,
+                    final_stack_height,
+                } => {
+                    if self.pop_stack() != 0 {
+                        // Jump back into the normal interpreter
+                        return Ok((offset.get() as usize, *final_stack_height as usize));
+                    }
+                }
+                IntOp::Jump { offset } => {
+                    ip = *offset as usize;
+                }
+                IntOp::JumpExternal {
+                    offset,
+                    final_stack_height,
+                } => {
                     // Jump back into the normal interpreter
-                    return Ok(offset.get() as usize);
+                    return Ok((offset.get() as usize, *final_stack_height as usize));
                 }
             }
         }
@@ -129,9 +171,45 @@ impl<'a> IntInterpreter<'a> {
         self.push_stack(value);
     }
 
+    fn op_greater_equals(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        let result = value1 >= value2;
+
+        self.push_stack(result as i32);
+    }
+
+    fn op_greater_than(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        let result = value1 > value2;
+
+        self.push_stack(result as i32);
+    }
+
     fn op_inc_local(&mut self, index: u32) {
         let value = self.frame_at(index);
         self.set_frame_at(index, value.wrapping_add(1));
+    }
+
+    fn op_less_equals(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        let result = value1 <= value2;
+
+        self.push_stack(result as i32);
+    }
+
+    fn op_less_than(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        let result = value1 < value2;
+
+        self.push_stack(result as i32);
     }
 
     fn op_li32(&mut self) -> Result<(), DomainMemoryError> {
@@ -165,6 +243,20 @@ impl<'a> IntInterpreter<'a> {
         }
 
         Ok(())
+    }
+
+    fn op_not(&mut self) {
+        let value = self.pop_stack();
+
+        if value == 0 {
+            self.push_stack(1);
+        } else {
+            self.push_stack(0);
+        }
+    }
+
+    fn op_pop(&mut self) {
+        self.pop_stack();
     }
 
     fn op_push_int(&mut self, value: i32) {

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -90,6 +90,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                 IntOp::IncLocal { index } => self.op_inc_local(*index),
                 IntOp::LessEquals => self.op_less_equals(),
                 IntOp::LessThan => self.op_less_than(),
+                IntOp::Li16 => self.op_li16()?,
                 IntOp::Li32 => self.op_li32()?,
                 IntOp::Li8 => self.op_li8()?,
                 IntOp::LShift => self.op_lshift(),
@@ -100,6 +101,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                 IntOp::PushObject { value } => self.op_push_int(*value as i32),
                 IntOp::RShift => self.op_rshift(),
                 IntOp::SetLocal { index } => self.op_set_local(*index),
+                IntOp::Si16 => self.op_si16()?,
                 IntOp::Si32 => self.op_si32()?,
                 IntOp::Si8 => self.op_si8()?,
                 IntOp::StoreLocal { index } => self.op_store_local(*index),
@@ -253,6 +255,22 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
         self.push_stack(result as i32);
     }
 
+    fn op_li16(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_li16` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let dm = &self.domain_memory;
+
+        if address > dm.len() - 2 {
+            return Err(DomainMemoryError);
+        }
+
+        let val = dm.read_at(2, address).expect("Already checked");
+        self.push_stack(u16::from_le_bytes(val.try_into().unwrap()) as i32);
+
+        Ok(())
+    }
+
     fn op_li32(&mut self) -> Result<(), DomainMemoryError> {
         // See `Activation::op_li32` for an explanation
         let address = self.pop_stack() as usize;
@@ -321,6 +339,24 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
     fn op_set_local(&mut self, index: u32) {
         let value = self.pop_stack();
         self.set_frame_at(index, value);
+    }
+
+    fn op_si16(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_si16` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let val = self.pop_stack() as i16;
+
+        let dm = &mut self.domain_memory;
+
+        if address > dm.len() - 2 {
+            return Err(DomainMemoryError);
+        }
+
+        dm.write_at_nongrowing(&val.to_le_bytes(), address)
+            .expect("Already checked");
+
+        Ok(())
     }
 
     fn op_si32(&mut self) -> Result<(), DomainMemoryError> {

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -116,6 +116,9 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                 IntOp::Si8 => self.op_si8()?,
                 IntOp::StoreLocal { index } => self.op_store_local(*index),
                 IntOp::Subtract => self.op_subtract(),
+                IntOp::Swap => self.op_swap(),
+                IntOp::Sxi16 => self.op_sxi16(),
+                IntOp::Sxi8 => self.op_sxi8(),
 
                 IntOp::IfFalse { offset } => {
                     if self.pop_stack() == 0 {
@@ -425,5 +428,29 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
         let value2 = self.pop_stack();
         let value1 = self.pop_stack();
         self.push_stack(value1.wrapping_sub(value2));
+    }
+
+    fn op_swap(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        self.push_stack(value2);
+        self.push_stack(value1);
+    }
+
+    fn op_sxi16(&mut self) {
+        let val = self.pop_stack();
+
+        let val = (val.wrapping_shl(15).wrapping_shr(15) & 0xFFFF) as i16 as i32;
+
+        self.push_stack(val);
+    }
+
+    fn op_sxi8(&mut self) {
+        let val = self.pop_stack();
+
+        let val = (val.wrapping_shl(23).wrapping_shr(23) & 0xFF) as i8 as i32;
+
+        self.push_stack(val);
     }
 }

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -67,6 +67,7 @@ impl<'a> IntInterpreter<'a> {
                 IntOp::BitXor => self.op_bitxor(),
                 IntOp::DecLocal { index } => self.op_dec_local(*index),
                 IntOp::Dup => self.op_dup(),
+                IntOp::Equals => self.op_equals(),
                 IntOp::GetLocal { index } => self.op_get_local(*index),
                 IntOp::GreaterEquals => self.op_greater_equals(),
                 IntOp::GreaterThan => self.op_greater_than(),
@@ -164,6 +165,15 @@ impl<'a> IntInterpreter<'a> {
     fn op_dup(&mut self) {
         let value = self.peek_stack();
         self.push_stack(value);
+    }
+
+    fn op_equals(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+
+        let result = value1 == value2;
+
+        self.push_stack(result as i32);
     }
 
     fn op_get_local(&mut self, index: u32) {

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -131,7 +131,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                         ip = *offset as usize;
                     }
                 }
-                IntOp::IfFalseExternal { offset } => {
+                IntOp::IfFalseExternal { offset, .. } => {
                     if self.pop_stack() == 0 {
                         // Jump back into the normal interpreter
                         return Ok(*offset as usize);
@@ -142,7 +142,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                         ip = *offset as usize;
                     }
                 }
-                IntOp::IfTrueExternal { offset } => {
+                IntOp::IfTrueExternal { offset, .. } => {
                     if self.pop_stack() != 0 {
                         // Jump back into the normal interpreter
                         return Ok(*offset as usize);
@@ -151,7 +151,7 @@ impl<'a, 'gc> IntInterpreter<'a, 'gc> {
                 IntOp::Jump { offset } => {
                     ip = *offset as usize;
                 }
-                IntOp::JumpExternal { offset } => {
+                IntOp::JumpExternal { offset, .. } => {
                     // Jump back into the normal interpreter
                     return Ok(*offset as usize);
                 }

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -1,17 +1,29 @@
+use crate::avm2::bytearray::ByteArrayStorage;
 use crate::avm2::op::IntOp;
+
+use std::cell::RefMut;
 
 pub const MAX_INT_INTERPRETER_FRAME: usize = 16;
 
-pub struct IntInterpreter {
+pub struct DomainMemoryError;
+
+pub struct IntInterpreter<'a> {
+    /// The frame, which stores both the locals and the stack.
     frame: [i32; MAX_INT_INTERPRETER_FRAME],
+
+    /// The current stack pointer.
     stack_pointer: usize,
+
+    /// The domain memory, pre-borrowed for speed.
+    domain_memory: RefMut<'a, ByteArrayStorage>,
 }
 
-impl IntInterpreter {
-    pub fn new() -> Self {
+impl<'a> IntInterpreter<'a> {
+    pub fn new(domain_memory: RefMut<'a, ByteArrayStorage>) -> Self {
         Self {
             frame: [0; MAX_INT_INTERPRETER_FRAME],
             stack_pointer: 0,
+            domain_memory,
         }
     }
 
@@ -37,7 +49,7 @@ impl IntInterpreter {
         self.frame[index as usize] = value;
     }
 
-    pub fn run(&mut self, opcodes: &[IntOp]) {
+    pub fn run(&mut self, opcodes: &[IntOp]) -> Result<(), DomainMemoryError> {
         let mut ip = 0;
 
         loop {
@@ -54,9 +66,13 @@ impl IntInterpreter {
                 IntOp::Dup => self.op_dup(),
                 IntOp::GetLocal { index } => self.op_get_local(*index),
                 IntOp::IncLocal { index } => self.op_inc_local(*index),
+                IntOp::Li32 => self.op_li32()?,
+                IntOp::Li8 => self.op_li8()?,
                 IntOp::Nop => {}
                 IntOp::PushInt { value } => self.op_push_int(*value),
                 IntOp::SetLocal { index } => self.op_set_local(*index),
+                IntOp::Si32 => self.op_si32()?,
+                IntOp::Si8 => self.op_si8()?,
                 IntOp::StoreLocal { index } => self.op_store_local(*index),
                 IntOp::Subtract => self.op_subtract(),
 
@@ -65,6 +81,8 @@ impl IntInterpreter {
                 }
             }
         }
+
+        Ok(())
     }
 
     fn op_add(&mut self) {
@@ -116,17 +134,85 @@ impl IntInterpreter {
         self.set_frame_at(index, value.wrapping_add(1));
     }
 
+    fn op_li32(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_li32` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let dm = &self.domain_memory;
+
+        if address > dm.len() - 4 {
+            return Err(DomainMemoryError);
+        }
+
+        let val = dm.read_at(4, address).expect("Already checked");
+        self.push_stack(i32::from_le_bytes(val.try_into().unwrap()));
+
+        Ok(())
+    }
+
+    fn op_li8(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_li8` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let dm = &self.domain_memory;
+
+        let val = dm.get(address);
+
+        if let Some(val) = val {
+            self.push_stack(val as i32);
+        } else {
+            return Err(DomainMemoryError);
+        }
+
+        Ok(())
+    }
+
     fn op_push_int(&mut self, value: i32) {
         self.push_stack(value);
     }
 
-    fn op_store_local(&mut self, index: u32) {
-        let value = self.peek_stack();
+    fn op_set_local(&mut self, index: u32) {
+        let value = self.pop_stack();
         self.set_frame_at(index, value);
     }
 
-    fn op_set_local(&mut self, index: u32) {
-        let value = self.pop_stack();
+    fn op_si32(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_si32` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let val = self.pop_stack();
+
+        let dm = &mut self.domain_memory;
+
+        if address > dm.len() - 4 {
+            return Err(DomainMemoryError);
+        }
+
+        dm.write_at_nongrowing(&val.to_le_bytes(), address)
+            .expect("Already checked");
+
+        Ok(())
+    }
+
+    fn op_si8(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_si8` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let val = self.pop_stack() as i8;
+
+        let dm = &mut self.domain_memory;
+
+        if address >= dm.len() {
+            return Err(DomainMemoryError);
+        }
+
+        dm.set_nongrowing(address, val as u8);
+
+        Ok(())
+    }
+
+    fn op_store_local(&mut self, index: u32) {
+        let value = self.peek_stack();
         self.set_frame_at(index, value);
     }
 

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -14,7 +14,7 @@ use std::cell::RefMut;
 /// Increasing this may result in worse overall performance in some SWFs.
 pub const MAX_INT_INTERPRETER_FRAME: usize = 20;
 
-#[derive(Clone, Copy, Debug, Enum, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Enum, FromPrimitive, PartialEq)]
 pub enum ObjectType {
     TopOuterScope = 0,
     Receiver = 1,

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -76,10 +76,12 @@ impl<'a> IntInterpreter<'a> {
                 IntOp::LessThan => self.op_less_than(),
                 IntOp::Li32 => self.op_li32()?,
                 IntOp::Li8 => self.op_li8()?,
+                IntOp::LShift => self.op_lshift(),
                 IntOp::Nop => {}
                 IntOp::Not => self.op_not(),
                 IntOp::Pop => self.op_pop(),
                 IntOp::PushInt { value } => self.op_push_int(*value),
+                IntOp::RShift => self.op_rshift(),
                 IntOp::SetLocal { index } => self.op_set_local(*index),
                 IntOp::Si32 => self.op_si32()?,
                 IntOp::Si8 => self.op_si8()?,
@@ -255,6 +257,13 @@ impl<'a> IntInterpreter<'a> {
         Ok(())
     }
 
+    fn op_lshift(&mut self) {
+        let value2 = self.pop_stack() as u32;
+        let value1 = self.pop_stack();
+
+        self.push_stack(value1 << (value2 & 0x1F));
+    }
+
     fn op_not(&mut self) {
         let value = self.pop_stack();
 
@@ -271,6 +280,13 @@ impl<'a> IntInterpreter<'a> {
 
     fn op_push_int(&mut self, value: i32) {
         self.push_stack(value);
+    }
+
+    fn op_rshift(&mut self) {
+        let value2 = self.pop_stack() as u32;
+        let value1 = self.pop_stack();
+
+        self.push_stack(value1 >> (value2 & 0x1F));
     }
 
     fn op_set_local(&mut self, index: u32) {

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -1,0 +1,138 @@
+use crate::avm2::op::IntOp;
+
+pub const MAX_INT_INTERPRETER_FRAME: usize = 16;
+
+pub struct IntInterpreter {
+    frame: [i32; MAX_INT_INTERPRETER_FRAME],
+    stack_pointer: usize,
+}
+
+impl IntInterpreter {
+    pub fn new() -> Self {
+        Self {
+            frame: [0; MAX_INT_INTERPRETER_FRAME],
+            stack_pointer: 0,
+        }
+    }
+
+    pub fn push_stack(&mut self, value: i32) {
+        self.frame[self.stack_pointer] = value;
+        self.stack_pointer += 1;
+    }
+
+    pub fn peek_stack(&mut self) -> i32 {
+        self.frame[self.stack_pointer - 1]
+    }
+
+    pub fn pop_stack(&mut self) -> i32 {
+        self.stack_pointer -= 1;
+        self.frame[self.stack_pointer]
+    }
+
+    pub fn frame_at(&mut self, index: u32) -> i32 {
+        self.frame[index as usize]
+    }
+
+    pub fn set_frame_at(&mut self, index: u32, value: i32) {
+        self.frame[index as usize] = value;
+    }
+
+    pub fn run(&mut self, opcodes: &[IntOp]) {
+        let mut ip = 0;
+
+        loop {
+            let op = &opcodes[ip];
+            ip += 1;
+
+            match op {
+                IntOp::Add => self.op_add(),
+                IntOp::BitAnd => self.op_bitand(),
+                IntOp::BitNot => self.op_bitnot(),
+                IntOp::BitOr => self.op_bitor(),
+                IntOp::BitXor => self.op_bitxor(),
+                IntOp::DecLocal { index } => self.op_dec_local(*index),
+                IntOp::Dup => self.op_dup(),
+                IntOp::GetLocal { index } => self.op_get_local(*index),
+                IntOp::IncLocal { index } => self.op_inc_local(*index),
+                IntOp::Nop => {}
+                IntOp::PushInt { value } => self.op_push_int(*value),
+                IntOp::SetLocal { index } => self.op_set_local(*index),
+                IntOp::StoreLocal { index } => self.op_store_local(*index),
+                IntOp::Subtract => self.op_subtract(),
+
+                IntOp::End => {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn op_add(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1.wrapping_add(value2));
+    }
+
+    fn op_bitand(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1 & value2);
+    }
+
+    fn op_bitnot(&mut self) {
+        let value = self.pop_stack();
+        self.push_stack(!value);
+    }
+
+    fn op_bitor(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1 | value2);
+    }
+
+    fn op_bitxor(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1 ^ value2);
+    }
+
+    fn op_dec_local(&mut self, index: u32) {
+        let value = self.frame_at(index);
+        self.set_frame_at(index, value.wrapping_sub(1));
+    }
+
+    fn op_dup(&mut self) {
+        let value = self.peek_stack();
+        self.push_stack(value);
+    }
+
+    fn op_get_local(&mut self, index: u32) {
+        let value = self.frame_at(index);
+        self.push_stack(value);
+    }
+
+    fn op_inc_local(&mut self, index: u32) {
+        let value = self.frame_at(index);
+        self.set_frame_at(index, value.wrapping_add(1));
+    }
+
+    fn op_push_int(&mut self, value: i32) {
+        self.push_stack(value);
+    }
+
+    fn op_store_local(&mut self, index: u32) {
+        let value = self.peek_stack();
+        self.set_frame_at(index, value);
+    }
+
+    fn op_set_local(&mut self, index: u32) {
+        let value = self.pop_stack();
+        self.set_frame_at(index, value);
+    }
+
+    fn op_subtract(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1.wrapping_sub(value2));
+    }
+}

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -522,6 +522,9 @@ pub enum IntOp {
     SetLocal {
         index: u32,
     },
+    SetSlot {
+        index: u32,
+    },
     Si16,
     Si32,
     Si8,

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -8,7 +8,7 @@ use crate::avm2::script::Script;
 use crate::string::AvmAtom;
 
 use gc_arena::{Collect, Gc};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 #[derive(Clone, Collect, Copy, Debug)]
 #[collect(no_drop)]
@@ -452,13 +452,13 @@ pub struct IntInterpreterInfo {
     pub synchronize_locals: SmallBitSet,
 
     /// The ops run by the int interpreter.
-    pub ops: Vec<IntOp>,
+    pub ops: RefCell<Vec<IntOp>>,
 }
 
 /// An op used in the int interpreter.
 ///
 /// These ops only work on `i32` values.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum IntOp {
     Add,
     BitAnd,
@@ -482,11 +482,8 @@ pub enum IntOp {
         offset: u32,
     },
     IfFalseExternal {
-        // NOTE: This has interior mutability so that we can rewrite the offset
-        // from the optimizer when we need to.
-        offset: Cell<u32>,
+        offset: u32,
 
-        // There can be at most 15 stack entries :p
         // Each external branch can lead to execution ending with a different
         // number of entries left on the stack, so we have to keep track
         final_stack_height: u8,
@@ -495,18 +492,18 @@ pub enum IntOp {
         offset: u32,
     },
     IfTrueExternal {
-        // See comments on IfFalseExternal
-        offset: Cell<u32>,
+        offset: u32,
 
+        // See comment on IfFalseExternal
         final_stack_height: u8,
     },
     Jump {
         offset: u32,
     },
     JumpExternal {
-        // See comment on IfFalseExternal
-        offset: Cell<u32>,
+        offset: u32,
 
+        // See comment on IfFalseExternal
         final_stack_height: u8,
     },
     IncLocal {

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -465,20 +465,50 @@ pub enum IntOp {
     BitNot,
     BitOr,
     BitXor,
-    DecLocal { index: u32 },
+    DecLocal {
+        index: u32,
+    },
     Dup,
     Equals,
-    GetLocal { index: u32 },
-    GetSlot { index: u32 },
+    GetLocal {
+        index: u32,
+    },
+    GetSlot {
+        index: u32,
+    },
     GreaterEquals,
     GreaterThan,
-    IfFalse { offset: u32 },
-    IfFalseExternal { offset: u32 },
-    IfTrue { offset: u32 },
-    IfTrueExternal { offset: u32 },
-    Jump { offset: u32 },
-    JumpExternal { offset: u32 },
-    IncLocal { index: u32 },
+    IfFalse {
+        offset: u32,
+    },
+    IfFalseExternal {
+        offset: u32,
+
+        // Only used during int interpretation analysis. At runtime, this should
+        // always be true.
+        valid: bool,
+    },
+    IfTrue {
+        offset: u32,
+    },
+    IfTrueExternal {
+        offset: u32,
+
+        // See comment on IfFalseExternal
+        valid: bool,
+    },
+    Jump {
+        offset: u32,
+    },
+    JumpExternal {
+        offset: u32,
+
+        // See comment on IfFalseExternal
+        valid: bool,
+    },
+    IncLocal {
+        index: u32,
+    },
     LessEquals,
     LessThan,
     Li16,
@@ -489,15 +519,25 @@ pub enum IntOp {
     Nop,
     Not,
     Pop,
-    PushInt { value: i32 },
-    PushObject { value: ObjectType },
+    PushInt {
+        value: i32,
+    },
+    PushObject {
+        value: ObjectType,
+    },
     RShift,
-    SetLocal { index: u32 },
-    SetSlot { index: u32 },
+    SetLocal {
+        index: u32,
+    },
+    SetSlot {
+        index: u32,
+    },
     Si16,
     Si32,
     Si8,
-    StoreLocal { index: u32 },
+    StoreLocal {
+        index: u32,
+    },
     Subtract,
     Swap,
     Sxi16,

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -467,9 +467,13 @@ pub enum IntOp {
     End,
     GetLocal { index: u32 },
     IncLocal { index: u32 },
+    Li32,
+    Li8,
     Nop,
     PushInt { value: i32 },
     SetLocal { index: u32 },
+    Si32,
+    Si8,
     StoreLocal { index: u32 },
     Subtract,
 }

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -234,7 +234,15 @@ pub enum Op<'gc> {
     LShift,
     Modulo,
     Multiply,
+    MultiplyIntegral,
     MultiplyI,
+
+    // NOTE: This is different from `MultiplyI`: this op is equivalent to
+    // `MultiplyIntegral`+`CoerceI`, rather than just `MultiplyI`.
+    // The former, which is essentially a `f64` multiplication that then becomes
+    // `as i32`, is different from the latter, an `i32` multiplication.
+    MultiplyIntegralI,
+
     Negate,
     NegateI,
     NewActivation {
@@ -346,6 +354,7 @@ pub enum Op<'gc> {
     TypeOf,
     Timestamp,
     URShift,
+    URShiftI,
 }
 
 #[cfg(target_pointer_width = "64")]
@@ -509,6 +518,7 @@ pub enum IntOp {
     Li32,
     Li8,
     LShift,
+    MultiplyNumbers,
     Nop,
     Not,
     Pop,
@@ -535,6 +545,7 @@ pub enum IntOp {
     Swap,
     Sxi16,
     Sxi8,
+    URShift,
 }
 
 const _: () = assert!(std::mem::size_of::<IntOp>() == 8);

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -505,6 +505,7 @@ pub enum IntOp {
     },
     LessEquals,
     LessThan,
+    Li16,
     Li32,
     Li8,
     LShift,
@@ -521,6 +522,7 @@ pub enum IntOp {
     SetLocal {
         index: u32,
     },
+    Si16,
     Si32,
     Si8,
     StoreLocal {

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -503,12 +503,14 @@ pub enum IntOp {
     LessThan,
     Li32,
     Li8,
+    LShift,
     Nop,
     Not,
     Pop,
     PushInt {
         value: i32,
     },
+    RShift,
     SetLocal {
         index: u32,
     },

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -532,6 +532,9 @@ pub enum IntOp {
         index: u32,
     },
     Subtract,
+    Swap,
+    Sxi16,
+    Sxi8,
 }
 
 const _: () = assert!(std::mem::size_of::<IntOp>() == 8);

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -1,4 +1,5 @@
 use crate::avm2::class::Class;
+use crate::avm2::int_interpreter::ObjectType;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::multiname::Multiname;
 use crate::avm2::namespace::Namespace;
@@ -463,6 +464,9 @@ pub enum IntOp {
     GetLocal {
         index: u32,
     },
+    GetSlot {
+        index: u32,
+    },
     GreaterEquals,
     GreaterThan,
     IfFalse {
@@ -509,6 +513,9 @@ pub enum IntOp {
     Pop,
     PushInt {
         value: i32,
+    },
+    PushObject {
+        value: ObjectType,
     },
     RShift,
     SetLocal {

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -182,7 +182,9 @@ pub enum Op<'gc> {
         multiname: Gc<'gc, Multiname<'gc>>,
     },
     GreaterEquals,
+    GreaterEqualsIntegral,
     GreaterThan,
+    GreaterThanIntegral,
     HasNext,
     HasNext2 {
         object_register: u32,
@@ -218,7 +220,9 @@ pub enum Op<'gc> {
         index: u32,
     },
     LessEquals,
+    LessEqualsIntegral,
     LessThan,
+    LessThanIntegral,
     Lf32,
     Lf64,
     Li16,
@@ -433,14 +437,8 @@ pub struct LookupSwitch {
 #[derive(Collect, Debug)]
 #[collect(require_static)]
 pub struct IntInterpreterInfo {
-    /// The locals that should be provided as inputs to the int interpreter.
-    pub input_locals: SmallBitSet,
-
-    /// The locals that are modified by the int interpreter.
-    pub output_locals: SmallBitSet,
-
-    /// The stack height of the int interpreter after execution ends.
-    pub final_stack_height: usize,
+    /// The locals that are read and written to by the int interpreter.
+    pub synchronize_locals: SmallBitSet,
 
     /// The ops run by the int interpreter.
     pub ops: Vec<IntOp>,
@@ -460,20 +458,52 @@ pub enum IntOp {
         index: u32,
     },
     Dup,
-    ExternalJump {
+    GetLocal {
+        index: u32,
+    },
+    GreaterEquals,
+    GreaterThan,
+    IfFalse {
+        offset: u32,
+    },
+    IfFalseExternal {
         // NOTE: This has interior mutability so that we can rewrite the offset
         // from the optimizer when we need to.
         offset: Cell<u32>,
+
+        // There can be at most 15 stack entries :p
+        // Each external branch can lead to execution ending with a different
+        // number of entries left on the stack, so we have to keep track
+        final_stack_height: u8,
     },
-    GetLocal {
-        index: u32,
+    IfTrue {
+        offset: u32,
+    },
+    IfTrueExternal {
+        // See comments on IfFalseExternal
+        offset: Cell<u32>,
+
+        final_stack_height: u8,
+    },
+    Jump {
+        offset: u32,
+    },
+    JumpExternal {
+        // See comment on IfFalseExternal
+        offset: Cell<u32>,
+
+        final_stack_height: u8,
     },
     IncLocal {
         index: u32,
     },
+    LessEquals,
+    LessThan,
     Li32,
     Li8,
     Nop,
+    Not,
+    Pop,
     PushInt {
         value: i32,
     },

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -131,6 +131,7 @@ pub enum Op<'gc> {
     },
     DxnsLate,
     Equals,
+    EqualsIntegral,
     EscXAttr,
     EscXElem,
     FindDef {
@@ -458,6 +459,7 @@ pub enum IntOp {
         index: u32,
     },
     Dup,
+    Equals,
     GetLocal {
         index: u32,
     },

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -2,6 +2,7 @@ use crate::avm2::class::Class;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::multiname::Multiname;
 use crate::avm2::namespace::Namespace;
+use crate::avm2::optimizer::utils::SmallBitSet;
 use crate::avm2::script::Script;
 use crate::string::AvmAtom;
 
@@ -284,6 +285,7 @@ pub enum Op<'gc> {
     ReturnVoid {
         return_type: Option<Class<'gc>>,
     },
+    RunIntInterpreter(Gc<'gc, IntInterpreterInfo>),
     RShift,
     SetGlobalSlot {
         // note: 0-indexed, as opposed to FP.
@@ -339,6 +341,9 @@ pub enum Op<'gc> {
     Timestamp,
     URShift,
 }
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<Op>() == 16);
 
 impl Op<'_> {
     pub fn can_throw_error(&self) -> bool {
@@ -425,5 +430,48 @@ pub struct LookupSwitch {
     pub case_offsets: Box<[Cell<usize>]>,
 }
 
-#[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<Op>() == 16);
+#[derive(Collect, Debug)]
+#[collect(require_static)]
+pub struct IntInterpreterInfo {
+    /// The locals that should be provided as inputs to the int interpreter.
+    pub input_locals: SmallBitSet,
+
+    /// The locals that are modified by the int interpreter.
+    pub output_locals: SmallBitSet,
+
+    /// The stack height of the int interpreter after execution ends.
+    pub final_stack_height: usize,
+
+    /// The offset in normal code that should be jumped to after execution ends.
+    ///
+    /// This has interior mutability so that we can rewrite the offset from the
+    /// optimizer when we need to.
+    pub exit_offset: Cell<usize>,
+
+    /// The ops run by the int interpreter.
+    pub ops: Vec<IntOp>,
+}
+
+/// An op used in the int interpreter.
+///
+/// These ops only work on `i32` values.
+#[derive(Debug)]
+pub enum IntOp {
+    Add,
+    BitAnd,
+    BitNot,
+    BitOr,
+    BitXor,
+    DecLocal { index: u32 },
+    Dup,
+    End,
+    GetLocal { index: u32 },
+    IncLocal { index: u32 },
+    Nop,
+    PushInt { value: i32 },
+    SetLocal { index: u32 },
+    StoreLocal { index: u32 },
+    Subtract,
+}
+
+const _: () = assert!(std::mem::size_of::<IntOp>() == 8);

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -465,50 +465,20 @@ pub enum IntOp {
     BitNot,
     BitOr,
     BitXor,
-    DecLocal {
-        index: u32,
-    },
+    DecLocal { index: u32 },
     Dup,
     Equals,
-    GetLocal {
-        index: u32,
-    },
-    GetSlot {
-        index: u32,
-    },
+    GetLocal { index: u32 },
+    GetSlot { index: u32 },
     GreaterEquals,
     GreaterThan,
-    IfFalse {
-        offset: u32,
-    },
-    IfFalseExternal {
-        offset: u32,
-
-        // Each external branch can lead to execution ending with a different
-        // number of entries left on the stack, so we have to keep track
-        final_stack_height: u8,
-    },
-    IfTrue {
-        offset: u32,
-    },
-    IfTrueExternal {
-        offset: u32,
-
-        // See comment on IfFalseExternal
-        final_stack_height: u8,
-    },
-    Jump {
-        offset: u32,
-    },
-    JumpExternal {
-        offset: u32,
-
-        // See comment on IfFalseExternal
-        final_stack_height: u8,
-    },
-    IncLocal {
-        index: u32,
-    },
+    IfFalse { offset: u32 },
+    IfFalseExternal { offset: u32 },
+    IfTrue { offset: u32 },
+    IfTrueExternal { offset: u32 },
+    Jump { offset: u32 },
+    JumpExternal { offset: u32 },
+    IncLocal { index: u32 },
     LessEquals,
     LessThan,
     Li16,
@@ -519,25 +489,15 @@ pub enum IntOp {
     Nop,
     Not,
     Pop,
-    PushInt {
-        value: i32,
-    },
-    PushObject {
-        value: ObjectType,
-    },
+    PushInt { value: i32 },
+    PushObject { value: ObjectType },
     RShift,
-    SetLocal {
-        index: u32,
-    },
-    SetSlot {
-        index: u32,
-    },
+    SetLocal { index: u32 },
+    SetSlot { index: u32 },
     Si16,
     Si32,
     Si8,
-    StoreLocal {
-        index: u32,
-    },
+    StoreLocal { index: u32 },
     Subtract,
     Swap,
     Sxi16,

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -442,12 +442,6 @@ pub struct IntInterpreterInfo {
     /// The stack height of the int interpreter after execution ends.
     pub final_stack_height: usize,
 
-    /// The offset in normal code that should be jumped to after execution ends.
-    ///
-    /// This has interior mutability so that we can rewrite the offset from the
-    /// optimizer when we need to.
-    pub exit_offset: Cell<usize>,
-
     /// The ops run by the int interpreter.
     pub ops: Vec<IntOp>,
 }
@@ -462,19 +456,35 @@ pub enum IntOp {
     BitNot,
     BitOr,
     BitXor,
-    DecLocal { index: u32 },
+    DecLocal {
+        index: u32,
+    },
     Dup,
-    End,
-    GetLocal { index: u32 },
-    IncLocal { index: u32 },
+    ExternalJump {
+        // NOTE: This has interior mutability so that we can rewrite the offset
+        // from the optimizer when we need to.
+        offset: Cell<u32>,
+    },
+    GetLocal {
+        index: u32,
+    },
+    IncLocal {
+        index: u32,
+    },
     Li32,
     Li8,
     Nop,
-    PushInt { value: i32 },
-    SetLocal { index: u32 },
+    PushInt {
+        value: i32,
+    },
+    SetLocal {
+        index: u32,
+    },
     Si32,
     Si8,
-    StoreLocal { index: u32 },
+    StoreLocal {
+        index: u32,
+    },
     Subtract,
 }
 

--- a/core/src/avm2/optimizer.rs
+++ b/core/src/avm2/optimizer.rs
@@ -37,7 +37,7 @@ pub fn optimize<'gc>(
 
     let mut empty_stack_positions = BTreeMap::new();
 
-    type_aware::type_aware_optimize(
+    let (op_index_to_block_index_table, abstract_states) = type_aware::type_aware_optimize(
         activation,
         method,
         code_slice,
@@ -61,6 +61,8 @@ pub fn optimize<'gc>(
         method,
         code_slice,
         &jump_targets,
+        &op_index_to_block_index_table,
+        &abstract_states,
         &empty_stack_positions,
         !method_exceptions.is_empty(),
     );

--- a/core/src/avm2/optimizer.rs
+++ b/core/src/avm2/optimizer.rs
@@ -56,6 +56,10 @@ pub fn optimize<'gc>(
 
     dce::eliminate_dead_code(code_slice, &jump_targets);
 
+    let mut s = crate::string::WString::new();
+    crate::avm2::function::display_function(&mut s, method);
+    println!("Analyzing {}", s);
+
     int_interpretation::run_analysis(
         activation,
         method,

--- a/core/src/avm2/optimizer.rs
+++ b/core/src/avm2/optimizer.rs
@@ -1,8 +1,10 @@
 mod blocks;
 mod dce;
+mod int_interpretation;
 mod nop_remover;
 mod peephole;
 mod type_aware;
+pub(crate) mod utils;
 
 use crate::avm2::activation::Activation;
 use crate::avm2::error::Error;
@@ -11,6 +13,7 @@ use crate::avm2::op::Op;
 use crate::avm2::verify::Exception;
 
 use std::cell::Cell;
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 
 /// Run all the optimizer passes on the given code. This method should be
@@ -32,6 +35,8 @@ pub fn optimize<'gc>(
     // zero-length jumps, which usually reduces the number of blocks in obfuscated code.
     peephole::preprocess_peephole(code_slice);
 
+    let mut empty_stack_positions = BTreeMap::new();
+
     type_aware::type_aware_optimize(
         activation,
         method,
@@ -39,11 +44,25 @@ pub fn optimize<'gc>(
         method_exceptions,
         resolved_parameters,
         &mut jump_targets,
+        &mut empty_stack_positions,
     )?;
 
-    peephole::postprocess_peephole(code_slice, &jump_targets, !method_exceptions.is_empty());
+    peephole::postprocess_peephole(
+        code_slice,
+        &jump_targets,
+        &mut empty_stack_positions,
+        !method_exceptions.is_empty(),
+    );
 
     dce::eliminate_dead_code(code_slice, &jump_targets);
+
+    int_interpretation::run_analysis(
+        activation,
+        method,
+        code_slice,
+        &empty_stack_positions,
+        !method_exceptions.is_empty(),
+    );
 
     nop_remover::remove_nops(code, method_exceptions);
 

--- a/core/src/avm2/optimizer.rs
+++ b/core/src/avm2/optimizer.rs
@@ -60,6 +60,7 @@ pub fn optimize<'gc>(
         activation,
         method,
         code_slice,
+        &jump_targets,
         &empty_stack_positions,
         !method_exceptions.is_empty(),
     );

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -774,6 +774,21 @@ fn run_single_analysis<'gc>(
         }
     }
 
+    // Once all ops are done executing, jump to the normal interpreter at the
+    // position where we should continue. Unless we got to the end of the
+    // method, in which case don't add this last op, as it'll confuse the nop
+    // remover.
+    if start_index + num_ops != ops.len() {
+        output_vec.push(IntOp::JumpExternal {
+            offset: (start_index + num_ops) as u32,
+            final_stack_height: stack.len() as u8,
+        });
+    }
+
+    remove_nops(&mut output_vec);
+
+    let num_ops = output_vec.len();
+
     // Not enough ops for entering the int interpreter to be worth it
     // (unless there's a backwards branch within the int interpreter; in that
     // case it's likely that this is a hot loop)
@@ -785,17 +800,6 @@ fn run_single_analysis<'gc>(
     // interpreter and the int interpreter, so we don't support it
     if !stack.is_entirely_ints() {
         return None;
-    }
-
-    // Once all ops are done executing, jump to the normal interpreter at the
-    // position where we should continue. Unless we got to the end of the
-    // method, in which case don't add this last op, as it'll confuse the nop
-    // remover.
-    if start_index + num_ops != ops.len() {
-        output_vec.push(IntOp::JumpExternal {
-            offset: (start_index + num_ops) as u32,
-            final_stack_height: stack.len() as u8,
-        });
     }
 
     let info = IntInterpreterInfo {
@@ -885,5 +889,38 @@ impl Stack {
 
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+}
+
+fn remove_nops(code: &mut Vec<IntOp>) {
+    let mut offset_vec = vec![0; code.len()];
+    let mut current_offset = 0;
+
+    // First, remove nops
+    let mut i = 0;
+    while i < code.len() {
+        offset_vec[i] = (i - current_offset) as u32;
+        if matches!(code[i], IntOp::Nop) {
+            current_offset += 1;
+        } else {
+            // Shift the ops over the nops
+            code[i - current_offset] = code[i];
+        }
+
+        i += 1;
+    }
+
+    // The ops have all been shifted over now, so remove the garbage ops left
+    // at the end of the code Vec
+    code.truncate(code.len() - current_offset);
+
+    // Rewrite jump offsets
+    for op in code {
+        match op {
+            IntOp::IfTrue { offset } | IntOp::IfFalse { offset } | IntOp::Jump { offset } => {
+                *offset = offset_vec[*offset as usize];
+            }
+            _ => {}
+        }
     }
 }

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -344,11 +344,15 @@ fn run_single_analysis<'gc>(
     let num_ops = output_vec.len();
 
     // Once all ops are done executing, jump to the normal interpreter at the
-    // position where we should continue.
-    output_vec.push(IntOp::JumpExternal {
-        offset: Cell::new((start_index + num_ops) as u32),
-        final_stack_height: stack.len() as u8,
-    });
+    // position where we should continue. Unless we got to the end of the
+    // method, in which case don't add this last op, as it'll confuse the nop
+    // remover.
+    if start_index + num_ops != ops.len() {
+        output_vec.push(IntOp::JumpExternal {
+            offset: Cell::new((start_index + num_ops) as u32),
+            final_stack_height: stack.len() as u8,
+        });
+    }
 
     // Not enough ops for entering the int interpreter to be worth it
     if num_ops < MIN_INT_OPS_LENGTH {

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -137,6 +137,7 @@ pub fn run_analysis<'gc>(
 
         if let Some((info, num_ops)) = analysis_results {
             already_covered_ranges.push(start_index..start_index + num_ops);
+            println!("    Success for {} ({} ops)!", start_index, info.ops.len());
 
             let op = Op::RunIntInterpreter(Gc::new(activation.gc(), info));
             ops[start_index].set(op);

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -70,8 +70,8 @@ pub fn run_analysis<'gc>(
             continue;
         }
 
-        if let Some(info) = run_single_analysis(ops, start_index, locals_state) {
-            covered_ranges.push(start_index..info.exit_offset.get());
+        if let Some((info, num_ops)) = run_single_analysis(ops, start_index, locals_state) {
+            covered_ranges.push(start_index..start_index + num_ops);
 
             let op = Op::RunIntInterpreter(Gc::new(activation.gc(), info));
             ops[start_index].set(op);
@@ -83,7 +83,7 @@ fn run_single_analysis<'gc>(
     ops: &[Cell<Op<'gc>>],
     start_index: usize,
     entry_locals_state: &SmallBitSet,
-) -> Option<IntInterpreterInfo> {
+) -> Option<(IntInterpreterInfo, usize)> {
     let mut output_vec = Vec::new();
 
     let mut current_locals_state = entry_locals_state.clone();
@@ -150,6 +150,9 @@ fn run_single_analysis<'gc>(
 
                 IntOp::IncLocal { index }
             }
+            Op::Jump { offset } => IntOp::ExternalJump {
+                offset: Cell::new(offset as u32),
+            },
             Op::Li8 => IntOp::Li8,
             Op::Li32 => IntOp::Li32,
             Op::Nop => IntOp::Nop,
@@ -195,7 +198,11 @@ fn run_single_analysis<'gc>(
 
     let num_ops = output_vec.len();
 
-    output_vec.push(IntOp::End);
+    // Once all ops are done executing, jump to the normal interpreter at the
+    // position where we should continue.
+    output_vec.push(IntOp::ExternalJump {
+        offset: Cell::new((start_index + num_ops) as u32),
+    });
 
     // Not enough ops for entering the int interpreter to be worth it
     if num_ops < MIN_INT_OPS_LENGTH {
@@ -206,9 +213,8 @@ fn run_single_analysis<'gc>(
         input_locals: entry_locals_state.clone(),
         output_locals: current_locals_state,
         final_stack_height: stack_height,
-        exit_offset: Cell::new(start_index + num_ops),
         ops: output_vec,
     };
 
-    Some(info)
+    Some((info, num_ops))
 }

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -320,6 +320,12 @@ fn run_single_analysis<'gc>(
 
                 IntOp::Li8
             }
+            Op::Li16 => {
+                stack.pop();
+                stack.push_int();
+
+                IntOp::Li16
+            }
             Op::Li32 => {
                 stack.pop();
                 stack.push_int();
@@ -383,6 +389,12 @@ fn run_single_analysis<'gc>(
                 stack.pop();
 
                 IntOp::Si8
+            }
+            Op::Si16 => {
+                stack.pop();
+                stack.pop();
+
+                IntOp::Si16
             }
             Op::Si32 => {
                 stack.pop();

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -499,6 +499,26 @@ fn run_single_analysis<'gc>(
 
                 IntOp::Subtract
             }
+            Op::Swap => {
+                let first = stack.pop();
+                let second = stack.pop();
+                stack.push(first);
+                stack.push(second);
+
+                IntOp::Swap
+            }
+            Op::Sxi16 => {
+                stack.pop();
+                stack.push_int();
+
+                IntOp::Sxi16
+            }
+            Op::Sxi8 => {
+                stack.pop();
+                stack.push_int();
+
+                IntOp::Sxi8
+            }
             _ => {
                 break;
             }

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -18,7 +18,7 @@ use std::ops::Range;
 /// ops. On the other hand, if this number is too high, some sequences of ops
 /// that would benefit from being run in the integer interpreter may end up
 /// being considered too short to be run in it.
-const MIN_INT_OPS_LENGTH: usize = 30;
+const MIN_INT_OPS_LENGTH: usize = 50;
 
 /// The maximum number of ops in a method that can be considered for int
 /// interpreter analysis.
@@ -705,8 +705,65 @@ fn run_single_analysis<'gc>(
 
     let num_ops = output_vec.len();
 
+    let mut has_backwards_branch = false;
+
+    // Right now all the branches/jumps are external, i.e. they will exit the int
+    // interpreter into normal code. This is technically correct, but let's see
+    // which of the branches we can make internal branches (branches that
+    // remain in the int interpreter). We want to stay in the int interpreter
+    // as much as possible.
+    for (i, op) in output_vec.iter_mut().enumerate() {
+        match op {
+            IntOp::IfFalseExternal { offset, .. } => {
+                let offset = offset.get() as usize;
+                if (start_index..start_index + num_ops).contains(&offset) {
+                    let new_offset = offset - start_index;
+
+                    *op = IntOp::IfFalse {
+                        offset: new_offset as u32,
+                    };
+
+                    if new_offset < i {
+                        has_backwards_branch = true;
+                    }
+                }
+            }
+            IntOp::IfTrueExternal { offset, .. } => {
+                let offset = offset.get() as usize;
+                if (start_index..start_index + num_ops).contains(&offset) {
+                    let new_offset = offset - start_index;
+
+                    *op = IntOp::IfTrue {
+                        offset: new_offset as u32,
+                    };
+
+                    if new_offset < i {
+                        has_backwards_branch = true;
+                    }
+                }
+            }
+            IntOp::JumpExternal { offset, .. } => {
+                let offset = offset.get() as usize;
+                if (start_index..start_index + num_ops).contains(&offset) {
+                    let new_offset = offset - start_index;
+
+                    *op = IntOp::Jump {
+                        offset: new_offset as u32,
+                    };
+
+                    if new_offset < i {
+                        has_backwards_branch = true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
     // Not enough ops for entering the int interpreter to be worth it
-    if num_ops < MIN_INT_OPS_LENGTH {
+    // (unless there's a backwards branch within the int interpreter; in that
+    // case it's likely that this is a hot loop)
+    if num_ops < MIN_INT_OPS_LENGTH && !has_backwards_branch {
         return None;
     }
 
@@ -725,41 +782,6 @@ fn run_single_analysis<'gc>(
             offset: Cell::new((start_index + num_ops) as u32),
             final_stack_height: stack.len() as u8,
         });
-    }
-
-    // Right now all the branches/jumps are external, i.e. they will exit the int
-    // interpreter into normal code. This is technically correct, but let's see
-    // which of the branches we can make internal branches (branches that
-    // remain in the int interpreter). We want to stay in the int interpreter
-    // as much as possible.
-    for op in &mut output_vec {
-        match op {
-            IntOp::IfFalseExternal { offset, .. } => {
-                let offset = offset.get() as usize;
-                if (start_index..start_index + num_ops).contains(&offset) {
-                    *op = IntOp::IfFalse {
-                        offset: (offset - start_index) as u32,
-                    };
-                }
-            }
-            IntOp::IfTrueExternal { offset, .. } => {
-                let offset = offset.get() as usize;
-                if (start_index..start_index + num_ops).contains(&offset) {
-                    *op = IntOp::IfTrue {
-                        offset: (offset - start_index) as u32,
-                    };
-                }
-            }
-            IntOp::JumpExternal { offset, .. } => {
-                let offset = offset.get() as usize;
-                if (start_index..start_index + num_ops).contains(&offset) {
-                    *op = IntOp::Jump {
-                        offset: (offset - start_index) as u32,
-                    };
-                }
-            }
-            _ => {}
-        }
     }
 
     let info = IntInterpreterInfo {

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -4,12 +4,13 @@ use crate::avm2::int_interpreter::{MAX_INT_INTERPRETER_FRAME, ObjectType};
 use crate::avm2::method::Method;
 use crate::avm2::object::TObject;
 use crate::avm2::op::{IntInterpreterInfo, IntOp, Op};
+use crate::avm2::optimizer::type_aware::AbstractState;
 use crate::avm2::optimizer::utils::SmallBitSet;
 
 use enum_map::EnumMap;
 use gc_arena::Gc;
 use std::cell::Cell;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Range;
 
 /// The minimum number of consecutive ops that will be run in the integer
@@ -29,6 +30,8 @@ pub fn run_analysis<'gc>(
     method: Method<'gc>,
     ops: &[Cell<Op<'gc>>],
     jump_targets: &HashSet<usize>,
+    op_index_to_block_index_table: &HashMap<usize, usize>,
+    abstract_states: &Vec<Option<AbstractState<'gc>>>,
     empty_stack_positions: &BTreeMap<usize, SmallBitSet>,
     has_exceptions: bool,
 ) {
@@ -126,6 +129,8 @@ pub fn run_analysis<'gc>(
             ops,
             start_index,
             *locals_state,
+            op_index_to_block_index_table,
+            abstract_states,
             &object_classes,
             sets_local_0,
         );
@@ -143,6 +148,8 @@ fn run_single_analysis<'gc>(
     ops: &[Cell<Op<'gc>>],
     start_index: usize,
     integral_locals: SmallBitSet,
+    op_index_to_block_index_table: &HashMap<usize, usize>,
+    abstract_states: &Vec<Option<AbstractState<'gc>>>,
     object_classes: &EnumMap<ObjectType, Option<Class<'gc>>>,
     sets_local_0: bool,
 ) -> Option<(IntInterpreterInfo, usize)> {
@@ -157,6 +164,37 @@ fn run_single_analysis<'gc>(
     // certain that these ops are only working on integers.
     let mut i = start_index;
     while i < ops.len() {
+        // If this op is the start of a block, it means that the previous op was
+        // a code terminator (i.e. jump). That means that we have no idea what
+        // the correct state should be. We can determine the correct state using
+        // information from the type-aware optimizer.
+        if let Some(block_index) = op_index_to_block_index_table.get(&i) {
+            let state = abstract_states[*block_index]
+                .as_ref()
+                .expect("Block entry states are all known");
+
+            let state_stack = &state.stack;
+
+            // The entry locals info is technically valid, so let's keep using it
+            // (checks on the code path ensure that no non-integral values are
+            // stored into the entry locals)
+
+            // However, we do need to update the stack's state
+            stack.clear();
+            for i in 0..state_stack.len() {
+                let item_class = state_stack.at(i).class;
+
+                if item_class.is_some_and(|c| c.is_builtin_int()) {
+                    stack.push(ValueType::Int);
+                } else if item_class.is_some_and(|c| c.is_builtin_boolean()) {
+                    stack.push(ValueType::Bool);
+                } else {
+                    stack.push(ValueType::Unknown);
+                }
+            }
+
+            // Now the locals and stack are correct again
+        }
         let op = ops[i].get();
 
         let translated_op = match op {
@@ -809,6 +847,7 @@ enum ValueType {
     Bool,
     Int,
     Object(ObjectType),
+    Unknown,
 }
 
 /// The stack of the abstract interpreter.
@@ -862,6 +901,10 @@ impl Stack {
 
     pub fn is_entirely_ints(&self) -> bool {
         self.0.iter().all(|v| matches!(v, ValueType::Int))
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
     }
 
     pub fn len(&self) -> usize {

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -22,7 +22,7 @@ const MIN_INT_OPS_LENGTH: usize = 30;
 
 /// The maximum number of ops in a method that can be considered for int
 /// interpreter analysis.
-const MAX_METHOD_OPS_LENGTH: usize = 600;
+const MAX_METHOD_OPS_LENGTH: usize = 40000;
 
 pub fn run_analysis<'gc>(
     activation: &mut Activation<'_, 'gc>,

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -261,6 +261,13 @@ fn run_single_analysis<'gc>(
 
                 IntOp::Li32
             }
+            Op::LShift => {
+                stack.pop();
+                stack.pop();
+                stack.push_int();
+
+                IntOp::LShift
+            }
             Op::Nop => IntOp::Nop,
             Op::Not => {
                 stack.pop();
@@ -298,6 +305,13 @@ fn run_single_analysis<'gc>(
                 }
 
                 IntOp::SetLocal { index }
+            }
+            Op::RShift => {
+                stack.pop();
+                stack.pop();
+                stack.push_int();
+
+                IntOp::RShift
             }
             Op::Si8 => {
                 stack.pop();

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -63,8 +63,40 @@ pub fn run_analysis<'gc>(
         .and_then(|s| s.values().as_object())
         .map(|o| o.instance_class());
 
+    // TODO we already have this information from earlier from
+    // `peephole::postprocess_peephole`; figure out some way to reuse it
+    let mut sets_local_0 = false;
+
+    for op in ops {
+        match op.get() {
+            Op::SetLocal { index }
+            | Op::Kill { index }
+            | Op::DecLocal { index }
+            | Op::DecLocalI { index }
+            | Op::IncLocal { index }
+            | Op::IncLocalI { index }
+                if index == 0 =>
+            {
+                sets_local_0 = true;
+                break;
+            }
+            Op::HasNext2 {
+                object_register,
+                index_register,
+            } if object_register == 0 || index_register == 0 => {
+                sets_local_0 = true;
+                break;
+            }
+
+            _ => {}
+        }
+    }
+
+    let receiver_class = method.bound_class().filter(|_| !sets_local_0);
+
     let object_classes = EnumMap::from_fn(|t| match t {
         ObjectType::TopOuterScope => top_outer_scope_class,
+        ObjectType::Receiver => receiver_class,
     });
 
     // Keep track of the ranges that we've already created int interpreter
@@ -83,8 +115,13 @@ pub fn run_analysis<'gc>(
             continue;
         }
 
-        let analysis_results =
-            run_single_analysis(ops, start_index, *locals_state, &object_classes);
+        let analysis_results = run_single_analysis(
+            ops,
+            start_index,
+            *locals_state,
+            &object_classes,
+            sets_local_0,
+        );
 
         if let Some((info, num_ops)) = analysis_results {
             covered_ranges.push(start_index..start_index + num_ops);
@@ -100,6 +137,7 @@ fn run_single_analysis<'gc>(
     start_index: usize,
     used_locals: SmallBitSet,
     object_classes: &EnumMap<ObjectType, Option<Class<'gc>>>,
+    sets_local_0: bool,
 ) -> Option<(IntInterpreterInfo, usize)> {
     let mut output_vec = Vec::new();
 
@@ -171,15 +209,23 @@ fn run_single_analysis<'gc>(
                 IntOp::Equals
             }
             Op::GetLocal { index } => {
-                if !used_locals.get(index as usize) {
-                    // Can't access a non-int
-                    break;
+                if !sets_local_0 && index == 0 {
+                    stack.push_object(ObjectType::Receiver);
+
+                    IntOp::PushObject {
+                        value: ObjectType::Receiver,
+                    }
+                } else {
+                    if !used_locals.get(index as usize) {
+                        // Can't access a non-int
+                        break;
+                    }
+
+                    // Only integers can be stored in locals
+                    stack.push_int();
+
+                    IntOp::GetLocal { index }
                 }
-
-                // Only integers can be stored in locals
-                stack.push_int();
-
-                IntOp::GetLocal { index }
             }
             Op::GetOuterScope { index: 0 } => {
                 stack.push_object(ObjectType::TopOuterScope);
@@ -376,6 +422,27 @@ fn run_single_analysis<'gc>(
                 }
 
                 IntOp::SetLocal { index }
+            }
+            Op::SetSlotNoCoerce { index } => {
+                if !stack.pop_expecting_int() {
+                    // Can't store a non-integer into a slot
+                    break;
+                }
+
+                if stack.pop_expecting_object().is_none() {
+                    // Getslot on a primitive is impossible thanks to the
+                    // verifier
+                    unreachable!();
+                }
+
+                // We just guaranteed that the stack has an integer on it and
+                // that the value was about to be stored without coercion
+                // (this is a SetSlotNoCoerce op), so we know that this is an
+                // integer store
+
+                IntOp::SetSlot {
+                    index: index as u32,
+                }
             }
             Op::RShift => {
                 stack.pop();

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -479,6 +479,18 @@ fn run_single_analysis<'gc>(
 
                 IntOp::LShift
             }
+            Op::MultiplyIntegralI => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
+                stack.pop();
+                stack.pop();
+                stack.push_int();
+
+                IntOp::MultiplyNumbers
+            }
             Op::Nop => IntOp::Nop,
             Op::Not => {
                 if !stack.expect(ValueType::Bool, 1) {
@@ -648,6 +660,18 @@ fn run_single_analysis<'gc>(
                 stack.push_int();
 
                 IntOp::Sxi8
+            }
+            Op::URShiftI => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
+                stack.pop();
+                stack.pop();
+                stack.push_int();
+
+                IntOp::URShift
             }
             _ => {
                 break;

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -1,0 +1,202 @@
+use crate::avm2::activation::Activation;
+use crate::avm2::int_interpreter::MAX_INT_INTERPRETER_FRAME;
+use crate::avm2::method::Method;
+use crate::avm2::op::{IntInterpreterInfo, IntOp, Op};
+use crate::avm2::optimizer::utils::SmallBitSet;
+
+use gc_arena::Gc;
+use std::cell::Cell;
+use std::collections::BTreeMap;
+use std::ops::Range;
+
+/// The minimum number of consecutive ops that will be run in the integer
+/// interpreter. If this number is too low, the overhead of entering and exiting
+/// the integer interpreter may be greater than the speedup of having faster
+/// ops. On the other hand, if this number is too high, some sequences of ops
+/// that would benefit from being run in the integer interpreter may end up
+/// being considered too short to be run in it.
+const MIN_INT_OPS_LENGTH: usize = 30;
+
+/// The maximum number of ops in a method that can be considered for int
+/// interpreter analysis.
+const MAX_METHOD_OPS_LENGTH: usize = 300;
+
+pub fn run_analysis<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    method: Method<'gc>,
+    ops: &[Cell<Op<'gc>>],
+    empty_stack_positions: &BTreeMap<usize, SmallBitSet>,
+    has_exceptions: bool,
+) {
+    let method_body = method
+        .body()
+        .expect("Cannot verify non-native method without body!");
+    let max_locals = method_body.num_locals;
+    let max_stack = method_body.max_stack;
+
+    if ops.len() > MAX_METHOD_OPS_LENGTH {
+        // Not worth trying to optimize a method this large
+        return;
+    } else if has_exceptions {
+        // The analysis does not support handling exceptions
+        return;
+    } else if (max_locals + max_stack) as usize >= MAX_INT_INTERPRETER_FRAME {
+        // The int interpreter does not support a frame size larger the max
+        return;
+    } else if method
+        .translation_unit()
+        .domain()
+        .is_playerglobals_domain(activation.avm2())
+    {
+        // Some playerglobals code will run before domain memory is initialized,
+        // so if playerglobals code attempts to access domain memory there'll
+        // be a panic on startup
+        return;
+    }
+
+    // Keep track of the ranges that we've already created int interpreter
+    // promotions for so that we don't create even more int interpreter
+    // promotions within them. Because `empty_stack_positions` is a `BTreeMap`,
+    // iterating over it will result in earlier positions (the ones that will
+    // yield the largest promoted areas) being handled first.
+    let mut covered_ranges: Vec<Range<usize>> = Vec::new();
+
+    // Now we can actually run the analysis pass.
+    for (start_index, locals_state) in empty_stack_positions {
+        let start_index = *start_index;
+
+        if covered_ranges.iter().any(|r| r.contains(&start_index)) {
+            // See above comment
+            continue;
+        }
+
+        if let Some(info) = run_single_analysis(ops, start_index, locals_state) {
+            covered_ranges.push(start_index..info.exit_offset.get());
+
+            let op = Op::RunIntInterpreter(Gc::new(activation.gc(), info));
+            ops[start_index].set(op);
+        }
+    }
+}
+
+fn run_single_analysis<'gc>(
+    ops: &[Cell<Op<'gc>>],
+    start_index: usize,
+    entry_locals_state: &SmallBitSet,
+) -> Option<IntInterpreterInfo> {
+    let mut output_vec = Vec::new();
+
+    let mut current_locals_state = entry_locals_state.clone();
+    let mut stack_height = 0;
+
+    // We run a simplified abstract interpreter pass. We know that at this point,
+    // the stack is empty and locals are either integral or non-integral. Loading
+    // a non-integral local results in the pass being aborted, so we can be
+    // certain that these ops are only working on integers.
+    let mut i = start_index;
+    while i < ops.len() {
+        let op = ops[i].get();
+
+        let translated_op = match op {
+            Op::AddI => {
+                stack_height -= 1;
+
+                IntOp::Add
+            }
+            Op::BitAnd => {
+                stack_height -= 1;
+
+                IntOp::BitAnd
+            }
+            Op::BitNot => IntOp::BitNot,
+            Op::BitOr => {
+                stack_height -= 1;
+
+                IntOp::BitOr
+            }
+            Op::BitXor => {
+                stack_height -= 1;
+
+                IntOp::BitXor
+            }
+            Op::DecLocalI { index } => {
+                if !current_locals_state.get(index as usize) {
+                    // Can't access a non-int
+                    break;
+                }
+
+                IntOp::DecLocal { index }
+            }
+            Op::Dup => {
+                stack_height += 1;
+
+                IntOp::Dup
+            }
+            Op::GetLocal { index } => {
+                if !current_locals_state.get(index as usize) {
+                    // Can't access a non-int
+                    break;
+                }
+
+                stack_height += 1;
+
+                IntOp::GetLocal { index }
+            }
+            Op::IncLocalI { index } => {
+                if !current_locals_state.get(index as usize) {
+                    // Can't access a non-int
+                    break;
+                }
+
+                IntOp::IncLocal { index }
+            }
+            Op::Nop => IntOp::Nop,
+            Op::PushInt { value } => {
+                stack_height += 1;
+
+                IntOp::PushInt { value }
+            }
+            Op::SetLocal { index } => {
+                stack_height -= 1;
+
+                current_locals_state.set(index as usize, true);
+                IntOp::SetLocal { index }
+            }
+            Op::StoreLocal { index } => {
+                current_locals_state.set(index as usize, true);
+                IntOp::StoreLocal { index }
+            }
+            Op::SubtractI => {
+                stack_height -= 1;
+
+                IntOp::Subtract
+            }
+            _ => {
+                break;
+            }
+        };
+
+        output_vec.push(translated_op);
+
+        i += 1;
+    }
+
+    let num_ops = output_vec.len();
+
+    output_vec.push(IntOp::End);
+
+    // Not enough ops for entering the int interpreter to be worth it
+    if num_ops < MIN_INT_OPS_LENGTH {
+        return None;
+    }
+
+    let info = IntInterpreterInfo {
+        input_locals: entry_locals_state.clone(),
+        output_locals: current_locals_state,
+        final_stack_height: stack_height,
+        exit_offset: Cell::new(start_index + num_ops),
+        ops: output_vec,
+    };
+
+    Some(info)
+}

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -136,8 +136,10 @@ pub fn run_analysis<'gc>(
         );
 
         if let Some((info, num_ops)) = analysis_results {
+            let code = info.ops.borrow();
             already_covered_ranges.push(start_index..start_index + num_ops);
-            println!("    Success for {} ({} ops)!", start_index, info.ops.len());
+            println!("    Success for {} ({} ops)!", start_index, code.len());
+            drop(code);
 
             let op = Op::RunIntInterpreter(Gc::new(activation.gc(), info));
             ops[start_index].set(op);

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -1,9 +1,12 @@
 use crate::avm2::activation::Activation;
-use crate::avm2::int_interpreter::MAX_INT_INTERPRETER_FRAME;
+use crate::avm2::class::Class;
+use crate::avm2::int_interpreter::{MAX_INT_INTERPRETER_FRAME, ObjectType};
 use crate::avm2::method::Method;
+use crate::avm2::object::TObject;
 use crate::avm2::op::{IntInterpreterInfo, IntOp, Op};
 use crate::avm2::optimizer::utils::SmallBitSet;
 
+use enum_map::EnumMap;
 use gc_arena::Gc;
 use std::cell::Cell;
 use std::collections::BTreeMap;
@@ -54,6 +57,16 @@ pub fn run_analysis<'gc>(
         return;
     }
 
+    let top_outer_scope_class = activation
+        .outer()
+        .get(0)
+        .and_then(|s| s.values().as_object())
+        .map(|o| o.instance_class());
+
+    let object_classes = EnumMap::from_fn(|t| match t {
+        ObjectType::TopOuterScope => top_outer_scope_class,
+    });
+
     // Keep track of the ranges that we've already created int interpreter
     // promotions for so that we don't create even more int interpreter
     // promotions within them. Because `empty_stack_positions` is a `BTreeMap`,
@@ -70,7 +83,10 @@ pub fn run_analysis<'gc>(
             continue;
         }
 
-        if let Some((info, num_ops)) = run_single_analysis(ops, start_index, *locals_state) {
+        let analysis_results =
+            run_single_analysis(ops, start_index, *locals_state, &object_classes);
+
+        if let Some((info, num_ops)) = analysis_results {
             covered_ranges.push(start_index..start_index + num_ops);
 
             let op = Op::RunIntInterpreter(Gc::new(activation.gc(), info));
@@ -83,6 +99,7 @@ fn run_single_analysis<'gc>(
     ops: &[Cell<Op<'gc>>],
     start_index: usize,
     used_locals: SmallBitSet,
+    object_classes: &EnumMap<ObjectType, Option<Class<'gc>>>,
 ) -> Option<(IntInterpreterInfo, usize)> {
     let mut output_vec = Vec::new();
 
@@ -163,6 +180,54 @@ fn run_single_analysis<'gc>(
                 stack.push_int();
 
                 IntOp::GetLocal { index }
+            }
+            Op::GetOuterScope { index: 0 } => {
+                stack.push_object(ObjectType::TopOuterScope);
+
+                IntOp::PushObject {
+                    value: ObjectType::TopOuterScope,
+                }
+            }
+            Op::GetSlot { index } => {
+                let Some(object_type) = stack.pop_expecting_object() else {
+                    // Getslot on a primitive is impossible thanks to the
+                    // verifier
+                    unreachable!()
+                };
+
+                let Some(class) = object_classes[object_type] else {
+                    // We couldn't conclude the class from the simplified
+                    // analysis that we perform. This is a very rare case.
+
+                    // We need to restore the stack to how it was before this
+                    // op was considered.
+                    stack.push_object(object_type);
+
+                    break;
+                };
+
+                let vtable = class.vtable();
+
+                let value_class = vtable
+                    .slot_class(index)
+                    .expect("Guaranteed by verifier")
+                    .get_existing_class();
+
+                if value_class.is_none_or(|c| !c.is_builtin_int()) {
+                    // Can't access a non-integral slot from an object.
+
+                    // We need to restore the stack to how it was before this
+                    // op was considered.
+                    stack.push_object(object_type);
+
+                    break;
+                }
+
+                stack.push_int();
+
+                IntOp::GetSlot {
+                    index: index as u32,
+                }
             }
             Op::GreaterEqualsIntegral => {
                 stack.pop();
@@ -358,18 +423,16 @@ fn run_single_analysis<'gc>(
         i += 1;
     }
 
-    let num_ops = output_vec.len();
+    // A single `pushobject` at the end of the output vec can lead to the pass
+    // failing. So if there is one, let's remove it now.
+    if matches!(output_vec.last(), Some(IntOp::PushObject { .. })) {
+        output_vec.pop();
 
-    // Once all ops are done executing, jump to the normal interpreter at the
-    // position where we should continue. Unless we got to the end of the
-    // method, in which case don't add this last op, as it'll confuse the nop
-    // remover.
-    if start_index + num_ops != ops.len() {
-        output_vec.push(IntOp::JumpExternal {
-            offset: Cell::new((start_index + num_ops) as u32),
-            final_stack_height: stack.len() as u8,
-        });
+        // Also remove the object from the stack
+        stack.pop();
     }
+
+    let num_ops = output_vec.len();
 
     // Not enough ops for entering the int interpreter to be worth it
     if num_ops < MIN_INT_OPS_LENGTH {
@@ -380,6 +443,17 @@ fn run_single_analysis<'gc>(
     // interpreter and the int interpreter, so we don't support it
     if !stack.is_entirely_ints() {
         return None;
+    }
+
+    // Once all ops are done executing, jump to the normal interpreter at the
+    // position where we should continue. Unless we got to the end of the
+    // method, in which case don't add this last op, as it'll confuse the nop
+    // remover.
+    if start_index + num_ops != ops.len() {
+        output_vec.push(IntOp::JumpExternal {
+            offset: Cell::new((start_index + num_ops) as u32),
+            final_stack_height: stack.len() as u8,
+        });
     }
 
     // Right now all the branches/jumps are external, i.e. they will exit the int
@@ -427,9 +501,9 @@ fn run_single_analysis<'gc>(
 
 /// A value in the int interpreter.
 ///
-/// Currently the int interpreter supports dealing with integers and booleans.
-/// However, booleans are limited- they cannot be stored in locals, and they
-/// cannot exist on the stack when the code ends.
+/// Currently the int interpreter supports dealing with integers, booleans, and
+/// some objects. However, non-integers are limited- they cannot be stored in
+/// locals, and they cannot exist on the stack when the code ends.
 ///
 /// Note that when coercing booleans to integers, AVM2 coerces `false` to `0`,
 /// and `true` to `1`. This is advantageous to us because we represent those two
@@ -441,6 +515,7 @@ fn run_single_analysis<'gc>(
 enum ValueType {
     Bool,
     Int,
+    Object(ObjectType),
 }
 
 /// The stack of the abstract interpreter.
@@ -466,12 +541,23 @@ impl Stack {
         self.0.push(ValueType::Int);
     }
 
+    pub fn push_object(&mut self, object_type: ObjectType) {
+        self.0.push(ValueType::Object(object_type));
+    }
+
     pub fn pop(&mut self) -> ValueType {
         self.0.pop().expect("Guaranteed by verifier previously")
     }
 
     pub fn pop_expecting_int(&mut self) -> bool {
         matches!(self.pop(), ValueType::Int)
+    }
+
+    pub fn pop_expecting_object(&mut self) -> Option<ObjectType> {
+        match self.pop() {
+            ValueType::Object(object_type) => Some(object_type),
+            _ => None,
+        }
     }
 
     pub fn is_entirely_ints(&self) -> bool {

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -19,7 +19,7 @@ use std::ops::Range;
 /// ops. On the other hand, if this number is too high, some sequences of ops
 /// that would benefit from being run in the integer interpreter may end up
 /// being considered too short to be run in it.
-const MIN_INT_OPS_LENGTH: usize = 50;
+const MIN_INT_OPS_LENGTH: usize = 40;
 
 /// The maximum number of ops in a method that can be considered for int
 /// interpreter analysis.
@@ -779,10 +779,17 @@ fn run_single_analysis<'gc>(
 
     let num_ops = output_vec.len();
 
+    // The more locals are used, the more overhead is required for entering and
+    // exiting the int interpreter. Therefore, if there are a high number of
+    // used locals (locals for which the corresponding bit is set), increase the
+    // number of ops required to be running in the int interpreter.
+    // TODO fine-tune this
+    let minimum_op_count = MIN_INT_OPS_LENGTH + used_locals.count_ones();
+
     // Not enough ops for entering the int interpreter to be worth it
     // (unless there's a backwards branch within the int interpreter; in that
     // case it's likely that this is a hot loop)
-    if num_ops < MIN_INT_OPS_LENGTH && !has_backwards_branch {
+    if num_ops < minimum_op_count && !has_backwards_branch {
         return None;
     }
 

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -153,6 +153,11 @@ fn run_single_analysis<'gc>(
 
         let translated_op = match op {
             Op::AddI => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_int();
@@ -160,6 +165,11 @@ fn run_single_analysis<'gc>(
                 IntOp::Add
             }
             Op::BitAnd => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_int();
@@ -167,12 +177,22 @@ fn run_single_analysis<'gc>(
                 IntOp::BitAnd
             }
             Op::BitNot => {
+                if !stack.expect(ValueType::Int, 1) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.push_int();
 
                 IntOp::BitNot
             }
             Op::BitOr => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_int();
@@ -180,6 +200,11 @@ fn run_single_analysis<'gc>(
                 IntOp::BitOr
             }
             Op::BitXor => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_int();
@@ -202,6 +227,11 @@ fn run_single_analysis<'gc>(
                 IntOp::Dup
             }
             Op::EqualsIntegral => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_bool();
@@ -279,6 +309,11 @@ fn run_single_analysis<'gc>(
                 }
             }
             Op::GreaterEqualsIntegral => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_bool();
@@ -286,6 +321,11 @@ fn run_single_analysis<'gc>(
                 IntOp::GreaterEquals
             }
             Op::GreaterThanIntegral => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_bool();
@@ -293,6 +333,11 @@ fn run_single_analysis<'gc>(
                 IntOp::GreaterThan
             }
             Op::IfFalse { offset } => {
+                if !stack.expect(ValueType::Bool, 1) {
+                    // Can't do this operation on non-bools
+                    break;
+                }
+
                 if stack.len() != 1 {
                     // It's fairly rare for items to be on the stack during
                     // merging, and this allows us to avoid dealing with
@@ -318,6 +363,11 @@ fn run_single_analysis<'gc>(
                 }
             }
             Op::IfTrue { offset } => {
+                if !stack.expect(ValueType::Bool, 1) {
+                    // Can't do this operation on non-bools
+                    break;
+                }
+
                 if stack.len() != 1 {
                     // See comment on `Op::IfFalse`
                     break;
@@ -354,6 +404,11 @@ fn run_single_analysis<'gc>(
                 IntOp::IncLocal { index }
             }
             Op::LessEqualsIntegral => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_bool();
@@ -361,6 +416,11 @@ fn run_single_analysis<'gc>(
                 IntOp::LessEquals
             }
             Op::LessThanIntegral => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_bool();
@@ -368,24 +428,44 @@ fn run_single_analysis<'gc>(
                 IntOp::LessThan
             }
             Op::Li8 => {
+                if !stack.expect(ValueType::Int, 1) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.push_int();
 
                 IntOp::Li8
             }
             Op::Li16 => {
+                if !stack.expect(ValueType::Int, 1) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.push_int();
 
                 IntOp::Li16
             }
             Op::Li32 => {
+                if !stack.expect(ValueType::Int, 1) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.push_int();
 
                 IntOp::Li32
             }
             Op::LShift => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_int();
@@ -394,6 +474,11 @@ fn run_single_analysis<'gc>(
             }
             Op::Nop => IntOp::Nop,
             Op::Not => {
+                if !stack.expect(ValueType::Bool, 1) {
+                    // Can't do this operation on non-bools
+                    break;
+                }
+
                 stack.pop();
                 stack.push_bool();
 
@@ -410,6 +495,11 @@ fn run_single_analysis<'gc>(
                 IntOp::PushInt { value }
             }
             Op::SetLocal { index } => {
+                if !stack.expect(ValueType::Int, 1) {
+                    // Can't store a non-integer into a local
+                    break;
+                }
+
                 if !used_locals.get(index as usize) {
                     // Can't access a non-int
 
@@ -421,9 +511,6 @@ fn run_single_analysis<'gc>(
                     // we would have to implement proper state merging to
                     // determine that local #X was non-integral.
                     break;
-                } else if !stack.peek_expecting_int() {
-                    // Can't store a non-integer into a local
-                    break;
                 }
 
                 stack.pop();
@@ -431,14 +518,13 @@ fn run_single_analysis<'gc>(
                 IntOp::SetLocal { index }
             }
             Op::SetSlotNoCoerce { index } => {
-                if !stack.peek_expecting_int() {
+                if !stack.expect(ValueType::Int, 1) {
                     // Can't store a non-integer into a slot
                     break;
-                } else if stack.peek_expecting_object() {
-                    // Getslot on a primitive is impossible thanks to the
-                    // verifier
-                    unreachable!();
                 }
+
+                // The verifier guarantees that the receiver value will be an
+                // object, as primitives have no slots
 
                 stack.pop();
                 stack.pop();
@@ -453,6 +539,11 @@ fn run_single_analysis<'gc>(
                 }
             }
             Op::RShift => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_int();
@@ -460,31 +551,48 @@ fn run_single_analysis<'gc>(
                 IntOp::RShift
             }
             Op::Si8 => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
 
                 IntOp::Si8
             }
             Op::Si16 => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
 
                 IntOp::Si16
             }
             Op::Si32 => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
 
                 IntOp::Si32
             }
             Op::StoreLocal { index } => {
+                if !stack.expect(ValueType::Int, 1) {
+                    // Can't store a non-integer into a local
+                    break;
+                }
+
                 if !used_locals.get(index as usize) {
                     // Can't access a non-int
 
                     // See comment on `Op::SetLocal`
-                    break;
-                } else if !stack.peek_expecting_int() {
-                    // Can't store a non-integer into a local
                     break;
                 }
 
@@ -493,6 +601,11 @@ fn run_single_analysis<'gc>(
                 IntOp::StoreLocal { index }
             }
             Op::SubtractI => {
+                if !stack.expect(ValueType::Int, 2) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.pop();
                 stack.push_int();
@@ -508,12 +621,22 @@ fn run_single_analysis<'gc>(
                 IntOp::Swap
             }
             Op::Sxi16 => {
+                if !stack.expect(ValueType::Int, 1) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.push_int();
 
                 IntOp::Sxi16
             }
             Op::Sxi8 => {
+                if !stack.expect(ValueType::Int, 1) {
+                    // Can't do this operation on non-ints
+                    break;
+                }
+
                 stack.pop();
                 stack.push_int();
 
@@ -617,7 +740,7 @@ fn run_single_analysis<'gc>(
 /// need to ensure that e.g. `add_i` is always being passed two integers- even
 /// if it's being passed two booleans, it'll still return the correct result at
 /// runtime. The same applies to the rest of the integral ops.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 enum ValueType {
     Bool,
     Int,
@@ -633,6 +756,17 @@ struct Stack(Vec<ValueType>);
 impl Stack {
     pub fn new() -> Self {
         Stack(Vec::with_capacity(MAX_INT_INTERPRETER_FRAME - 1))
+    }
+
+    /// Expect the topmost `count` items of the stack to be of type `expected`.
+    pub fn expect(&mut self, expected: ValueType, count: usize) -> bool {
+        for item in self.0.iter().rev().take(count) {
+            if *item != expected {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     pub fn push(&mut self, value: ValueType) {
@@ -651,20 +785,8 @@ impl Stack {
         self.0.push(ValueType::Object(object_type));
     }
 
-    pub fn peek(&mut self) -> ValueType {
-        *self.0.last().expect("Guaranteed by verifier previously")
-    }
-
     pub fn pop(&mut self) -> ValueType {
         self.0.pop().expect("Guaranteed by verifier previously")
-    }
-
-    pub fn peek_expecting_int(&mut self) -> bool {
-        matches!(self.peek(), ValueType::Int)
-    }
-
-    pub fn peek_expecting_object(&mut self) -> bool {
-        matches!(self.peek(), ValueType::Object(_))
     }
 
     pub fn pop_object(&mut self) -> Option<ObjectType> {

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -395,6 +395,14 @@ fn run_single_analysis<'gc>(
 
                 IntOp::IfFalseExternal {
                     offset: offset as u32,
+
+                    // If the stack isn't entirely ints, keeping this op as an
+                    // external jump is invalid, as when the int interpreter is
+                    // exited the entire stack must be integers (to keep
+                    // synchronization of stack simple). However, it's also
+                    // possible that this op will be an internal jump, in which
+                    // case this flag can be ignored.
+                    valid: stack.is_entirely_ints(),
                 }
             }
             Op::IfTrue { offset } => {
@@ -407,10 +415,16 @@ fn run_single_analysis<'gc>(
 
                 IntOp::IfTrueExternal {
                     offset: offset as u32,
+
+                    // See comment on `Op::IfFalse`
+                    valid: stack.is_entirely_ints(),
                 }
             }
             Op::Jump { offset } => IntOp::JumpExternal {
                 offset: offset as u32,
+
+                // See comment on `Op::IfFalse`
+                valid: stack.is_entirely_ints(),
             },
             Op::IncLocalI { index } => {
                 if !integral_locals.get(index as usize) {
@@ -772,7 +786,23 @@ fn run_single_analysis<'gc>(
     if start_index + num_ops != ops.len() {
         output_vec.push(IntOp::JumpExternal {
             offset: (start_index + num_ops) as u32,
+            valid: stack.is_entirely_ints(),
         });
+    }
+
+    // If there are any invalid external jumps (the stack state at them isn't
+    // entirely integers), abort.
+    for op in &mut output_vec {
+        match op {
+            IntOp::IfFalseExternal { valid, .. }
+            | IntOp::IfTrueExternal { valid, .. }
+            | IntOp::JumpExternal { valid, .. } => {
+                if !*valid {
+                    return None;
+                }
+            }
+            _ => {}
+        }
     }
 
     remove_nops(&mut output_vec);
@@ -790,12 +820,6 @@ fn run_single_analysis<'gc>(
     // (unless there's a backwards branch within the int interpreter; in that
     // case it's likely that this is a hot loop)
     if num_ops < minimum_op_count && !has_backwards_branch {
-        return None;
-    }
-
-    // This massively complicates synchronization of locals between the normal
-    // interpreter and the int interpreter, so we don't support it
-    if !stack.is_entirely_ints() {
         return None;
     }
 

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -907,10 +907,6 @@ impl Stack {
     pub fn clear(&mut self) {
         self.0.clear();
     }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
 }
 
 fn remove_nops(code: &mut Vec<IntOp>) {

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -142,11 +142,12 @@ pub fn run_analysis<'gc>(
 fn run_single_analysis<'gc>(
     ops: &[Cell<Op<'gc>>],
     start_index: usize,
-    used_locals: SmallBitSet,
+    integral_locals: SmallBitSet,
     object_classes: &EnumMap<ObjectType, Option<Class<'gc>>>,
     sets_local_0: bool,
 ) -> Option<(IntInterpreterInfo, usize)> {
     let mut output_vec = Vec::new();
+    let mut used_locals = SmallBitSet::new(integral_locals.len());
 
     let mut stack = Stack::new();
 
@@ -219,10 +220,12 @@ fn run_single_analysis<'gc>(
                 IntOp::BitXor
             }
             Op::DecLocalI { index } => {
-                if !used_locals.get(index as usize) {
+                if !integral_locals.get(index as usize) {
                     // Can't access a non-int
                     break;
                 }
+
+                used_locals.set(index as usize);
 
                 IntOp::DecLocal { index }
             }
@@ -256,10 +259,12 @@ fn run_single_analysis<'gc>(
                         value: ObjectType::Receiver,
                     }
                 } else {
-                    if !used_locals.get(index as usize) {
+                    if !integral_locals.get(index as usize) {
                         // Can't access a non-int
                         break;
                     }
+
+                    used_locals.set(index as usize);
 
                     // Only integers can be stored in locals
                     stack.push_int();
@@ -403,10 +408,12 @@ fn run_single_analysis<'gc>(
                 }
             }
             Op::IncLocalI { index } => {
-                if !used_locals.get(index as usize) {
+                if !integral_locals.get(index as usize) {
                     // Can't access a non-int
                     break;
                 }
+
+                used_locals.set(index as usize);
 
                 IntOp::IncLocal { index }
             }
@@ -519,7 +526,7 @@ fn run_single_analysis<'gc>(
                     break;
                 }
 
-                if !used_locals.get(index as usize) {
+                if !integral_locals.get(index as usize) {
                     // Can't access a non-int
 
                     // i.e. we cannot set a non-int to an int, which would
@@ -531,6 +538,8 @@ fn run_single_analysis<'gc>(
                     // determine that local #X was non-integral.
                     break;
                 }
+
+                used_locals.set(index as usize);
 
                 stack.pop();
 
@@ -608,12 +617,14 @@ fn run_single_analysis<'gc>(
                     break;
                 }
 
-                if !used_locals.get(index as usize) {
+                if !integral_locals.get(index as usize) {
                     // Can't access a non-int
 
                     // See comment on `Op::SetLocal`
                     break;
                 }
+
+                used_locals.set(index as usize);
 
                 // No need to change the stack
 

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -388,20 +388,6 @@ fn run_single_analysis<'gc>(
                     break;
                 }
 
-                if stack.len() != 1 {
-                    // It's fairly rare for items to be on the stack during
-                    // merging, and this allows us to avoid dealing with
-                    // state merging or tracking to know the correct height of
-                    // the stack at a certain point. However, this does mean
-                    // all ternary expressions disable int interpreter
-                    // promotion. TODO support this case
-
-                    // (note: this is a != 1 check rather than an is_empty
-                    // check, as the one value on the stack will be popped by
-                    // this op)
-                    break;
-                }
-
                 stack.pop();
 
                 IntOp::IfFalseExternal {
@@ -418,11 +404,6 @@ fn run_single_analysis<'gc>(
                     break;
                 }
 
-                if stack.len() != 1 {
-                    // See comment on `Op::IfFalse`
-                    break;
-                }
-
                 stack.pop();
 
                 IntOp::IfTrueExternal {
@@ -433,11 +414,6 @@ fn run_single_analysis<'gc>(
                 }
             }
             Op::Jump { offset } => {
-                if !stack.is_empty() {
-                    // See comment on `Op::IfFalse`
-                    break;
-                }
-
                 IntOp::JumpExternal {
                     offset: Cell::new(offset as u32),
 
@@ -909,9 +885,5 @@ impl Stack {
 
     pub fn len(&self) -> usize {
         self.0.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
     }
 }

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -181,10 +181,13 @@ fn run_single_analysis<'gc>(
             Op::IfFalse { offset } => {
                 stack.pop();
 
-                if !stack.is_entirely_ints() {
-                    // It's fairly rare for booleans to be on the stack during
-                    // merging, and this allows us to avoid dealing with state
-                    // merging
+                if !stack.is_empty() {
+                    // It's fairly rare for items to be on the stack during
+                    // merging, and this allows us to avoid dealing with
+                    // state merging or tracking to know the correct height of
+                    // the stack at a certain point. However, this does mean
+                    // all ternary expressions disable int interpreter
+                    // promotion. TODO support this case
                     break;
                 }
 
@@ -199,7 +202,7 @@ fn run_single_analysis<'gc>(
             Op::IfTrue { offset } => {
                 stack.pop();
 
-                if !stack.is_entirely_ints() {
+                if !stack.is_empty() {
                     // See comment on `Op::IfFalse`
                     break;
                 }
@@ -212,7 +215,7 @@ fn run_single_analysis<'gc>(
                 }
             }
             Op::Jump { offset } => {
-                if !stack.is_entirely_ints() {
+                if !stack.is_empty() {
                     // See comment on `Op::IfFalse`
                     break;
                 }
@@ -412,7 +415,7 @@ fn run_single_analysis<'gc>(
 ///
 /// Currently the int interpreter supports dealing with integers and booleans.
 /// However, booleans are limited- they cannot be stored in locals, and they
-/// cannot exist on the stack when a jump/branch is made or when the code ends.
+/// cannot exist on the stack when the code ends.
 ///
 /// Note that when coercing booleans to integers, AVM2 coerces `false` to `0`,
 /// and `true` to `1`. This is advantageous to us because we represent those two
@@ -463,5 +466,9 @@ impl Stack {
 
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -146,6 +146,13 @@ fn run_single_analysis<'gc>(
 
                 IntOp::Dup
             }
+            Op::EqualsIntegral => {
+                stack.pop();
+                stack.pop();
+                stack.push_bool();
+
+                IntOp::Equals
+            }
             Op::GetLocal { index } => {
                 if !used_locals.get(index as usize) {
                     // Can't access a non-int

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -19,7 +19,7 @@ const MIN_INT_OPS_LENGTH: usize = 30;
 
 /// The maximum number of ops in a method that can be considered for int
 /// interpreter analysis.
-const MAX_METHOD_OPS_LENGTH: usize = 300;
+const MAX_METHOD_OPS_LENGTH: usize = 600;
 
 pub fn run_analysis<'gc>(
     activation: &mut Activation<'_, 'gc>,

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -9,7 +9,7 @@ use crate::avm2::optimizer::utils::SmallBitSet;
 use enum_map::EnumMap;
 use gc_arena::Gc;
 use std::cell::Cell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::ops::Range;
 
 /// The minimum number of consecutive ops that will be run in the integer
@@ -28,6 +28,7 @@ pub fn run_analysis<'gc>(
     activation: &mut Activation<'_, 'gc>,
     method: Method<'gc>,
     ops: &[Cell<Op<'gc>>],
+    jump_targets: &HashSet<usize>,
     empty_stack_positions: &BTreeMap<usize, SmallBitSet>,
     has_exceptions: bool,
 ) {
@@ -104,15 +105,21 @@ pub fn run_analysis<'gc>(
     // promotions within them. Because `empty_stack_positions` is a `BTreeMap`,
     // iterating over it will result in earlier positions (the ones that will
     // yield the largest promoted areas) being handled first.
-    let mut covered_ranges: Vec<Range<usize>> = Vec::new();
+    let mut already_covered_ranges: Vec<Range<usize>> = Vec::new();
 
     // Now we can actually run the analysis pass.
     for (start_index, locals_state) in empty_stack_positions {
         let start_index = *start_index;
 
-        if covered_ranges.iter().any(|r| r.contains(&start_index)) {
-            // See above comment
-            continue;
+        // If the start index is a jump target, do promotion anyway
+        if !jump_targets.contains(&start_index) {
+            if already_covered_ranges
+                .iter()
+                .any(|r| r.contains(&start_index))
+            {
+                // See above comment
+                continue;
+            }
         }
 
         let analysis_results = run_single_analysis(
@@ -124,7 +131,7 @@ pub fn run_analysis<'gc>(
         );
 
         if let Some((info, num_ops)) = analysis_results {
-            covered_ranges.push(start_index..start_index + num_ops);
+            already_covered_ranges.push(start_index..start_index + num_ops);
 
             let op = Op::RunIntInterpreter(Gc::new(activation.gc(), info));
             ops[start_index].set(op);

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -70,7 +70,7 @@ pub fn run_analysis<'gc>(
             continue;
         }
 
-        if let Some((info, num_ops)) = run_single_analysis(ops, start_index, locals_state) {
+        if let Some((info, num_ops)) = run_single_analysis(ops, start_index, *locals_state) {
             covered_ranges.push(start_index..start_index + num_ops);
 
             let op = Op::RunIntInterpreter(Gc::new(activation.gc(), info));
@@ -82,12 +82,11 @@ pub fn run_analysis<'gc>(
 fn run_single_analysis<'gc>(
     ops: &[Cell<Op<'gc>>],
     start_index: usize,
-    entry_locals_state: &SmallBitSet,
+    used_locals: SmallBitSet,
 ) -> Option<(IntInterpreterInfo, usize)> {
     let mut output_vec = Vec::new();
 
-    let mut current_locals_state = entry_locals_state.clone();
-    let mut stack_height = 0;
+    let mut stack = Stack::new();
 
     // We run a simplified abstract interpreter pass. We know that at this point,
     // the stack is empty and locals are either integral or non-integral. Loading
@@ -99,28 +98,41 @@ fn run_single_analysis<'gc>(
 
         let translated_op = match op {
             Op::AddI => {
-                stack_height -= 1;
+                stack.pop();
+                stack.pop();
+                stack.push_int();
 
                 IntOp::Add
             }
             Op::BitAnd => {
-                stack_height -= 1;
+                stack.pop();
+                stack.pop();
+                stack.push_int();
 
                 IntOp::BitAnd
             }
-            Op::BitNot => IntOp::BitNot,
+            Op::BitNot => {
+                stack.pop();
+                stack.push_int();
+
+                IntOp::BitNot
+            }
             Op::BitOr => {
-                stack_height -= 1;
+                stack.pop();
+                stack.pop();
+                stack.push_int();
 
                 IntOp::BitOr
             }
             Op::BitXor => {
-                stack_height -= 1;
+                stack.pop();
+                stack.pop();
+                stack.push_int();
 
                 IntOp::BitXor
             }
             Op::DecLocalI { index } => {
-                if !current_locals_state.get(index as usize) {
+                if !used_locals.get(index as usize) {
                     // Can't access a non-int
                     break;
                 }
@@ -128,61 +140,187 @@ fn run_single_analysis<'gc>(
                 IntOp::DecLocal { index }
             }
             Op::Dup => {
-                stack_height += 1;
+                let value = stack.pop();
+                stack.push(value);
+                stack.push(value);
 
                 IntOp::Dup
             }
             Op::GetLocal { index } => {
-                if !current_locals_state.get(index as usize) {
+                if !used_locals.get(index as usize) {
                     // Can't access a non-int
                     break;
                 }
 
-                stack_height += 1;
+                // Only integers can be stored in locals
+                stack.push_int();
 
                 IntOp::GetLocal { index }
             }
+            Op::GreaterEqualsIntegral => {
+                stack.pop();
+                stack.pop();
+                stack.push_bool();
+
+                IntOp::GreaterEquals
+            }
+            Op::GreaterThanIntegral => {
+                stack.pop();
+                stack.pop();
+                stack.push_bool();
+
+                IntOp::GreaterThan
+            }
+            Op::IfFalse { offset } => {
+                stack.pop();
+
+                if !stack.is_entirely_ints() {
+                    // It's fairly rare for booleans to be on the stack during
+                    // merging, and this allows us to avoid dealing with state
+                    // merging
+                    break;
+                }
+
+                IntOp::IfFalseExternal {
+                    offset: Cell::new(offset as u32),
+
+                    // The frame size of the abstract interpreter should fit in
+                    // a u8
+                    final_stack_height: stack.len() as u8,
+                }
+            }
+            Op::IfTrue { offset } => {
+                stack.pop();
+
+                if !stack.is_entirely_ints() {
+                    // See comment on `Op::IfFalse`
+                    break;
+                }
+
+                IntOp::IfTrueExternal {
+                    offset: Cell::new(offset as u32),
+
+                    // See comment on `Op::IfFalse`
+                    final_stack_height: stack.len() as u8,
+                }
+            }
+            Op::Jump { offset } => {
+                if !stack.is_entirely_ints() {
+                    // See comment on `Op::IfFalse`
+                    break;
+                }
+
+                IntOp::JumpExternal {
+                    offset: Cell::new(offset as u32),
+
+                    // See comment on `Op::IfFalse`
+                    final_stack_height: stack.len() as u8,
+                }
+            }
             Op::IncLocalI { index } => {
-                if !current_locals_state.get(index as usize) {
+                if !used_locals.get(index as usize) {
                     // Can't access a non-int
                     break;
                 }
 
                 IntOp::IncLocal { index }
             }
-            Op::Jump { offset } => IntOp::ExternalJump {
-                offset: Cell::new(offset as u32),
-            },
-            Op::Li8 => IntOp::Li8,
-            Op::Li32 => IntOp::Li32,
+            Op::LessEqualsIntegral => {
+                stack.pop();
+                stack.pop();
+                stack.push_bool();
+
+                IntOp::LessEquals
+            }
+            Op::LessThanIntegral => {
+                stack.pop();
+                stack.pop();
+                stack.push_bool();
+
+                IntOp::LessThan
+            }
+            Op::Li8 => {
+                stack.pop();
+                stack.push_int();
+
+                IntOp::Li8
+            }
+            Op::Li32 => {
+                stack.pop();
+                stack.push_int();
+
+                IntOp::Li32
+            }
             Op::Nop => IntOp::Nop,
+            Op::Not => {
+                stack.pop();
+                stack.push_bool();
+
+                IntOp::Not
+            }
+            Op::Pop => {
+                stack.pop();
+
+                IntOp::Pop
+            }
             Op::PushInt { value } => {
-                stack_height += 1;
+                stack.push_int();
 
                 IntOp::PushInt { value }
             }
             Op::SetLocal { index } => {
-                stack_height -= 1;
+                if !used_locals.get(index as usize) {
+                    // Can't access a non-int
 
-                current_locals_state.set(index as usize, true);
+                    // i.e. we cannot set a non-int to an int, which would
+                    // break certain guarantees that simplify handling of
+                    // branching. For example, if the program proceeded for a
+                    // while assuming that local #X was non-integral, then
+                    // local #X were to be set to be integral in a branch, then
+                    // we would have to implement proper state merging to
+                    // determine that local #X was non-integral.
+                    break;
+                }
+
+                if !stack.pop_expecting_int() {
+                    // Can't store a non-integer into a local
+                    break;
+                }
+
                 IntOp::SetLocal { index }
             }
             Op::Si8 => {
-                stack_height -= 2;
+                stack.pop();
+                stack.pop();
 
                 IntOp::Si8
             }
             Op::Si32 => {
-                stack_height -= 2;
+                stack.pop();
+                stack.pop();
 
                 IntOp::Si32
             }
             Op::StoreLocal { index } => {
-                current_locals_state.set(index as usize, true);
+                if !used_locals.get(index as usize) {
+                    // Can't access a non-int
+
+                    // See comment on `Op::SetLocal`
+                    break;
+                }
+
+                if !stack.pop_expecting_int() {
+                    // Can't store a non-integer into a local
+                    break;
+                }
+                stack.push_int();
+
                 IntOp::StoreLocal { index }
             }
             Op::SubtractI => {
-                stack_height -= 1;
+                stack.pop();
+                stack.pop();
+                stack.push_int();
 
                 IntOp::Subtract
             }
@@ -200,8 +338,9 @@ fn run_single_analysis<'gc>(
 
     // Once all ops are done executing, jump to the normal interpreter at the
     // position where we should continue.
-    output_vec.push(IntOp::ExternalJump {
+    output_vec.push(IntOp::JumpExternal {
         offset: Cell::new((start_index + num_ops) as u32),
+        final_stack_height: stack.len() as u8,
     });
 
     // Not enough ops for entering the int interpreter to be worth it
@@ -209,12 +348,109 @@ fn run_single_analysis<'gc>(
         return None;
     }
 
+    // This massively complicates synchronization of locals between the normal
+    // interpreter and the int interpreter, so we don't support it
+    if !stack.is_entirely_ints() {
+        return None;
+    }
+
+    // Right now all the branches/jumps are external, i.e. they will exit the int
+    // interpreter into normal code. This is technically correct, but let's see
+    // which of the branches we can make internal branches (branches that
+    // remain in the int interpreter). We want to stay in the int interpreter
+    // as much as possible.
+    for op in &mut output_vec {
+        match op {
+            IntOp::IfFalseExternal { offset, .. } => {
+                let offset = offset.get() as usize;
+                if (start_index..start_index + num_ops).contains(&offset) {
+                    *op = IntOp::IfFalse {
+                        offset: (offset - start_index) as u32,
+                    };
+                }
+            }
+            IntOp::IfTrueExternal { offset, .. } => {
+                let offset = offset.get() as usize;
+                if (start_index..start_index + num_ops).contains(&offset) {
+                    *op = IntOp::IfTrue {
+                        offset: (offset - start_index) as u32,
+                    };
+                }
+            }
+            IntOp::JumpExternal { offset, .. } => {
+                let offset = offset.get() as usize;
+                if (start_index..start_index + num_ops).contains(&offset) {
+                    *op = IntOp::Jump {
+                        offset: (offset - start_index) as u32,
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+
     let info = IntInterpreterInfo {
-        input_locals: entry_locals_state.clone(),
-        output_locals: current_locals_state,
-        final_stack_height: stack_height,
+        synchronize_locals: used_locals,
         ops: output_vec,
     };
 
     Some((info, num_ops))
+}
+
+/// A value in the int interpreter.
+///
+/// Currently the int interpreter supports dealing with integers and booleans.
+/// However, booleans are limited- they cannot be stored in locals, and they
+/// cannot exist on the stack when a jump/branch is made or when the code ends.
+///
+/// Note that when coercing booleans to integers, AVM2 coerces `false` to `0`,
+/// and `true` to `1`. This is advantageous to us because we represent those two
+/// boolean values as those two integer values at runtime, which means we don't
+/// need to ensure that e.g. `add_i` is always being passed two integers- even
+/// if it's being passed two booleans, it'll still return the correct result at
+/// runtime. The same applies to the rest of the integral ops.
+#[derive(Clone, Copy)]
+enum ValueType {
+    Bool,
+    Int,
+}
+
+/// The stack of the abstract interpreter.
+///
+/// As the abstract interpreter only supports up to MAX_INT_INTERPRETER_FRAME
+/// slots, this will never have a length greater than MAX_INT_INTERPRETER_FRAME.
+struct Stack(Vec<ValueType>);
+
+impl Stack {
+    pub fn new() -> Self {
+        Stack(Vec::with_capacity(MAX_INT_INTERPRETER_FRAME - 1))
+    }
+
+    pub fn push(&mut self, value: ValueType) {
+        self.0.push(value);
+    }
+
+    pub fn push_bool(&mut self) {
+        self.0.push(ValueType::Bool);
+    }
+
+    pub fn push_int(&mut self) {
+        self.0.push(ValueType::Int);
+    }
+
+    pub fn pop(&mut self) -> ValueType {
+        self.0.pop().expect("Guaranteed by verifier previously")
+    }
+
+    pub fn pop_expecting_int(&mut self) -> bool {
+        matches!(self.pop(), ValueType::Int)
+    }
+
+    pub fn is_entirely_ints(&self) -> bool {
+        self.0.iter().all(|v| matches!(v, ValueType::Int))
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 }

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -9,7 +9,7 @@ use crate::avm2::optimizer::utils::SmallBitSet;
 
 use enum_map::EnumMap;
 use gc_arena::Gc;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Range;
 
@@ -391,7 +391,7 @@ fn run_single_analysis<'gc>(
                 stack.pop();
 
                 IntOp::IfFalseExternal {
-                    offset: Cell::new(offset as u32),
+                    offset: offset as u32,
 
                     // The frame size of the abstract interpreter should fit in
                     // a u8
@@ -407,7 +407,7 @@ fn run_single_analysis<'gc>(
                 stack.pop();
 
                 IntOp::IfTrueExternal {
-                    offset: Cell::new(offset as u32),
+                    offset: offset as u32,
 
                     // See comment on `Op::IfFalse`
                     final_stack_height: stack.len() as u8,
@@ -415,7 +415,7 @@ fn run_single_analysis<'gc>(
             }
             Op::Jump { offset } => {
                 IntOp::JumpExternal {
-                    offset: Cell::new(offset as u32),
+                    offset: offset as u32,
 
                     // See comment on `Op::IfFalse`
                     final_stack_height: stack.len() as u8,
@@ -729,7 +729,7 @@ fn run_single_analysis<'gc>(
     for (i, op) in output_vec.iter_mut().enumerate() {
         match op {
             IntOp::IfFalseExternal { offset, .. } => {
-                let offset = offset.get() as usize;
+                let offset = *offset as usize;
                 if (start_index..start_index + num_ops).contains(&offset) {
                     let new_offset = offset - start_index;
 
@@ -743,7 +743,7 @@ fn run_single_analysis<'gc>(
                 }
             }
             IntOp::IfTrueExternal { offset, .. } => {
-                let offset = offset.get() as usize;
+                let offset = *offset as usize;
                 if (start_index..start_index + num_ops).contains(&offset) {
                     let new_offset = offset - start_index;
 
@@ -757,7 +757,7 @@ fn run_single_analysis<'gc>(
                 }
             }
             IntOp::JumpExternal { offset, .. } => {
-                let offset = offset.get() as usize;
+                let offset = *offset as usize;
                 if (start_index..start_index + num_ops).contains(&offset) {
                     let new_offset = offset - start_index;
 
@@ -793,14 +793,14 @@ fn run_single_analysis<'gc>(
     // remover.
     if start_index + num_ops != ops.len() {
         output_vec.push(IntOp::JumpExternal {
-            offset: Cell::new((start_index + num_ops) as u32),
+            offset: (start_index + num_ops) as u32,
             final_stack_height: stack.len() as u8,
         });
     }
 
     let info = IntInterpreterInfo {
         synchronize_locals: used_locals,
-        ops: output_vec,
+        ops: RefCell::new(output_vec),
     };
 
     Some((info, num_ops))

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -395,10 +395,6 @@ fn run_single_analysis<'gc>(
 
                 IntOp::IfFalseExternal {
                     offset: offset as u32,
-
-                    // The frame size of the abstract interpreter should fit in
-                    // a u8
-                    final_stack_height: stack.len() as u8,
                 }
             }
             Op::IfTrue { offset } => {
@@ -411,19 +407,11 @@ fn run_single_analysis<'gc>(
 
                 IntOp::IfTrueExternal {
                     offset: offset as u32,
-
-                    // See comment on `Op::IfFalse`
-                    final_stack_height: stack.len() as u8,
                 }
             }
-            Op::Jump { offset } => {
-                IntOp::JumpExternal {
-                    offset: offset as u32,
-
-                    // See comment on `Op::IfFalse`
-                    final_stack_height: stack.len() as u8,
-                }
-            }
+            Op::Jump { offset } => IntOp::JumpExternal {
+                offset: offset as u32,
+            },
             Op::IncLocalI { index } => {
                 if !integral_locals.get(index as usize) {
                     // Can't access a non-int
@@ -784,7 +772,6 @@ fn run_single_analysis<'gc>(
     if start_index + num_ops != ops.len() {
         output_vec.push(IntOp::JumpExternal {
             offset: (start_index + num_ops) as u32,
-            final_stack_height: stack.len() as u8,
         });
     }
 

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -150,6 +150,8 @@ fn run_single_analysis<'gc>(
 
                 IntOp::IncLocal { index }
             }
+            Op::Li8 => IntOp::Li8,
+            Op::Li32 => IntOp::Li32,
             Op::Nop => IntOp::Nop,
             Op::PushInt { value } => {
                 stack_height += 1;
@@ -161,6 +163,16 @@ fn run_single_analysis<'gc>(
 
                 current_locals_state.set(index as usize, true);
                 IntOp::SetLocal { index }
+            }
+            Op::Si8 => {
+                stack_height -= 2;
+
+                IntOp::Si8
+            }
+            Op::Si32 => {
+                stack_height -= 2;
+
+                IntOp::Si32
             }
             Op::StoreLocal { index } => {
                 current_locals_state.set(index as usize, true);

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -209,6 +209,9 @@ fn run_single_analysis<'gc>(
                 IntOp::Equals
             }
             Op::GetLocal { index } => {
+                // Accessing the receiver and accessing an integer local are
+                // two completely different things, so handle them separately
+
                 if !sets_local_0 && index == 0 {
                     stack.push_object(ObjectType::Receiver);
 
@@ -235,7 +238,7 @@ fn run_single_analysis<'gc>(
                 }
             }
             Op::GetSlot { index } => {
-                let Some(object_type) = stack.pop_expecting_object() else {
+                let Some(object_type) = stack.pop_object() else {
                     // Getslot on a primitive is impossible thanks to the
                     // verifier
                     unreachable!()
@@ -290,17 +293,21 @@ fn run_single_analysis<'gc>(
                 IntOp::GreaterThan
             }
             Op::IfFalse { offset } => {
-                stack.pop();
-
-                if !stack.is_empty() {
+                if stack.len() != 1 {
                     // It's fairly rare for items to be on the stack during
                     // merging, and this allows us to avoid dealing with
                     // state merging or tracking to know the correct height of
                     // the stack at a certain point. However, this does mean
                     // all ternary expressions disable int interpreter
                     // promotion. TODO support this case
+
+                    // (note: this is a != 1 check rather than an is_empty
+                    // check, as the one value on the stack will be popped by
+                    // this op)
                     break;
                 }
+
+                stack.pop();
 
                 IntOp::IfFalseExternal {
                     offset: Cell::new(offset as u32),
@@ -311,12 +318,12 @@ fn run_single_analysis<'gc>(
                 }
             }
             Op::IfTrue { offset } => {
-                stack.pop();
-
-                if !stack.is_empty() {
+                if stack.len() != 1 {
                     // See comment on `Op::IfFalse`
                     break;
                 }
+
+                stack.pop();
 
                 IntOp::IfTrueExternal {
                     offset: Cell::new(offset as u32),
@@ -414,26 +421,27 @@ fn run_single_analysis<'gc>(
                     // we would have to implement proper state merging to
                     // determine that local #X was non-integral.
                     break;
-                }
-
-                if !stack.pop_expecting_int() {
+                } else if !stack.peek_expecting_int() {
                     // Can't store a non-integer into a local
                     break;
                 }
 
+                stack.pop();
+
                 IntOp::SetLocal { index }
             }
             Op::SetSlotNoCoerce { index } => {
-                if !stack.pop_expecting_int() {
+                if !stack.peek_expecting_int() {
                     // Can't store a non-integer into a slot
                     break;
-                }
-
-                if stack.pop_expecting_object().is_none() {
+                } else if stack.peek_expecting_object() {
                     // Getslot on a primitive is impossible thanks to the
                     // verifier
                     unreachable!();
                 }
+
+                stack.pop();
+                stack.pop();
 
                 // We just guaranteed that the stack has an integer on it and
                 // that the value was about to be stored without coercion
@@ -475,13 +483,12 @@ fn run_single_analysis<'gc>(
 
                     // See comment on `Op::SetLocal`
                     break;
-                }
-
-                if !stack.pop_expecting_int() {
+                } else if !stack.peek_expecting_int() {
                     // Can't store a non-integer into a local
                     break;
                 }
-                stack.push_int();
+
+                // No need to change the stack
 
                 IntOp::StoreLocal { index }
             }
@@ -624,15 +631,23 @@ impl Stack {
         self.0.push(ValueType::Object(object_type));
     }
 
+    pub fn peek(&mut self) -> ValueType {
+        *self.0.last().expect("Guaranteed by verifier previously")
+    }
+
     pub fn pop(&mut self) -> ValueType {
         self.0.pop().expect("Guaranteed by verifier previously")
     }
 
-    pub fn pop_expecting_int(&mut self) -> bool {
-        matches!(self.pop(), ValueType::Int)
+    pub fn peek_expecting_int(&mut self) -> bool {
+        matches!(self.peek(), ValueType::Int)
     }
 
-    pub fn pop_expecting_object(&mut self) -> Option<ObjectType> {
+    pub fn peek_expecting_object(&mut self) -> bool {
+        matches!(self.peek(), ValueType::Object(_))
+    }
+
+    pub fn pop_object(&mut self) -> Option<ObjectType> {
         match self.pop() {
             ValueType::Object(object_type) => Some(object_type),
             _ => None,

--- a/core/src/avm2/optimizer/nop_remover.rs
+++ b/core/src/avm2/optimizer/nop_remover.rs
@@ -44,7 +44,13 @@ pub fn remove_nops<'gc>(code: &mut Vec<Op<'gc>>, exceptions: &mut [Exception<'gc
             Op::RunIntInterpreter(info) => {
                 for op in &info.ops {
                     match op {
-                        IntOp::ExternalJump { offset } => {
+                        IntOp::IfFalseExternal { offset, .. } => {
+                            offset.set(offset_vec[offset.get() as usize] as u32);
+                        }
+                        IntOp::IfTrueExternal { offset, .. } => {
+                            offset.set(offset_vec[offset.get() as usize] as u32);
+                        }
+                        IntOp::JumpExternal { offset, .. } => {
                             offset.set(offset_vec[offset.get() as usize] as u32);
                         }
                         _ => {}

--- a/core/src/avm2/optimizer/nop_remover.rs
+++ b/core/src/avm2/optimizer/nop_remover.rs
@@ -41,6 +41,9 @@ pub fn remove_nops<'gc>(code: &mut Vec<Op<'gc>>, exceptions: &mut [Exception<'gc
                     target.set(offset_vec[target.get()]);
                 }
             }
+            Op::RunIntInterpreter(info) => {
+                info.exit_offset.set(offset_vec[info.exit_offset.get()]);
+            }
             _ => {}
         }
     }

--- a/core/src/avm2/optimizer/nop_remover.rs
+++ b/core/src/avm2/optimizer/nop_remover.rs
@@ -42,16 +42,14 @@ pub fn remove_nops<'gc>(code: &mut Vec<Op<'gc>>, exceptions: &mut [Exception<'gc
                 }
             }
             Op::RunIntInterpreter(info) => {
-                for op in &info.ops {
+                let mut ops = info.ops.borrow_mut();
+
+                for op in &mut *ops {
                     match op {
-                        IntOp::IfFalseExternal { offset, .. } => {
-                            offset.set(offset_vec[offset.get() as usize] as u32);
-                        }
-                        IntOp::IfTrueExternal { offset, .. } => {
-                            offset.set(offset_vec[offset.get() as usize] as u32);
-                        }
-                        IntOp::JumpExternal { offset, .. } => {
-                            offset.set(offset_vec[offset.get() as usize] as u32);
+                        IntOp::IfFalseExternal { offset, .. }
+                        | IntOp::IfTrueExternal { offset, .. }
+                        | IntOp::JumpExternal { offset, .. } => {
+                            *offset = offset_vec[*offset as usize] as u32;
                         }
                         _ => {}
                     }

--- a/core/src/avm2/optimizer/nop_remover.rs
+++ b/core/src/avm2/optimizer/nop_remover.rs
@@ -1,4 +1,4 @@
-use crate::avm2::op::Op;
+use crate::avm2::op::{IntOp, Op};
 use crate::avm2::verify::Exception;
 
 pub fn remove_nops<'gc>(code: &mut Vec<Op<'gc>>, exceptions: &mut [Exception<'gc>]) {
@@ -42,7 +42,14 @@ pub fn remove_nops<'gc>(code: &mut Vec<Op<'gc>>, exceptions: &mut [Exception<'gc
                 }
             }
             Op::RunIntInterpreter(info) => {
-                info.exit_offset.set(offset_vec[info.exit_offset.get()]);
+                for op in &info.ops {
+                    match op {
+                        IntOp::ExternalJump { offset } => {
+                            offset.set(offset_vec[offset.get() as usize] as u32);
+                        }
+                        _ => {}
+                    }
+                }
             }
             _ => {}
         }

--- a/core/src/avm2/optimizer/peephole.rs
+++ b/core/src/avm2/optimizer/peephole.rs
@@ -1,7 +1,8 @@
 use crate::avm2::op::Op;
+use crate::avm2::optimizer::utils::SmallBitSet;
 
 use std::cell::Cell;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 /// A peephole optimizer to run before type-aware optimizations. This should be
 /// called once on the entire code slice.
@@ -24,6 +25,7 @@ pub fn preprocess_peephole(ops: &[Cell<Op<'_>>]) {
 pub fn postprocess_peephole<'a>(
     ops: &'a [Cell<Op<'_>>],
     jump_targets: &HashSet<usize>,
+    empty_stack_positions: &mut BTreeMap<usize, SmallBitSet>,
     has_exceptions: bool,
 ) {
     // Gather some information...
@@ -66,6 +68,10 @@ pub fn postprocess_peephole<'a>(
             last_op = None;
         }
 
+        // NOTE: If a peephole optimization changes the stack from being empty
+        // to being non-empty at a certain position, it MUST make sure to
+        // invalidate that position in `empty_stack_positions`.
+
         if let Some(last_op) = last_op {
             // Optimizations on both the current and the last op
             match (last_op.get(), current_op.get()) {
@@ -94,6 +100,13 @@ pub fn postprocess_peephole<'a>(
                     // SetLocal+GetLocal becomes Nop+StoreLocal
                     last_op.set(Op::Nop);
                     current_op.set(Op::StoreLocal { index: index1 });
+
+                    // It's possible that before this peephole optimization, the
+                    // stack was empty at the `GetLocal`'s position. However,
+                    // after this optimization, it is guaranteed that the stack
+                    // is no longer empty at the `GetLocal`'s position, as the
+                    // `StoreLocal` keeps one entry on the stack.
+                    empty_stack_positions.remove(&i);
                 }
                 (Op::AddIntegral, Op::CoerceI) => {
                     // An integral addition that yields Number on overflow

--- a/core/src/avm2/optimizer/peephole.rs
+++ b/core/src/avm2/optimizer/peephole.rs
@@ -120,6 +120,19 @@ pub fn postprocess_peephole<'a>(
                     last_op.set(Op::SubtractI);
                     current_op.set(Op::Nop);
                 }
+                (Op::MultiplyIntegral, Op::CoerceI) => {
+                    // The same is *not* true for multiplication, but we do have
+                    // a specialized `MultiplyIntegralI` op for this purpose.
+                    last_op.set(Op::MultiplyIntegralI);
+                    current_op.set(Op::Nop);
+                }
+                (Op::URShift, Op::CoerceI) => {
+                    // An unsigned right shift followed by coerce-to-integer is
+                    // equivalent to an unsigned right shift with the result
+                    // interpreted as a signed integer
+                    last_op.set(Op::URShiftI);
+                    current_op.set(Op::Nop);
+                }
                 (
                     Op::AddIntegral,
                     Op::Li8 | Op::Li16 | Op::Li32 | Op::Si8 | Op::Si16 | Op::Si32,
@@ -134,6 +147,18 @@ pub fn postprocess_peephole<'a>(
                     // The same is true for subtraction
                     last_op.set(Op::SubtractI);
                 }
+                (
+                    Op::MultiplyIntegral,
+                    Op::Li8 | Op::Li16 | Op::Li32 | Op::Si8 | Op::Si16 | Op::Si32,
+                ) => {
+                    // The same is *not* true for multiplication, but we do have
+                    // a specialized `MultiplyIntegralI` op for this purpose.
+                    last_op.set(Op::MultiplyIntegralI);
+                }
+                (Op::URShift, Op::Li8 | Op::Li16 | Op::Li32 | Op::Si8 | Op::Si16 | Op::Si32) => {
+                    // See comments above
+                    last_op.set(Op::URShiftI);
+                }
                 (Op::AddIntegral, Op::SetSlotCoerceI { index }) => {
                     // See comments above
                     last_op.set(Op::AddI);
@@ -142,6 +167,17 @@ pub fn postprocess_peephole<'a>(
                 (Op::SubtractIntegral, Op::SetSlotCoerceI { index }) => {
                     // The same is true for subtraction
                     last_op.set(Op::SubtractI);
+                    current_op.set(Op::SetSlotNoCoerce { index });
+                }
+                (Op::MultiplyIntegral, Op::SetSlotCoerceI { index }) => {
+                    // The same is *not* true for multiplication, but we do have
+                    // a specialized `MultiplyIntegralI` op for this purpose.
+                    last_op.set(Op::MultiplyIntegralI);
+                    current_op.set(Op::SetSlotNoCoerce { index });
+                }
+                (Op::URShift, Op::SetSlotCoerceI { index }) => {
+                    // See comments above
+                    last_op.set(Op::URShiftI);
                     current_op.set(Op::SetSlotNoCoerce { index });
                 }
                 _ => {}

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -18,7 +18,7 @@ use std::cell::Cell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-enum ConstantValue {
+pub enum ConstantValue {
     True,
     False,
     Null,
@@ -34,7 +34,7 @@ impl ConstantValue {
 }
 
 #[derive(Clone, Copy, PartialEq)]
-struct OptValue<'gc> {
+pub struct OptValue<'gc> {
     // This corresponds to the compile-time assumptions about the type:
     // - primitive types can't be undefined or null,
     // - Object (and any other non-primitive type) is non-undefined, but can be null
@@ -290,7 +290,7 @@ impl std::fmt::Debug for OptValue<'_> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct Locals<'gc>(Vec<OptValue<'gc>>);
+pub struct Locals<'gc>(Vec<OptValue<'gc>>);
 
 impl<'gc> Locals<'gc> {
     fn new(size: usize) -> Self {
@@ -305,17 +305,17 @@ impl<'gc> Locals<'gc> {
         self.0[index] = value;
     }
 
-    fn at(&self, index: usize) -> OptValue<'gc> {
+    pub fn at(&self, index: usize) -> OptValue<'gc> {
         self.0[index]
     }
 
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.0.len()
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct Stack<'gc>(Vec<OptValue<'gc>>, usize);
+pub struct Stack<'gc>(Vec<OptValue<'gc>>, usize);
 
 impl<'gc> Stack<'gc> {
     fn new(max_height: usize) -> Self {
@@ -411,11 +411,11 @@ impl<'gc> Stack<'gc> {
         self.0[index] = value;
     }
 
-    fn at(&self, index: usize) -> OptValue<'gc> {
+    pub fn at(&self, index: usize) -> OptValue<'gc> {
         self.0[index]
     }
 
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.0.len()
     }
 
@@ -425,7 +425,7 @@ impl<'gc> Stack<'gc> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct ScopeStack<'gc>(Vec<(OptValue<'gc>, bool)>, usize);
+pub struct ScopeStack<'gc>(Vec<(OptValue<'gc>, bool)>, usize);
 
 impl<'gc> ScopeStack<'gc> {
     fn new(max_height: usize) -> Self {
@@ -492,10 +492,10 @@ impl<'gc> ScopeStack<'gc> {
 }
 
 #[derive(Clone, Debug)]
-struct AbstractState<'gc> {
-    locals: Locals<'gc>,
-    stack: Stack<'gc>,
-    scope_stack: ScopeStack<'gc>,
+pub struct AbstractState<'gc> {
+    pub locals: Locals<'gc>,
+    pub stack: Stack<'gc>,
+    pub scope_stack: ScopeStack<'gc>,
 }
 
 struct AbstractStateRef<'a, 'gc> {
@@ -611,7 +611,7 @@ pub fn type_aware_optimize<'gc>(
     resolved_parameters: &[ResolvedParamConfig<'gc>],
     jump_targets: &mut HashSet<usize>,
     mut empty_stack_positions: &mut BTreeMap<usize, SmallBitSet>,
-) -> Result<(), Error<'gc>> {
+) -> Result<(HashMap<usize, usize>, Vec<Option<AbstractState<'gc>>>), Error<'gc>> {
     let (block_list, op_index_to_block_index_table) = assemble_blocks(code_slice, jump_targets);
 
     let types = Types {
@@ -731,7 +731,7 @@ pub fn type_aware_optimize<'gc>(
     // as dead code elimination, more likely to happen.
     recalculate_jump_targets(code_slice, method_exceptions, jump_targets);
 
-    Ok(())
+    Ok((op_index_to_block_index_table, abstract_states))
 }
 
 fn process_jump<'gc>(

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -921,8 +921,12 @@ fn abstract_interpret_ops<'gc>(
                 stack.push_class(activation, types.uint)?;
             }
             Op::Equals | Op::StrictEquals => {
-                stack.pop(activation)?;
-                stack.pop(activation)?;
+                let value2 = stack.pop(activation)?;
+                let value1 = stack.pop(activation)?;
+
+                if value1.class == Some(types.int) && value2.class == Some(types.int) {
+                    optimize_op_to!(Op::EqualsIntegral);
+                }
 
                 stack.push_class(activation, types.boolean)?;
             }
@@ -2204,6 +2208,7 @@ fn abstract_interpret_ops<'gc>(
             | Op::CoerceISwapPop
             | Op::CoerceUSwapPop
             | Op::ConstructSlot { .. }
+            | Op::EqualsIntegral
             | Op::GetScriptGlobals { .. }
             | Op::GreaterEqualsIntegral
             | Op::GreaterThanIntegral

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -7,6 +7,7 @@ use crate::avm2::method::{Method, MethodAssociation, MethodKind, ResolvedParamCo
 use crate::avm2::multiname::Multiname;
 use crate::avm2::op::Op;
 use crate::avm2::optimizer::blocks::assemble_blocks;
+use crate::avm2::optimizer::utils::SmallBitSet;
 use crate::avm2::property::Property;
 use crate::avm2::verify::Exception;
 use crate::avm2::vtable::VTable;
@@ -14,7 +15,7 @@ use crate::avm2::{Activation, Class, Error};
 
 use gc_arena::Gc;
 use std::cell::Cell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum ConstantValue {
@@ -609,6 +610,7 @@ pub fn type_aware_optimize<'gc>(
     method_exceptions: &mut [Exception<'gc>],
     resolved_parameters: &[ResolvedParamConfig<'gc>],
     jump_targets: &mut HashSet<usize>,
+    mut empty_stack_positions: &mut BTreeMap<usize, SmallBitSet>,
 ) -> Result<(), Error<'gc>> {
     let (block_list, op_index_to_block_index_table) = assemble_blocks(code_slice, jump_targets);
 
@@ -697,29 +699,31 @@ pub fn type_aware_optimize<'gc>(
             &types,
             &op_index_to_block_index_table,
             method_exceptions,
+            &mut empty_stack_positions,
             &mut worklist,
             false,
         )?;
     }
 
-    if activation.avm2().optimizer_enabled() {
-        // Now run through the ops and actually optimize them
-        for (i, block) in block_list.iter().enumerate() {
-            // todo: don't need to clone here
-            let block_entry_state = abstract_states[i].clone().expect("Entry state not found");
-            abstract_interpret_ops(
-                activation,
-                block.start_index,
-                block.ops,
-                block_entry_state,
-                &mut abstract_states,
-                &types,
-                &op_index_to_block_index_table,
-                method_exceptions,
-                &mut worklist,
-                true,
-            )?;
-        }
+    // Now run through the ops for the final pass for actual optimizations. No
+    // actual optimizations will be done if `activation.avm2().optimizer_enabled`
+    // is `false`.
+    for (i, block) in block_list.iter().enumerate() {
+        // todo: don't need to clone here
+        let block_entry_state = abstract_states[i].clone().expect("Entry state not found");
+        abstract_interpret_ops(
+            activation,
+            block.start_index,
+            block.ops,
+            block_entry_state,
+            &mut abstract_states,
+            &types,
+            &op_index_to_block_index_table,
+            method_exceptions,
+            &mut empty_stack_positions,
+            &mut worklist,
+            true,
+        )?;
     }
 
     // It's possible that an optimization removed some jumps, so let's
@@ -776,12 +780,15 @@ fn abstract_interpret_ops<'gc>(
     types: &Types<'gc>,
     op_index_to_block_index_table: &HashMap<usize, usize>,
     method_exceptions: &[Exception<'gc>],
+    empty_stack_positions: &mut BTreeMap<usize, SmallBitSet>,
     worklist: &mut Vec<usize>,
     do_optimize: bool,
 ) -> Result<(), Error<'gc>> {
     let mut locals = initial_state.locals;
     let mut stack = initial_state.stack;
     let mut scope_stack = initial_state.scope_stack;
+
+    let optimizer_enabled = activation.avm2().optimizer_enabled();
 
     for (i, op) in ops.iter().enumerate() {
         if op.get().can_throw_error() {
@@ -817,9 +824,29 @@ fn abstract_interpret_ops<'gc>(
             }
         }
 
+        // During the final optimization pass, for all empty stack positions,
+        // determine which of the locals are integral at each of those stack
+        // positions.
+        if do_optimize {
+            if stack.len() == 0 {
+                // `FromIterator` will truncate the bitset if there are too many
+                // locals. However, that doesn't matter, as that would mean that
+                // there are so many locals that int interpreter analysis will
+                // never be done, which means that this bitset's contents will
+                // be discarded.
+                let locals_integral_state = locals
+                    .0
+                    .iter()
+                    .map(|l| l.class.is_some_and(|c| c.is_builtin_int()))
+                    .collect::<SmallBitSet>();
+
+                empty_stack_positions.insert(start_index + i, locals_integral_state);
+            }
+        }
+
         macro_rules! optimize_op_to {
             ($replacement_op:expr) => {
-                if do_optimize {
+                if optimizer_enabled && do_optimize {
                     op.set($replacement_op);
                 }
             };
@@ -2143,6 +2170,7 @@ fn abstract_interpret_ops<'gc>(
             | Op::ConstructSlot { .. }
             | Op::GetScriptGlobals { .. }
             | Op::PopJump { .. }
+            | Op::RunIntInterpreter { .. }
             | Op::SetSlotCoerceI { .. }
             | Op::SetSlotNoCoerce { .. }
             | Op::SubtractIntegral => unreachable!("Custom ops should not be encountered"),

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -1093,8 +1093,13 @@ fn abstract_interpret_ops<'gc>(
                 stack.push_class(activation, types.number)?;
             }
             Op::Multiply => {
-                stack.pop(activation)?;
-                stack.pop(activation)?;
+                let value2 = stack.pop(activation)?;
+                let value1 = stack.pop(activation)?;
+
+                if value1.class == Some(types.int) && value2.class == Some(types.int) {
+                    optimize_op_to!(Op::MultiplyIntegral);
+                }
+
                 stack.push_class(activation, types.number)?;
             }
             Op::Divide => {
@@ -2214,11 +2219,14 @@ fn abstract_interpret_ops<'gc>(
             | Op::GreaterThanIntegral
             | Op::LessEqualsIntegral
             | Op::LessThanIntegral
+            | Op::MultiplyIntegral
+            | Op::MultiplyIntegralI
             | Op::PopJump { .. }
             | Op::RunIntInterpreter { .. }
             | Op::SetSlotCoerceI { .. }
             | Op::SetSlotNoCoerce { .. }
-            | Op::SubtractIntegral => unreachable!("Custom ops should not be encountered"),
+            | Op::SubtractIntegral
+            | Op::URShiftI => unreachable!("Custom ops should not be encountered"),
         }
     }
 

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -920,14 +920,50 @@ fn abstract_interpret_ops<'gc>(
                 }
                 stack.push_class(activation, types.uint)?;
             }
-            Op::Equals
-            | Op::StrictEquals
-            | Op::LessEquals
-            | Op::LessThan
-            | Op::GreaterThan
-            | Op::GreaterEquals => {
+            Op::Equals | Op::StrictEquals => {
                 stack.pop(activation)?;
                 stack.pop(activation)?;
+
+                stack.push_class(activation, types.boolean)?;
+            }
+            Op::GreaterEquals => {
+                let value2 = stack.pop(activation)?;
+                let value1 = stack.pop(activation)?;
+
+                if value1.class == Some(types.int) && value2.class == Some(types.int) {
+                    optimize_op_to!(Op::GreaterEqualsIntegral);
+                }
+
+                stack.push_class(activation, types.boolean)?;
+            }
+            Op::GreaterThan => {
+                let value2 = stack.pop(activation)?;
+                let value1 = stack.pop(activation)?;
+
+                if value1.class == Some(types.int) && value2.class == Some(types.int) {
+                    optimize_op_to!(Op::GreaterThanIntegral);
+                }
+
+                stack.push_class(activation, types.boolean)?;
+            }
+            Op::LessEquals => {
+                let value2 = stack.pop(activation)?;
+                let value1 = stack.pop(activation)?;
+
+                if value1.class == Some(types.int) && value2.class == Some(types.int) {
+                    optimize_op_to!(Op::LessEqualsIntegral);
+                }
+
+                stack.push_class(activation, types.boolean)?;
+            }
+            Op::LessThan => {
+                let value2 = stack.pop(activation)?;
+                let value1 = stack.pop(activation)?;
+
+                if value1.class == Some(types.int) && value2.class == Some(types.int) {
+                    optimize_op_to!(Op::LessThanIntegral);
+                }
+
                 stack.push_class(activation, types.boolean)?;
             }
             Op::Not => {
@@ -2169,6 +2205,10 @@ fn abstract_interpret_ops<'gc>(
             | Op::CoerceUSwapPop
             | Op::ConstructSlot { .. }
             | Op::GetScriptGlobals { .. }
+            | Op::GreaterEqualsIntegral
+            | Op::GreaterThanIntegral
+            | Op::LessEqualsIntegral
+            | Op::LessThanIntegral
             | Op::PopJump { .. }
             | Op::RunIntInterpreter { .. }
             | Op::SetSlotCoerceI { .. }

--- a/core/src/avm2/optimizer/utils.rs
+++ b/core/src/avm2/optimizer/utils.rs
@@ -1,16 +1,20 @@
 use std::fmt;
 
-/// A bitset only large enough to store 32 bits.
+/// A bitset only large enough to store 64 bits.
 ///
 /// Trying to create a bitset with more items will result in it being silently
 /// truncated.
 #[derive(Clone, Copy)]
 pub struct SmallBitSet {
-    bits: u32,
-    len: u8,
+    bits: u64,
+    len: usize,
 }
 
 impl SmallBitSet {
+    pub fn new(len: usize) -> Self {
+        Self { bits: 0, len }
+    }
+
     pub fn get(&self, index: usize) -> bool {
         if index >= self.len() {
             panic!("Attempted to access bit out of range");
@@ -19,12 +23,8 @@ impl SmallBitSet {
         ((self.bits >> index) & 1) == 1
     }
 
-    pub fn set(&mut self, index: usize, value: bool) {
-        if value {
-            self.bits |= 1 << index;
-        } else {
-            self.bits &= !(1 << index);
-        }
+    pub fn set(&mut self, index: usize) {
+        self.bits |= 1 << index;
     }
 
     pub fn iter(&self) -> SmallBitSetIter {
@@ -36,7 +36,7 @@ impl SmallBitSet {
     }
 
     pub fn len(&self) -> usize {
-        self.len as usize
+        self.len
     }
 }
 
@@ -45,20 +45,19 @@ impl FromIterator<bool> for SmallBitSet {
     where
         I: IntoIterator<Item = bool>,
     {
-        let mut len: u8 = 0;
+        let mut len = 0;
         let mut bits = 0;
 
-        // NOTE: We take only 32 items from the iterator, as that's the most
+        // NOTE: We take only 64 items from the iterator, as that's the most
         // that can fit in this bitset.
-        let iter = iter.into_iter().enumerate().take(u32::BITS as usize);
+        let iter = iter.into_iter().enumerate().take(u64::BITS as usize);
 
         for (i, bit) in iter {
             if bit {
                 bits |= 1 << i;
             }
 
-            // size should never overflow
-            len = len.strict_add(1);
+            len += 1;
         }
 
         Self { bits, len }

--- a/core/src/avm2/optimizer/utils.rs
+++ b/core/src/avm2/optimizer/utils.rs
@@ -27,6 +27,10 @@ impl SmallBitSet {
         self.bits |= 1 << index;
     }
 
+    pub fn clear(&mut self) {
+        self.bits = 0;
+    }
+
     pub fn iter(&self) -> SmallBitSetIter {
         SmallBitSetIter {
             // Clone is free

--- a/core/src/avm2/optimizer/utils.rs
+++ b/core/src/avm2/optimizer/utils.rs
@@ -4,7 +4,7 @@ use std::fmt;
 ///
 /// Trying to create a bitset with more items will result in it being silently
 /// truncated.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct SmallBitSet {
     bits: u32,
     len: u8,

--- a/core/src/avm2/optimizer/utils.rs
+++ b/core/src/avm2/optimizer/utils.rs
@@ -39,6 +39,10 @@ impl SmallBitSet {
         }
     }
 
+    pub fn count_ones(&self) -> usize {
+        self.bits.count_ones() as usize
+    }
+
     pub fn len(&self) -> usize {
         self.len
     }

--- a/core/src/avm2/optimizer/utils.rs
+++ b/core/src/avm2/optimizer/utils.rs
@@ -1,0 +1,101 @@
+use std::fmt;
+
+/// A bitset only large enough to store 32 bits.
+///
+/// Trying to create a bitset with more items will result in it being silently
+/// truncated.
+#[derive(Clone)]
+pub struct SmallBitSet {
+    bits: u32,
+    len: u8,
+}
+
+impl SmallBitSet {
+    pub fn get(&self, index: usize) -> bool {
+        if index >= self.len() {
+            panic!("Attempted to access bit out of range");
+        }
+
+        ((self.bits >> index) & 1) == 1
+    }
+
+    pub fn set(&mut self, index: usize, value: bool) {
+        if value {
+            self.bits |= 1 << index;
+        } else {
+            self.bits &= !(1 << index);
+        }
+    }
+
+    pub fn iter(&self) -> SmallBitSetIter {
+        SmallBitSetIter {
+            // Clone is free
+            state: self.clone(),
+            next: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+}
+
+impl FromIterator<bool> for SmallBitSet {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = bool>,
+    {
+        let mut len: u8 = 0;
+        let mut bits = 0;
+
+        // NOTE: We take only 32 items from the iterator, as that's the most
+        // that can fit in this bitset.
+        let iter = iter.into_iter().enumerate().take(u32::BITS as usize);
+
+        for (i, bit) in iter {
+            if bit {
+                bits |= 1 << i;
+            }
+
+            // size should never overflow
+            len = len.strict_add(1);
+        }
+
+        Self { bits, len }
+    }
+}
+
+pub struct SmallBitSetIter {
+    state: SmallBitSet,
+    next: usize,
+}
+
+impl Iterator for SmallBitSetIter {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        if self.next >= self.state.len() {
+            None
+        } else {
+            let value = self.state.get(self.next);
+            self.next += 1;
+
+            Some(value)
+        }
+    }
+}
+
+impl fmt::Debug for SmallBitSet {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let mut result = String::new();
+        for i in 0..self.len() {
+            if self.get(i) {
+                result.push('1');
+            } else {
+                result.push('0');
+            }
+        }
+
+        write!(f, "{}", result)
+    }
+}

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -117,6 +117,16 @@ impl<'gc> PropertyClass<'gc> {
         }
     }
 
+    pub fn get_existing_class(&self) -> Option<Class<'gc>> {
+        match self {
+            PropertyClass::Class(class) => Some(*class),
+            PropertyClass::Name(_, _) => {
+                panic!("get_existing_class was called but class was not initialized")
+            }
+            PropertyClass::Any => None,
+        }
+    }
+
     pub fn get_name(&self, context: &mut StringContext<'gc>) -> AvmString<'gc> {
         match self {
             PropertyClass::Class(class) => class.name().to_qualified_name(context.gc()),


### PR DESCRIPTION
## Description

Full implementation of the int interpreter, a specialized version of the normal AVM2 interpreter that works mostly on integers. This allows it to be "much" (~20-50%) faster than the normal interpreter. Only limited sections of code can be run in the int interpreter, but this is very helpful for hot loops that only do those operations. For example, in Evoland, this code is run every frame:

```
        public function applyMask(param1:int, param2:int) : void {
            var _loc7_:int = 0;
            var _loc8_:int = 0;
            var _loc9_:int = 0;
            var _loc10_:int = 0;
            var _loc3_:ByteArray = output.getPixels(output.rect);
            ApplicationDomain.currentDomain.domainMemory = _loc3_;
            var _loc4_:int = 0;
            var _loc5_:int = 0;
            var _loc6_:int = output.width * output.height;
            while(_loc5_ < _loc6_) {
                _loc7_ = _loc5_++;
                _loc8_ = li8(_loc4_) + param1;
                if(_loc8_ > 255) {
                    _loc8_ = 255;
                }
                si8(_loc8_ & param2,_loc4_++);
                _loc9_ = li8(_loc4_) + param1;
                if(_loc9_ > 255) {
                    _loc9_ = 255;
                }
                si8(_loc9_ & param2,_loc4_++);
                _loc10_ = li8(_loc4_) + param1;
                if(_loc10_ > 255) {
                    _loc10_ = 255;
                }
                si8(_loc10_ & param2,_loc4_++);
                _loc4_++;
            }
            _loc3_.position = 0;
            output.setPixels(output.rect,_loc3_);
        }
```

With this PR, the entire loop is run in the int interpreter- for me, the method goes from taking about 150ms to about 75ms.

This PR will be a draft forever; I'll PR separate parts of the int interpreter separately.

TODO:
- [x] Improve heuristics and add nop removal to fix performance regression on very specific cases
- [ ] Add tests for a few silly things I caught while writing the PR
- [ ] Some cleanup
  - [ ] Separate a lot of the optimizer code into functions
  - [ ] Remove last comment on ValueType as it's no longer true
- [ ] Appease clippy
- [x] Separate first three/four commits into another PR to start getting work in (#23926)

## Testing

I've tested this on Doom Triple Pack (#14816) and the original Evoland (#10560). In Doom, the FPS increases by ~40%. In Evoland, the FPS increases by ~100%.

Here are the results on Evoland:

Before:

https://github.com/user-attachments/assets/4d63928d-87fe-4c24-828b-cb214bb92b6c


After:

https://github.com/user-attachments/assets/c490e8e2-d1c0-40c2-9f51-9ab8f3e0f5f1


## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
