### PR TITLE
core: Remove unnecessary `dyn` usage

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1284,7 +1284,7 @@ impl<'gc> EditText<'gc> {
                 text,
                 self.text_transform(color),
                 params,
-                &mut |pos, transform, glyph, advance, x| {
+                |pos, transform, glyph, advance, x| {
                     if glyph.renderable(context) {
                         // If it's highlighted, override the color.
                         if matches!(visible_selection, Some(visible_selection) if visible_selection.contains(start + pos)) {
@@ -1636,7 +1636,7 @@ impl<'gc> EditText<'gc> {
                     text,
                     self.text_transform(color),
                     params,
-                    &mut |pos, _transform, _glyph, advance, x| {
+                    |pos, _transform, _glyph, advance, x| {
                         if local_position.x >= x {
                             if local_position.x > x + (advance / 2) {
                                 result = string_utils::next_char_boundary(text, pos);

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -874,7 +874,7 @@ pub trait FontLike<'gc> {
         text: &WStr, // TODO: take an `IntoIterator<Item=char>`, to not depend on string representation?
         mut transform: Transform,
         params: EvalParameters,
-        glyph_func: &mut dyn FnMut(usize, &Transform, GlyphRef, Twips, Twips),
+        mut glyph_func: impl FnMut(usize, &Transform, GlyphRef, Twips, Twips),
     ) {
         let baseline = self.metrics().ascent(params.height);
 
@@ -944,7 +944,7 @@ pub trait FontLike<'gc> {
             text,
             Default::default(),
             params,
-            &mut |_pos, _transform, _glyph, advance, x| {
+            |_pos, _transform, _glyph, advance, x| {
                 width = width.max(x + advance);
             },
         );

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -1232,14 +1232,9 @@ impl<'gc> LayoutBox<'gc> {
         let params = EvalParameters::from_span(span);
         let mut char_end_pos = Vec::with_capacity(end - start);
 
-        font_set.evaluate(
-            text,
-            Default::default(),
-            params,
-            &mut |_, _, _, advance, x| {
-                char_end_pos.push(x + advance);
-            },
-        );
+        font_set.evaluate(text, Default::default(), params, |_, _, _, advance, x| {
+            char_end_pos.push(x + advance);
+        });
 
         Self {
             bounds: Default::default(),

--- a/core/src/html/line_wrapping.rs
+++ b/core/src/html/line_wrapping.rs
@@ -40,8 +40,8 @@ use itertools::Itertools;
 /// If is_start_of_line, the function is guaranteed to not return 0.
 ///
 /// This function yields `None` if the line is not broken.
-pub fn wrap_line(
-    font: &dyn FontLike<'_>,
+pub fn wrap_line<'gc, T: FontLike<'gc>>(
+    font: &T,
     text: &WStr,
     params: EvalParameters,
     width: Twips,


### PR DESCRIPTION
## Description

There is no reason to use dyn in these places (Well, unless we ever want to use Box\<dyn FontLike\>, then only half of this PR would be valid.)

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
