### PR TITLE
core: Use __jcvt() intrinsic on AArch64 for f64→i32 conversion

### DIFF
--- a/core/src/ecma_conversions.rs
+++ b/core/src/ecma_conversions.rs
@@ -40,49 +40,22 @@ pub fn f64_to_wrapping_u32(n: f64) -> u32 {
 /// Converts an `f64` to an `i32` with ECMAScript `ToInt32` wrapping behavior.
 /// The value will be wrapped in the range [-2^31, 2^31).
 pub fn f64_to_wrapping_i32(n: f64) -> i32 {
-    // TODO: use core intrinsic when https://github.com/rust-lang/rust/issues/147555 is stabilized.
-    #[cfg(target_arch = "aarch64")]
-    {
-        if std::arch::is_aarch64_feature_detected!("jsconv") {
-            // SAFETY: `jsconv` feature is checked in both compile time and runtime to be existed, so it's safe to call.
-            unsafe { f64_to_wrapping_int32_aarch64(n) }
-        } else {
-            f64_to_wrapping_i32_generic(n)
+    cfg_select! {
+        target_arch = "aarch64" => {
+            if std::arch::is_aarch64_feature_detected!("jsconv") {
+                // SAFETY: the `jsconv` target feature was just verified to be available above,
+                // so the `fjcvtzs` instruction used by `__jcvt` is available.
+                unsafe { std::arch::aarch64::__jcvt(n) }
+            } else {
+                f64_to_wrapping_i32_generic(n)
+            }
         }
+        _ => f64_to_wrapping_i32_generic(n),
     }
-    #[cfg(not(target_arch = "aarch64"))]
-    f64_to_wrapping_i32_generic(n)
 }
 
-#[allow(unused)]
 fn f64_to_wrapping_i32_generic(n: f64) -> i32 {
     f64_to_wrapping_u32(n) as i32
-}
-
-/// Converts an `f64` to an `i32` with ECMAScript `ToInt32` wrapping behavior.
-/// The value will be wrapped in the range [-2^31, 2^31).
-/// Optimized for aarch64 cpu with the fjcvtzs instruction.
-///
-/// # Safety
-///
-/// The caller must ensure either:
-/// - The target platform is aarch64 with `jsconv` feature enabled, or
-/// - Runtime feature detection has been performed to verify `jsconv` support
-#[allow(unused)]
-#[cfg(target_arch = "aarch64")]
-#[target_feature(enable = "jsconv")]
-unsafe fn f64_to_wrapping_int32_aarch64(number: f64) -> i32 {
-    let ret: i32;
-    // SAFETY: fjcvtzs instruction is available under jsconv feature.
-    unsafe {
-        std::arch::asm!(
-            "fjcvtzs {dst:w}, {src:d}",
-            src = in(vreg) number,
-            dst = out(reg) ret,
-            options(nostack, nomem, pure)
-        );
-    }
-    ret
 }
 
 /// Implements the IEEE-754 "Round to nearest, ties to even" rounding rule.


### PR DESCRIPTION
Supersedes #22138.

## Description
See #22138.

## Testing

_How can we test this PR?_

Good question :D. I guess someone has to have the hardware or we have to check if it's available in CI.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
