### PR TITLE
avm2: Initial implementation of int interpreter

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -59,6 +59,7 @@ mod filters;
 mod flv;
 mod function;
 pub mod globals;
+mod int_interpreter;
 mod metadata;
 mod method;
 mod multiname;

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2784,7 +2784,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
         dm.write_at_nongrowing(&val.to_le_bytes(), address)
-            .map_err(|e| e.to_avm(self))?;
+            .expect("Just checked that the address was valid");
 
         Ok(())
     }
@@ -2803,7 +2803,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
         dm.write_at_nongrowing(&val.to_le_bytes(), address)
-            .map_err(|e| e.to_avm(self))?;
+            .expect("Just checked that the address was valid");
 
         Ok(())
     }
@@ -2822,7 +2822,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
         dm.write_at_nongrowing(&val.to_le_bytes(), address)
-            .map_err(|e| e.to_avm(self))?;
+            .expect("Just checked that the address was valid");
 
         Ok(())
     }
@@ -2841,7 +2841,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
         dm.write_at_nongrowing(&val.to_le_bytes(), address)
-            .map_err(|e| e.to_avm(self))?;
+            .expect("Just checked that the address was valid");
 
         Ok(())
     }
@@ -2879,7 +2879,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
 
-        let val = dm.read_at(2, address).map_err(|e| e.to_avm(self))?;
+        let val = dm
+            .read_at(2, address)
+            .expect("Just checked that the address was valid");
         self.push_stack(u16::from_le_bytes(val.try_into().unwrap()));
 
         Ok(())
@@ -2898,7 +2900,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
 
-        let val = dm.read_at(4, address).map_err(|e| e.to_avm(self))?;
+        let val = dm
+            .read_at(4, address)
+            .expect("Just checked that the address was valid");
         self.push_stack(i32::from_le_bytes(val.try_into().unwrap()));
         Ok(())
     }
@@ -2916,7 +2920,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
 
-        let val = dm.read_at(4, address).map_err(|e| e.to_avm(self))?;
+        let val = dm
+            .read_at(4, address)
+            .expect("Just checked that the address was valid");
         self.push_stack(f32::from_le_bytes(val.try_into().unwrap()));
 
         Ok(())
@@ -2935,7 +2941,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             return Err(make_error_1506(self));
         }
 
-        let val = dm.read_at(8, address).map_err(|e| e.to_avm(self))?;
+        let val = dm
+            .read_at(8, address)
+            .expect("Just checked that the address was valid");
         self.push_stack(f64::from_le_bytes(val.try_into().unwrap()));
         Ok(())
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -12,13 +12,14 @@ use crate::avm2::error::{
     make_null_or_undefined_error,
 };
 use crate::avm2::function::FunctionArgs;
+use crate::avm2::int_interpreter::IntInterpreter;
 use crate::avm2::method::{Method, NativeMethodImpl, ResolvedParamConfig};
 use crate::avm2::object::TObject;
 use crate::avm2::object::{
     ArrayObject, ByteArrayObject, ClassObject, FunctionObject, NamespaceObject, ScriptObject,
     XmlListObject,
 };
-use crate::avm2::op::{LookupSwitch, Op};
+use crate::avm2::op::{IntInterpreterInfo, LookupSwitch, Op};
 use crate::avm2::scope::{Scope, ScopeChain, search_scope_stack};
 use crate::avm2::script::Script;
 use crate::avm2::stack::StackFrame;
@@ -831,6 +832,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::Sxi8 => self.op_sxi8(),
                 Op::Sxi16 => self.op_sxi16(),
                 Op::Throw => self.op_throw(),
+
+                Op::RunIntInterpreter(info) => {
+                    self.run_int_interpreter(info);
+
+                    ip = info.exit_offset.get();
+
+                    continue;
+                }
 
                 // Branch ops
                 Op::Jump { offset } => {
@@ -3052,5 +3061,42 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     fn op_throw(&mut self) -> Result<(), Error<'gc>> {
         let error_val = self.pop_stack();
         Err(Error::from_value(self, error_val))
+    }
+
+    fn run_int_interpreter(&mut self, info: &IntInterpreterInfo) {
+        let mut interpreter = IntInterpreter::new();
+
+        // Synchronize all the int locals in this interpreter to the int
+        // interpreter
+        for (i, is_int) in info.input_locals.iter().enumerate() {
+            if is_int {
+                // This local might be read from the code run in the int
+                // interpreter, so pass it to it properly.
+                interpreter.push_stack(self.local_register(i as u32).as_i32());
+            } else {
+                // This local won't be read from by the code run in the int
+                // interpreter, so we can just pass nothing.
+                interpreter.push_stack(0);
+            }
+        }
+
+        interpreter.run(&info.ops);
+
+        // Synchronize all the int locals in the int interpreter to this
+        // interpreter
+        for (i, is_int) in info.output_locals.iter().enumerate() {
+            if is_int {
+                // This local might have been written to by the code run in the
+                // int interpreter, so synchronize it back to us.
+                self.set_local_register(i as u32, interpreter.frame_at(i as u32));
+            }
+        }
+
+        // Finally, synchronize the stack from the int interpreter to this
+        // interpreter.
+        let num_locals = info.input_locals.len();
+        for i in num_locals..num_locals + info.final_stack_height {
+            self.push_stack(interpreter.frame_at(i as u32));
+        }
     }
 }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -834,7 +834,13 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::Throw => self.op_throw(),
 
                 Op::RunIntInterpreter(info) => {
-                    self.run_int_interpreter(info);
+                    // NOTE: Int interpreter promotion is never done if this
+                    // method has exception handlers. This means that we don't
+                    // need to worry about this error not making it to an
+                    // exception handler; we can simply throw it from here (as
+                    // there are no exception handlers in this method that could
+                    // handle the error).
+                    self.run_int_interpreter(info)?;
 
                     ip = info.exit_offset.get();
 
@@ -3063,8 +3069,14 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Err(Error::from_value(self, error_val))
     }
 
-    fn run_int_interpreter(&mut self, info: &IntInterpreterInfo) {
-        let mut interpreter = IntInterpreter::new();
+    fn run_int_interpreter(&mut self, info: &IntInterpreterInfo) -> Result<(), Error<'gc>> {
+        // Code run in the int interpreter does not have the ability to borrow
+        // or swap out the domain memory, so borrow it here. This means that
+        // domain memory ops run in the int interpreter can just access the
+        // stored domain memory bytearray.
+        let domain_memory = self.domain_memory().storage_mut();
+
+        let mut interpreter = IntInterpreter::new(domain_memory);
 
         // Synchronize all the int locals in this interpreter to the int
         // interpreter
@@ -3080,7 +3092,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             }
         }
 
-        interpreter.run(&info.ops);
+        // NOTE: Int interpreter promotion is never done if this method has
+        // exception handlers. This means that it's fine to not synchronize
+        // correct state of locals once this throws an error, as there are no
+        // exception handlers to which that state is observable to (this method
+        // will simply immediately return to its caller with the error).
+        let result = interpreter.run(&info.ops);
+        if result.is_err() {
+            // The only exception that can happen from the int interpreter is
+            // an out-of-bounds domain memory read/write.
+            return Err(make_error_1506(self));
+        }
 
         // Synchronize all the int locals in the int interpreter to this
         // interpreter
@@ -3098,5 +3120,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         for i in num_locals..num_locals + info.final_stack_height {
             self.push_stack(interpreter.frame_at(i as u32));
         }
+
+        Ok(())
     }
 }

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -1,4 +1,7 @@
+use crate::avm2::bytearray::ByteArrayStorage;
 use crate::avm2::op::IntOp;
+
+use std::cell::RefMut;
 
 /// The largest method frame size supported by the int interpreter.
 ///
@@ -6,16 +9,25 @@ use crate::avm2::op::IntOp;
 /// that `optimizer::utils::SmallBitSet` can store!
 pub const MAX_INT_INTERPRETER_FRAME: usize = 16;
 
-pub struct IntInterpreter {
+pub struct DomainMemoryError;
+
+pub struct IntInterpreter<'a> {
+    /// The frame, which stores both the locals and the stack.
     frame: [i32; MAX_INT_INTERPRETER_FRAME],
+
+    /// The current stack pointer.
     stack_pointer: usize,
+
+    /// The domain memory, pre-borrowed for speed.
+    domain_memory: RefMut<'a, ByteArrayStorage>,
 }
 
-impl IntInterpreter {
-    pub fn new() -> Self {
+impl<'a> IntInterpreter<'a> {
+    pub fn new(domain_memory: RefMut<'a, ByteArrayStorage>) -> Self {
         Self {
             frame: [0; MAX_INT_INTERPRETER_FRAME],
             stack_pointer: 0,
+            domain_memory,
         }
     }
 
@@ -41,7 +53,7 @@ impl IntInterpreter {
         self.frame[index as usize] = value;
     }
 
-    pub fn run(&mut self, opcodes: &[IntOp]) {
+    pub fn run(&mut self, opcodes: &[IntOp]) -> Result<(), DomainMemoryError> {
         let mut ip = 0;
 
         loop {
@@ -58,9 +70,13 @@ impl IntInterpreter {
                 IntOp::Dup => self.op_dup(),
                 IntOp::GetLocal { index } => self.op_get_local(*index),
                 IntOp::IncLocal { index } => self.op_inc_local(*index),
+                IntOp::Li32 => self.op_li32()?,
+                IntOp::Li8 => self.op_li8()?,
                 IntOp::Nop => {}
                 IntOp::PushInt { value } => self.op_push_int(*value),
                 IntOp::SetLocal { index } => self.op_set_local(*index),
+                IntOp::Si32 => self.op_si32()?,
+                IntOp::Si8 => self.op_si8()?,
                 IntOp::StoreLocal { index } => self.op_store_local(*index),
                 IntOp::Subtract => self.op_subtract(),
 
@@ -69,6 +85,8 @@ impl IntInterpreter {
                 }
             }
         }
+
+        Ok(())
     }
 
     fn op_add(&mut self) {
@@ -120,17 +138,85 @@ impl IntInterpreter {
         self.set_frame_at(index, value.wrapping_add(1));
     }
 
+    fn op_li32(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_li32` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let dm = &self.domain_memory;
+
+        if address > dm.len() - 4 {
+            return Err(DomainMemoryError);
+        }
+
+        let val = dm.read_at(4, address).expect("Already checked");
+        self.push_stack(i32::from_le_bytes(val.try_into().unwrap()));
+
+        Ok(())
+    }
+
+    fn op_li8(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_li8` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let dm = &self.domain_memory;
+
+        let val = dm.get(address);
+
+        if let Some(val) = val {
+            self.push_stack(val as i32);
+        } else {
+            return Err(DomainMemoryError);
+        }
+
+        Ok(())
+    }
+
     fn op_push_int(&mut self, value: i32) {
         self.push_stack(value);
     }
 
-    fn op_store_local(&mut self, index: u32) {
-        let value = self.peek_stack();
+    fn op_set_local(&mut self, index: u32) {
+        let value = self.pop_stack();
         self.set_frame_at(index, value);
     }
 
-    fn op_set_local(&mut self, index: u32) {
-        let value = self.pop_stack();
+    fn op_si32(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_si32` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let val = self.pop_stack();
+
+        let dm = &mut self.domain_memory;
+
+        if address > dm.len() - 4 {
+            return Err(DomainMemoryError);
+        }
+
+        dm.write_at_nongrowing(&val.to_le_bytes(), address)
+            .expect("Already checked");
+
+        Ok(())
+    }
+
+    fn op_si8(&mut self) -> Result<(), DomainMemoryError> {
+        // See `Activation::op_si8` for an explanation
+        let address = self.pop_stack() as usize;
+
+        let val = self.pop_stack() as i8;
+
+        let dm = &mut self.domain_memory;
+
+        if address >= dm.len() {
+            return Err(DomainMemoryError);
+        }
+
+        dm.set_nongrowing(address, val as u8);
+
+        Ok(())
+    }
+
+    fn op_store_local(&mut self, index: u32) {
+        let value = self.peek_stack();
         self.set_frame_at(index, value);
     }
 

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -53,6 +53,7 @@ impl<'a> IntInterpreter<'a> {
         self.frame[index as usize] = value;
     }
 
+    #[inline(never)]
     pub fn run(&mut self, opcodes: &[IntOp]) -> Result<(), DomainMemoryError> {
         let mut ip = 0;
 

--- a/core/src/avm2/int_interpreter.rs
+++ b/core/src/avm2/int_interpreter.rs
@@ -1,0 +1,142 @@
+use crate::avm2::op::IntOp;
+
+/// The largest method frame size supported by the int interpreter.
+///
+/// NOTE: This value must be smaller than `u32::BITS`, as that is the most bits
+/// that `optimizer::utils::SmallBitSet` can store!
+pub const MAX_INT_INTERPRETER_FRAME: usize = 16;
+
+pub struct IntInterpreter {
+    frame: [i32; MAX_INT_INTERPRETER_FRAME],
+    stack_pointer: usize,
+}
+
+impl IntInterpreter {
+    pub fn new() -> Self {
+        Self {
+            frame: [0; MAX_INT_INTERPRETER_FRAME],
+            stack_pointer: 0,
+        }
+    }
+
+    pub fn push_stack(&mut self, value: i32) {
+        self.frame[self.stack_pointer] = value;
+        self.stack_pointer += 1;
+    }
+
+    pub fn peek_stack(&mut self) -> i32 {
+        self.frame[self.stack_pointer - 1]
+    }
+
+    pub fn pop_stack(&mut self) -> i32 {
+        self.stack_pointer -= 1;
+        self.frame[self.stack_pointer]
+    }
+
+    pub fn frame_at(&mut self, index: u32) -> i32 {
+        self.frame[index as usize]
+    }
+
+    pub fn set_frame_at(&mut self, index: u32, value: i32) {
+        self.frame[index as usize] = value;
+    }
+
+    pub fn run(&mut self, opcodes: &[IntOp]) {
+        let mut ip = 0;
+
+        loop {
+            let op = &opcodes[ip];
+            ip += 1;
+
+            match op {
+                IntOp::Add => self.op_add(),
+                IntOp::BitAnd => self.op_bitand(),
+                IntOp::BitNot => self.op_bitnot(),
+                IntOp::BitOr => self.op_bitor(),
+                IntOp::BitXor => self.op_bitxor(),
+                IntOp::DecLocal { index } => self.op_dec_local(*index),
+                IntOp::Dup => self.op_dup(),
+                IntOp::GetLocal { index } => self.op_get_local(*index),
+                IntOp::IncLocal { index } => self.op_inc_local(*index),
+                IntOp::Nop => {}
+                IntOp::PushInt { value } => self.op_push_int(*value),
+                IntOp::SetLocal { index } => self.op_set_local(*index),
+                IntOp::StoreLocal { index } => self.op_store_local(*index),
+                IntOp::Subtract => self.op_subtract(),
+
+                IntOp::End => {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn op_add(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1.wrapping_add(value2));
+    }
+
+    fn op_bitand(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1 & value2);
+    }
+
+    fn op_bitnot(&mut self) {
+        let value = self.pop_stack();
+        self.push_stack(!value);
+    }
+
+    fn op_bitor(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1 | value2);
+    }
+
+    fn op_bitxor(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1 ^ value2);
+    }
+
+    fn op_dec_local(&mut self, index: u32) {
+        let value = self.frame_at(index);
+        self.set_frame_at(index, value.wrapping_sub(1));
+    }
+
+    fn op_dup(&mut self) {
+        let value = self.peek_stack();
+        self.push_stack(value);
+    }
+
+    fn op_get_local(&mut self, index: u32) {
+        let value = self.frame_at(index);
+        self.push_stack(value);
+    }
+
+    fn op_inc_local(&mut self, index: u32) {
+        let value = self.frame_at(index);
+        self.set_frame_at(index, value.wrapping_add(1));
+    }
+
+    fn op_push_int(&mut self, value: i32) {
+        self.push_stack(value);
+    }
+
+    fn op_store_local(&mut self, index: u32) {
+        let value = self.peek_stack();
+        self.set_frame_at(index, value);
+    }
+
+    fn op_set_local(&mut self, index: u32) {
+        let value = self.pop_stack();
+        self.set_frame_at(index, value);
+    }
+
+    fn op_subtract(&mut self) {
+        let value2 = self.pop_stack();
+        let value1 = self.pop_stack();
+        self.push_stack(value1.wrapping_sub(value2));
+    }
+}

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -476,9 +476,13 @@ pub enum IntOp {
     End,
     GetLocal { index: u32 },
     IncLocal { index: u32 },
+    Li32,
+    Li8,
     Nop,
     PushInt { value: i32 },
     SetLocal { index: u32 },
+    Si32,
+    Si8,
     StoreLocal { index: u32 },
     Subtract,
 }

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -2,6 +2,7 @@ use crate::avm2::class::Class;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::multiname::Multiname;
 use crate::avm2::namespace::Namespace;
+use crate::avm2::optimizer::utils::SmallBitSet;
 use crate::avm2::script::Script;
 use crate::string::AvmAtom;
 
@@ -291,6 +292,7 @@ pub enum Op<'gc> {
     ReturnVoid {
         return_type: Option<Class<'gc>>,
     },
+    RunIntInterpreter(Gc<'gc, IntInterpreterInfo>),
     RShift,
     SetGlobalSlot {
         // note: 0-indexed, as opposed to FP.
@@ -348,6 +350,9 @@ pub enum Op<'gc> {
     Timestamp,
     URShift,
 }
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<Op>() == 16);
 
 impl Op<'_> {
     pub fn can_throw_error(&self) -> bool {
@@ -434,5 +439,48 @@ pub struct LookupSwitch {
     pub case_offsets: Box<[Cell<usize>]>,
 }
 
-#[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<Op>() == 16);
+#[derive(Collect, Debug)]
+#[collect(require_static)]
+pub struct IntInterpreterInfo {
+    /// The locals that should be provided as inputs to the int interpreter.
+    pub input_locals: SmallBitSet,
+
+    /// The locals that are modified by the int interpreter.
+    pub output_locals: SmallBitSet,
+
+    /// The stack height of the int interpreter after execution ends.
+    pub final_stack_height: usize,
+
+    /// The offset in normal code that should be jumped to after execution ends.
+    ///
+    /// This has interior mutability so that we can rewrite the offset from the
+    /// optimizer when we need to.
+    pub exit_offset: Cell<usize>,
+
+    /// The ops run by the int interpreter.
+    pub ops: Vec<IntOp>,
+}
+
+/// An op used in the int interpreter.
+///
+/// These ops only work on `i32` values.
+#[derive(Debug)]
+pub enum IntOp {
+    Add,
+    BitAnd,
+    BitNot,
+    BitOr,
+    BitXor,
+    DecLocal { index: u32 },
+    Dup,
+    End,
+    GetLocal { index: u32 },
+    IncLocal { index: u32 },
+    Nop,
+    PushInt { value: i32 },
+    SetLocal { index: u32 },
+    StoreLocal { index: u32 },
+    Subtract,
+}
+
+const _: () = assert!(std::mem::size_of::<IntOp>() == 8);

--- a/core/src/avm2/optimizer.rs
+++ b/core/src/avm2/optimizer.rs
@@ -1,13 +1,16 @@
 mod blocks;
 mod dce;
+mod int_interpretation;
 mod nop_remover;
 mod peephole;
 mod type_aware;
+pub(crate) mod utils;
 
 use crate::avm2::activation::Activation;
 use crate::avm2::error::Error;
 use crate::avm2::method::{Method, ResolvedParamConfig};
 use crate::avm2::op::Op;
+use crate::avm2::optimizer::int_interpretation::IntAnalysisInfo;
 use crate::avm2::verify::Exception;
 
 use std::cell::Cell;
@@ -34,6 +37,13 @@ pub fn optimize<'gc>(
     // zero-length jumps, which usually reduces the number of blocks in obfuscated code.
     peephole::preprocess_peephole(code_slice);
 
+    let mut int_analysis_info = IntAnalysisInfo::new(
+        activation,
+        method,
+        !method_exceptions.is_empty(),
+        code_slice,
+    );
+
     type_aware::type_aware_optimize(
         activation,
         method,
@@ -41,12 +51,15 @@ pub fn optimize<'gc>(
         method_exceptions,
         resolved_parameters,
         &mut jump_targets,
+        &mut int_analysis_info,
         sets_local_0,
     )?;
 
-    peephole::postprocess_peephole(code_slice, &jump_targets);
+    peephole::postprocess_peephole(code_slice, &jump_targets, &mut int_analysis_info);
 
     dce::eliminate_dead_code(code_slice, &jump_targets);
+
+    int_interpretation::run_analysis(activation, code_slice, &int_analysis_info);
 
     nop_remover::remove_nops(code, method_exceptions);
 

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -1,0 +1,258 @@
+use crate::avm2::activation::Activation;
+use crate::avm2::int_interpreter::MAX_INT_INTERPRETER_FRAME;
+use crate::avm2::method::Method;
+use crate::avm2::op::{IntInterpreterInfo, IntOp, Op};
+use crate::avm2::optimizer::utils::SmallBitSet;
+
+use gc_arena::Gc;
+use std::cell::Cell;
+use std::collections::BTreeMap;
+use std::ops::Range;
+
+/// The minimum number of consecutive ops that will be run in the integer
+/// interpreter. If this number is too low, the overhead of entering and exiting
+/// the integer interpreter may be greater than the speedup of having faster
+/// ops. On the other hand, if this number is too high, some sequences of ops
+/// that would benefit from being run in the integer interpreter may end up
+/// being considered too short to be run in it.
+const MIN_INT_OPS_LENGTH: usize = 30;
+
+/// The maximum number of ops in a method that can be considered for int
+/// interpreter analysis.
+const MAX_METHOD_OPS_LENGTH: usize = 300;
+
+pub fn run_analysis<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    ops: &[Cell<Op<'gc>>],
+    int_analysis_info: &IntAnalysisInfo,
+) {
+    if !int_analysis_info.is_valid() {
+        return;
+    }
+
+    // Keep track of the ranges that we've already created int interpreter
+    // promotions for so that we don't create even more int interpreter
+    // promotions within them. Because `empty_stack_positions` is a `BTreeMap`,
+    // iterating over it will result in earlier positions (the ones that will
+    // yield the largest promoted areas) being handled first.
+    let mut covered_ranges: Vec<Range<usize>> = Vec::new();
+
+    // Now we can actually run the analysis pass.
+    for (start_index, locals_state) in int_analysis_info.empty_stack_positions.iter() {
+        let start_index = *start_index;
+
+        if covered_ranges.iter().any(|r| r.contains(&start_index)) {
+            // See above comment
+            continue;
+        }
+
+        if let Some(info) = run_single_analysis(ops, start_index, locals_state) {
+            covered_ranges.push(start_index..info.exit_offset.get());
+
+            let op = Op::RunIntInterpreter(Gc::new(activation.gc(), info));
+            ops[start_index].set(op);
+        }
+    }
+}
+
+fn run_single_analysis<'gc>(
+    ops: &[Cell<Op<'gc>>],
+    start_index: usize,
+    entry_locals_state: &SmallBitSet,
+) -> Option<IntInterpreterInfo> {
+    let mut output_vec = Vec::new();
+
+    let mut current_locals_state = entry_locals_state.clone();
+    let mut stack_height = 0;
+
+    // We run a simplified abstract interpreter pass. We know that at this point,
+    // the stack is empty and locals are either integral or non-integral. Loading
+    // a non-integral local results in the pass being aborted, so we can be
+    // certain that these ops are only working on integers.
+    let mut i = start_index;
+    while i < ops.len() {
+        let op = ops[i].get();
+
+        let translated_op = match op {
+            Op::AddI => {
+                stack_height -= 1;
+
+                IntOp::Add
+            }
+            Op::BitAnd => {
+                stack_height -= 1;
+
+                IntOp::BitAnd
+            }
+            Op::BitNot => IntOp::BitNot,
+            Op::BitOr => {
+                stack_height -= 1;
+
+                IntOp::BitOr
+            }
+            Op::BitXor => {
+                stack_height -= 1;
+
+                IntOp::BitXor
+            }
+            Op::DecLocalI { index } => {
+                if !current_locals_state.get(index as usize) {
+                    // Can't access a non-int
+                    break;
+                }
+
+                IntOp::DecLocal { index }
+            }
+            Op::Dup => {
+                stack_height += 1;
+
+                IntOp::Dup
+            }
+            Op::GetLocal { index } => {
+                if !current_locals_state.get(index as usize) {
+                    // Can't access a non-int
+                    break;
+                }
+
+                stack_height += 1;
+
+                IntOp::GetLocal { index }
+            }
+            Op::IncLocalI { index } => {
+                if !current_locals_state.get(index as usize) {
+                    // Can't access a non-int
+                    break;
+                }
+
+                IntOp::IncLocal { index }
+            }
+            Op::Nop => IntOp::Nop,
+            Op::PushInt { value } => {
+                stack_height += 1;
+
+                IntOp::PushInt { value }
+            }
+            Op::SetLocal { index } => {
+                stack_height -= 1;
+
+                current_locals_state.set(index as usize, true);
+                IntOp::SetLocal { index }
+            }
+            Op::StoreLocal { index } => {
+                current_locals_state.set(index as usize, true);
+                IntOp::StoreLocal { index }
+            }
+            Op::SubtractI => {
+                stack_height -= 1;
+
+                IntOp::Subtract
+            }
+            _ => {
+                break;
+            }
+        };
+
+        output_vec.push(translated_op);
+
+        i += 1;
+    }
+
+    let num_ops = output_vec.len();
+
+    output_vec.push(IntOp::End);
+
+    // Not enough ops for entering the int interpreter to be worth it
+    if num_ops < MIN_INT_OPS_LENGTH {
+        return None;
+    }
+
+    let info = IntInterpreterInfo {
+        input_locals: entry_locals_state.clone(),
+        output_locals: current_locals_state,
+        final_stack_height: stack_height,
+        exit_offset: Cell::new(start_index + num_ops),
+        ops: output_vec,
+    };
+
+    Some(info)
+}
+
+/// Information about if and where to perform int interpreter analysis.
+///
+/// This struct is filled out before the int interpreter analysis begins (in the
+/// type-aware optimizer), and is used by the int interpreter analysis code.
+pub struct IntAnalysisInfo {
+    /// Every op index in this method where the stack is empty. For each of
+    /// these positions, previously, in the type-aware optimizer, we recorded
+    /// which of the locals was integral. That information is stored in the
+    /// `SmallBitSet` corresponding to each location.
+    ///
+    /// NOTE: these op indices are indices of ops before the nop remover has
+    /// been run.
+    empty_stack_positions: BTreeMap<usize, SmallBitSet>,
+
+    /// Whether int interpreter analysis should be performed at all.
+    is_valid: bool,
+}
+
+impl IntAnalysisInfo {
+    pub fn new<'gc>(
+        activation: &mut Activation<'_, 'gc>,
+        method: Method<'gc>,
+        has_exceptions: bool,
+        ops: &[Cell<Op<'gc>>],
+    ) -> Self {
+        let method_body = method
+            .body()
+            .expect("Cannot verify non-native method without body!");
+        let max_locals = method_body.num_locals;
+        let max_stack = method_body.max_stack;
+
+        let is_valid = if ops.len() > MAX_METHOD_OPS_LENGTH {
+            // Not worth trying to optimize a method this large
+            false
+        } else if has_exceptions {
+            // The int interpreter and the analysis do not handle exceptions
+            false
+        } else if method
+            .translation_unit()
+            .domain()
+            .is_playerglobals_domain(activation.avm2())
+        {
+            // Some playerglobals code will run before domain memory is initialized,
+            // so if playerglobals code attempts to access domain memory there'll
+            // be a panic on startup
+            false
+        } else if (max_locals + max_stack) as usize >= MAX_INT_INTERPRETER_FRAME {
+            // Frame is too large to run in the int interpreter
+            false
+        } else {
+            true
+        };
+
+        Self {
+            empty_stack_positions: BTreeMap::new(),
+            is_valid,
+        }
+    }
+
+    /// Determine if this `IntAnalysisInfo` claims that it is valid to perform
+    /// an int-interpretation analysis.
+    pub fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    /// Mark an position in the method where the stack is empty.
+    ///
+    /// This method requires a `SmallBitSet` of which locals are integral at
+    /// that point, as that is necessary for the analysis.
+    pub fn mark_empty_stack_position(&mut self, position: usize, integral_locals: SmallBitSet) {
+        self.empty_stack_positions.insert(position, integral_locals);
+    }
+
+    /// Mark an position in the method where the stack was previously marked as
+    /// empty but now no longer is.
+    pub fn remove_empty_stack_position(&mut self, position: usize) {
+        self.empty_stack_positions.remove(&position);
+    }
+}

--- a/core/src/avm2/optimizer/int_interpretation.rs
+++ b/core/src/avm2/optimizer/int_interpretation.rs
@@ -126,6 +126,8 @@ fn run_single_analysis<'gc>(
 
                 IntOp::IncLocal { index }
             }
+            Op::Li8 => IntOp::Li8,
+            Op::Li32 => IntOp::Li32,
             Op::Nop => IntOp::Nop,
             Op::PushInt { value } => {
                 stack_height += 1;
@@ -137,6 +139,16 @@ fn run_single_analysis<'gc>(
 
                 current_locals_state.set(index as usize, true);
                 IntOp::SetLocal { index }
+            }
+            Op::Si8 => {
+                stack_height -= 2;
+
+                IntOp::Si8
+            }
+            Op::Si32 => {
+                stack_height -= 2;
+
+                IntOp::Si32
             }
             Op::StoreLocal { index } => {
                 current_locals_state.set(index as usize, true);

--- a/core/src/avm2/optimizer/nop_remover.rs
+++ b/core/src/avm2/optimizer/nop_remover.rs
@@ -41,6 +41,9 @@ pub fn remove_nops<'gc>(code: &mut Vec<Op<'gc>>, exceptions: &mut [Exception<'gc
                     target.set(offset_vec[target.get()]);
                 }
             }
+            Op::RunIntInterpreter(info) => {
+                info.exit_offset.set(offset_vec[info.exit_offset.get()]);
+            }
             _ => {}
         }
     }

--- a/core/src/avm2/optimizer/peephole.rs
+++ b/core/src/avm2/optimizer/peephole.rs
@@ -1,4 +1,5 @@
 use crate::avm2::op::Op;
+use crate::avm2::optimizer::int_interpretation::IntAnalysisInfo;
 
 use std::cell::Cell;
 use std::collections::HashSet;
@@ -21,7 +22,11 @@ pub fn preprocess_peephole(ops: &[Cell<Op<'_>>]) {
 
 /// A peephole optimizer to run after type-aware optimizations. This should be
 /// called once on the entire code slice.
-pub fn postprocess_peephole<'a>(ops: &'a [Cell<Op<'_>>], jump_targets: &HashSet<usize>) {
+pub fn postprocess_peephole<'a>(
+    ops: &'a [Cell<Op<'_>>],
+    jump_targets: &HashSet<usize>,
+    int_analysis_info: &mut IntAnalysisInfo,
+) {
     // Determine if this method ever depends on the state of the scope stack.
     let mut uses_scope_ops = false;
 
@@ -65,6 +70,10 @@ pub fn postprocess_peephole<'a>(ops: &'a [Cell<Op<'_>>], jump_targets: &HashSet<
             last_op = None;
         }
 
+        // NOTE: If a peephole optimization changes the stack from being empty
+        // to being non-empty at a certain position, it MUST make sure to
+        // invalidate that position in `empty_stack_positions`.
+
         if let Some(last_op) = last_op {
             // Optimizations on both the current and the last op
             match (last_op.get(), current_op.get()) {
@@ -93,6 +102,13 @@ pub fn postprocess_peephole<'a>(ops: &'a [Cell<Op<'_>>], jump_targets: &HashSet<
                     // SetLocal+GetLocal becomes Nop+StoreLocal
                     last_op.set(Op::Nop);
                     current_op.set(Op::StoreLocal { index: index1 });
+
+                    // It's possible that before this peephole optimization, the
+                    // stack was empty at the `GetLocal`'s position. However,
+                    // after this optimization, it is guaranteed that the stack
+                    // is no longer empty at the `GetLocal`'s position, as the
+                    // `StoreLocal` keeps one entry on the stack.
+                    int_analysis_info.remove_empty_stack_position(i);
                 }
                 (
                     Op::Add {

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -7,6 +7,8 @@ use crate::avm2::method::{Method, MethodAssociation, MethodKind, ResolvedParamCo
 use crate::avm2::multiname::Multiname;
 use crate::avm2::op::Op;
 use crate::avm2::optimizer::blocks::assemble_blocks;
+use crate::avm2::optimizer::int_interpretation::IntAnalysisInfo;
+use crate::avm2::optimizer::utils::SmallBitSet;
 use crate::avm2::property::Property;
 use crate::avm2::verify::Exception;
 use crate::avm2::vtable::VTable;
@@ -603,6 +605,7 @@ struct Types<'gc> {
 /// "disable AVM2 optimizer" player option is on or not. If the "disable AVM2
 // optimizer" player option is on, this method will not actually optimize the
 // resulting code.
+#[expect(clippy::too_many_arguments)]
 pub fn type_aware_optimize<'gc>(
     activation: &mut Activation<'_, 'gc>,
     method: Method<'gc>,
@@ -610,6 +613,7 @@ pub fn type_aware_optimize<'gc>(
     method_exceptions: &mut [Exception<'gc>],
     resolved_parameters: &[ResolvedParamConfig<'gc>],
     jump_targets: &mut HashSet<usize>,
+    int_analysis_info: &mut IntAnalysisInfo,
     sets_local_0: bool,
 ) -> Result<(), Error<'gc>> {
     let (block_list, op_index_to_block_index_table) = assemble_blocks(code_slice, jump_targets);
@@ -700,31 +704,33 @@ pub fn type_aware_optimize<'gc>(
             &types,
             &op_index_to_block_index_table,
             method_exceptions,
+            int_analysis_info,
             sets_local_0,
             &mut worklist,
             false,
         )?;
     }
 
-    if activation.avm2().optimizer_enabled() {
-        // Now run through the ops and actually optimize them
-        for (i, block) in block_list.iter().enumerate() {
-            // todo: don't need to clone here
-            let block_entry_state = abstract_states[i].clone().expect("Entry state not found");
-            abstract_interpret_ops(
-                activation,
-                block.start_index,
-                block.ops,
-                block_entry_state,
-                &mut abstract_states,
-                &types,
-                &op_index_to_block_index_table,
-                method_exceptions,
-                sets_local_0,
-                &mut worklist,
-                true,
-            )?;
-        }
+    // Now run through the ops for the final pass for actual optimizations. No
+    // actual optimizations will be done if `activation.avm2().optimizer_enabled`
+    // is `false`.
+    for (i, block) in block_list.iter().enumerate() {
+        // todo: don't need to clone here
+        let block_entry_state = abstract_states[i].clone().expect("Entry state not found");
+        abstract_interpret_ops(
+            activation,
+            block.start_index,
+            block.ops,
+            block_entry_state,
+            &mut abstract_states,
+            &types,
+            &op_index_to_block_index_table,
+            method_exceptions,
+            int_analysis_info,
+            sets_local_0,
+            &mut worklist,
+            true,
+        )?;
     }
 
     // It's possible that an optimization removed some jumps, so let's
@@ -781,6 +787,7 @@ fn abstract_interpret_ops<'gc>(
     types: &Types<'gc>,
     op_index_to_block_index_table: &HashMap<usize, usize>,
     method_exceptions: &[Exception<'gc>],
+    int_analysis_info: &mut IntAnalysisInfo,
     sets_local_0: bool,
     worklist: &mut Vec<usize>,
     do_optimize: bool,
@@ -788,6 +795,8 @@ fn abstract_interpret_ops<'gc>(
     let mut locals = initial_state.locals;
     let mut stack = initial_state.stack;
     let mut scope_stack = initial_state.scope_stack;
+
+    let optimizer_enabled = activation.avm2().optimizer_enabled();
 
     for (i, op) in ops.iter().enumerate() {
         if op.get().can_throw_error() {
@@ -823,9 +832,29 @@ fn abstract_interpret_ops<'gc>(
             }
         }
 
+        if do_optimize {
+            // During the final optimization pass, for all empty stack positions,
+            // determine which of the locals are integral at each of those stack
+            // positions.
+            if stack.len() == 0 {
+                // `FromIterator` will truncate the bitset if there are too many
+                // locals. However, that doesn't matter, as that would mean that
+                // there are so many locals that int interpreter analysis will
+                // never be done, which means that this bitset's contents will
+                // be discarded.
+                let integral_locals = locals
+                    .0
+                    .iter()
+                    .map(|l| l.class.is_some_and(|c| c.is_builtin_int()))
+                    .collect::<SmallBitSet>();
+
+                int_analysis_info.mark_empty_stack_position(start_index + i, integral_locals);
+            }
+        }
+
         macro_rules! optimize_op_to {
             ($replacement_op:expr) => {
-                if do_optimize {
+                if optimizer_enabled && do_optimize {
                     op.set($replacement_op);
                 }
             };
@@ -2186,6 +2215,7 @@ fn abstract_interpret_ops<'gc>(
             | Op::ConstructSlot { .. }
             | Op::GetScriptGlobals { .. }
             | Op::PopJump { .. }
+            | Op::RunIntInterpreter { .. }
             | Op::SetSlotCoerceI { .. }
             | Op::SetSlotNoCoerce { .. } => unreachable!("Custom ops should not be encountered"),
         }

--- a/core/src/avm2/optimizer/utils.rs
+++ b/core/src/avm2/optimizer/utils.rs
@@ -1,0 +1,102 @@
+use std::fmt;
+
+/// A bitset only large enough to store 32 bits.
+///
+/// Trying to create a bitset with more items will result in it being silently
+/// truncated.
+#[derive(Clone)]
+pub struct SmallBitSet {
+    bits: u32,
+    len: usize,
+}
+
+impl SmallBitSet {
+    pub fn get(&self, index: usize) -> bool {
+        if index >= self.len {
+            panic!("Attempted to access bit out of range");
+        }
+
+        ((self.bits >> index) & 1) == 1
+    }
+
+    pub fn set(&mut self, index: usize, value: bool) {
+        if value {
+            self.bits |= 1 << index;
+        } else {
+            self.bits &= !(1 << index);
+        }
+    }
+
+    pub fn iter(&self) -> SmallBitSetIter {
+        SmallBitSetIter {
+            // Clone is free
+            data: self.clone(),
+            next: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl FromIterator<bool> for SmallBitSet {
+    // NOTE: This method will truncate the values from the iterator to 32 values
+    // total, as that is the maximum that can fit in a `SmallBitSet`.
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = bool>,
+    {
+        let mut len = 0;
+        let mut bits = 0;
+
+        // NOTE: We take only 32 items from the iterator, as that's the most
+        // that can fit in this bitset.
+        let iter = iter.into_iter().enumerate().take(u32::BITS as usize);
+
+        for (i, bit) in iter {
+            if bit {
+                bits |= 1 << i;
+            }
+
+            len += 1;
+        }
+
+        Self { bits, len }
+    }
+}
+
+pub struct SmallBitSetIter {
+    data: SmallBitSet,
+    next: usize,
+}
+
+impl Iterator for SmallBitSetIter {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        if self.next >= self.data.len {
+            None
+        } else {
+            let value = self.data.get(self.next);
+            self.next += 1;
+
+            Some(value)
+        }
+    }
+}
+
+impl fmt::Debug for SmallBitSet {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let mut result = String::new();
+        for i in 0..self.len() {
+            if self.get(i) {
+                result.push('1');
+            } else {
+                result.push('0');
+            }
+        }
+
+        write!(f, "{}", result)
+    }
+}


### PR DESCRIPTION
## Description

This PR sets up the initial implementation of the int interpreter (see #23864). This allows for very small amounts of code in some SWFs to run in the int interpreter.

Many of the changes made in this PR will be reverted or significantly changed in my next PR, which will fully implement the int interpreter, with support for branching, comparison ops, `getslot`, etc.

## Testing

This PR includes no SWF-observable changes. I've tested the code myself on several SWFs.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
