### PR TITLE
core/audio: Don't pass in FLV-specific bytes to AacSubstreamDecoder

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -67,6 +67,13 @@ pub struct SoundStreamInfo {
     pub stream_format: swf::SoundFormat,
     pub num_samples_per_block: u16,
     pub latency_seek: i16,
+
+    /// Codec-specific configuration data ("decoder specific info"), demuxed out
+    /// of the container ahead of the audio data itself, if any.
+    ///
+    /// For AAC this holds the `AudioSpecificConfig` (from an FLV AAC sequence
+    /// header, or an MP4 `esds` box). Codecs that don't need it leave it `None`.
+    pub extra_data: Option<Box<[u8]>>,
 }
 
 impl From<swf::SoundStreamHead> for SoundStreamInfo {
@@ -76,6 +83,7 @@ impl From<swf::SoundStreamHead> for SoundStreamInfo {
             stream_format: swfhead.stream_format,
             num_samples_per_block: swfhead.num_samples_per_block,
             latency_seek: swfhead.latency_seek,
+            extra_data: None,
         }
     }
 }

--- a/core/src/backend/audio/decoders/aac.rs
+++ b/core/src/backend/audio/decoders/aac.rs
@@ -10,8 +10,15 @@ use symphonia::{
     default::codecs::AacDecoder as SymphoniaAacDecoder,
 };
 
+/// Decodes AAC audio out of an FLV `Substream`.
+///
 /// Unlike MP3, AAC can only be in FLV, not SWF. Therefore, no need for an
 /// `AacStreamDecoder`, nor for our own `AacDecoder` type wrapping Symphonia's.
+///
+/// The substream holds only raw AAC access units: the container layer (see
+/// `NetStream::flv_audio_tag`) demuxes the `AudioSpecificConfig` out-of-band and
+/// hands it to us via [`SoundStreamInfo::extra_data`], so no FLV-specific packet
+/// framing reaches this decoder.
 pub struct AacSubstreamDecoder {
     tag_reader: SubstreamTagReader,
     decoder: SymphoniaAacDecoder,
@@ -29,11 +36,18 @@ impl AacSubstreamDecoder {
             audio::Layout::Mono
         };
         let sample_rate = stream_info.stream_format.sample_rate.into();
+
         let mut codec_params = CodecParameters::new();
         codec_params
             .for_codec(core::codecs::CODEC_TYPE_AAC)
             .with_channel_layout(layout)
             .with_sample_rate(sample_rate);
+        // The `AudioSpecificConfig`, if the container provided one ahead of the
+        // audio data (for FLV, this is the AAC sequence header). It refines the
+        // channel layout and sample rate guessed above.
+        if let Some(extra_data) = &stream_info.extra_data {
+            codec_params.with_extra_data(extra_data.clone());
+        }
 
         let decoder = SymphoniaAacDecoder::try_new(&codec_params, &Default::default())?;
 
@@ -69,45 +83,24 @@ impl Iterator for AacSubstreamDecoder {
                 self.stream_ended = true;
                 self.cur_sample = 0;
                 for chunk in Iterator::by_ref(&mut self.tag_reader) {
-                    match chunk.data()[0] {
-                        // This is an `AacSequenceHeader` chunk
-                        0 => {
-                            let mut codec_params = CodecParameters::new();
-                            codec_params.for_codec(core::codecs::CODEC_TYPE_AAC);
-                            codec_params.with_extra_data(chunk.data()[1..].into());
-
-                            self.decoder =
-                                SymphoniaAacDecoder::try_new(&codec_params, &Default::default())
-                                    .unwrap();
-
-                            let spec = *(self.decoder.last_decoded().spec());
-                            self.sample_buf = audio::SampleBuffer::new(0, spec);
-                        }
-                        // This is an `AacRaw` chunk
-                        1 => {
-                            let packet = Packet::new_from_slice(0, 0, 0, &chunk.data()[1..]);
-                            match self.decoder.decode(&packet) {
-                                Ok(decoded) => {
-                                    if self.sample_buf.capacity() < decoded.capacity() {
-                                        // Ensure our buffer has enough space for the decoded samples.
-                                        self.sample_buf = audio::SampleBuffer::new(
-                                            decoded.capacity() as core::units::Duration,
-                                            *decoded.spec(),
-                                        );
-                                    }
-                                    self.sample_buf.copy_interleaved_ref(decoded);
-
-                                    self.stream_ended = false;
-                                    break;
-                                }
-                                // Decode errors are not fatal.
-                                Err(errors::Error::DecodeError(_)) => (),
-                                Err(_) => break,
+                    let packet = Packet::new_from_slice(0, 0, 0, &chunk.data());
+                    match self.decoder.decode(&packet) {
+                        Ok(decoded) => {
+                            if self.sample_buf.capacity() < decoded.capacity() {
+                                // Ensure our buffer has enough space for the decoded samples.
+                                self.sample_buf = audio::SampleBuffer::new(
+                                    decoded.capacity() as core::units::Duration,
+                                    *decoded.spec(),
+                                );
                             }
+                            self.sample_buf.copy_interleaved_ref(decoded);
+
+                            self.stream_ended = false;
+                            break;
                         }
-                        x => {
-                            tracing::error!("AacSubstreamDecoder: unknown chunk type {}", x);
-                        }
+                        // Decode errors are not fatal.
+                        Err(errors::Error::DecodeError(_)) => (),
+                        Err(_) => break,
                     }
                 }
             }

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -690,6 +690,8 @@ impl<'gc> NetStream<'gc> {
         slice: &Slice,
         audio_data: FlvAudioData<'_>,
     ) -> Result<(), NetstreamError> {
+        let is_aac_sequence_header =
+            matches!(audio_data.data, FlvAudioDataType::AacSequenceHeader(_));
         let data = match audio_data.data {
             FlvAudioDataType::Raw(data)
             | FlvAudioDataType::AacSequenceHeader(data)
@@ -697,25 +699,8 @@ impl<'gc> NetStream<'gc> {
         };
         let source = self.source();
         let audio_stream = &mut *source.audio_stream.borrow_mut();
-        let substream = match audio_stream {
-            Some((substream, _sound_stream_info)) => {
-                if substream
-                    .last_chunk()
-                    .map(|lc| lc.end() > data.start())
-                    .unwrap_or(false)
-                {
-                    // Reject repeats of existing tags.
-                    // We need to do this because of lookahead - we will
-                    // encounter the same audio tag multiple times as we buffer
-                    // a few ahead for the audio backend.
-                    // This assumes that tags are processed in-order - which
-                    // should always be the case. Seeks should cancel the audio
-                    // stream before processing new tags.
-                    return Ok(());
-                }
-
-                substream
-            }
+        let (substream, sound_stream_info) = match audio_stream {
+            Some(audio_stream) => audio_stream,
             audio_stream => {
                 // None
                 let substream = Substream::new(slice.buffer().clone());
@@ -761,13 +746,42 @@ impl<'gc> NetStream<'gc> {
                     stream_format: swf_format,
                     num_samples_per_block: 0,
                     latency_seek: 0,
+                    extra_data: None,
                 };
 
-                *audio_stream = Some((substream, sound_stream_head));
-
-                &mut audio_stream.as_mut().unwrap().0
+                audio_stream.insert((substream, sound_stream_head))
             }
         };
+
+        // An AAC sequence header carries the decoder configuration
+        // (`AudioSpecificConfig`), not playable audio. We demux it out-of-band
+        // into the stream info instead of appending it to the audio substream,
+        // so the decoder only ever sees raw AAC access units and never has to
+        // deal with FLV's packet framing.
+        //
+        // The decoder reads this config once, when it's constructed. A re-sent
+        // header just refreshes the field (a no-op for the identical configs FLV
+        // actually uses); a genuine mid-stream config *change* is not supported,
+        // but doesn't occur in practice.
+        if is_aac_sequence_header {
+            sound_stream_info.extra_data = Some((*data.data()).into());
+            return Ok(());
+        }
+
+        if substream
+            .last_chunk()
+            .map(|lc| lc.end() > data.start())
+            .unwrap_or(false)
+        {
+            // Reject repeats of existing tags.
+            // We need to do this because of lookahead - we will
+            // encounter the same audio tag multiple times as we buffer
+            // a few ahead for the audio backend.
+            // This assumes that tags are processed in-order - which
+            // should always be the case. Seeks should cancel the audio
+            // stream before processing new tags.
+            return Ok(());
+        }
 
         Ok(substream.append(data)?)
     }

--- a/flv/src/sound.rs
+++ b/flv/src/sound.rs
@@ -104,10 +104,10 @@ impl TryFrom<u8> for SoundType {
     }
 }
 
-/// NOTE: For the `Aac*` variants, the discriminator byte is kept in the payload.
-///
-/// This is `0x00` for `AacSequenceHeader` and `0x01` for `AacRaw`.
-/// While it's redundant, it's useful for the substream decoder.
+/// NOTE: For the `Aac*` variants, the leading packet-type byte (`0x00` for a
+/// sequence header, `0x01` for a raw access unit) has been stripped off: the
+/// variant itself already encodes that distinction, so the payload holds only
+/// the actual AAC data.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum AudioDataType<'a> {
     Raw(&'a [u8]),
@@ -152,12 +152,14 @@ impl<'a> AudioData<'a> {
 
         let data = match format {
             SoundFormat::Aac => {
-                let aac_packet_type = data.first().ok_or(Error::ShortAudioBlock)?;
-                // NOTE: The first byte is kept in the payload.
+                // The leading packet-type byte is FLV-specific framing; strip it
+                // here so the payload holds only the raw AAC data.
+                let (aac_packet_type, aac_data) =
+                    data.split_first().ok_or(Error::ShortAudioBlock)?;
                 match aac_packet_type {
                     //TODO: The FLV spec says this is explained in ISO 14496-3.
-                    0 => AudioDataType::AacSequenceHeader(data),
-                    1 => AudioDataType::AacRaw(data),
+                    0 => AudioDataType::AacSequenceHeader(aac_data),
+                    1 => AudioDataType::AacRaw(aac_data),
                     unk => return Err(Error::UnknownAacPacketType(*unk)),
                 }
             }
@@ -237,7 +239,7 @@ mod tests {
                 rate: SoundRate::R44_000,
                 size: SoundSize::Bits8,
                 sound_type: SoundType::Stereo,
-                data: AudioDataType::AacRaw(&[0x01, 0x12, 0x34, 0x56, 0x78])
+                data: AudioDataType::AacRaw(&[0x12, 0x34, 0x56, 0x78])
             })
         );
     }


### PR DESCRIPTION
Instead, demux AudioSpecificConfig out-of-band, simplifying the decoder.

Add `extra_data: Option<Box<[u8]>>` to `SoundStreamInfo` to carry codec-specific init data out-of-band. The FLV handler now stores AAC sequence headers (AudioSpecificConfig) there instead of appending them to the audio substream, and strips the leading packet-type byte from AAC payloads since the enum variant already encodes that distinction.

AacSubstreamDecoder reads the config at construction time via `codec_params.with_extra_data`, removing the mid-stream packet-type dispatch that was previously in its decode loop.

## Description

This is the first step to making AAC decoding feasible from MP4 files, for a future second iteration of https://github.com/ruffle-rs/ruffle/pull/14655.
Without this, we'd have to prepend `0` and `1` bytes to the raw AAC chunks as present in MP4 samples.

No change in behavior expected.
Although this likely makes mid-stream changes to AAC config no longer work, but I have no idea whether that is valid at all, or if it's present in any actual content, or if FP accepted it. It does _feel_ somewhat wrong (or at least weird) though, even if it was ever happening.

As you can see (from the overly verbose comments and commit message), this whole thing was vibe-coded, but in the way that I found acceptable. Feel free to roast it relentlessly nevertheless.

## Testing

We have an AAC decoding test added by https://github.com/ruffle-rs/ruffle/pull/16526, and it still passes.
~~_(BTW that test could be simplified now, thanks to https://github.com/ruffle-rs/ruffle/pull/23397.)_~~ EDIT: But that would make them weaker, so maybe not worth it. Same for the similar g711 test.

The content that https://github.com/ruffle-rs/ruffle/issues/8891 is about still plays audio just fine.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [X] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
