### PR TITLE
swf: Add support for PlaceObject/allEventFlags

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1539,6 +1539,7 @@ impl<'gc> MovieClip<'gc> {
                         // Convert from `swf::ClipAction` to Ruffle's `ClipEventHandler`.
                         clip.init_clip_event_handlers(
                             clip_actions
+                                .records
                                 .iter()
                                 .cloned()
                                 .map(|a| ClipEventHandler::from_action_and_movie(a, movie.clone()))

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -2057,14 +2057,17 @@ impl<'a> Reader<'a> {
         BlendMode::from_u8(self.read_u8()?).ok_or_else(|| Error::invalid_data("Invalid blend mode"))
     }
 
-    fn read_clip_actions(&mut self) -> Result<Vec<ClipAction<'a>>> {
+    fn read_clip_actions(&mut self) -> Result<ClipActions<'a>> {
         self.read_u16()?; // Must be 0
-        self.read_clip_event_flags(); // All event flags
-        let mut clip_actions = vec![];
+        let all_event_flags = self.read_clip_event_flags();
+        let mut records = vec![];
         while let Some(clip_action) = self.read_clip_action()? {
-            clip_actions.push(clip_action);
+            records.push(clip_action);
         }
-        Ok(clip_actions)
+        Ok(ClipActions {
+            all_event_flags,
+            records,
+        })
     }
 
     fn read_clip_action(&mut self) -> Result<Option<ClipAction<'a>>> {

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -1895,11 +1895,14 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 filters: None,
                 background_color: None,
                 blend_mode: None,
-                clip_actions: Some(vec![ClipAction {
-                    events: ClipEventFlag::ENTER_FRAME,
-                    key_code: None,
-                    action_data: &[150, 6, 0, 0, 99, 108, 105, 112, 0, 38, 0],
-                }]),
+                clip_actions: Some(ClipActions {
+                    all_event_flags: ClipEventFlag::ENTER_FRAME,
+                    records: vec![ClipAction {
+                        events: ClipEventFlag::ENTER_FRAME,
+                        key_code: None,
+                        action_data: &[150, 6, 0, 0, 99, 108, 105, 112, 0, 38, 0],
+                    }],
+                }),
                 has_image: false,
                 is_bitmap_cached: None,
                 is_visible: None,
@@ -1925,23 +1928,29 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 filters: None,
                 background_color: None,
                 blend_mode: None,
-                clip_actions: Some(vec![
-                    ClipAction {
-                        events: ClipEventFlag::PRESS | ClipEventFlag::RELEASE,
-                        key_code: None,
-                        action_data: &[150, 3, 0, 0, 65, 0, 38, 0],
-                    },
-                    ClipAction {
-                        events: ClipEventFlag::KEY_PRESS,
-                        key_code: Some(99),
-                        action_data: &[150, 3, 0, 0, 66, 0, 38, 0],
-                    },
-                    ClipAction {
-                        events: ClipEventFlag::ENTER_FRAME,
-                        key_code: None,
-                        action_data: &[150, 3, 0, 0, 67, 0, 38, 0],
-                    },
-                ]),
+                clip_actions: Some(ClipActions {
+                    all_event_flags: ClipEventFlag::PRESS
+                        | ClipEventFlag::RELEASE
+                        | ClipEventFlag::KEY_PRESS
+                        | ClipEventFlag::ENTER_FRAME,
+                    records: vec![
+                        ClipAction {
+                            events: ClipEventFlag::PRESS | ClipEventFlag::RELEASE,
+                            key_code: None,
+                            action_data: &[150, 3, 0, 0, 65, 0, 38, 0],
+                        },
+                        ClipAction {
+                            events: ClipEventFlag::KEY_PRESS,
+                            key_code: Some(99),
+                            action_data: &[150, 3, 0, 0, 66, 0, 38, 0],
+                        },
+                        ClipAction {
+                            events: ClipEventFlag::ENTER_FRAME,
+                            key_code: None,
+                            action_data: &[150, 3, 0, 0, 67, 0, 38, 0],
+                        },
+                    ],
+                }),
                 has_image: false,
                 is_bitmap_cached: None,
                 is_visible: None,
@@ -2094,18 +2103,23 @@ pub fn tag_tests() -> Vec<TagTestData> {
                     a: 255,
                 }),
                 blend_mode: Some(BlendMode::Difference),
-                clip_actions: Some(vec![
-                    ClipAction {
-                        events: ClipEventFlag::RELEASE_OUTSIDE | ClipEventFlag::ROLL_OVER,
-                        key_code: None,
-                        action_data: &[0],
-                    },
-                    ClipAction {
-                        events: ClipEventFlag::DATA,
-                        key_code: None,
-                        action_data: &[150, 3, 0, 0, 66, 0, 38, 0],
-                    },
-                ]),
+                clip_actions: Some(ClipActions {
+                    all_event_flags: ClipEventFlag::RELEASE_OUTSIDE
+                        | ClipEventFlag::ROLL_OVER
+                        | ClipEventFlag::DATA,
+                    records: vec![
+                        ClipAction {
+                            events: ClipEventFlag::RELEASE_OUTSIDE | ClipEventFlag::ROLL_OVER,
+                            key_code: None,
+                            action_data: &[0],
+                        },
+                        ClipAction {
+                            events: ClipEventFlag::DATA,
+                            key_code: None,
+                            action_data: &[150, 3, 0, 0, 66, 0, 38, 0],
+                        },
+                    ],
+                }),
                 has_image: false,
                 is_bitmap_cached: Some(true),
                 is_visible: Some(false),

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -324,7 +324,7 @@ pub struct PlaceObject<'a> {
     pub filters: Option<Vec<Filter>>,
     pub background_color: Option<Color>,
     pub blend_mode: Option<BlendMode>,
-    pub clip_actions: Option<Vec<ClipAction<'a>>>,
+    pub clip_actions: Option<ClipActions<'a>>,
     pub has_image: bool,
     pub is_bitmap_cached: Option<bool>,
     pub is_visible: Option<bool>,
@@ -456,6 +456,12 @@ pub struct ClipAction<'a> {
     pub events: ClipEventFlag,
     pub key_code: Option<KeyCode>,
     pub action_data: &'a [u8],
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClipActions<'a> {
+    pub all_event_flags: ClipEventFlag,
+    pub records: Vec<ClipAction<'a>>,
 }
 
 bitflags! {

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -1910,16 +1910,10 @@ impl<W: Write> Writer<W> {
         }
     }
 
-    fn write_clip_actions(&mut self, clip_actions: &[ClipAction]) -> Result<()> {
+    fn write_clip_actions(&mut self, clip_actions: &ClipActions) -> Result<()> {
         self.write_u16(0)?; // Reserved
-        {
-            let mut all_events = ClipEventFlag::empty();
-            for action in clip_actions {
-                all_events |= action.events;
-            }
-            self.write_clip_event_flags(all_events)?;
-        }
-        for action in clip_actions {
+        self.write_clip_event_flags(clip_actions.all_event_flags)?;
+        for action in &clip_actions.records {
             self.write_clip_event_flags(action.events)?;
             let action_length =
                 action.action_data.len() as u32 + if action.key_code.is_some() { 1 } else { 0 };


### PR DESCRIPTION
## Description

Previously, the swf crate assumed that this field contains only events available in records. This doesn't have to be the case, and Flash Player appears to be using this field for filtering events.

## Testing

No tests, this is groundwork for implementing SWF-observable Flash behaviors in core.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
