### PR TITLE
web: Use non-streaming WebAssembly.instantiate in Node-like environments

### DIFF
--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -111,7 +111,23 @@ async function fetchRuffle(
         response = wasmResponse;
     }
 
-    await init({ module_or_path: response });
+    // Electron renderers with `nodeIntegration` enabled crash inside
+    // `WebAssembly.instantiateStreaming` with
+    // `Assertion failed: !impl.IsEmpty()` from node_wasm_web_api.cc
+    // (electron/electron#36282). The streaming path is what wasm-bindgen
+    // picks when `module_or_path` is a `Response`; since the bump to
+    // wasm-bindgen 0.2.120 this is the default dispatch and any Node-like
+    // host now hits the crash. Read the bytes first when we're in a
+    // Node-like environment so wasm-bindgen falls back to the non-streaming
+    // `WebAssembly.instantiate`. Plain browsers (where `process` is
+    // undefined) keep the streaming-compile fast path.
+    const isNodeLike =
+        typeof (globalThis as { process?: { versions?: { node?: string } } })
+            .process?.versions?.node === "string";
+
+    await init({
+        module_or_path: isNodeLike ? await response.arrayBuffer() : response,
+    });
 
     return [RuffleInstanceBuilder, ZipWriter];
 }


### PR DESCRIPTION
Fixes #23983

## What this does

`load-ruffle.ts` currently hands a `Response` to wasm-bindgen's `init({ module_or_path })`. Since `wasm-bindgen 0.2.120`, this dispatches to `WebAssembly.instantiateStreaming`, which crashes in Electron renderers with `nodeIntegration` (see linked issue and [electron/electron#36282](https://github.com/electron/electron/issues/36282)).

When we detect a Node-like environment, read the bytes first and call `init` with an `ArrayBuffer` instead — wasm-bindgen falls back to `WebAssembly.instantiate`, which works everywhere. In normal browsers the streaming path is preserved.

```ts
const isNodeLike =
    typeof process !== "undefined" && process.versions?.node !== undefined;
const init_arg = isNodeLike ? await response.arrayBuffer() : response;
await init({ module_or_path: init_arg });
```

## Trade-offs

- Browsers: unchanged. `instantiateStreaming` still used; full streaming-compile preserved.
- Node / Electron renderers: one extra in-memory buffer for the wasm bytes during init. For locally-hosted wasm (the common case in Electron) this costs effectively nothing.
- The `process` check is intentionally cheap and synchronous; no async detection or feature probing.

## Validated

- Browser (Chrome, Firefox): streaming path taken, no behavior change.
- Electron 42 with `nodeIntegration: true`: previously crashed at startup, now boots and runs to completion (tested against a real Flex 4.6 application — same workload that exhibited the original crash).

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
