### PR TITLE
ci: Don't enable fontconfig-dlopen in the macOS Rust tester job

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -90,12 +90,6 @@ jobs:
         shell: bash
         run: echo FEATURES=${FEATURES},imgtests | tee -a $GITHUB_ENV
 
-        # TODO: Remove this once https://github.com/actions/runner-images/issues/14176 is fixed.
-      - name: Enable fontconfig-dlopen on macOS
-        if: runner.os == 'macOS'
-        shell: bash
-        run: echo FEATURES=${FEATURES},fontconfig-dlopen | tee -a $GITHUB_ENV
-
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
This reverts commit 6487ab548eef52c340e80b54322295b8c9f453ef (https://github.com/ruffle-rs/ruffle/pull/23855).

## Description

It was probably a caching problem. I have wiped them all, let's see.

## Testing

See if CI passes.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
