### PR TITLE
core: Simplify code in MovieClip.event_dispatch

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2911,50 +2911,49 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
         }
 
         let mut handled = ClipEventResult::NotHandled;
-        if let Some(object) = self.0.object1.get() {
-            let swf_version = self.0.movie().version();
-            if swf_version >= 5 {
-                if let Some(flag) = event.flag() {
-                    for event_handler in self
-                        .clip_actions()
-                        .iter()
-                        .filter(|handler| handler.events.contains(flag))
-                    {
-                        // KeyPress event must have matching key code.
-                        if let ClipEvent::KeyPress { key_code } = event {
-                            if key_code == event_handler.key_code {
-                                // KeyPress events are consumed by a single instance.
-                                handled = ClipEventResult::Handled;
-                            } else {
-                                continue;
-                            }
-                        }
-
-                        context.action_queue.queue_action(
-                            self.into(),
-                            ActionType::Normal {
-                                bytecode: event_handler.action_data.clone(),
-                            },
-                            event == ClipEvent::Unload,
-                        );
-                    }
-                }
-
-                // Queue ActionScript-defined event handlers after the SWF defined ones.
-                // (e.g., clip.onEnterFrame = foo).
-                if self.should_fire_event_handlers(context, event)
-                    && let Some(name) = event.method_name(&context.strings)
+        if self.0.movie().version() >= 5
+            && let Some(object) = self.0.object1.get()
+        {
+            if let Some(flag) = event.flag() {
+                for event_handler in self
+                    .clip_actions()
+                    .iter()
+                    .filter(|handler| handler.events.contains(flag))
                 {
+                    // KeyPress event must have matching key code.
+                    if let ClipEvent::KeyPress { key_code } = event {
+                        if key_code == event_handler.key_code {
+                            // KeyPress events are consumed by a single instance.
+                            handled = ClipEventResult::Handled;
+                        } else {
+                            continue;
+                        }
+                    }
+
                     context.action_queue.queue_action(
                         self.into(),
-                        ActionType::Method {
-                            object,
-                            name,
-                            args: vec![],
+                        ActionType::Normal {
+                            bytecode: event_handler.action_data.clone(),
                         },
                         event == ClipEvent::Unload,
                     );
                 }
+            }
+
+            // Queue ActionScript-defined event handlers after the SWF defined ones.
+            // (e.g., clip.onEnterFrame = foo).
+            if self.should_fire_event_handlers(context, event)
+                && let Some(name) = event.method_name(&context.strings)
+            {
+                context.action_queue.queue_action(
+                    self.into(),
+                    ActionType::Method {
+                        object,
+                        name,
+                        args: vec![],
+                    },
+                    event == ClipEvent::Unload,
+                );
             }
         }
 


### PR DESCRIPTION

## Description

We can get rid of one indentation level.

## Testing

N/A

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
