### PR TITLE
avm1: Match Flash broadcaster prototype enumeration order

### DIFF
--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -197,11 +197,9 @@ fn initialize_internal<'gc>(
 ) {
     broadcaster.define_value(
         context.gc(),
-        istr!(context, "_listeners"),
-        ArrayBuilder::new_with_proto(context, array_proto)
-            .with([])
-            .into(),
-        Attribute::DONT_ENUM,
+        istr!(context, "broadcastMessage"),
+        functions.broadcast_message.into(),
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
     broadcaster.define_value(
         context.gc(),
@@ -217,8 +215,10 @@ fn initialize_internal<'gc>(
     );
     broadcaster.define_value(
         context.gc(),
-        istr!(context, "broadcastMessage"),
-        functions.broadcast_message.into(),
+        istr!(context, "_listeners"),
+        ArrayBuilder::new_with_proto(context, array_proto)
+            .with([])
+            .into(),
         Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 }

--- a/tests/tests/swfs/avm1/global_proto_decls/output.ruffle.txt
+++ b/tests/tests/swfs/avm1/global_proto_decls/output.ruffle.txt
@@ -31,10 +31,10 @@ Testing _global.MovieClipLoader
   prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.MovieClipLoader.prototype
-  broadcastMessage, own, DONT_ENUM, type=[function]
+  _listeners, own, DONT_ENUM, type=[object]
   removeListener, own, DONT_ENUM, type=[function]
   addListener, own, DONT_ENUM, type=[function]
-  _listeners, own, DONT_ENUM, type=[object]
+  broadcastMessage, own, DONT_ENUM, type=[function]
   getProgress, own, DONT_ENUM, type=[function]
   unloadClip, own, DONT_ENUM, type=[function]
   loadClip, own, DONT_ENUM, type=[function]
@@ -154,10 +154,10 @@ Testing _global.flash.net.FileReference
   prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.flash.net.FileReference.prototype
-  broadcastMessage, own, DONT_ENUM, type=[function]
+  _listeners, own, DONT_ENUM, type=[object]
   removeListener, own, DONT_ENUM, type=[function]
   addListener, own, DONT_ENUM, type=[function]
-  _listeners, own, DONT_ENUM, type=[object]
+  broadcastMessage, own, DONT_ENUM, type=[function]
   cancel, own, DONT_ENUM, type=[function]
   download, own, DONT_ENUM, type=[function]
   upload, own, DONT_ENUM, type=[function]
@@ -504,10 +504,10 @@ Testing _global.System.IME
   JAPANESE_KATAKANA_HALF, own, DONT_ENUM, READ_ONLY, type=[string]
   KOREAN, own, DONT_ENUM, READ_ONLY, type=[string]
   UNKNOWN, own, DONT_ENUM, READ_ONLY, type=[string]
-  broadcastMessage, own, DONT_ENUM, type=[function]
+  _listeners, own, DONT_ENUM, type=[object]
   removeListener, own, DONT_ENUM, type=[function]
   addListener, own, DONT_ENUM, type=[function]
-  _listeners, own, DONT_ENUM, type=[object]
+  broadcastMessage, own, DONT_ENUM, type=[function]
   __proto__, own, type=[object]
 Testing _global.System.IME.onIMEComposition
   __proto__, own, type=[object]
@@ -531,23 +531,16 @@ Testing _global.System.IME.JAPANESE_KATAKANA_FULL
 Testing _global.System.IME.JAPANESE_KATAKANA_HALF
 Testing _global.System.IME.KOREAN
 Testing _global.System.IME.UNKNOWN
-Testing _global.System.IME.broadcastMessage
-  prototype, own, DONT_ENUM, type=[object]
+Testing _global.System.IME._listeners
+  length, own, DONT_ENUM, type=[number]
   __proto__, own, type=[object]
-Testing _global.System.IME.broadcastMessage.prototype
-  apply, own, DONT_ENUM, type=[function]
-  call, own, DONT_ENUM, type=[function]
-  constructor, own, type=[function]
-  __proto__, own, type=[object]
+Testing _global.System.IME._listeners.length
 Testing _global.System.IME.removeListener
-  apply, type=[function]
-  call, type=[function]
-  constructor, type=[function]
   prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
 Testing _global.System.IME.removeListener.prototype
-  apply, own, type=[function]
-  call, own, type=[function]
+  apply, own, DONT_ENUM, type=[function]
+  call, own, DONT_ENUM, type=[function]
   constructor, own, type=[function]
   __proto__, own, type=[object]
 Testing _global.System.IME.addListener
@@ -561,10 +554,17 @@ Testing _global.System.IME.addListener.prototype
   call, own, type=[function]
   constructor, own, type=[function]
   __proto__, own, type=[object]
-Testing _global.System.IME._listeners
-  length, own, DONT_ENUM, type=[number]
+Testing _global.System.IME.broadcastMessage
+  apply, type=[function]
+  call, type=[function]
+  constructor, type=[function]
+  prototype, own, DONT_ENUM, type=[object]
   __proto__, own, type=[object]
-Testing _global.System.IME._listeners.length
+Testing _global.System.IME.broadcastMessage.prototype
+  apply, own, type=[function]
+  call, own, type=[function]
+  constructor, own, type=[function]
+  __proto__, own, type=[object]
 Testing _global.System.security
   PolicyFileResolver, own, type=[function]
   sandboxType, own, READ_ONLY, type=[string]
@@ -738,10 +738,10 @@ Testing _global.Stage
   height, own, READ_ONLY, type=[number]
   scaleMode, own, READ_ONLY, type=[string]
   align, own, READ_ONLY, type=[string]
-  broadcastMessage, own, DONT_ENUM, type=[function]
+  _listeners, own, DONT_ENUM, type=[object]
   removeListener, own, DONT_ENUM, type=[function]
   addListener, own, DONT_ENUM, type=[function]
-  _listeners, own, DONT_ENUM, type=[object]
+  broadcastMessage, own, DONT_ENUM, type=[function]
   __proto__, own, type=[object]
 Testing _global.Stage.displayState
 Testing _global.Stage.showMenu
@@ -749,21 +749,14 @@ Testing _global.Stage.width
 Testing _global.Stage.height
 Testing _global.Stage.scaleMode
 Testing _global.Stage.align
-Testing _global.Stage.broadcastMessage
+Testing _global.Stage._listeners
+  length, own, DONT_ENUM, type=[number]
+  __proto__, own, type=[object]
+Testing _global.Stage._listeners.length
+Testing _global.Stage.removeListener
   apply, type=[function]
   call, type=[function]
   constructor, type=[function]
-  prototype, own, type=[object]
-  __proto__, own, type=[object]
-Testing _global.Stage.broadcastMessage.prototype
-  apply, own, type=[function]
-  call, own, type=[function]
-  constructor, own, type=[function]
-  __proto__, own, type=[object]
-Testing _global.Stage.removeListener
-  constructor, own, type=[function]
-  call, own, type=[function]
-  apply, own, type=[function]
   prototype, own, type=[object]
   __proto__, own, type=[object]
 Testing _global.Stage.removeListener.prototype
@@ -782,10 +775,17 @@ Testing _global.Stage.addListener.prototype
   call, own, type=[function]
   constructor, own, type=[function]
   __proto__, own, type=[object]
-Testing _global.Stage._listeners
-  length, own, DONT_ENUM, type=[number]
+Testing _global.Stage.broadcastMessage
+  constructor, own, type=[function]
+  call, own, type=[function]
+  apply, own, type=[function]
+  prototype, own, type=[object]
   __proto__, own, type=[object]
-Testing _global.Stage._listeners.length
+Testing _global.Stage.broadcastMessage.prototype
+  apply, own, type=[function]
+  call, own, type=[function]
+  constructor, own, type=[function]
+  __proto__, own, type=[object]
 Testing _global.TextFormat
   apply, type=[function]
   call, type=[function]
@@ -909,10 +909,10 @@ Testing _global.Key
   DELETEKEY, own, DONT_ENUM, READ_ONLY, type=[number]
   BACKSPACE, own, DONT_ENUM, READ_ONLY, type=[number]
   CAPSLOCK, own, DONT_ENUM, READ_ONLY, type=[number]
-  broadcastMessage, own, DONT_ENUM, type=[function]
+  _listeners, own, DONT_ENUM, type=[object]
   removeListener, own, DONT_ENUM, type=[function]
   addListener, own, DONT_ENUM, type=[function]
-  _listeners, own, DONT_ENUM, type=[object]
+  broadcastMessage, own, DONT_ENUM, type=[function]
   __proto__, own, type=[object]
 Testing _global.Key.isToggled
   apply, type=[function]
@@ -953,17 +953,10 @@ Testing _global.Key.INSERT
 Testing _global.Key.DELETEKEY
 Testing _global.Key.BACKSPACE
 Testing _global.Key.CAPSLOCK
-Testing _global.Key.broadcastMessage
-  constructor, own, type=[function]
-  call, own, type=[function]
-  apply, own, type=[function]
-  prototype, own, type=[object]
+Testing _global.Key._listeners
+  length, own, DONT_ENUM, type=[number]
   __proto__, own, type=[object]
-Testing _global.Key.broadcastMessage.prototype
-  apply, own, type=[function]
-  call, own, type=[function]
-  constructor, own, type=[function]
-  __proto__, own, type=[object]
+Testing _global.Key._listeners.length
 Testing _global.Key.removeListener
   constructor, own, type=[function]
   call, own, type=[function]
@@ -986,17 +979,24 @@ Testing _global.Key.addListener.prototype
   call, own, type=[function]
   constructor, own, type=[function]
   __proto__, own, type=[object]
-Testing _global.Key._listeners
-  length, own, DONT_ENUM, type=[number]
+Testing _global.Key.broadcastMessage
+  constructor, own, type=[function]
+  call, own, type=[function]
+  apply, own, type=[function]
+  prototype, own, type=[object]
   __proto__, own, type=[object]
-Testing _global.Key._listeners.length
+Testing _global.Key.broadcastMessage.prototype
+  apply, own, type=[function]
+  call, own, type=[function]
+  constructor, own, type=[function]
+  __proto__, own, type=[object]
 Testing _global.Mouse
   hide, own, DONT_ENUM, READ_ONLY, type=[function]
   show, own, DONT_ENUM, READ_ONLY, type=[function]
-  broadcastMessage, own, DONT_ENUM, type=[function]
+  _listeners, own, DONT_ENUM, type=[object]
   removeListener, own, DONT_ENUM, type=[function]
   addListener, own, DONT_ENUM, type=[function]
-  _listeners, own, DONT_ENUM, type=[object]
+  broadcastMessage, own, DONT_ENUM, type=[function]
   __proto__, own, type=[object]
 Testing _global.Mouse.hide
   apply, type=[function]
@@ -1008,17 +1008,10 @@ Testing _global.Mouse.show
   call, type=[function]
   constructor, type=[function]
   __proto__, own, type=[object]
-Testing _global.Mouse.broadcastMessage
-  constructor, own, type=[function]
-  call, own, type=[function]
-  apply, own, type=[function]
-  prototype, own, type=[object]
+Testing _global.Mouse._listeners
+  length, own, DONT_ENUM, type=[number]
   __proto__, own, type=[object]
-Testing _global.Mouse.broadcastMessage.prototype
-  apply, own, type=[function]
-  call, own, type=[function]
-  constructor, own, type=[function]
-  __proto__, own, type=[object]
+Testing _global.Mouse._listeners.length
 Testing _global.Mouse.removeListener
   constructor, own, type=[function]
   call, own, type=[function]
@@ -1041,10 +1034,17 @@ Testing _global.Mouse.addListener.prototype
   call, own, type=[function]
   constructor, own, type=[function]
   __proto__, own, type=[object]
-Testing _global.Mouse._listeners
-  length, own, DONT_ENUM, type=[number]
+Testing _global.Mouse.broadcastMessage
+  constructor, own, type=[function]
+  call, own, type=[function]
+  apply, own, type=[function]
+  prototype, own, type=[object]
   __proto__, own, type=[object]
-Testing _global.Mouse._listeners.length
+Testing _global.Mouse.broadcastMessage.prototype
+  apply, own, type=[function]
+  call, own, type=[function]
+  constructor, own, type=[function]
+  __proto__, own, type=[object]
 Testing _global.Selection
   setSelection, own, DONT_ENUM, READ_ONLY, type=[function]
   setFocus, own, DONT_ENUM, READ_ONLY, type=[function]
@@ -1052,10 +1052,10 @@ Testing _global.Selection
   getCaretIndex, own, DONT_ENUM, READ_ONLY, type=[function]
   getEndIndex, own, DONT_ENUM, READ_ONLY, type=[function]
   getBeginIndex, own, DONT_ENUM, READ_ONLY, type=[function]
-  broadcastMessage, own, DONT_ENUM, type=[function]
+  _listeners, own, DONT_ENUM, type=[object]
   removeListener, own, DONT_ENUM, type=[function]
   addListener, own, DONT_ENUM, type=[function]
-  _listeners, own, DONT_ENUM, type=[object]
+  broadcastMessage, own, DONT_ENUM, type=[function]
   __proto__, own, type=[object]
 Testing _global.Selection.setSelection
   apply, type=[function]
@@ -1087,17 +1087,10 @@ Testing _global.Selection.getBeginIndex
   call, type=[function]
   constructor, type=[function]
   __proto__, own, type=[object]
-Testing _global.Selection.broadcastMessage
-  constructor, own, type=[function]
-  call, own, type=[function]
-  apply, own, type=[function]
-  prototype, own, type=[object]
+Testing _global.Selection._listeners
+  length, own, DONT_ENUM, type=[number]
   __proto__, own, type=[object]
-Testing _global.Selection.broadcastMessage.prototype
-  apply, own, type=[function]
-  call, own, type=[function]
-  constructor, own, type=[function]
-  __proto__, own, type=[object]
+Testing _global.Selection._listeners.length
 Testing _global.Selection.removeListener
   constructor, own, type=[function]
   call, own, type=[function]
@@ -1120,10 +1113,17 @@ Testing _global.Selection.addListener.prototype
   call, own, type=[function]
   constructor, own, type=[function]
   __proto__, own, type=[object]
-Testing _global.Selection._listeners
-  length, own, DONT_ENUM, type=[number]
+Testing _global.Selection.broadcastMessage
+  constructor, own, type=[function]
+  call, own, type=[function]
+  apply, own, type=[function]
+  prototype, own, type=[object]
   __proto__, own, type=[object]
-Testing _global.Selection._listeners.length
+Testing _global.Selection.broadcastMessage.prototype
+  apply, own, type=[function]
+  call, own, type=[function]
+  constructor, own, type=[function]
+  __proto__, own, type=[object]
 Testing _global.LoadVars
   apply, type=[function]
   call, type=[function]

--- a/tests/tests/swfs/avm1/global_proto_decls_delete/output.ruffle.txt
+++ b/tests/tests/swfs/avm1/global_proto_decls_delete/output.ruffle.txt
@@ -20,9 +20,10 @@ Testing _global.MovieClipLoader
   prototype, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.MovieClipLoader.prototype
-  broadcastMessage, DONT_DELETE
+  _listeners, DONT_DELETE
   removeListener, DONT_DELETE
   addListener, DONT_DELETE
+  broadcastMessage, DONT_DELETE
   getProgress, DONT_DELETE
   unloadClip, DONT_DELETE
   loadClip, DONT_DELETE
@@ -108,9 +109,10 @@ Testing _global.flash.net.FileReference
   prototype, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.flash.net.FileReference.prototype
-  broadcastMessage, DONT_DELETE
+  _listeners, DONT_DELETE
   removeListener, DONT_DELETE
   addListener, DONT_DELETE
+  broadcastMessage, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.flash.net
   __proto__, DONT_DELETE
@@ -240,16 +242,11 @@ Testing _global.System.IME.JAPANESE_KATAKANA_FULL
 Testing _global.System.IME.JAPANESE_KATAKANA_HALF
 Testing _global.System.IME.KOREAN
 Testing _global.System.IME.UNKNOWN
-Testing _global.System.IME.broadcastMessage
-  prototype, DONT_DELETE
-  __proto__, DONT_DELETE
-Testing _global.System.IME.broadcastMessage.prototype
-  apply, DONT_DELETE
-  call, DONT_DELETE
+Testing _global.System.IME._listeners.length
+Testing _global.System.IME._listeners
+  length, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.System.IME.removeListener
-  apply, DONT_DELETE
-  call, DONT_DELETE
   prototype, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.System.IME.removeListener.prototype
@@ -265,9 +262,14 @@ Testing _global.System.IME.addListener.prototype
   apply, DONT_DELETE
   call, DONT_DELETE
   __proto__, DONT_DELETE
-Testing _global.System.IME._listeners.length
-Testing _global.System.IME._listeners
-  length, DONT_DELETE
+Testing _global.System.IME.broadcastMessage
+  apply, DONT_DELETE
+  call, DONT_DELETE
+  prototype, DONT_DELETE
+  __proto__, DONT_DELETE
+Testing _global.System.IME.broadcastMessage.prototype
+  apply, DONT_DELETE
+  call, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.System.IME
   onIMEComposition, DONT_DELETE
@@ -285,9 +287,10 @@ Testing _global.System.IME
   JAPANESE_KATAKANA_HALF, DONT_DELETE
   KOREAN, DONT_DELETE
   UNKNOWN, DONT_DELETE
-  broadcastMessage, DONT_DELETE
+  _listeners, DONT_DELETE
   removeListener, DONT_DELETE
   addListener, DONT_DELETE
+  broadcastMessage, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.System.security.PolicyFileResolver
   apply, DONT_DELETE
@@ -402,14 +405,9 @@ Testing _global.Stage.width
 Testing _global.Stage.height
 Testing _global.Stage.scaleMode
 Testing _global.Stage.align
-Testing _global.Stage.broadcastMessage
-  apply, DONT_DELETE
-  call, DONT_DELETE
-  prototype, DONT_DELETE
-  __proto__, DONT_DELETE
-Testing _global.Stage.broadcastMessage.prototype
-  apply, DONT_DELETE
-  call, DONT_DELETE
+Testing _global.Stage._listeners.length
+Testing _global.Stage._listeners
+  length, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Stage.removeListener
   apply, DONT_DELETE
@@ -429,14 +427,20 @@ Testing _global.Stage.addListener.prototype
   apply, DONT_DELETE
   call, DONT_DELETE
   __proto__, DONT_DELETE
-Testing _global.Stage._listeners.length
-Testing _global.Stage._listeners
-  length, DONT_DELETE
+Testing _global.Stage.broadcastMessage
+  apply, DONT_DELETE
+  call, DONT_DELETE
+  prototype, DONT_DELETE
+  __proto__, DONT_DELETE
+Testing _global.Stage.broadcastMessage.prototype
+  apply, DONT_DELETE
+  call, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Stage
-  broadcastMessage, DONT_DELETE
+  _listeners, DONT_DELETE
   removeListener, DONT_DELETE
   addListener, DONT_DELETE
+  broadcastMessage, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.TextFormat
   apply, DONT_DELETE
@@ -504,14 +508,9 @@ Testing _global.Key.INSERT
 Testing _global.Key.DELETEKEY
 Testing _global.Key.BACKSPACE
 Testing _global.Key.CAPSLOCK
-Testing _global.Key.broadcastMessage
-  apply, DONT_DELETE
-  call, DONT_DELETE
-  prototype, DONT_DELETE
-  __proto__, DONT_DELETE
-Testing _global.Key.broadcastMessage.prototype
-  apply, DONT_DELETE
-  call, DONT_DELETE
+Testing _global.Key._listeners.length
+Testing _global.Key._listeners
+  length, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Key.removeListener
   apply, DONT_DELETE
@@ -531,9 +530,14 @@ Testing _global.Key.addListener.prototype
   apply, DONT_DELETE
   call, DONT_DELETE
   __proto__, DONT_DELETE
-Testing _global.Key._listeners.length
-Testing _global.Key._listeners
-  length, DONT_DELETE
+Testing _global.Key.broadcastMessage
+  apply, DONT_DELETE
+  call, DONT_DELETE
+  prototype, DONT_DELETE
+  __proto__, DONT_DELETE
+Testing _global.Key.broadcastMessage.prototype
+  apply, DONT_DELETE
+  call, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Key
   isToggled, DONT_DELETE
@@ -559,9 +563,10 @@ Testing _global.Key
   DELETEKEY, DONT_DELETE
   BACKSPACE, DONT_DELETE
   CAPSLOCK, DONT_DELETE
-  broadcastMessage, DONT_DELETE
+  _listeners, DONT_DELETE
   removeListener, DONT_DELETE
   addListener, DONT_DELETE
+  broadcastMessage, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Mouse.hide
   apply, DONT_DELETE
@@ -571,14 +576,9 @@ Testing _global.Mouse.show
   apply, DONT_DELETE
   call, DONT_DELETE
   __proto__, DONT_DELETE
-Testing _global.Mouse.broadcastMessage
-  apply, DONT_DELETE
-  call, DONT_DELETE
-  prototype, DONT_DELETE
-  __proto__, DONT_DELETE
-Testing _global.Mouse.broadcastMessage.prototype
-  apply, DONT_DELETE
-  call, DONT_DELETE
+Testing _global.Mouse._listeners.length
+Testing _global.Mouse._listeners
+  length, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Mouse.removeListener
   apply, DONT_DELETE
@@ -598,16 +598,22 @@ Testing _global.Mouse.addListener.prototype
   apply, DONT_DELETE
   call, DONT_DELETE
   __proto__, DONT_DELETE
-Testing _global.Mouse._listeners.length
-Testing _global.Mouse._listeners
-  length, DONT_DELETE
+Testing _global.Mouse.broadcastMessage
+  apply, DONT_DELETE
+  call, DONT_DELETE
+  prototype, DONT_DELETE
+  __proto__, DONT_DELETE
+Testing _global.Mouse.broadcastMessage.prototype
+  apply, DONT_DELETE
+  call, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Mouse
   hide, DONT_DELETE
   show, DONT_DELETE
-  broadcastMessage, DONT_DELETE
+  _listeners, DONT_DELETE
   removeListener, DONT_DELETE
   addListener, DONT_DELETE
+  broadcastMessage, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Selection.setSelection
   apply, DONT_DELETE
@@ -633,14 +639,9 @@ Testing _global.Selection.getBeginIndex
   apply, DONT_DELETE
   call, DONT_DELETE
   __proto__, DONT_DELETE
-Testing _global.Selection.broadcastMessage
-  apply, DONT_DELETE
-  call, DONT_DELETE
-  prototype, DONT_DELETE
-  __proto__, DONT_DELETE
-Testing _global.Selection.broadcastMessage.prototype
-  apply, DONT_DELETE
-  call, DONT_DELETE
+Testing _global.Selection._listeners.length
+Testing _global.Selection._listeners
+  length, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Selection.removeListener
   apply, DONT_DELETE
@@ -660,9 +661,14 @@ Testing _global.Selection.addListener.prototype
   apply, DONT_DELETE
   call, DONT_DELETE
   __proto__, DONT_DELETE
-Testing _global.Selection._listeners.length
-Testing _global.Selection._listeners
-  length, DONT_DELETE
+Testing _global.Selection.broadcastMessage
+  apply, DONT_DELETE
+  call, DONT_DELETE
+  prototype, DONT_DELETE
+  __proto__, DONT_DELETE
+Testing _global.Selection.broadcastMessage.prototype
+  apply, DONT_DELETE
+  call, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.Selection
   setSelection, DONT_DELETE
@@ -671,9 +677,10 @@ Testing _global.Selection
   getCaretIndex, DONT_DELETE
   getEndIndex, DONT_DELETE
   getBeginIndex, DONT_DELETE
-  broadcastMessage, DONT_DELETE
+  _listeners, DONT_DELETE
   removeListener, DONT_DELETE
   addListener, DONT_DELETE
+  broadcastMessage, DONT_DELETE
   __proto__, DONT_DELETE
 Testing _global.LoadVars
   apply, DONT_DELETE

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp10.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp10.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -119,15 +119,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -146,8 +139,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -284,15 +284,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -311,8 +304,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -449,15 +449,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -476,8 +469,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -491,15 +491,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -518,8 +511,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -557,15 +557,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -584,8 +577,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp11-14.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp11-14.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -119,15 +119,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -146,8 +139,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -284,15 +284,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -311,8 +304,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -449,15 +449,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -476,8 +469,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -491,15 +491,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -518,8 +511,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -557,15 +557,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -584,8 +577,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp13-18.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp13-18.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -119,15 +119,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -146,8 +139,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -284,15 +284,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -311,8 +304,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -449,15 +449,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -476,8 +469,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -491,15 +491,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -518,8 +511,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -557,15 +557,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -584,8 +577,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp32.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp32.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -119,15 +119,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -146,8 +139,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -284,15 +284,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -311,8 +304,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -449,15 +449,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -476,8 +469,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -491,15 +491,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -518,8 +511,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -557,15 +557,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -584,8 +577,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp9.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v6/output.fp9.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -119,15 +119,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -146,8 +139,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -284,15 +284,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -311,8 +304,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -449,15 +449,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -476,8 +469,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -491,15 +491,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -518,8 +511,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -557,15 +557,8 @@ Object was constructed
 Testing constructor()
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -584,8 +577,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp10.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp10.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -112,15 +112,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -139,8 +132,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -266,15 +266,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -293,8 +286,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -427,15 +427,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -454,8 +447,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -467,15 +467,8 @@ Trying to construct _global.Mouse.show
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -494,8 +487,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -527,15 +527,8 @@ Trying to construct _global.Selection.getBeginIndex
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -554,8 +547,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp11-14.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp11-14.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -112,15 +112,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -139,8 +132,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -266,15 +266,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -293,8 +286,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -427,15 +427,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -454,8 +447,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -467,15 +467,8 @@ Trying to construct _global.Mouse.show
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -494,8 +487,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -527,15 +527,8 @@ Trying to construct _global.Selection.getBeginIndex
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -554,8 +547,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp13-18.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp13-18.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -112,15 +112,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -139,8 +132,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -266,15 +266,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -293,8 +286,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -427,15 +427,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -454,8 +447,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -467,15 +467,8 @@ Trying to construct _global.Mouse.show
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -494,8 +487,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -527,15 +527,8 @@ Trying to construct _global.Selection.getBeginIndex
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -554,8 +547,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp32.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp32.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -112,15 +112,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -139,8 +132,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -266,15 +266,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -293,8 +286,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -427,15 +427,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -454,8 +447,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -467,15 +467,8 @@ Trying to construct _global.Mouse.show
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -494,8 +487,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -527,15 +527,8 @@ Trying to construct _global.Selection.getBeginIndex
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -554,8 +547,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp9.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v7/output.fp9.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -112,15 +112,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -139,8 +132,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -266,15 +266,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -293,8 +286,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -427,15 +427,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -454,8 +447,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -467,15 +467,8 @@ Trying to construct _global.Mouse.show
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -494,8 +487,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -527,15 +527,8 @@ Trying to construct _global.Selection.getBeginIndex
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -554,8 +547,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp11-14.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp11-14.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -126,10 +126,10 @@ Testing __proto__()
 testing _global.flash.net.FileReference(function)
 Trying to construct _global.flash.net.FileReference
 Object was constructed
-Testing broadcastMessage()
+Testing _listeners()
 Testing removeListener()
 Testing addListener()
-Testing _listeners()
+Testing broadcastMessage()
 Testing cancel()
 Testing download()
 Testing upload()
@@ -465,15 +465,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -492,8 +485,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -619,15 +619,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -646,8 +639,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -780,15 +780,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -807,8 +800,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -820,15 +820,8 @@ Trying to construct _global.Mouse.show
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -847,8 +840,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -880,15 +880,8 @@ Trying to construct _global.Selection.getBeginIndex
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -907,8 +900,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp13-18.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp13-18.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -126,10 +126,10 @@ Testing __proto__()
 testing _global.flash.net.FileReference(function)
 Trying to construct _global.flash.net.FileReference
 Object was constructed
-Testing broadcastMessage()
+Testing _listeners()
 Testing removeListener()
 Testing addListener()
-Testing _listeners()
+Testing broadcastMessage()
 Testing cancel()
 Testing download()
 Testing upload()
@@ -465,15 +465,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -492,8 +485,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -619,15 +619,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -646,8 +639,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -780,15 +780,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -807,8 +800,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -820,15 +820,8 @@ Trying to construct _global.Mouse.show
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -847,8 +840,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -880,15 +880,8 @@ Trying to construct _global.Selection.getBeginIndex
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -907,8 +900,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed

--- a/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp32.ruffle.txt
+++ b/tests/tests/swfs/from_gnash/actionscript.all/argstest-v8/output.fp32.ruffle.txt
@@ -35,9 +35,9 @@ Testing __proto__()
 testing _global.MovieClipLoader(function)
 Trying to construct _global.MovieClipLoader
 Object was constructed
-Testing broadcastMessage()
 Testing removeListener()
 Testing addListener()
+Testing broadcastMessage()
 Testing getProgress()
 Testing unloadClip()
 Testing loadClip()
@@ -126,10 +126,10 @@ Testing __proto__()
 testing _global.flash.net.FileReference(function)
 Trying to construct _global.flash.net.FileReference
 Object was constructed
-Testing broadcastMessage()
+Testing _listeners()
 Testing removeListener()
 Testing addListener()
-Testing _listeners()
+Testing broadcastMessage()
 Testing cancel()
 Testing download()
 Testing upload()
@@ -465,15 +465,8 @@ testing _global.System.IME.JAPANESE_KATAKANA_FULL(string)
 testing _global.System.IME.JAPANESE_KATAKANA_HALF(string)
 testing _global.System.IME.KOREAN(string)
 testing _global.System.IME.UNKNOWN(string)
-testing _global.System.IME.broadcastMessage(function)
-Trying to construct _global.System.IME.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.System.IME.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.System.IME._listeners(object)
+testing _global.System.IME._listeners.length(number)
 testing _global.System.IME.removeListener(function)
 Trying to construct _global.System.IME.removeListener
 Object was constructed
@@ -492,8 +485,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.System.IME.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.System.IME._listeners(object)
-testing _global.System.IME._listeners.length(number)
+testing _global.System.IME.broadcastMessage(function)
+Trying to construct _global.System.IME.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.System.IME.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.System.security(object)
 testing _global.System.security.PolicyFileResolver(function)
 Trying to construct _global.System.security.PolicyFileResolver
@@ -619,15 +619,8 @@ testing _global.Stage.width(number)
 testing _global.Stage.height(number)
 testing _global.Stage.scaleMode(string)
 testing _global.Stage.align(string)
-testing _global.Stage.broadcastMessage(function)
-Trying to construct _global.Stage.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Stage.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Stage._listeners(object)
+testing _global.Stage._listeners.length(number)
 testing _global.Stage.removeListener(function)
 Trying to construct _global.Stage.removeListener
 Object was constructed
@@ -646,8 +639,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Stage.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Stage._listeners(object)
-testing _global.Stage._listeners.length(number)
+testing _global.Stage.broadcastMessage(function)
+Trying to construct _global.Stage.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Stage.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.TextFormat(function)
 Trying to construct _global.TextFormat
 Object was constructed
@@ -780,15 +780,8 @@ testing _global.Key.INSERT(number)
 testing _global.Key.DELETEKEY(number)
 testing _global.Key.BACKSPACE(number)
 testing _global.Key.CAPSLOCK(number)
-testing _global.Key.broadcastMessage(function)
-Trying to construct _global.Key.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Key.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Key._listeners(object)
+testing _global.Key._listeners.length(number)
 testing _global.Key.removeListener(function)
 Trying to construct _global.Key.removeListener
 Object was constructed
@@ -807,8 +800,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Key.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Key._listeners(object)
-testing _global.Key._listeners.length(number)
+testing _global.Key.broadcastMessage(function)
+Trying to construct _global.Key.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Key.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Mouse(object)
 testing _global.Mouse.hide(function)
 Trying to construct _global.Mouse.hide
@@ -820,15 +820,8 @@ Trying to construct _global.Mouse.show
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Mouse.broadcastMessage(function)
-Trying to construct _global.Mouse.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Mouse.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Mouse._listeners(object)
+testing _global.Mouse._listeners.length(number)
 testing _global.Mouse.removeListener(function)
 Trying to construct _global.Mouse.removeListener
 Object was constructed
@@ -847,8 +840,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Mouse.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Mouse._listeners(object)
-testing _global.Mouse._listeners.length(number)
+testing _global.Mouse.broadcastMessage(function)
+Trying to construct _global.Mouse.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Mouse.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.Selection(object)
 testing _global.Selection.setSelection(function)
 Trying to construct _global.Selection.setSelection
@@ -880,15 +880,8 @@ Trying to construct _global.Selection.getBeginIndex
 Object was constructed
 Testing __constructor__()
 Testing __proto__()
-testing _global.Selection.broadcastMessage(function)
-Trying to construct _global.Selection.broadcastMessage
-Object was constructed
-Testing apply()
-Testing call()
-Testing constructor()
-Testing __constructor__()
-testing _global.Selection.broadcastMessage.__constructor__(undefined)
-Testing __proto__()
+testing _global.Selection._listeners(object)
+testing _global.Selection._listeners.length(number)
 testing _global.Selection.removeListener(function)
 Trying to construct _global.Selection.removeListener
 Object was constructed
@@ -907,8 +900,15 @@ Testing constructor()
 Testing __constructor__()
 testing _global.Selection.addListener.__constructor__(undefined)
 Testing __proto__()
-testing _global.Selection._listeners(object)
-testing _global.Selection._listeners.length(number)
+testing _global.Selection.broadcastMessage(function)
+Trying to construct _global.Selection.broadcastMessage
+Object was constructed
+Testing apply()
+Testing call()
+Testing constructor()
+Testing __constructor__()
+testing _global.Selection.broadcastMessage.__constructor__(undefined)
+Testing __proto__()
 testing _global.LoadVars(function)
 Trying to construct _global.LoadVars
 Object was constructed


### PR DESCRIPTION
## Description

Noticed during development of #23889.

AVM1 enumerates own properties in reverse insertion order. The broadcaster methods on `MovieClipLoader`, `FileReference`, `FileReferenceList`, `System.IME`, `Stage`, `Key`, `Mouse` and `Selection` were defined in the order `_listeners, addListener, removeListener, broadcastMessage`, so `for-in` yielded the reverse — the opposite of Flash, which yields `_listeners, removeListener, addListener, broadcastMessage`.

Define them in the matching reverse order so iteration lines up with Flash. Additionally, give `_listeners` the `DONT_DELETE` flag Flash assigns to it (previously `DONT_ENUM` only).

## Testing

Good luck reviewing the diff :(

It seems to be true that _listeners comes prior to broadcastMessage everywhere I looked though (which is not every changed line), so it seems this change is correct. There are other order differences with Flash, so comparing it visually is difficult.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
