### PR TITLE
core: Use enum-map for ActionQueue priorities

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -41,6 +41,8 @@ use crate::timer::Timers;
 use crate::vminterface::Instantiator;
 use async_channel::Sender;
 use core::fmt;
+use enum_map::Enum;
+use enum_map::EnumMap;
 use gc_arena::{Collect, Mutation};
 use ruffle_render::backend::{BitmapCacheEntry, RenderBackend};
 use ruffle_render::commands::{CommandHandler, CommandList};
@@ -485,22 +487,36 @@ pub struct QueuedAction<'gc> {
     pub is_unload: bool,
 }
 
+/// Priority bucket for queued actions, grouped by which `ActionType`s land in
+/// them. Variants are declared in execution order; [`ActionQueue::pop_action`]
+/// drains the first-declared bucket first.
+#[derive(Copy, Clone, Collect, Enum)]
+#[collect(require_static)]
+pub enum ActionPriority {
+    /// AVM1 `initialize` clip events. Run first.
+    Initialize,
+    /// `MovieClip` construction actions.
+    Construct,
+    /// Normal frame/event actions, method calls and listener notifications. Run last.
+    Default,
+}
+
 /// Action and gotos need to be queued up to execute at the end of the frame.
 #[derive(Collect)]
 #[collect(no_drop)]
 pub struct ActionQueue<'gc> {
     /// Each priority is kept in a separate bucket.
-    action_queue: [VecDeque<QueuedAction<'gc>>; ActionQueue::NUM_PRIORITIES],
+    action_queue: EnumMap<ActionPriority, VecDeque<QueuedAction<'gc>>>,
 }
 
 impl<'gc> ActionQueue<'gc> {
     const DEFAULT_CAPACITY: usize = 32;
-    const NUM_PRIORITIES: usize = 3;
 
     /// Crates a new `ActionQueue` with an empty queue.
     pub fn new() -> Self {
-        let action_queue = std::array::from_fn(|_| VecDeque::with_capacity(Self::DEFAULT_CAPACITY));
-        Self { action_queue }
+        Self {
+            action_queue: EnumMap::from_fn(|_| VecDeque::with_capacity(Self::DEFAULT_CAPACITY)),
+        }
     }
 
     /// Queues an action to run for the given movie clip.
@@ -512,23 +528,21 @@ impl<'gc> ActionQueue<'gc> {
         is_unload: bool,
     ) {
         let priority = action_type.priority();
-        let action = QueuedAction {
+        let queue = &mut self.action_queue[priority];
+
+        queue.push_back(QueuedAction {
             clip,
             action_type,
             is_unload,
-        };
-        debug_assert!(priority < Self::NUM_PRIORITIES);
-        if let Some(queue) = self.action_queue.get_mut(priority) {
-            queue.push_back(action)
-        }
+        });
     }
 
     /// Sorts and drains the actions from the queue.
     pub fn pop_action(&mut self) -> Option<QueuedAction<'gc>> {
+        // The correct order of iteration of `EnumMap::iter_mut` is guaranteed by the comment on the `enum_map::Enum` macro.
         self.action_queue
             .iter_mut()
-            .rev()
-            .find_map(VecDeque::pop_front)
+            .find_map(|(_, v)| v.pop_front())
     }
 }
 
@@ -653,11 +667,11 @@ pub enum ActionType<'gc> {
 }
 
 impl ActionType<'_> {
-    fn priority(&self) -> usize {
+    fn priority(&self) -> ActionPriority {
         match self {
-            ActionType::Initialize { .. } => 2,
-            ActionType::Construct { .. } => 1,
-            _ => 0,
+            ActionType::Initialize { .. } => ActionPriority::Initialize,
+            ActionType::Construct { .. } => ActionPriority::Construct,
+            _ => ActionPriority::Default,
         }
     }
 }


### PR DESCRIPTION
## Description

Replaces the raw `usize` priority index and fixed-size array with a   typed `ActionPriority` enum and `enum_map::EnumMap`.

Not 100% sure about the variant names, that's something I'm seeking feedback on. 

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
