### PR TITLE
avm2: Add a field to ops instead of adding separate integral variants

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -753,8 +753,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::CoerceUSwapPop => self.op_coerce_u_swap_pop(),
                 Op::ConvertO => self.op_convert_o(),
                 Op::ConvertS => self.op_convert_s(),
-                Op::Add => self.op_add(),
-                Op::AddIntegral => self.op_add_integral(),
+                Op::Add { .. } => self.op_add(),
                 Op::AddI => self.op_add_i(),
                 Op::BitAnd => self.op_bitand(),
                 Op::BitNot => self.op_bitnot(),
@@ -776,8 +775,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::Negate => self.op_negate(),
                 Op::NegateI => self.op_negate_i(),
                 Op::RShift => self.op_rshift(),
-                Op::Subtract => self.op_subtract(),
-                Op::SubtractIntegral => self.op_subtract_integral(),
+                Op::Subtract { .. } => self.op_subtract(),
                 Op::SubtractI => self.op_subtract_i(),
                 Op::Swap => self.op_swap(),
                 Op::URShift => self.op_urshift(),
@@ -2074,29 +2072,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(())
     }
 
-    fn op_add_integral(&mut self) -> Result<(), Error<'gc>> {
-        let value2 = self.pop_stack();
-        let value1 = self.pop_stack();
-
-        let sum_value: Value<'gc> = match (value1, value2) {
-            (Value::Integer(n1), Value::Integer(n2)) => {
-                if let Some(res) = n1.checked_add(n2) {
-                    res.into()
-                } else {
-                    ((n1 as i64 + n2 as i64) as f64).into()
-                }
-            }
-            (Value::Number(n1), Value::Number(n2)) => (n1 + n2).into(),
-            (Value::Integer(n1), Value::Number(n2)) => (n1 as f64 + n2).into(),
-            (Value::Number(n1), Value::Integer(n2)) => (n1 + n2 as f64).into(),
-            _ => unreachable!("Guaranteed by verifier"),
-        };
-
-        self.push_stack(sum_value);
-
-        Ok(())
-    }
-
     fn op_add_i(&mut self) -> Result<(), Error<'gc>> {
         let value2 = self.pop_stack();
         let value1 = self.pop_stack();
@@ -2315,29 +2290,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 let value1 = value1.coerce_to_number(self)?;
                 (value1 - value2).into()
             }
-        };
-
-        self.push_stack(sub_value);
-
-        Ok(())
-    }
-
-    fn op_subtract_integral(&mut self) -> Result<(), Error<'gc>> {
-        let value2 = self.pop_stack();
-        let value1 = self.pop_stack();
-
-        let sub_value: Value<'gc> = match (value1, value2) {
-            (Value::Integer(n1), Value::Integer(n2)) => {
-                if let Some(res) = n1.checked_sub(n2) {
-                    res.into()
-                } else {
-                    ((n1 as i64 - n2 as i64) as f64).into()
-                }
-            }
-            (Value::Number(n1), Value::Number(n2)) => (n1 - n2).into(),
-            (Value::Integer(n1), Value::Number(n2)) => (n1 as f64 - n2).into(),
-            (Value::Number(n1), Value::Integer(n2)) => (n1 - n2 as f64).into(),
-            _ => unreachable!("Guaranteed by verifier"),
         };
 
         self.push_stack(sub_value);

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -11,8 +11,11 @@ use std::cell::Cell;
 #[derive(Clone, Collect, Copy, Debug)]
 #[collect(no_drop)]
 pub enum Op<'gc> {
-    Add,
-    AddIntegral,
+    Add {
+        /// Whether the two inputs to this op are both guaranteed to be
+        /// integers. This field is used in the optimizer.
+        inputs_integral: bool,
+    },
     AddI,
     ApplyType {
         num_types: u32,
@@ -327,8 +330,10 @@ pub enum Op<'gc> {
     StoreLocal {
         index: u32,
     },
-    Subtract,
-    SubtractIntegral,
+    Subtract {
+        /// See comment on `Op::Add`
+        inputs_integral: bool,
+    },
     SubtractI,
     Swap,
     Sxi1,

--- a/core/src/avm2/optimizer/peephole.rs
+++ b/core/src/avm2/optimizer/peephole.rs
@@ -95,38 +95,62 @@ pub fn postprocess_peephole<'a>(
                     last_op.set(Op::Nop);
                     current_op.set(Op::StoreLocal { index: index1 });
                 }
-                (Op::AddIntegral, Op::CoerceI) => {
+                (
+                    Op::Add {
+                        inputs_integral: true,
+                    },
+                    Op::CoerceI,
+                ) => {
                     // An integral addition that yields Number on overflow
                     // followed by coerce-to-integer is equivalent to wrapping
                     // integral addition
                     last_op.set(Op::AddI);
                     current_op.set(Op::Nop);
                 }
-                (Op::SubtractIntegral, Op::CoerceI) => {
+                (
+                    Op::Subtract {
+                        inputs_integral: true,
+                    },
+                    Op::CoerceI,
+                ) => {
                     // The same is true for subtraction
                     last_op.set(Op::SubtractI);
                     current_op.set(Op::Nop);
                 }
                 (
-                    Op::AddIntegral,
+                    Op::Add {
+                        inputs_integral: true,
+                    },
                     Op::Li8 | Op::Li16 | Op::Li32 | Op::Si8 | Op::Si16 | Op::Si32,
                 ) => {
                     // See comments above
                     last_op.set(Op::AddI);
                 }
                 (
-                    Op::SubtractIntegral,
+                    Op::Subtract {
+                        inputs_integral: true,
+                    },
                     Op::Li8 | Op::Li16 | Op::Li32 | Op::Si8 | Op::Si16 | Op::Si32,
                 ) => {
                     // The same is true for subtraction
                     last_op.set(Op::SubtractI);
                 }
-                (Op::AddIntegral, Op::SetSlotCoerceI { index }) => {
+                (
+                    Op::Add {
+                        inputs_integral: true,
+                    },
+                    Op::SetSlotCoerceI { index },
+                ) => {
                     // See comments above
                     last_op.set(Op::AddI);
                     current_op.set(Op::SetSlotNoCoerce { index });
                 }
-                (Op::SubtractIntegral, Op::SetSlotCoerceI { index }) => {
+                (
+                    Op::Subtract {
+                        inputs_integral: true,
+                    },
+                    Op::SetSlotCoerceI { index },
+                ) => {
                     // The same is true for subtraction
                     last_op.set(Op::SubtractI);
                     current_op.set(Op::SetSlotNoCoerce { index });

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -991,12 +991,14 @@ fn abstract_interpret_ops<'gc>(
                 stack.pop(activation)?;
                 stack.push_class(activation, types.int)?;
             }
-            Op::Add => {
+            Op::Add { .. } => {
                 let value2 = stack.pop(activation)?;
                 let value1 = stack.pop(activation)?;
 
                 if value1.class == Some(types.int) && value2.class == Some(types.int) {
-                    optimize_op_to!(Op::AddIntegral);
+                    optimize_op_to!(Op::Add {
+                        inputs_integral: true
+                    });
                 }
 
                 if (value1.class == Some(types.int)
@@ -1015,12 +1017,14 @@ fn abstract_interpret_ops<'gc>(
                     stack.push_any(activation)?;
                 }
             }
-            Op::Subtract => {
+            Op::Subtract { .. } => {
                 let value2 = stack.pop(activation)?;
                 let value1 = stack.pop(activation)?;
 
                 if value1.class == Some(types.int) && value2.class == Some(types.int) {
-                    optimize_op_to!(Op::SubtractIntegral);
+                    optimize_op_to!(Op::Subtract {
+                        inputs_integral: true
+                    });
                 }
 
                 stack.push_class(activation, types.number)?;
@@ -2133,8 +2137,7 @@ fn abstract_interpret_ops<'gc>(
                 return Ok(());
             }
 
-            Op::AddIntegral
-            | Op::CallMethod { .. }
+            Op::CallMethod { .. }
             | Op::CallNative { .. }
             | Op::CoerceSwapPop { .. }
             | Op::CoerceDSwapPop
@@ -2144,8 +2147,7 @@ fn abstract_interpret_ops<'gc>(
             | Op::GetScriptGlobals { .. }
             | Op::PopJump { .. }
             | Op::SetSlotCoerceI { .. }
-            | Op::SetSlotNoCoerce { .. }
-            | Op::SubtractIntegral => unreachable!("Custom ops should not be encountered"),
+            | Op::SetSlotNoCoerce { .. } => unreachable!("Custom ops should not be encountered"),
         }
     }
 

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -992,7 +992,9 @@ fn translate_op<'gc>(
         AbcOp::CoerceU | AbcOp::ConvertU => Op::CoerceU,
         AbcOp::ConvertO => Op::ConvertO,
         AbcOp::ConvertS => Op::ConvertS,
-        AbcOp::Add => Op::Add,
+        AbcOp::Add => Op::Add {
+            inputs_integral: false,
+        },
         AbcOp::AddI => Op::AddI,
         AbcOp::BitAnd => Op::BitAnd,
         AbcOp::BitNot => Op::BitNot,
@@ -1014,7 +1016,9 @@ fn translate_op<'gc>(
         AbcOp::Negate => Op::Negate,
         AbcOp::NegateI => Op::NegateI,
         AbcOp::RShift => Op::RShift,
-        AbcOp::Subtract => Op::Subtract,
+        AbcOp::Subtract => Op::Subtract {
+            inputs_integral: false,
+        },
         AbcOp::SubtractI => Op::SubtractI,
         AbcOp::Swap => Op::Swap,
         AbcOp::URShift => Op::URShift,


### PR DESCRIPTION


## Description

Applies to `Op::Add` and `Op::Subtract`. As per moulins's advice, instead of adding separate `*Integral` variants of those two ops, we can just set a field on them.

## Testing

No observable changes.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
