### PR TITLE
web: Support named access on document.embeds

### DIFF
--- a/web/packages/core/src/internal/polyfill-document-embeds.ts
+++ b/web/packages/core/src/internal/polyfill-document-embeds.ts
@@ -185,7 +185,19 @@ export function polyfillDocumentEmbeds(tries: number) {
                         if (!Number.isNaN(index) && index >= 0) {
                             return nodes()[index];
                         }
+
+                        // Let native properties ('length', 'item', etc.) pass through normally
+                        if (Reflect.has(target, prop)) {
+                            return Reflect.get(target, prop, receiver);
+                        }
+
+                        // Fallback to named item resolution for standard dot/bracket notation
+                        const element = target.namedItem(prop);
+                        if (element) {
+                            return element;
+                        }
                     }
+
                     return Reflect.get(target, prop, receiver);
                 },
                 has(target, prop) {
@@ -194,6 +206,12 @@ export function polyfillDocumentEmbeds(tries: number) {
                         if (!Number.isNaN(index) && index >= 0) {
                             return index < nodes().length;
                         }
+
+                        // Check if it's a native property or exists in the named list
+                        if (Reflect.has(target, prop)) {
+                            return true;
+                        }
+                        return target.namedItem(prop) !== null;
                     }
                     return Reflect.has(target, prop);
                 },

--- a/web/packages/selfhosted/test/polyfill/document_embeds/test.ts
+++ b/web/packages/selfhosted/test/polyfill/document_embeds/test.ts
@@ -273,4 +273,31 @@ describe("Document embeds", () => {
             hasLength: true,
         });
     });
+
+    it("prioritizes native 'length' property over an element named 'length'", async () => {
+        const result = await browser.execute(() => {
+            const e = document.createElement("embed");
+            e.id = "length_embed";
+            e.name = "length";
+            e.src = "about:blank";
+            document.body.appendChild(e);
+
+            const lengthValue = document.embeds["length"];
+            const typeofLength = typeof lengthValue;
+
+            const namedItemValue = document.embeds.namedItem("length")?.id;
+
+            return {
+                lengthValue,
+                typeofLength,
+                namedItemValue,
+            };
+        });
+
+        expect(result).to.deep.equal({
+            lengthValue: 6,
+            typeofLength: "number",
+            namedItemValue: "length_embed",
+        });
+    });
 });

--- a/web/packages/selfhosted/test/polyfill/document_embeds/test.ts
+++ b/web/packages/selfhosted/test/polyfill/document_embeds/test.ts
@@ -225,4 +225,52 @@ describe("Document embeds", () => {
             gamma: "emb4",
         });
     });
+
+    it("supports direct named access via proxy get", async () => {
+        const result = await browser.execute(() => {
+            // Explicitly declare the properties we intend to access to satisfy TS.
+            type EmbedPolyfillTest = HTMLCollectionOf<HTMLEmbedElement> & {
+                alpha?: Element;
+                beta?: Element;
+                delta?: Element;
+                emb3?: Element;
+                nope?: Element;
+            };
+            const embeds = document.embeds as unknown as EmbedPolyfillTest;
+
+            return {
+                alpha: embeds.alpha?.id,
+                beta: embeds["beta"]?.id,
+                delta: embeds.delta?.id,
+                emb3: embeds.emb3?.id,
+                missing: embeds.nope,
+            };
+        });
+
+        expect(result).to.deep.equal({
+            alpha: "emb1",
+            beta: "emb2",
+            delta: "basic_emb2",
+            emb3: "emb3",
+            missing: undefined,
+        });
+    });
+
+    it("supports the 'in' operator for named embeds", async () => {
+        const result = await browser.execute(() => {
+            return {
+                hasAlpha: "alpha" in document.embeds,
+                hasEmb3: "emb3" in document.embeds,
+                hasNope: "nope" in document.embeds,
+                hasLength: "length" in document.embeds,
+            };
+        });
+
+        expect(result).to.deep.equal({
+            hasAlpha: true,
+            hasEmb3: true,
+            hasNope: false,
+            hasLength: true,
+        });
+    });
 });


### PR DESCRIPTION
## Description

Add support for named accessors on document.embeds (e.g. document.embeds.movieemb or document.embeds["movieemb"]

https://sombrastorage.z19.web.core.windows.net/ruffle/js_flash tries to use this or named access on document (see https://github.com/ruffle-rs/ruffle/issues/22442 and https://github.com/ruffle-rs/ruffle/pull/22465) for its getFlashMovieObject function:
```js
function getFlashMovieObject()
{
  if (window.movieemb) 
  {
  let myMovie = window.movieemb; //window is standard to W3C, but only binds the name property
	document.getElementById("f1").innerHTML = "Hit " + myMovie + " directly!";
    return myMovie;
  }
  if (navigator.appName.indexOf("Microsoft Internet")==-1)
  {
	document.getElementById("f1").innerHTML = 'Hit on the embeds!';
    if (document.embeds && document.embeds["movieemb"])
      return document.embeds["movieemb"]; 
  }
  else // if (navigator.appName.indexOf("Microsoft Internet")!=-1)
  {
	  document.getElementById("f1").innerHTML = 'Hit on the ID!';
	  return document.getElementById("movieemb");
  }
}
```

## Testing

`npm install`
`npm run build`
`npm run wdio --workspaces --if-present -- --headless --parallel --firefox`

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
