### PR TITLE
tests: Compile SWFs *before* loading them

### DIFF
--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -52,6 +52,8 @@ impl Test {
     }
 
     pub fn create_test_runner(&self, environment: &impl Environment) -> Result<TestRunner> {
+        self.compile(environment.compile_mode())?;
+
         let movie = self.movie()?;
         let viewport_dimensions = self.options.player_options.viewport_dimensions(&movie);
         let renderer = self
@@ -59,7 +61,6 @@ impl Test {
             .player_options
             .create_renderer(environment, viewport_dimensions);
 
-        self.compile(environment.compile_mode())?;
         let injector = self.input_injector()?;
         let socket_events = self.socket_events()?;
         let runner = TestRunner::new(


### PR DESCRIPTION
Otherwise the test runner will either fail to load the SWF (if it doesn't exist yet), or load the wrong version (if the source code changed).


## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [N/A] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
