### PR TITLE
desktop: Do not wrap text in recents menu

### DIFF
--- a/desktop/src/gui/menu_bar.rs
+++ b/desktop/src/gui/menu_bar.rs
@@ -252,6 +252,9 @@ impl MenuBar {
 
             let recent_menu_response = ui
                 .menu_button(text(locale, "file-menu-recents"), |ui| {
+                    ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
+                    ui.set_min_width(250.0);
+
                     if self
                         .cached_recents
                         .as_ref()


### PR DESCRIPTION
## Description

* Fixes https://github.com/ruffle-rs/ruffle/issues/23998

Text wrapping caused weird rendering, sometimes shrinking the width a lot.

This patch sets minimum width and sets the text to be truncated instead.

## Testing

Before
<img width="345" height="386" alt="image" src="https://github.com/user-attachments/assets/20752ddc-75a5-4051-abdf-7fd8ac421e0a" />

After
<img width="510" height="292" alt="image" src="https://github.com/user-attachments/assets/50489ce3-f6e7-496b-bca6-4c3aad04b2c5" />

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
