### PR TITLE
avm2: Add type enum for error 2006

### DIFF
--- a/core/src/avm2/bytearray.rs
+++ b/core/src/avm2/bytearray.rs
@@ -1,6 +1,6 @@
 use crate::avm2::Activation;
 use crate::avm2::Error;
-use crate::avm2::error::{make_error_2006, make_error_2030};
+use crate::avm2::error::{Error2006Type, make_error_2006, make_error_2030};
 use crate::context::UpdateContext;
 use crate::string::{FromWStr, WStr};
 use flate2::Compression;
@@ -37,7 +37,9 @@ impl ByteArrayError {
     pub fn to_avm<'gc>(self, activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
         match self {
             ByteArrayError::EndOfFile => make_error_2030(activation),
-            ByteArrayError::IndexOutOfBounds => make_error_2006(activation),
+            ByteArrayError::IndexOutOfBounds => {
+                make_error_2006(activation, Error2006Type::RangeError)
+            }
         }
     }
 }

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -1322,14 +1322,24 @@ pub fn make_error_2005<'gc>(
     ))
 }
 
+pub enum Error2006Type {
+    // Stage3D x/y setters (not yet implemented) can throw this error as an ArgumentError
+    #[expect(unused)]
+    ArgumentError,
+    RangeError,
+}
+
 #[inline(never)]
 #[cold]
-pub fn make_error_2006<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
-    make_error!(range_error(
-        activation,
-        "Error #2006: The supplied index is out of bounds.",
-        2006,
-    ))
+pub fn make_error_2006<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    kind: Error2006Type,
+) -> Error<'gc> {
+    let message = "Error #2006: The supplied index is out of bounds.";
+    make_error!(match kind {
+        Error2006Type::ArgumentError => argument_error(activation, message, 2006),
+        Error2006Type::RangeError => range_error(activation, message, 2006),
+    })
 }
 
 #[inline(never)]

--- a/core/src/avm2/globals/flash/display/display_object_container.rs
+++ b/core/src/avm2/globals/flash/display/display_object_container.rs
@@ -5,8 +5,8 @@ use swf::Twips;
 
 use crate::avm2::activation::Activation;
 use crate::avm2::error::{
-    make_error_2006, make_error_2024, make_error_2025, make_error_2150, make_error_2180,
-    make_error_3783,
+    Error2006Type, make_error_2006, make_error_2024, make_error_2025, make_error_2150,
+    make_error_2180, make_error_3783,
 };
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::object::{Object, TObject as _};
@@ -58,7 +58,7 @@ fn validate_add_operation<'gc>(
     }
 
     if proposed_index > ctr.num_children() {
-        return Err(make_error_2006(activation));
+        return Err(make_error_2006(activation, Error2006Type::RangeError));
     }
 
     Ok(())
@@ -126,7 +126,7 @@ pub fn get_child_at<'gc>(
         return if let Some(child) = dobj.child_by_index(index as usize) {
             Ok(child.object2_or_null())
         } else {
-            Err(make_error_2006(activation))
+            Err(make_error_2006(activation, Error2006Type::RangeError))
         };
     }
 
@@ -312,7 +312,7 @@ pub fn remove_child_at<'gc>(
         let target_child = args.get_i32(0);
 
         if target_child >= ctr.num_children() as i32 || target_child < 0 {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         let child = ctr.child_by_index(target_child as usize).unwrap();
@@ -345,15 +345,15 @@ pub fn remove_children<'gc>(
         // https://github.com/ruffle-rs/ruffle/issues/11382
 
         if (from >= ctr.num_children() as i32 || from < 0) && to != i32::MAX {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         if (to >= ctr.num_children() as i32 || to < 0) && to != i32::MAX {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         if from > to {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         ctr.remove_range(
@@ -408,11 +408,11 @@ pub fn swap_children_at<'gc>(
         let bounds = ctr.num_children();
 
         if index0 < 0 || index0 as usize >= bounds {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         if index1 < 0 || index1 as usize >= bounds {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         let child0 = ctr.child_by_index(index0 as usize).unwrap();

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -1,4 +1,4 @@
-use crate::avm2::error::{Error, make_error_2006, make_error_2136};
+use crate::avm2::error::{Error, Error2006Type, make_error_2006, make_error_2136};
 use crate::avm2::globals::flash::display::display_object::initialize_for_allocator;
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::{Activation, ClassObject, Object, Value};
@@ -58,7 +58,7 @@ pub fn init<'gc>(
         let height = args.get_i32(1);
 
         if width < 0 || height < 0 {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         // Per Adobe docs, 0 falls back to the default dimensions.
@@ -67,7 +67,7 @@ pub fn init<'gc>(
         } else {
             let swf_version = activation.caller_movie_or_root().version();
             if !is_size_valid(swf_version, width as u32, height as u32) {
-                return Err(make_error_2006(activation));
+                return Err(make_error_2006(activation, Error2006Type::RangeError));
             }
             (width, height)
         };

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -1,7 +1,7 @@
 //! `flash.text.TextField` builtin/prototype
 
 use crate::avm2::activation::Activation;
-use crate::avm2::error::{make_error_2006, make_error_2008};
+use crate::avm2::error::{Error2006Type, make_error_2006, make_error_2008};
 use crate::avm2::globals::flash::display::display_object::initialize_for_allocator;
 use crate::avm2::object::{ClassObject, Object, TextFormatObject};
 use crate::avm2::parameters::ParametersExt;
@@ -777,7 +777,7 @@ pub fn get_text_format<'gc>(
         let mut end_index = args.get_i32(1);
 
         if end_index >= 0 && (begin_index >= end_index || begin_index < 0) {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         if begin_index < 0 {
@@ -957,7 +957,7 @@ pub fn set_text_format<'gc>(
         }
 
         if begin_index as usize > this.text_length() {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         if end_index < 0 {
@@ -965,7 +965,7 @@ pub fn set_text_format<'gc>(
         }
 
         if end_index as usize > this.text_length() {
-            return Err(make_error_2006(activation));
+            return Err(make_error_2006(activation, Error2006Type::RangeError));
         }
 
         this.set_text_format(
@@ -1187,13 +1187,13 @@ pub fn get_line_metrics<'gc>(
 
     let line_num = args.get_i32(0);
     if line_num < 0 {
-        return Err(make_error_2006(activation));
+        return Err(make_error_2006(activation, Error2006Type::RangeError));
     }
 
     let metrics = this.line_metrics(line_num as usize);
 
     let Some(metrics) = metrics else {
-        return Err(make_error_2006(activation));
+        return Err(make_error_2006(activation, Error2006Type::RangeError));
     };
 
     let metrics_class = activation.avm2().classes().textlinemetrics;
@@ -1226,13 +1226,13 @@ pub fn get_line_length<'gc>(
 
     let line_num = args.get_i32(0);
     if line_num < 0 {
-        return Err(make_error_2006(activation));
+        return Err(make_error_2006(activation, Error2006Type::RangeError));
     }
 
     if let Some(length) = this.line_length(line_num as usize) {
         Ok(Value::from_usize_lossy(length))
     } else {
-        Err(make_error_2006(activation))
+        Err(make_error_2006(activation, Error2006Type::RangeError))
     }
 }
 
@@ -1251,7 +1251,7 @@ pub fn get_line_text<'gc>(
         return if let Some(text) = this.line_text(line_num as usize) {
             Ok(AvmString::new(activation.gc(), text).into())
         } else {
-            Err(make_error_2006(activation))
+            Err(make_error_2006(activation, Error2006Type::RangeError))
         };
     }
 
@@ -1274,13 +1274,13 @@ pub fn get_line_offset<'gc>(
 
     let line_num = args.get_i32(0);
     if line_num < 0 {
-        return Err(make_error_2006(activation));
+        return Err(make_error_2006(activation, Error2006Type::RangeError));
     }
 
     if let Some(offset) = this.line_offset(line_num as usize) {
         Ok(Value::from_usize_lossy(offset))
     } else {
-        Err(make_error_2006(activation))
+        Err(make_error_2006(activation, Error2006Type::RangeError))
     }
 }
 

--- a/core/src/avm2/object/socket_object.rs
+++ b/core/src/avm2/object/socket_object.rs
@@ -1,6 +1,6 @@
 use crate::avm2::Activation;
 use crate::avm2::bytearray::{ByteArrayError, Endian, ObjectEncoding};
-use crate::avm2::error::{Error, make_error_2006};
+use crate::avm2::error::{Error, Error2006Type, make_error_2006};
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, TObject};
 use crate::socket::SocketHandle;
@@ -147,7 +147,7 @@ impl<'gc> SocketObject<'gc> {
             self.write_bytes(utf_string.as_bytes());
             Ok(())
         } else {
-            Err(make_error_2006(activation))
+            Err(make_error_2006(activation, Error2006Type::RangeError))
         }
     }
 }

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -1,5 +1,5 @@
 use crate::avm2::bytearray::{ByteArrayError, ByteArrayStorage};
-use crate::avm2::error::make_error_2006;
+use crate::avm2::error::{Error2006Type, make_error_2006};
 use crate::avm2::vector::VectorStorage;
 use crate::avm2::{Activation, Error, Value as Avm2Value};
 use crate::bitmap::bitmap_data::{
@@ -1654,7 +1654,7 @@ pub fn set_vector<'gc>(
     let width = (x_max - x_min) as usize;
     let height = (y_max - y_min) as usize;
     if vector.length() < width * height {
-        return Err(make_error_2006(activation));
+        return Err(make_error_2006(activation, Error2006Type::RangeError));
     }
 
     let region = PixelRegion::for_region(x_min, y_min, width as u32, height as u32);


### PR DESCRIPTION
## Description

The `Stage3D` `x`/`y` setters (TBA) can throw this error as an ArgumentError (https://docs.ruffle.rs/en_US/FlashPlatform/reference/actionscript/3/flash/display/Stage3D.html#x). This adds the enum now so that those setters can be implemented without needing to change all of the `make_error_2006` calls then.

## Testing

No tests, everything should behaviorally be the same.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
