### PR TITLE
core: Add AvmString::split_dependent

### DIFF
--- a/core/common/src/avm_string/avm_string.rs
+++ b/core/common/src/avm_string/avm_string.rs
@@ -1,8 +1,9 @@
+use super::context::StringContext;
 use super::interner::AvmAtom;
 use super::repr::AvmStringRepr;
 
 use gc_arena::{Collect, Gc, Mutation};
-use ruffle_wstr::{WStr, WString, wstr_impl_traits};
+use ruffle_wstr::{Pattern, WStr, WString, wstr_impl_traits};
 use std::borrow::Cow;
 use std::ops::Deref;
 
@@ -102,6 +103,20 @@ impl<'gc> AvmString<'gc> {
     #[inline]
     pub fn ptr_eq(this: &Self, other: &Self) -> bool {
         std::ptr::eq(this.as_wstr(), other.as_wstr())
+    }
+
+    /// Like [`WStr::split`], but yields dependent `AvmString`s
+    pub fn split_dependent<'a, P>(
+        self,
+        context: &'a StringContext<'gc>,
+        pattern: P,
+    ) -> impl Iterator<Item = AvmString<'gc>> + 'a
+    where
+        P: Pattern<'gc> + 'a,
+    {
+        self.as_wstr()
+            .split_indices(pattern)
+            .map(move |range| context.substring(self, range))
     }
 }
 

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -8,7 +8,7 @@ use crate::avm1::property_decl::{DeclContext, PropertyOrder, StaticDeclarations,
 use crate::avm1::{Object, Value};
 use crate::avm1_stub;
 use crate::display_object::TDisplayObject;
-use crate::string::AvmString;
+use ruffle_common::avm_string::HasStringContext;
 use ruffle_macros::istr;
 
 const PROTO_DECLS: StaticDeclarations = declare_static_properties! {
@@ -325,11 +325,12 @@ pub fn as_set_prop_flags<'gc>(
         }
         Some(v) => {
             let props = v.coerce_to_string(activation)?;
+
             if props.contains(b',') {
-                for prop_name in props.split(b',') {
+                for prop_name in props.split_dependent(activation.strings_ref(), b',') {
                     object.set_attributes(
                         activation.gc(),
-                        Some(AvmString::new(activation.gc(), prop_name)),
+                        Some(prop_name),
                         set_attributes,
                         clear_attributes,
                     )

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -273,12 +273,11 @@ fn split<'gc>(
                 )
                 .into())
         } else {
-            // TODO(moulins): make dependent AvmStrings instead of reallocating.
             Ok(ArrayBuilder::new(activation)
                 .with(
-                    this.split(&delimiter)
+                    this.split_dependent(activation.strings(), delimiter.as_wstr())
                         .take(limit)
-                        .map(|c| AvmString::new(activation.gc(), c).into()),
+                        .map(Value::from),
                 )
                 .into())
         }

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -453,9 +453,8 @@ pub fn split<'gc>(
                 .collect()
         }
     } else {
-        this.split(&delimiter)
+        this.split_dependent(activation.strings(), delimiter.as_wstr())
             .take(limit.get())
-            .map(|c| AvmString::new(activation.gc(), c))
             .collect()
     };
 

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -153,8 +153,10 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
 
         let params = EvalParameters::from_span(span);
 
-        for text in span_text.split([b'\n', b'\r', b'\t']) {
-            let slice_start = text.offset_in(span_text).unwrap();
+        for range in span_text.split_indices([b'\n', b'\r', b'\t']) {
+            let slice_start = range.start;
+            let text = &span_text[range];
+
             let delimiter = if slice_start > 0 {
                 span_text
                     .get(slice_start - 1)
@@ -651,9 +653,9 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
     fn append_text(&mut self, text: &'a WStr, start: usize, end: usize, span: &TextSpan) {
         let empty = start == end;
         if !empty && self.effective_alignment() == swf::TextAlign::Justify {
-            for word in text.split(b' ') {
-                let word_start = word.offset_in(text).unwrap();
-                let word_end = min(word_start + word.len() + 1, text.len());
+            for range in text.split_indices(b' ') {
+                let word_start = range.start;
+                let word_end = min(range.end + 1, text.len());
 
                 if word_start == word_end {
                     // Do not append empty boxes

--- a/wstr/src/common.rs
+++ b/wstr/src/common.rs
@@ -391,6 +391,15 @@ impl WStr {
         super::ops::str_split(self, separator)
     }
 
+    /// Like [`Self::split`], but yields index ranges into `self` rather than substrings.
+    #[inline]
+    pub fn split_indices<'a, P: Pattern<'a>>(
+        &'a self,
+        separator: P,
+    ) -> super::ops::SplitIndices<'a, P> {
+        super::ops::str_split_indices(self, separator)
+    }
+
     /// Analogue of [`str::split_at`].
     #[inline]
     pub fn split_at(&self, index: usize) -> (&WStr, &WStr) {

--- a/wstr/src/lib.rs
+++ b/wstr/src/lib.rs
@@ -27,7 +27,7 @@ mod tests;
 
 pub use buf::WString;
 pub use common::{Units, WStr};
-pub use ops::{CharIndices, Chars, Iter, Split, WStrToUtf8};
+pub use ops::{CharIndices, Chars, Iter, Split, SplitIndices, WStrToUtf8};
 pub use parse::{FromWStr, Integer};
 pub use pattern::Pattern;
 pub use ptr::WStrMetadata;

--- a/wstr/src/ops.rs
+++ b/wstr/src/ops.rs
@@ -3,6 +3,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::{self, Write};
 use core::hash::Hasher;
+use core::ops::Range;
 use core::slice::Iter as SliceIter;
 
 use super::pattern::{SearchStep, Searcher};
@@ -331,9 +332,18 @@ pub fn str_rfind<'a, P: Pattern<'a>>(haystack: &'a WStr, pattern: P) -> Option<u
 #[inline]
 pub fn str_split<'a, P: Pattern<'a>>(string: &'a WStr, pattern: P) -> Split<'a, P> {
     Split {
-        string: Some(string),
+        string,
+        indices: str_split_indices(string, pattern),
+    }
+}
+
+#[inline]
+pub fn str_split_indices<'a, P: Pattern<'a>>(string: &'a WStr, pattern: P) -> SplitIndices<'a, P> {
+    SplitIndices {
         searcher: pattern.into_searcher(string),
         prev_end: 0,
+        string_len: string.len(),
+        done: false,
     }
 }
 
@@ -418,25 +428,41 @@ pub fn str_trim_end_matches<'a, P: Pattern<'a>>(string: &'a WStr, pattern: P) ->
 }
 
 pub struct Split<'a, P: Pattern<'a>> {
-    string: Option<&'a WStr>,
-    searcher: P::Searcher,
-    prev_end: usize,
+    string: &'a WStr,
+    indices: SplitIndices<'a, P>,
 }
 
 impl<'a, P: Pattern<'a>> Iterator for Split<'a, P> {
     type Item = &'a WStr;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let string = self.string?;
+        self.indices.next().map(|r| &self.string[r])
+    }
+}
+
+pub struct SplitIndices<'a, P: Pattern<'a>> {
+    searcher: P::Searcher,
+    prev_end: usize,
+    string_len: usize,
+    done: bool,
+}
+
+impl<'a, P: Pattern<'a>> Iterator for SplitIndices<'a, P> {
+    type Item = Range<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
 
         match self.searcher.next_match() {
             Some((start, end)) => {
-                let end = core::mem::replace(&mut self.prev_end, end);
-                Some(&string[end..start])
+                let prev = core::mem::replace(&mut self.prev_end, end);
+                Some(prev..start)
             }
             None => {
-                self.string = None;
-                Some(&string[self.prev_end..])
+                self.done = true;
+                Some(self.prev_end..self.string_len)
             }
         }
     }


### PR DESCRIPTION
## Description

This implements a TODO in code and refactors some related code.

I'm not much of a lifetime guy, so I'm not 100% sure if the lifetimes on `AvmString::split_dependent` are correct. 

## Testing

_How can we test this PR?_

String.split is covered by existing tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
