### PR TITLE
avm2: Remove redundant method `PropertyMap::insert_with_namespace`

### DIFF
--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -124,25 +124,6 @@ impl<'gc, V> PropertyMap<'gc, V> {
         }
     }
 
-    pub fn insert_with_namespace(
-        &mut self,
-        ns: Namespace<'gc>,
-        name: AvmString<'gc>,
-        mut value: V,
-    ) -> Option<V> {
-        let bucket = self.0.entry(name).or_default();
-
-        if let Some((_, old_value)) = bucket.iter_mut().find(|(n, _)| n.matches_ns(ns)) {
-            swap(old_value, &mut value);
-
-            Some(value)
-        } else {
-            bucket.push((ns, value));
-
-            None
-        }
-    }
-
     pub fn remove(&mut self, name: QName<'gc>) -> Option<V> {
         let bucket = self.0.get_mut(&name.local_name());
 

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -5,14 +5,14 @@ use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
 use crate::avm2::domain::Domain;
 use crate::avm2::object::TObject;
+use crate::avm2::property_map::PropertyMap;
+use crate::avm2::qname::QName;
 use crate::avm2::value::Value;
 use crate::avm2::{Multiname, Namespace};
 use core::fmt;
 use gc_arena::barrier::field;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, Mutation};
-
-use super::property_map::PropertyMap;
 
 /// Represents a Scope that can be on either a ScopeChain or local ScopeStack.
 #[derive(Collect, Clone, Copy, Debug)]
@@ -232,10 +232,9 @@ impl<'gc> ScopeChain<'gc> {
                 let name = multiname
                     .local_name()
                     .expect("Resolvable multinames should always have a local name");
-                cache
-                    .unlock()
-                    .borrow_mut()
-                    .insert_with_namespace(ns, name, obj);
+                let qname = QName::new(ns, name);
+
+                cache.unlock().borrow_mut().insert(qname, obj);
             }
         }
         Ok(found.map(|o| o.1))


### PR DESCRIPTION
## Description

Uses of `PropertyMap::insert_with_namespace` could all be replaced with `PropertyMap::insert`.

## Testing

No functional changes.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
