### PR TITLE
core: Add tilemalloc, a size-class allocator for enterprise workloads

### DIFF
--- a/core/src/avm2/globals/flash/system/System.as
+++ b/core/src/avm2/globals/flash/system/System.as
@@ -2,7 +2,6 @@ package flash.system {
     [Ruffle(Abstract)]
     public final class System {
         import __ruffle__.stub_method;
-        import __ruffle__.stub_getter;
 
         public static function gc():void {}
 
@@ -16,20 +15,11 @@ package flash.system {
             stub_method("flash.system.System", "disposeXML");
         }
 
-        public static function get freeMemory():Number {
-            stub_getter("flash.system.System", "freeMemory");
-            return 1024*1024*10; // 10MB
-        }
+        public static native function get freeMemory():Number;
 
-        public static function get privateMemory():Number {
-            stub_getter("flash.system.System", "privateMemory");
-            return 1024*1024*100; // 100MB
-        }
+        public static native function get privateMemory():Number;
 
-        public static function get totalMemoryNumber():Number {
-            stub_getter("flash.system.System", "totalMemoryNumber");
-            return 1024*1024*90; // 90MB
-        }
+        public static native function get totalMemoryNumber():Number;
 
         public static function get totalMemory():uint {
             return totalMemoryNumber as uint;

--- a/core/src/avm2/globals/flash/system/system.rs
+++ b/core/src/avm2/globals/flash/system/system.rs
@@ -26,3 +26,147 @@ pub fn set_clipboard<'gc>(
 
     Ok(Value::Undefined)
 }
+
+// ---------------------------------------------------------------------------
+// Memory introspection helpers (WASM-only, return 0 on native targets).
+//
+// The three `flash.system.System` memory getters
+// (`totalMemoryNumber`, `freeMemory`, `privateMemory`) are derived from
+// two primitive measurements of the running WASM module:
+//
+//   * `wasm_linear_memory_bytes()` — the total size of the module's
+//     linear memory at this moment (grows monotonically via
+//     `memory.grow`; the WASM MVP has no shrink). This is the entire
+//     address space the module has requested from the host browser.
+//
+//   * `heap_base()` — the link-time offset where the heap region
+//     starts, exposed by wasm-ld as the `__heap_base` symbol.
+//     Everything below this offset is the fixed boot cost of the
+//     module (static data + initial stack). Everything at or above
+//     this offset is dynamic heap, served by the tilemalloc pools and
+//     the fallback dlmalloc.
+//
+// From these two values plus the tilemalloc live-byte counters we
+// compute the three Adobe-AS3 properties. On non-WASM targets both
+// primitives return 0 and the three getters degrade to 0 — the
+// tilemalloc isn't the global allocator on desktop builds anyway, so
+// the counters wouldn't carry useful information there.
+
+/// WASM linear memory page size as fixed by the WASM specification.
+/// Same value on wasm32 and wasm64.
+#[cfg(target_family = "wasm")]
+const WASM_PAGE_SIZE: usize = 65536;
+
+/// Offset of the start of the heap region within the WASM linear
+/// memory. `__heap_base` is a link-time constant emitted by wasm-ld;
+/// the bytes in `[0, __heap_base)` are statics + initial stack (fixed
+/// at module boot), the bytes in `[__heap_base, linear_memory_size)`
+/// are the dynamic heap actually consumed by tilemalloc and dlmalloc.
+#[cfg(target_family = "wasm")]
+fn heap_base() -> usize {
+    unsafe extern "C" {
+        static __heap_base: u8;
+    }
+    // SAFETY: We never dereference the symbol — we only read its
+    // address. `__heap_base` is a link-time constant placed by wasm-ld
+    // at a valid offset inside the module's linear memory.
+    unsafe { &__heap_base as *const u8 as usize }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn heap_base() -> usize {
+    0
+}
+
+/// Total size of the WASM linear memory in bytes at this moment.
+/// Monotonically non-decreasing.
+//
+// `wasm32::memory_size` is stable since Rust 1.33; `wasm64::memory_size`
+// lives behind the nightly `simd_wasm64` feature gate (tracking #90599)
+// — enabled here for the wasm64 build, which uses `RUSTC_BOOTSTRAP=1`.
+#[cfg(target_arch = "wasm32")]
+fn wasm_linear_memory_bytes() -> usize {
+    core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE
+}
+
+#[cfg(target_arch = "wasm64")]
+fn wasm_linear_memory_bytes() -> usize {
+    core::arch::wasm64::memory_size(0) * WASM_PAGE_SIZE
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn wasm_linear_memory_bytes() -> usize {
+    0
+}
+
+/// Bytes of dynamic heap currently held by the module — the portion
+/// of the linear memory that lives at or above `__heap_base`. This is
+/// the memory the player has actually requested from the host at
+/// runtime (`memory.grow` calls triggered by the tilemalloc or the
+/// dlmalloc fallback), after subtracting the fixed boot cost.
+fn dynamic_heap_bytes() -> usize {
+    wasm_linear_memory_bytes().saturating_sub(heap_base())
+}
+
+/// Implements `flash.system.System.totalMemoryNumber` getter.
+///
+/// Adobe defines `totalMemoryNumber` as "the amount of memory
+/// currently in use that has been directly allocated by Flash Player
+/// or AIR". On Ruffle WASM this maps to the dynamic heap region of the
+/// linear memory: every byte at or above `__heap_base` is either held
+/// by a tilemalloc pool extent, by a live dlmalloc allocation, or by
+/// dlmalloc free-list headroom — all of which were obtained through
+/// `memory.grow` calls driven by the player's allocations.
+///
+/// Pairs with `freeMemory` (the not-in-use share of this number).
+pub fn get_total_memory_number<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    _this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(Value::Number(dynamic_heap_bytes() as f64))
+}
+
+/// Implements `flash.system.System.freeMemory` getter.
+///
+/// Adobe defines `freeMemory` as "the amount of memory that is
+/// allocated to Flash Player and that is not in use. This unused
+/// portion of allocated memory fluctuates as garbage collection takes
+/// place. Use this property to monitor garbage collection."
+///
+/// On Ruffle WASM the "in use" share is the sum of live tilemalloc
+/// bytes (`total_tile_alive_bytes`) and live fallback dlmalloc bytes
+/// (`fallback.bytes_alive`); subtracting from `totalMemoryNumber`
+/// gives the bytes inside the dynamic heap that no live allocation
+/// currently holds — pool free lists, dlmalloc free lists, and any
+/// linear-memory headroom past the high-water mark. After a
+/// `System.gc()` call drains the AS3 arena and the backing buffers
+/// are released, this value rises accordingly.
+pub fn get_free_memory<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    _this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let stats = crate::tilemalloc::GLOBAL_TILEMALLOC.snapshot_stats();
+    let in_use = stats.total_tile_alive_bytes() + stats.fallback.bytes_alive;
+    let free = dynamic_heap_bytes().saturating_sub(in_use);
+    Ok(Value::Number(free as f64))
+}
+
+/// Implements `flash.system.System.privateMemory` getter.
+///
+/// Adobe defines `privateMemory` as "the entire amount of memory used
+/// by an application. This is the amount of resident private memory
+/// for the entire process." On Ruffle WASM the closest measurable
+/// analogue is the total size of the module's linear memory: it
+/// includes everything `totalMemoryNumber` covers plus the fixed boot
+/// cost (statics + initial stack). The JS heap of the wrapping host
+/// page is not included here; integrating `performance.memory`
+/// (Chrome-only) is a separate iteration.
+pub fn get_private_memory<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    _this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(Value::Number(wasm_linear_memory_bytes() as f64))
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,8 @@
+// Enable the wasm64 intrinsics used by the tilemalloc-backed memory getters in
+// `avm2::globals::flash::system`. `wasm64::memory_size` is nightly-gated
+// (tracking #90599); the wasm64 build uses `RUSTC_BOOTSTRAP=1` so this is fine.
+// Inert on every other target. Remove once `simd_wasm64` is stabilized.
+#![cfg_attr(target_arch = "wasm64", feature(simd_wasm64))]
 // This lint is helpful, but right now we have too many instances of it.
 // TODO: Remove this once all instances are fixed.
 #![allow(clippy::needless_pass_by_ref_mut)]
@@ -45,6 +50,7 @@ pub mod string;
 mod system_properties;
 pub mod tag_utils;
 mod tessellation_cache;
+pub mod tilemalloc;
 pub mod timer;
 mod types;
 mod vminterface;

--- a/core/src/tilemalloc/config.rs
+++ b/core/src/tilemalloc/config.rs
@@ -1,0 +1,141 @@
+//! Tilemalloc size-class configuration.
+//!
+//! **THIS IS THE FILE TO EDIT** when tuning the allocator for a different
+//! workload. After editing, rebuild the web binary:
+//!
+//! ```text
+//! cargo build -p ruffle_web --target wasm32-unknown-unknown
+//! ```
+//!
+//! Each `TileClass` entry describes one size class served by the tile
+//! allocator. Allocations whose `Layout::size <= class.size_bytes` AND
+//! `Layout::align <= class.tile_align` are routed to that class's free
+//! list. Requests larger than the biggest class — or with an alignment
+//! larger than the largest class's `tile_align` — fall back to the
+//! system allocator (dlmalloc on `wasm32-unknown-unknown`).
+//!
+//! `tile_align` is **not** a config knob — it is auto-derived as the
+//! greatest power-of-two divisor of `size_bytes` (i.e. the lowest set
+//! bit). For pow-2 sizes this is identical to `size_bytes` itself; for
+//! non-pow-2 sizes like 24 / 48 / 96 the alignment falls to the
+//! closest pow-2 divisor (8 / 16 / 32 respectively), which still
+//! covers the vast majority of Rust allocations (most types have
+//! `align <= 8`). Requests whose `Layout::align` exceeds a class's
+//! derived `tile_align` skip that class and fall through to one with
+//! sufficient alignment, or to the system allocator.
+//!
+//! ## How `extent_mb` works
+//!
+//! When a class's free list is empty, the allocator adds one **extent**:
+//! it asks the system allocator for a contiguous region of approximately
+//! `extent_mb` megabytes, then splits the extent into
+//! `floor((extent_mb * 1 MiB) / size_bytes)` free tiles and pushes them
+//! all on the free list. Subsequent allocations from that class then pop
+//! from the head in O(1) until the list is empty again.
+//!
+//! - **Larger `extent_mb`** → fewer extents added → less amortized
+//!   overhead, but more memory pre-allocated up front.
+//! - **Smaller `extent_mb`** → more extents added over time, but tighter
+//!   memory tracking.
+//!
+//! The actual byte count is `extent_mb * 1024 * 1024`, rounded down to
+//! the nearest multiple of `size_bytes` when carving tiles. Tiny leftover
+//! bytes at the tail of each extent (`< size_bytes` worth) are unused.
+//!
+//! ## Choosing the size classes
+//!
+//! Pick size classes that cover the buckets with the highest churn —
+//! those are the ones producing the per-frame allocator pressure that
+//! this allocator is designed to eliminate. Anything above the largest
+//! configured class falls back to dlmalloc and pays the standard
+//! fragmentation cost; we accept that for the long tail of rare large
+//! allocations.
+
+/// Build-time toggle for the per-class `size_histogram` and
+/// `align_histogram` instrumentation, plus the fallback
+/// `size_histogram`.
+///
+/// When `true`, every `class_alloc` / `class_dealloc` updates one
+/// `Vec<u64>` entry (size_histogram, heap-indirect — the dominant
+/// hot-path cost of the histogram instrumentation) plus one
+/// `[u64; 8]` entry (align_histogram, inline), and every fallback
+/// alloc/dealloc updates one `[u64; 10]` entry. When `false`, those
+/// updates are dead-code-eliminated by LLVM, the histogram backing
+/// storage stays empty (`Vec::new()` with `cap == 0`, inline arrays
+/// stay all-zero), and the JSON output omits the histogram fields
+/// entirely. The `to_table` one-liner is unaffected — it never
+/// emitted histograms.
+///
+/// **Why build-time, not runtime**: histograms accumulate **live**
+/// state (alloc-minus-dealloc per bucket). Switching at runtime would
+/// leave the counters out of sync with what's actually in the pool —
+/// you'd see only the deltas since the toggle, with no way to
+/// reconcile against the alive tiles already in flight. Either you
+/// collect from boot or you don't collect at all.
+///
+/// Default `true` for diagnostic-friendly builds. Flip to `false` for
+/// production / performance-sensitive builds to reclaim the per-alloc
+/// cost of the heap-indirect `Vec<u64>` update.
+pub const ENABLE_HISTOGRAMS: bool = false;
+
+/// One size class served by the tile allocator. See module doc for
+/// detailed tuning guidance.
+#[derive(Clone, Copy)]
+pub struct TileClass {
+    /// Maximum allocation size (in bytes) served by this class. A
+    /// request for `N` bytes is rounded up to the smallest class with
+    /// `size_bytes >= N`. The tile alignment is auto-derived as the
+    /// greatest power-of-two divisor of `size_bytes`.
+    pub size_bytes: usize,
+
+    /// Extent size in **megabytes**. Each newly added extent allocates
+    /// approximately this many MiB from the system allocator and carves
+    /// it into `floor((extent_mb * 1 MiB) / size_bytes)` tiles. Must be
+    /// at least 1.
+    pub extent_mb: usize,
+}
+
+/// **EDIT HERE** to change the tilemalloc size classes.
+///
+/// The default below is an opinionated starting point covering the
+/// 8-256 byte range at sub-power-of-two granularity, with 8 MiB of
+/// extent memory reserved per class. Anything outside that range falls
+/// back to the system allocator. Inspect per-class activity at runtime
+/// via `TileAllocator::snapshot_stats` (re-exported as a wasm-bindgen
+/// JS function by the web binary) and tune for your workload.
+///
+/// Constraints:
+/// - Entries MUST be in strictly ascending order of `size_bytes` (the
+///   picker walks the array once and picks the first class large
+///   enough).
+/// - `size_bytes` MUST be at least `core::mem::size_of::<*mut ()>()`
+///   (4 bytes on wasm32) — the intrusive free list reuses the first
+///   bytes of a free tile to store a `next` pointer.
+/// - `extent_mb` MUST be at least 1.
+/// - `TILE_CONFIG.len()` MUST be `<= MAX_CLASSES` in `core.rs`
+///   (currently 128).
+#[rustfmt::skip]
+pub const TILE_CONFIG: &[TileClass] = &[
+    // step 8
+    TileClass { size_bytes:    8, extent_mb: 8 },
+    TileClass { size_bytes:   16, extent_mb: 8 },
+    TileClass { size_bytes:   24, extent_mb: 8 },
+    TileClass { size_bytes:   32, extent_mb: 8 },
+    TileClass { size_bytes:   40, extent_mb: 8 },
+    TileClass { size_bytes:   48, extent_mb: 8 },
+    TileClass { size_bytes:   56, extent_mb: 8 },
+    TileClass { size_bytes:   64, extent_mb: 8 },
+    // step 16
+    TileClass { size_bytes:   80, extent_mb: 8 },
+    TileClass { size_bytes:   96, extent_mb: 8 },
+    TileClass { size_bytes:  112, extent_mb: 8 },
+    TileClass { size_bytes:  128, extent_mb: 8 },
+    TileClass { size_bytes:  144, extent_mb: 8 },
+    TileClass { size_bytes:  160, extent_mb: 8 },
+    TileClass { size_bytes:  176, extent_mb: 8 },
+    TileClass { size_bytes:  192, extent_mb: 8 },
+    TileClass { size_bytes:  208, extent_mb: 8 },
+    TileClass { size_bytes:  224, extent_mb: 8 },
+    TileClass { size_bytes:  240, extent_mb: 8 },
+    TileClass { size_bytes:  256, extent_mb: 8 },
+];

--- a/core/src/tilemalloc/core.rs
+++ b/core/src/tilemalloc/core.rs
@@ -1,0 +1,862 @@
+//! Core tile allocator implementation.
+//!
+//! Design summary (see `mod.rs` for rationale):
+//! - One **free list** per size class, intrusive: each free tile's
+//!   first `size_of::<*mut ()>()` bytes hold the `next` pointer.
+//! - Per class we also keep a **bump range** `[bump_ptr, bump_end)`
+//!   pointing into the current extent. Tiles that have never been
+//!   handed out yet are carved off the front of this range on demand;
+//!   only tiles that have been freed re-enter the free list. This
+//!   avoids the O(`tiles_per_extent`) write loop that a pre-populated
+//!   free list would pay at every `add_extent`.
+//! - **alloc** =
+//!     1. If the free list is non-empty, pop the head.
+//!     2. Else if `bump_ptr < bump_end`, carve one tile off the front
+//!        of the bump range and advance `bump_ptr` by `tile_size`.
+//!     3. Else call `add_extent` and retry from (2).
+//! - **dealloc** = push back onto the free list head. Always O(1).
+//! - **add_extent** = ask the system allocator for one extent and set
+//!   the class's bump range to span it. No per-tile setup write. Each
+//!   extent is tracked so we can report `extent_count` for stats and
+//!   (eventually) walk the extents for cleanup.
+//!
+//! Concurrency: the allocator is `Sync` via interior mutability
+//! (`UnsafeCell`). On `wasm32-unknown-unknown` execution is
+//! single-threaded so concurrent access is impossible in practice; if
+//! Ruffle ever moves to wasm-threads this needs a `Mutex` wrapper.
+
+use core::alloc::Layout;
+use core::cell::UnsafeCell;
+use core::ptr;
+use std::alloc::{GlobalAlloc, System};
+
+use super::config::{ENABLE_HISTOGRAMS, TILE_CONFIG, TileClass};
+use super::stats::{TileAllocatorStats, TileClassStats, TileFallbackStats};
+
+/// Maximum supported size class count. Sized to comfortably fit the
+/// `TILE_CONFIG` array while staying a compile-time constant so the
+/// per-class arrays can live inline in the allocator struct.
+const MAX_CLASSES: usize = 128;
+
+/// Header at the start of every free tile. The first word is reused
+/// to chain tiles into the free list, so the tile size must be at
+/// least `size_of::<FreeTile>()` (= 4 bytes on wasm32).
+#[repr(C)]
+struct FreeTile {
+    next: *mut FreeTile,
+}
+
+/// Metadata for one extent (a contiguous region obtained from the
+/// system allocator and split into `tiles_per_extent` tiles). Kept in
+/// a `Vec` for stats reporting and as the anchor any future extent
+/// cleanup would need (the allocator is currently grow-only).
+#[allow(dead_code)]
+struct ExtentRecord {
+    ptr: *mut u8,
+    total_bytes: usize,
+}
+
+/// Per–size-class runtime state.
+struct ClassState {
+    /// Tile size in bytes. Mirrors `TileClass::size_bytes`.
+    tile_size: usize,
+    /// Effective alignment guaranteed for every tile of this class.
+    /// Auto-derived as the greatest power-of-two divisor of
+    /// `tile_size` (= lowest set bit), so for pow-2 sizes it equals
+    /// `tile_size`, and for sizes like 24 / 48 / 96 it lands on
+    /// 8 / 16 / 32 respectively. Used by `pick_class` to gate
+    /// over-aligned requests and by `add_extent` to align the extent.
+    tile_align: usize,
+    /// Tiles carved per extent. Derived from `TileClass::extent_mb`
+    /// as `floor((extent_mb * 1 MiB) / size_bytes)`.
+    tiles_per_extent: usize,
+    /// Head of the intrusive free list. `null` when empty. Populated
+    /// exclusively by `class_dealloc`: fresh tiles from a newly-added
+    /// extent are handed out via `bump_ptr` (see below), not chained
+    /// onto the free list.
+    free_head: *mut FreeTile,
+    /// Lazy carve cursor into the current extent. `class_alloc` hands
+    /// out tiles by stepping this pointer forward in `tile_size`-sized
+    /// chunks, avoiding the O(`tiles_per_extent`) write loop that an
+    /// eager free-list build would pay at every `add_extent`. Both
+    /// `bump_ptr` and `bump_end` are `null` until the first
+    /// `add_extent` call.
+    bump_ptr: *mut u8,
+    /// One past the last byte of the current extent. The invariant
+    /// `(bump_end - extent_start) % tile_size == 0` is preserved by
+    /// `add_extent`, so the check `bump_ptr < bump_end` is sufficient
+    /// to guarantee at least one full tile fits before the carve.
+    bump_end: *mut u8,
+    /// Extent tracking (for stats and potential cleanup).
+    extents: Vec<ExtentRecord>,
+    /// Cumulative counters.
+    alloc_total: usize,
+    dealloc_total: usize,
+    /// Cumulative count of extents added to this class since boot.
+    /// Equals `extents.len()` as long as the allocator stays
+    /// grow-only.
+    extents_added: usize,
+    /// **Live** byte count of internal fragmentation currently held by
+    /// this class: sum of `(tile_size - layout.size())` over every tile
+    /// currently alive in the pool. Incremented in `class_alloc`,
+    /// decremented in `class_dealloc` using the `layout.size()` that
+    /// Rust's `GlobalAlloc` contract guarantees is passed back at
+    /// dealloc — so the value reflects the present state of the pool
+    /// rather than a lifetime total. Pair with `requested_bytes_total`
+    /// for the live waste-as-percent.
+    wasted_bytes_total: u64,
+    /// **Live** byte count actually requested by callers and currently
+    /// held by tiles in this class: sum of `layout.size()` over the
+    /// alive tiles. Same alloc/dealloc symmetry as `wasted_bytes_total`.
+    requested_bytes_total: u64,
+    /// Peak `alive_tiles` ever observed for this class. Updated in
+    /// `class_alloc`. Tells you how much capacity the class actually
+    /// needed under load — useful to size `extent_mb` for the next
+    /// run (if `peak ≤ tiles_per_extent`, one extent suffices).
+    peak_alive_tiles: usize,
+    /// Minimum request size (in bytes) routed to this class
+    /// (inclusive). Equals the previous class's `size_bytes + 1` (from
+    /// `TileClass`), or `1` for the first class. The histogram covers
+    /// `size_min..=tile_size`. Exposed as `TileClassStats::size_min`.
+    size_min: usize,
+    /// **Live** histogram: one counter per `layout.size()` value in
+    /// `size_min..=tile_size`. Index `i` corresponds to
+    /// `requested_size = size_min + i`. Length = `tile_size -
+    /// size_min + 1`. Incremented in `class_alloc`, decremented in
+    /// `class_dealloc` — so each bucket counts the tiles of that
+    /// requested size **currently alive** in the pool, not all the
+    /// allocs that ever happened. Snapshot diffs over time reveal
+    /// growth / shrinkage by requested size.
+    size_histogram: Vec<u64>,
+    /// Cumulative in-place realloc fast-path hits served by this class:
+    /// the times `realloc` was called and both the old and new
+    /// `layout.size()` landed here, so we returned the same pointer
+    /// without copy. Pairs with `cross_class_realloc_total` (global) to
+    /// gauge how often the fast path actually kicks in.
+    inplace_realloc_total: u64,
+    /// Cumulative cross-class realloc **arrivals from a smaller
+    /// origin**: realloc calls where `new_size > old_size` and
+    /// `new_layout` landed in this class. The classic "Vec::push
+    /// triggered a grow that overflowed into this larger class"
+    /// pattern.
+    ///
+    /// **Edge asymmetry**: for the **smallest** class this counter
+    /// is always 0 (no smaller class exists from which a grow can
+    /// arrive).
+    inbound_realloc_total_grow: u64,
+    /// Cumulative cross-class realloc **arrivals from a larger
+    /// origin**: realloc calls where `new_size < old_size` and
+    /// `new_layout` landed in this class. The buffer shrank down
+    /// into us from a larger pool class or from the fallback. Mirror
+    /// of `inbound_realloc_total_grow`.
+    inbound_realloc_total_shrink: u64,
+    /// Cumulative cross-class realloc **departures toward a larger
+    /// destination**: realloc calls where `new_size > old_size` and
+    /// the old buffer lived in this class. The "this class was
+    /// outgrown" counter.
+    ///
+    /// **Edge asymmetry**: for the **largest** pool class, departures
+    /// of this kind always land in the fallback (no larger pool
+    /// class to receive them).
+    outbound_realloc_total_grow: u64,
+    /// Cumulative cross-class realloc **departures toward a smaller
+    /// destination**: realloc calls where `new_size < old_size` and
+    /// the old buffer lived in this class. The "this class lost a
+    /// buffer to a smaller one" counter.
+    ///
+    /// **Edge asymmetry**: for the **smallest** class this counter
+    /// is always 0 (no smaller class to shrink into).
+    outbound_realloc_total_shrink: u64,
+    /// **Live** histogram of `layout.align()` for tiles currently alive
+    /// in this class. Buckets are `1, 2, 4, 8, 16, 32, 64, 128+` (top
+    /// saturates). Same alloc/dealloc symmetry as `size_histogram`. The
+    /// sum of the buckets equals `alive_tiles`. Together with
+    /// `size_histogram` it lets you separate "alloc with size N that
+    /// could fit in a smaller class if it weren't for align" from
+    /// "alloc with size N that only fits here on size alone".
+    align_histogram: [u64; ALIGN_BUCKET_COUNT],
+}
+
+impl ClassState {
+    /// `prev_size` is the previous class's `size_bytes`, or 0 for the
+    /// first class. Used to set `size_min = prev_size + 1` and size
+    /// the per-class request histogram.
+    fn new(cls: &TileClass, prev_size: usize) -> Self {
+        // Greatest power-of-two divisor of size_bytes (= lowest set bit).
+        // For pow-2 sizes returns size_bytes itself; for 24 → 8, 48 → 16,
+        // 96 → 32, etc.
+        let tile_align = cls.size_bytes & cls.size_bytes.wrapping_neg();
+        let tiles_per_extent = (cls.extent_mb * 1024 * 1024) / cls.size_bytes;
+        let size_min = prev_size + 1;
+        // Length = tile_size - size_min + 1 = tile_size - prev_size.
+        let bucket_count = cls.size_bytes - prev_size;
+        Self {
+            tile_size: cls.size_bytes,
+            tile_align,
+            tiles_per_extent,
+            free_head: ptr::null_mut(),
+            bump_ptr: ptr::null_mut(),
+            bump_end: ptr::null_mut(),
+            extents: Vec::new(),
+            alloc_total: 0,
+            dealloc_total: 0,
+            extents_added: 0,
+            wasted_bytes_total: 0,
+            requested_bytes_total: 0,
+            peak_alive_tiles: 0,
+            size_min,
+            // When `ENABLE_HISTOGRAMS == false` we keep the field for
+            // API stability but never allocate the backing storage —
+            // `Vec::new()` has `cap == 0`, no heap touch — and the
+            // hot-path updates in `class_alloc` / `class_dealloc` are
+            // dead-code-eliminated by LLVM. JSON serialization in
+            // `stats.rs` likewise omits the field entirely.
+            size_histogram: if ENABLE_HISTOGRAMS {
+                vec![0u64; bucket_count]
+            } else {
+                Vec::new()
+            },
+            inplace_realloc_total: 0,
+            inbound_realloc_total_grow: 0,
+            inbound_realloc_total_shrink: 0,
+            outbound_realloc_total_grow: 0,
+            outbound_realloc_total_shrink: 0,
+            align_histogram: [0u64; ALIGN_BUCKET_COUNT],
+        }
+    }
+
+    /// Snapshot this class's counters into a stats struct.
+    fn snapshot(&self) -> TileClassStats {
+        let alive = self.alloc_total.saturating_sub(self.dealloc_total);
+        let capacity = self.extents.len() * self.tiles_per_extent;
+        let free = capacity.saturating_sub(alive);
+        TileClassStats {
+            size_min: self.size_min,
+            size_max: self.tile_size,
+            free_tiles: free,
+            alive_tiles: alive,
+            extent_bytes: self.extents.iter().map(|s| s.total_bytes).sum(),
+            extent_count: self.extents.len(),
+            extents_added: self.extents_added,
+            alloc_total: self.alloc_total,
+            dealloc_total: self.dealloc_total,
+            peak_alive_tiles: self.peak_alive_tiles,
+            wasted_bytes_total: self.wasted_bytes_total,
+            requested_bytes_total: self.requested_bytes_total,
+            inplace_realloc_total: self.inplace_realloc_total,
+            inbound_realloc_total_grow: self.inbound_realloc_total_grow,
+            inbound_realloc_total_shrink: self.inbound_realloc_total_shrink,
+            outbound_realloc_total_grow: self.outbound_realloc_total_grow,
+            outbound_realloc_total_shrink: self.outbound_realloc_total_shrink,
+            size_histogram: self.size_histogram.clone(),
+            align_histogram: self.align_histogram,
+        }
+    }
+}
+
+/// Number of buckets in the fallback size histogram. See
+/// `fallback_bucket_for_size` for the boundary mapping.
+const FALLBACK_BUCKET_COUNT: usize = 10;
+
+/// Number of buckets in the per-class request-align histogram.
+/// Buckets correspond to align values `1, 2, 4, 8, 16, 32, 64, 128+`
+/// (top bucket saturates for any `align ≥ 128`). Sized to cover the
+/// realistic spectrum in Rust on wasm32: cache-line `#[repr(align(64))]`
+/// is conceivable, and even `#[repr(align(128))]` is occasionally used
+/// for anti-false-sharing. Above 128 the distinction stops being useful
+/// for tuning — those allocs all land in the largest pow-2 size classes.
+pub(crate) const ALIGN_BUCKET_COUNT: usize = 8;
+
+/// Map a power-of-two `align` to its histogram bucket index.
+///
+/// Buckets:
+/// - 0 → `align == 1`
+/// - 1 → `align == 2`
+/// - 2 → `align == 4`
+/// - 3 → `align == 8`
+/// - 4 → `align == 16`
+/// - 5 → `align == 32`
+/// - 6 → `align == 64`
+/// - 7 → `align ≥ 128` (saturating; very rare in Rust user code)
+///
+/// Rust guarantees `align` is a power of two via the `Layout`
+/// invariants, so `trailing_zeros()` gives the exact log2.
+fn align_bucket_for(align: usize) -> usize {
+    let bucket = align.trailing_zeros() as usize;
+    if bucket >= ALIGN_BUCKET_COUNT {
+        ALIGN_BUCKET_COUNT - 1
+    } else {
+        bucket
+    }
+}
+
+/// Map a fallback allocation size to its histogram bucket index.
+///
+/// Bucket boundaries (inclusive upper bound):
+/// - 0: ≤ 512
+/// - 1: ≤ 1 024
+/// - 2: ≤ 2 048
+/// - 3: ≤ 4 096
+/// - 4: ≤ 8 192
+/// - 5: ≤ 16 384
+/// - 6: ≤ 32 768
+/// - 7: ≤ 65 536
+/// - 8: ≤ 131 072
+/// - 9: >  131 072
+///
+/// Designed to spotlight clusters of medium-large allocations that
+/// currently bypass the tile pool — candidates for new size classes.
+fn fallback_bucket_for_size(size: usize) -> usize {
+    if size <= 512 {
+        0
+    } else if size <= 1024 {
+        1
+    } else if size <= 2048 {
+        2
+    } else if size <= 4096 {
+        3
+    } else if size <= 8192 {
+        4
+    } else if size <= 16384 {
+        5
+    } else if size <= 32768 {
+        6
+    } else if size <= 65536 {
+        7
+    } else if size <= 131072 {
+        8
+    } else {
+        9
+    }
+}
+
+/// Inner state of the tile allocator. All mutation goes through here,
+/// reached from the outer wrapper via `UnsafeCell`.
+struct TileInner {
+    classes: [Option<ClassState>; MAX_CLASSES],
+    class_count: usize,
+
+    /// Counters for allocations that bypassed the tile pools (too big
+    /// or over-aligned). `bytes_alive` is approximate — we track size
+    /// only at request time, so an inflight `realloc` may briefly
+    /// double-count.
+    ///
+    /// `fallback_bytes_alloc` and `fallback_bytes_dealloc` are `u64`
+    /// rather than `usize` because they are **cumulative-over-lifetime**:
+    /// every fallback alloc and dealloc adds its `layout.size()` to
+    /// them, forever. On `wasm32-unknown-unknown`, `usize` is 32 bits
+    /// and would wrap past 4 GiB of accumulated byte traffic — under a
+    /// sustained fallback churn that's only minutes of runtime. When
+    /// one of the two wraps before the other, `bytes_alive =
+    /// saturating_sub(alloc, dealloc)` collapses to 0 (or shoots to a
+    /// bogus high value) and snaps back when the second wraps too,
+    /// producing periodic ~minute-scale oscillations in the snapshot.
+    /// `u64` gives ~18 EiB of headroom — for all practical purposes,
+    /// the cumulative bytes counters cannot wrap.
+    fallback_alloc_total: usize,
+    fallback_dealloc_total: usize,
+    fallback_bytes_alloc: u64,
+    fallback_bytes_dealloc: u64,
+
+    /// **Live** bucketed histogram of fallback allocations currently
+    /// outstanding (size-keyed via `fallback_bucket_for_size`).
+    /// Incremented in the fallback alloc path, decremented in the
+    /// fallback dealloc path. Helps decide whether to add larger size
+    /// classes above the current ceiling: a sustained large count in a
+    /// specific bucket signals a hot fallback path worth absorbing.
+    fallback_size_histogram: [u64; FALLBACK_BUCKET_COUNT],
+
+    /// Cumulative count of realloc calls that could not be served by
+    /// the in-place fast path and required alloc+copy+dealloc. Includes
+    /// tile-to-tile cross-class and any transition involving fallback.
+    /// Compare against the sum of per-class `inplace_realloc_total` to
+    /// gauge fast-path effectiveness on the current workload.
+    cross_class_realloc_total: u64,
+}
+
+impl TileInner {
+    const fn empty() -> Self {
+        const NONE: Option<ClassState> = None;
+        Self {
+            classes: [NONE; MAX_CLASSES],
+            class_count: 0,
+            fallback_alloc_total: 0,
+            fallback_dealloc_total: 0,
+            fallback_bytes_alloc: 0,
+            fallback_bytes_dealloc: 0,
+            fallback_size_histogram: [0u64; FALLBACK_BUCKET_COUNT],
+            cross_class_realloc_total: 0,
+        }
+    }
+
+    /// One-time init from `TILE_CONFIG`. Called lazily on first
+    /// allocation so we don't need a `const fn` for `Vec::new`.
+    ///
+    /// **Re-entrancy**: `ClassState::new` calls `vec![0u64; N]` to
+    /// allocate its per-class size histogram. That allocation routes
+    /// back through the global allocator — i.e. back through us. If
+    /// we leave `class_count == 0` while building the classes, the
+    /// re-entrant alloc loops back into this function and stack-
+    /// overflows. We therefore set `class_count = TILE_CONFIG.len()`
+    /// **before** touching any class slot. Re-entrant allocs landing
+    /// in here during the bootstrap loop see "initialized", and the
+    /// `pick_class` path finds the requested class's `classes[i] ==
+    /// None` for slots not yet populated — falling cleanly through to
+    /// the system allocator. Those bootstrap allocs (the histogram
+    /// buffers themselves) are therefore served by dlmalloc, after
+    /// which every subsequent allocation routes through the tile
+    /// pools as normal.
+    fn ensure_initialized(&mut self) {
+        if self.class_count != 0 {
+            return;
+        }
+        assert!(
+            TILE_CONFIG.len() <= MAX_CLASSES,
+            "TILE_CONFIG has more entries than MAX_CLASSES",
+        );
+        // Validate ordering, minimum size, and extent sizing at init.
+        // Note: size_bytes is NOT required to be a power of two; the
+        // effective tile alignment is auto-derived (see ClassState::new).
+        let min_tile_size = core::mem::size_of::<FreeTile>();
+        let mut last_size = 0usize;
+        for cls in TILE_CONFIG.iter() {
+            assert!(
+                cls.size_bytes > last_size,
+                "TILE_CONFIG must be in strictly ascending size order",
+            );
+            assert!(
+                cls.size_bytes >= min_tile_size,
+                "TILE_CONFIG size_bytes must be at least size_of::<*mut ()>",
+            );
+            assert!(
+                cls.extent_mb >= 1,
+                "TILE_CONFIG extent_mb must be at least 1",
+            );
+            let tiles = (cls.extent_mb * 1024 * 1024) / cls.size_bytes;
+            assert!(
+                tiles >= 1,
+                "TILE_CONFIG extent_mb / size_bytes must yield at least 1 tile",
+            );
+            last_size = cls.size_bytes;
+        }
+        // Mark as initialized BEFORE building any class — see the
+        // re-entrancy note in the doc comment above.
+        self.class_count = TILE_CONFIG.len();
+        let mut prev_size = 0usize;
+        for (i, cls) in TILE_CONFIG.iter().enumerate() {
+            self.classes[i] = Some(ClassState::new(cls, prev_size));
+            prev_size = cls.size_bytes;
+        }
+    }
+
+    /// Pick the smallest class that satisfies both `size_bytes >= size`
+    /// and `tile_align >= align`. Returns `None` if no class fits —
+    /// caller falls back to system allocator.
+    ///
+    /// With non-pow-2 size classes, `tile_align` can be smaller than
+    /// `size_bytes` (e.g. class 24 has tile_align=8). A request with
+    /// `align == 16` therefore skips class 24 and lands in class 32 or
+    /// 48 instead, even though class 24 would have been big enough on
+    /// size alone.
+    fn pick_class(&self, layout: Layout) -> Option<usize> {
+        let required_size = layout.size();
+        let required_align = layout.align();
+        for i in 0..self.class_count {
+            if let Some(c) = &self.classes[i]
+                && c.tile_size >= required_size
+                && c.tile_align >= required_align
+            {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    /// Add a new extent to a class. Allocates a fresh region from the
+    /// system allocator and installs it as the class's new bump range.
+    /// The previous bump range, if any, was already drained (the only
+    /// caller is `class_alloc`, which calls this only when
+    /// `bump_ptr >= bump_end`). The free list is left untouched: tiles
+    /// enter it exclusively through `class_dealloc`. Returns `false`
+    /// on OOM.
+    ///
+    /// The bump-pointer carve performs no per-tile setup write at
+    /// extent creation. The alternative — chaining every tile into
+    /// the free list eagerly — would cost `tiles_per_extent` stores
+    /// per call (potentially hundreds of thousands for small-tile
+    /// classes), all touching fresh wasm linear-memory pages, and
+    /// would surface as a visible stall at the first alloc per class.
+    /// Carving lazily amortizes that per-tile touch across the
+    /// subsequent N allocs.
+    ///
+    /// Safety: `class_idx` must be a valid initialized class.
+    unsafe fn add_extent(&mut self, class_idx: usize) -> bool {
+        let class = self.classes[class_idx]
+            .as_mut()
+            .expect("class must be initialized");
+        let tile_size = class.tile_size;
+        let tile_align = class.tile_align;
+        let tiles_per_extent = class.tiles_per_extent;
+        let extent_total = tile_size * tiles_per_extent;
+
+        // Extent is aligned to tile_align (the greatest power-of-2
+        // divisor of tile_size). Since every tile sits at an offset
+        // that is a multiple of tile_size, and tile_size is itself
+        // a multiple of tile_align, every tile ends up naturally
+        // aligned to tile_align as well.
+        let layout = match Layout::from_size_align(extent_total, tile_align) {
+            Ok(l) => l,
+            Err(_) => return false,
+        };
+        let extent_ptr = unsafe { System.alloc(layout) };
+        if extent_ptr.is_null() {
+            return false;
+        }
+
+        // Install the bump range. By construction
+        // `extent_total = tile_size * tiles_per_extent` is an exact
+        // multiple of `tile_size`, so `bump_ptr < bump_end` is the only
+        // check `class_alloc` needs to confirm at least one full tile
+        // fits before the carve.
+        class.bump_ptr = extent_ptr;
+        class.bump_end = unsafe { extent_ptr.add(extent_total) };
+        class.extents.push(ExtentRecord {
+            ptr: extent_ptr,
+            total_bytes: extent_total,
+        });
+        class.extents_added += 1;
+        true
+    }
+
+    /// Tile-pool alloc fast path. Returns `null` if the class is OOM
+    /// or `pick_class` rejected the request — caller falls back.
+    ///
+    /// `layout` is the original request from the caller; we use
+    /// `layout.size()` to track internal fragmentation (waste) per
+    /// class and bucket the per-class request-size histogram, and
+    /// `layout.align()` to bucket the per-class align histogram.
+    /// `layout.size() <= tile_size` and `layout.align() <= tile_align`
+    /// are guaranteed by `pick_class`.
+    ///
+    /// Tile-resolution policy (see module doc):
+    /// 1. Pop the free list if non-empty (recycles a recently-freed
+    ///    tile — likely still hot in cache).
+    /// 2. Else carve one tile off the front of `[bump_ptr, bump_end)`
+    ///    (the unused tail of the current extent).
+    /// 3. Else call `add_extent` to install a new bump range and retry.
+    unsafe fn class_alloc(&mut self, class_idx: usize, layout: Layout) -> *mut u8 {
+        // Resolve a tile. The loop runs at most twice: at most one
+        // bump-range exhaustion can happen before `add_extent`
+        // installs a fresh, non-empty range.
+        let tile: *mut u8 = loop {
+            let class = self.classes[class_idx]
+                .as_mut()
+                .expect("class must be initialized");
+            // Fast path 1: free-list pop (recycled tile).
+            if !class.free_head.is_null() {
+                let head = class.free_head;
+                // SAFETY: head is non-null and was previously a valid
+                // tile address returned from this same class.
+                class.free_head = unsafe { (*head).next };
+                break head as *mut u8;
+            }
+            // Fast path 2: bump-pointer carve from the current extent.
+            // By construction the bump range spans an integer number
+            // of tiles, so `bump_ptr < bump_end` is sufficient to know
+            // a full tile fits.
+            if class.bump_ptr < class.bump_end {
+                let carved = class.bump_ptr;
+                // SAFETY: `add` stays within the extent — see invariant
+                // documented on `bump_end`.
+                class.bump_ptr = unsafe { class.bump_ptr.add(class.tile_size) };
+                break carved;
+            }
+            // Slow path: grow. `add_extent` either installs a fresh
+            // bump range (looping back into the carve branch above) or
+            // reports OOM, in which case the caller falls back.
+            if !unsafe { self.add_extent(class_idx) } {
+                return ptr::null_mut();
+            }
+        };
+
+        // Common accounting.
+        let class = self.classes[class_idx]
+            .as_mut()
+            .expect("class must be initialized");
+        class.alloc_total += 1;
+        let requested_size = layout.size();
+        // Internal-fragmentation tracking. `tile_size >= requested_size`
+        // is guaranteed by `pick_class`; the difference is the byte
+        // count rounded up by routing into this class.
+        let waste = class.tile_size.saturating_sub(requested_size) as u64;
+        class.wasted_bytes_total = class.wasted_bytes_total.saturating_add(waste);
+        class.requested_bytes_total = class
+            .requested_bytes_total
+            .saturating_add(requested_size as u64);
+        // High-water mark of alive tiles for capacity sizing diagnostics.
+        let alive_now = class.alloc_total.saturating_sub(class.dealloc_total);
+        if alive_now > class.peak_alive_tiles {
+            class.peak_alive_tiles = alive_now;
+        }
+        // Per-class request-size and align histograms. Gated by
+        // `ENABLE_HISTOGRAMS` so the whole block — the bucket compute,
+        // the heap-indirect `size_histogram` update, and the inline
+        // `align_histogram` update — is dead-code-eliminated when the
+        // const is `false`. The heap-indirect Vec update is the
+        // dominant hot-path cost of the histogram instrumentation;
+        // gating it keeps `class_alloc` lean in production builds.
+        if ENABLE_HISTOGRAMS {
+            // When an over-aligned request skips a smaller class on
+            // `tile_align` grounds, `requested_size` can be <
+            // `size_min`; we clamp to bucket 0 (= `size_min`) —
+            // slightly imprecise but bounded.
+            let bucket_idx = requested_size.saturating_sub(class.size_min);
+            if bucket_idx < class.size_histogram.len() {
+                class.size_histogram[bucket_idx] =
+                    class.size_histogram[bucket_idx].saturating_add(1);
+            }
+            let align_bucket = align_bucket_for(layout.align());
+            class.align_histogram[align_bucket] =
+                class.align_histogram[align_bucket].saturating_add(1);
+        }
+        tile
+    }
+
+    /// Push a tile back onto its class's free list. Safety: `ptr` must
+    /// have come from `class_alloc(class_idx, layout)` with the same
+    /// `layout` and not yet been freed.
+    ///
+    /// The Rust `GlobalAlloc` contract guarantees the layout passed to
+    /// `dealloc` matches the one used at `alloc`, so we recover the
+    /// original size and align for free. We use both to decrement the
+    /// per-class waste / requested / size-histogram / align-histogram
+    /// counters so they reflect the live state of the pool (not
+    /// lifetime cumulative).
+    unsafe fn class_dealloc(&mut self, class_idx: usize, ptr: *mut u8, layout: Layout) {
+        let class = self.classes[class_idx]
+            .as_mut()
+            .expect("class must be initialized");
+        let tile = ptr as *mut FreeTile;
+        unsafe { (*tile).next = class.free_head };
+        class.free_head = tile;
+        class.dealloc_total += 1;
+        let requested_size = layout.size();
+        // Mirror the alloc-side accounting so the counters track the
+        // currently-live state of the pool.
+        let waste = class.tile_size.saturating_sub(requested_size) as u64;
+        class.wasted_bytes_total = class.wasted_bytes_total.saturating_sub(waste);
+        class.requested_bytes_total = class
+            .requested_bytes_total
+            .saturating_sub(requested_size as u64);
+        // Histograms — gated symmetrically with `class_alloc`; see the
+        // doc-comment there.
+        if ENABLE_HISTOGRAMS {
+            let bucket_idx = requested_size.saturating_sub(class.size_min);
+            if bucket_idx < class.size_histogram.len() {
+                class.size_histogram[bucket_idx] =
+                    class.size_histogram[bucket_idx].saturating_sub(1);
+            }
+            let align_bucket = align_bucket_for(layout.align());
+            class.align_histogram[align_bucket] =
+                class.align_histogram[align_bucket].saturating_sub(1);
+        }
+    }
+}
+
+/// Public allocator. Wraps `TileInner` in an `UnsafeCell` and asserts
+/// `Sync` for the wasm32 single-threaded global-allocator slot.
+pub struct TileAllocator {
+    inner: UnsafeCell<TileInner>,
+}
+
+// SAFETY: wasm32-unknown-unknown is single-threaded. The global
+// allocator is reached from exactly one execution context at a time.
+// If Ruffle ever moves to wasm-threads, wrap `inner` in a `Mutex`.
+unsafe impl Sync for TileAllocator {}
+
+impl Default for TileAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TileAllocator {
+    pub const fn new() -> Self {
+        Self {
+            inner: UnsafeCell::new(TileInner::empty()),
+        }
+    }
+
+    /// Snapshot the allocator's counters. Cheap — copies a handful of
+    /// `usize`s per class. Safe to call from any runtime diagnostic
+    /// path; the web binary re-exports it as a wasm-bindgen JS
+    /// function.
+    pub fn snapshot_stats(&self) -> TileAllocatorStats {
+        // SAFETY: see Sync impl. Single-threaded on wasm32.
+        let inner = unsafe { &*self.inner.get() };
+        let mut classes = Vec::with_capacity(inner.class_count);
+        for i in 0..inner.class_count {
+            if let Some(c) = &inner.classes[i] {
+                classes.push(c.snapshot());
+            }
+        }
+        TileAllocatorStats {
+            classes,
+            fallback: TileFallbackStats {
+                alloc_total: inner.fallback_alloc_total,
+                dealloc_total: inner.fallback_dealloc_total,
+                // The cumulative `u64` counters cannot wrap in practice
+                // (see `TileInner` field doc). The live difference is
+                // bounded by the WASM linear memory cap (4 GiB on
+                // wasm32), so the down-cast to `usize` never truncates
+                // information — and on 64-bit targets it's a no-op.
+                bytes_alive: inner
+                    .fallback_bytes_alloc
+                    .saturating_sub(inner.fallback_bytes_dealloc)
+                    as usize,
+                size_histogram: inner.fallback_size_histogram,
+            },
+            cross_class_realloc_total: inner.cross_class_realloc_total,
+        }
+    }
+}
+
+unsafe impl GlobalAlloc for TileAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: see Sync impl.
+        let inner = unsafe { &mut *self.inner.get() };
+        inner.ensure_initialized();
+
+        if let Some(class_idx) = inner.pick_class(layout) {
+            let p = unsafe { inner.class_alloc(class_idx, layout) };
+            if !p.is_null() {
+                return p;
+            }
+            // add_extent failed (OOM). Fall through to system allocator.
+        }
+
+        // Fallback path.
+        let p = unsafe { System.alloc(layout) };
+        if !p.is_null() {
+            inner.fallback_alloc_total += 1;
+            inner.fallback_bytes_alloc += layout.size() as u64;
+            // Fallback size histogram — gated symmetrically with the
+            // per-class histograms. The scalar counters above (`*_total`
+            // and `*_bytes`) stay always-on: they're cheap and useful
+            // even in production builds.
+            if ENABLE_HISTOGRAMS {
+                let bucket = fallback_bucket_for_size(layout.size());
+                inner.fallback_size_histogram[bucket] =
+                    inner.fallback_size_histogram[bucket].saturating_add(1);
+            }
+        }
+        p
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        let inner = unsafe { &mut *self.inner.get() };
+        // ensure_initialized has already run during the matching alloc;
+        // but be defensive in case dealloc somehow runs first.
+        inner.ensure_initialized();
+
+        if let Some(class_idx) = inner.pick_class(layout) {
+            unsafe { inner.class_dealloc(class_idx, ptr, layout) };
+            return;
+        }
+
+        // Fallback path — mirror the alloc side.
+        inner.fallback_dealloc_total += 1;
+        inner.fallback_bytes_dealloc += layout.size() as u64;
+        if ENABLE_HISTOGRAMS {
+            let bucket = fallback_bucket_for_size(layout.size());
+            inner.fallback_size_histogram[bucket] =
+                inner.fallback_size_histogram[bucket].saturating_sub(1);
+        }
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    // `alloc_zeroed` uses the default implementation (alloc + write_bytes).
+
+    /// In-place `realloc` optimization. The default `GlobalAlloc::realloc`
+    /// always does `alloc(new) + memcpy + dealloc(old)`, which holds two
+    /// tiles live at once and pressures the source class's free list
+    /// — a driver of peak-transient overshoots that can force extra
+    /// extents under sustained reallocation.
+    ///
+    /// When `new_size` fits in the same size class as `layout.size()`,
+    /// the existing tile is already big enough: we return it
+    /// unchanged. Zero alloc, zero copy, zero dealloc — and crucially
+    /// no transient where two tiles are simultaneously alive in the
+    /// same class. The cross-class path falls back to the standard
+    /// alloc+copy+dealloc sequence.
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let inner = unsafe { &mut *self.inner.get() };
+        inner.ensure_initialized();
+
+        // Build the would-be new layout (same alignment as the old one;
+        // realloc never changes alignment).
+        let new_layout = match Layout::from_size_align(new_size, layout.align()) {
+            Ok(l) => l,
+            Err(_) => return ptr::null_mut(),
+        };
+        let old_class = inner.pick_class(layout);
+        let new_class = inner.pick_class(new_layout);
+
+        // Fast path: both the old and new size land in the same size
+        // class, so the existing tile is still big enough. Return the
+        // same pointer; the caller can write up to `new_size` bytes
+        // into it.
+        if let Some(old_idx) = old_class
+            && old_class == new_class
+        {
+            if let Some(c) = inner.classes[old_idx].as_mut() {
+                c.inplace_realloc_total = c.inplace_realloc_total.saturating_add(1);
+            }
+            return ptr;
+        }
+
+        // Slow path: different class (or fallback path). Allocate a
+        // fresh tile, copy the live bytes, free the old one.
+        inner.cross_class_realloc_total = inner.cross_class_realloc_total.saturating_add(1);
+        // In the slow path `new_size != layout.size()` is guaranteed:
+        // if they were equal and align is invariant under realloc,
+        // `pick_class` would have returned the same index → fast
+        // inplace path above. So this comparison cleanly partitions
+        // every slow-path call into "grow" or "shrink".
+        let is_grow = new_size > layout.size();
+        // Per-class outbound counter: charge the source class for
+        // letting go of a buffer that needed to migrate. Only when
+        // `old_class` is a pool class.
+        if let Some(old_idx) = old_class
+            && let Some(c) = inner.classes[old_idx].as_mut()
+        {
+            if is_grow {
+                c.outbound_realloc_total_grow = c.outbound_realloc_total_grow.saturating_add(1);
+            } else {
+                c.outbound_realloc_total_shrink = c.outbound_realloc_total_shrink.saturating_add(1);
+            }
+        }
+        // Per-class inbound counter: charge the destination class for
+        // receiving a cross-class realloc. Only when `new_class` is a
+        // pool class — cross-class reallocs that land in the fallback
+        // are captured by `cross_class_realloc_total` alone (the gap
+        // vs sum-of-inbound tells you how many reallocs outgrew the
+        // pool entirely).
+        if let Some(new_idx) = new_class
+            && let Some(c) = inner.classes[new_idx].as_mut()
+        {
+            if is_grow {
+                c.inbound_realloc_total_grow = c.inbound_realloc_total_grow.saturating_add(1);
+            } else {
+                c.inbound_realloc_total_shrink = c.inbound_realloc_total_shrink.saturating_add(1);
+            }
+        }
+        let new_ptr = unsafe { self.alloc(new_layout) };
+        if !new_ptr.is_null() {
+            let copy_size = core::cmp::min(layout.size(), new_size);
+            unsafe { core::ptr::copy_nonoverlapping(ptr, new_ptr, copy_size) };
+            unsafe { self.dealloc(ptr, layout) };
+        }
+        new_ptr
+    }
+}

--- a/core/src/tilemalloc/core.rs
+++ b/core/src/tilemalloc/core.rs
@@ -17,8 +17,12 @@
 //! - **dealloc** = push back onto the free list head. Always O(1).
 //! - **add_extent** = ask the system allocator for one extent and set
 //!   the class's bump range to span it. No per-tile setup write. Each
-//!   extent is tracked so we can report `extent_count` for stats and
-//!   (eventually) walk the extents for cleanup.
+//!   extent is tracked so we can report `extent_count` for stats and so
+//!   `trim_empty_extents` can hand fully-free extents back.
+//! - **trim** (on demand only) = sweep the free lists and return every
+//!   fully-empty extent to the system allocator, undoing a transient
+//!   spike that stranded extents in the otherwise grow-only pool. Never
+//!   runs on the alloc/dealloc hot path. See `trim_empty_extents`.
 //!
 //! Concurrency: the allocator is `Sync` via interior mutability
 //! (`UnsafeCell`). On `wasm32-unknown-unknown` execution is
@@ -48,12 +52,18 @@ struct FreeTile {
 
 /// Metadata for one extent (a contiguous region obtained from the
 /// system allocator and split into `tiles_per_extent` tiles). Kept in
-/// a `Vec` for stats reporting and as the anchor any future extent
-/// cleanup would need (the allocator is currently grow-only).
-#[allow(dead_code)]
+/// a `Vec` for stats reporting and as the anchor `trim_empty_extents`
+/// uses to hand fully-free extents back to the system allocator.
 struct ExtentRecord {
     ptr: *mut u8,
     total_bytes: usize,
+    /// Transient scratch, meaningful **only** during a single
+    /// `trim_empty_extents` sweep: how many of this extent's tiles are
+    /// currently on the free list, and the head of those same tiles
+    /// re-chained into a per-extent bucket. Reset at the start of every
+    /// sweep; never read on the alloc/dealloc hot path.
+    free_count: usize,
+    bucket: *mut FreeTile,
 }
 
 /// Per–size-class runtime state.
@@ -87,15 +97,20 @@ struct ClassState {
     /// `add_extent`, so the check `bump_ptr < bump_end` is sufficient
     /// to guarantee at least one full tile fits before the carve.
     bump_end: *mut u8,
-    /// Extent tracking (for stats and potential cleanup).
+    /// Extent tracking (for stats and `trim_empty_extents` reclamation).
     extents: Vec<ExtentRecord>,
     /// Cumulative counters.
     alloc_total: usize,
     dealloc_total: usize,
     /// Cumulative count of extents added to this class since boot.
-    /// Equals `extents.len()` as long as the allocator stays
-    /// grow-only.
+    /// `extents.len()` equals `extents_added - extents_released`; before
+    /// any `trim_empty_extents` reclaims an extent the latter is 0 and it
+    /// equals `extents_added`.
     extents_added: usize,
+    /// Cumulative count of extents handed back to the system allocator by
+    /// `trim_empty_extents` since boot. The current extent count is
+    /// `extents_added - extents_released`.
+    extents_released: usize,
     /// **Live** byte count of internal fragmentation currently held by
     /// this class: sum of `(tile_size - layout.size())` over every tile
     /// currently alive in the pool. Incremented in `class_alloc`,
@@ -201,6 +216,7 @@ impl ClassState {
             alloc_total: 0,
             dealloc_total: 0,
             extents_added: 0,
+            extents_released: 0,
             wasted_bytes_total: 0,
             requested_bytes_total: 0,
             peak_alive_tiles: 0,
@@ -238,6 +254,7 @@ impl ClassState {
             extent_bytes: self.extents.iter().map(|s| s.total_bytes).sum(),
             extent_count: self.extents.len(),
             extents_added: self.extents_added,
+            extents_released: self.extents_released,
             alloc_total: self.alloc_total,
             dealloc_total: self.dealloc_total,
             peak_alive_tiles: self.peak_alive_tiles,
@@ -523,6 +540,8 @@ impl TileInner {
         class.extents.push(ExtentRecord {
             ptr: extent_ptr,
             total_bytes: extent_total,
+            free_count: 0,
+            bucket: ptr::null_mut(),
         });
         class.extents_added += 1;
         true
@@ -661,6 +680,114 @@ impl TileInner {
                 class.align_histogram[align_bucket].saturating_sub(1);
         }
     }
+
+    /// Release fully-empty extents back to the system allocator, returning the
+    /// total bytes reclaimed.
+    ///
+    /// The pool is otherwise grow-only: a transient spike — e.g. millions of
+    /// short-lived objects that all land in one size class faster than the GC
+    /// can reclaim them — permanently inflates `extents`. On WASM, where linear
+    /// memory never shrinks, that memory then stays reserved by the pool and
+    /// starves later allocations (including the fallback path other code relies
+    /// on), even though it is entirely free. This hands the empty extents back
+    /// to dlmalloc, where any size class *or* the fallback can reuse them.
+    ///
+    /// An extent is releasable when *every* one of its tiles is on the free
+    /// list (all were carved and then freed). The current bump extent is never
+    /// released; its un-carved tail keeps its `free_count` below
+    /// `tiles_per_extent` anyway, but the `is_current` guard makes that
+    /// explicit (and covers the fully-carved-then-drained edge).
+    ///
+    /// Cost: O(free tiles · log extents), paid only when called — typically on
+    /// memory pressure or after a GC — never on the alloc/dealloc hot path.
+    ///
+    /// **Allocation-free** by construction: this runs *as* the global
+    /// allocator, so it must not route back through `self`. It uses only
+    /// in-place scratch — an in-place `sort_unstable` (which never allocates)
+    /// and the per-extent `free_count`/`bucket` fields on the existing Vec.
+    ///
+    /// Safety / soundness: single-threaded on wasm32 (see the `Sync` impl).
+    unsafe fn trim_empty_extents(&mut self) -> usize {
+        let mut released_total = 0usize;
+        for ci in 0..self.class_count {
+            let Some(class) = self.classes[ci].as_mut() else {
+                continue;
+            };
+            if class.extents.is_empty() || class.free_head.is_null() {
+                continue;
+            }
+
+            // Sort extents by base address so a free tile's owning extent is a
+            // binary search. `sort_unstable` is in place and never allocates.
+            class.extents.sort_unstable_by_key(|e| e.ptr as usize);
+            for e in class.extents.iter_mut() {
+                e.free_count = 0;
+                e.bucket = ptr::null_mut();
+            }
+
+            // Pass 1: drain the free list, re-chaining each tile into its
+            // owning extent's bucket and counting per extent. Each bucket stays
+            // entirely within one extent, so a released extent's chain never
+            // dangles into a retained one.
+            let mut orphans: *mut FreeTile = ptr::null_mut();
+            let mut tile = class.free_head;
+            while !tile.is_null() {
+                let next = unsafe { (*tile).next };
+                let addr = tile as usize;
+                let pp = class.extents.partition_point(|e| (e.ptr as usize) <= addr);
+                if pp > 0 && addr < class.extents[pp - 1].ptr as usize + class.extents[pp - 1].total_bytes {
+                    let e = &mut class.extents[pp - 1];
+                    unsafe { (*tile).next = e.bucket };
+                    e.bucket = tile;
+                    e.free_count += 1;
+                } else {
+                    // A free tile mapping to no extent should be impossible;
+                    // park it on the orphan chain rather than leak it.
+                    unsafe { (*tile).next = orphans };
+                    orphans = tile;
+                }
+                tile = next;
+            }
+
+            // Pass 2: release fully-free extents, re-chain the rest. Start the
+            // rebuilt free list from any orphans so none are lost.
+            let tpe = class.tiles_per_extent;
+            let tile_align = class.tile_align;
+            let bump_end = class.bump_end;
+            let mut new_head: *mut FreeTile = orphans;
+            let mut released = 0usize;
+            let mut released_count = 0usize;
+            class.extents.retain(|e| {
+                let e_end = unsafe { e.ptr.add(e.total_bytes) };
+                let is_current = !bump_end.is_null() && bump_end == e_end;
+                if e.free_count == tpe && !is_current {
+                    let layout =
+                        unsafe { Layout::from_size_align_unchecked(e.total_bytes, tile_align) };
+                    unsafe { System.dealloc(e.ptr, layout) };
+                    released += e.total_bytes;
+                    released_count += 1;
+                    false
+                } else {
+                    if !e.bucket.is_null() {
+                        // Prepend this extent's self-contained bucket chain.
+                        let mut t = e.bucket;
+                        unsafe {
+                            while !(*t).next.is_null() {
+                                t = (*t).next;
+                            }
+                            (*t).next = new_head;
+                        }
+                        new_head = e.bucket;
+                    }
+                    true
+                }
+            });
+            class.free_head = new_head;
+            class.extents_released += released_count;
+            released_total += released;
+        }
+        released_total
+    }
 }
 
 /// Public allocator. Wraps `TileInner` in an `UnsafeCell` and asserts
@@ -719,6 +846,18 @@ impl TileAllocator {
             cross_class_realloc_total: inner.cross_class_realloc_total,
         }
     }
+
+    /// Release every fully-empty pool extent back to the system allocator and
+    /// return the bytes reclaimed. Use from a memory-pressure or post-GC hook
+    /// to undo a transient spike that stranded extents in the (otherwise
+    /// grow-only) pool. Cheap when there is nothing to release; the cost scales
+    /// with the number of free tiles, so prefer calling it while idle rather
+    /// than per frame. See [`TileInner::trim_empty_extents`].
+    pub fn trim(&self) -> usize {
+        // SAFETY: see Sync impl. Single-threaded on wasm32.
+        let inner = unsafe { &mut *self.inner.get() };
+        unsafe { inner.trim_empty_extents() }
+    }
 }
 
 unsafe impl GlobalAlloc for TileAllocator {
@@ -736,7 +875,15 @@ unsafe impl GlobalAlloc for TileAllocator {
         }
 
         // Fallback path.
-        let p = unsafe { System.alloc(layout) };
+        let mut p = unsafe { System.alloc(layout) };
+        if p.is_null() {
+            // dlmalloc could not satisfy the request within the current WASM
+            // pages. A transient pool spike may have stranded reusable memory
+            // in fully-empty extents — hand them back to the system allocator
+            // and retry once. (Trim is allocation-free, so this can't recurse.)
+            unsafe { inner.trim_empty_extents() };
+            p = unsafe { System.alloc(layout) };
+        }
         if !p.is_null() {
             inner.fallback_alloc_total += 1;
             inner.fallback_bytes_alloc += layout.size() as u64;
@@ -858,5 +1005,64 @@ unsafe impl GlobalAlloc for TileAllocator {
             unsafe { self.dealloc(ptr, layout) };
         }
         new_ptr
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::alloc::{GlobalAlloc, Layout};
+
+    /// Fill three extents of one class, free every tile, and confirm `trim`
+    /// hands back the two fully-free non-current extents (16 MiB) while keeping
+    /// the current bump extent — and that its recycled tiles stay usable.
+    #[test]
+    fn trim_releases_fully_empty_extents() {
+        let a = TileAllocator::new();
+        let layout = Layout::from_size_align(256, 8).unwrap();
+        // Mirror config: extent_mb = 8 for the 256-byte class.
+        let tpe = (8 * 1024 * 1024) / 256;
+        let extent_bytes = tpe * 256;
+        let n = tpe * 2 + 10; // two full extents + a partly-carved third
+
+        let mut ptrs = Vec::with_capacity(n);
+        for _ in 0..n {
+            let p = unsafe { a.alloc(layout) };
+            assert!(!p.is_null());
+            ptrs.push(p);
+        }
+
+        let count_256 = |s: &TileAllocatorStats| {
+            s.classes.iter().find(|c| c.size_max == 256).unwrap().extent_count
+        };
+        assert_eq!(count_256(&a.snapshot_stats()), 3);
+
+        for p in &ptrs {
+            unsafe { a.dealloc(*p, layout) };
+        }
+
+        let released = a.trim();
+        assert_eq!(released, 2 * extent_bytes);
+
+        // Stats must reflect the reclamation, not just the byte count: one
+        // extent survives, `extents_released` records the two handed back, and
+        // the derived counters re-track (capacity shrank so `free_tiles` drops
+        // to one extent's worth; `extents_added` stays a lifetime total).
+        let snap = a.snapshot_stats();
+        let cls = snap.classes.iter().find(|c| c.size_max == 256).unwrap();
+        assert_eq!(cls.extent_count, 1);
+        assert_eq!(cls.extents_added, 3);
+        assert_eq!(cls.extents_released, 2);
+        assert_eq!(cls.extent_count, cls.extents_added - cls.extents_released);
+        assert_eq!(cls.alive_tiles, 0);
+        assert_eq!(cls.free_tiles, tpe);
+
+        // Recycled tiles from the surviving extent must still allocate.
+        for _ in 0..10 {
+            assert!(!unsafe { a.alloc(layout) }.is_null());
+        }
+
+        // Trimming again is a no-op (nothing fully free now).
+        assert_eq!(a.trim(), 0);
     }
 }

--- a/core/src/tilemalloc/mod.rs
+++ b/core/src/tilemalloc/mod.rs
@@ -1,0 +1,84 @@
+//! Tilemalloc — size-class allocator with intrusive free lists.
+//!
+//! ## Why this allocator exists
+//!
+//! Long-running WASM workloads that sustain heavy churn of small
+//! allocations — many short-lived tiles under a few hundred bytes —
+//! push general-purpose allocators (dlmalloc on the
+//! `wasm32-unknown-unknown` target) into per-call costs that can grow
+//! with the live set. The cost surfaces as free-list traversal and
+//! coalescing work that compounds on top of every alloc/free site in
+//! hot paths, even when the steady-state working set is bounded.
+//!
+//! This allocator targets that pathology. For the configured size
+//! classes (see `config.rs`):
+//!
+//! - **alloc**: pop the head of an intrusive free list if non-empty,
+//!   otherwise carve one tile off a bump pointer into the current
+//!   extent. Either way O(1), no list walk, no coalescing search.
+//! - **dealloc**: push back onto the free-list head — same cost.
+//! - **add_extent** (rare, amortized): when both the free list is
+//!   empty and the bump range is exhausted, ask the system allocator
+//!   for one extent and install it as the new bump range. No per-tile
+//!   setup write at extent creation — the per-tile cost is paid lazily
+//!   as the bump pointer advances on subsequent allocs.
+//! - **fallback**: anything bigger than the largest class, or with
+//!   alignment greater than the largest class's auto-derived
+//!   `tile_align`, transparently goes to the system allocator
+//!   (dlmalloc on `wasm32-unknown-unknown`).
+//!
+//! Critically, the allocator **does not coalesce on free**. Tiles
+//! freed by an object's destruction stay carved at their original
+//! size, ready to be popped by the next allocation of the same shape.
+//! A workload that repeatedly constructs and destructs objects of
+//! similar layout settles into a steady state where later
+//! constructions reuse the exact tiles earlier destructions freed
+//! — **no additional `memory.grow()` calls** past the initial extent
+//! fills.
+//!
+//! ## How to use
+//!
+//! Install as the binary's global allocator:
+//!
+//! ```ignore
+//! use ruffle_core::tilemalloc::TileAllocator;
+//!
+//! #[global_allocator]
+//! static GLOBAL: TileAllocator = TileAllocator::new();
+//! ```
+//!
+//! Inspect at runtime via `GLOBAL.snapshot_stats()` (cheap; copies
+//! a handful of `usize`s per class).
+//!
+//! ## How to tune
+//!
+//! Edit `config::TILE_CONFIG` and rebuild. At runtime, obtain a JSON
+//! snapshot of per-class state via `TileAllocator::snapshot_stats`
+//! (see the `stats` module for the full schema) — the web binary
+//! re-exports it as a wasm-bindgen JS function. A class with steadily
+//! growing `extents_added` wants a larger `extent_mb`; a class with
+//! `alive_tiles == 0` across many snapshots is unused and can be
+//! removed (or merged with an adjacent class).
+//!
+//! ## Safety
+//!
+//! The allocator is `Sync` via interior mutability with no locking,
+//! which is sound on `wasm32-unknown-unknown` because the runtime is
+//! single-threaded. On wasm-threads (when/if that target is enabled)
+//! the inner state needs a `Mutex` wrapper.
+
+pub mod config;
+mod core;
+pub mod stats;
+
+pub use config::{TILE_CONFIG, TileClass};
+pub use core::TileAllocator;
+pub use stats::{TileAllocatorStats, TileClassStats, TileFallbackStats};
+
+/// Shared global instance. The web binary's `#[global_allocator]`
+/// wrapper delegates to this, and the wasm-bindgen JS stats exports
+/// read their snapshots from here. On non-WASM targets the static is
+/// harmless: it allocates no memory until first use, and first use
+/// only happens if a code path explicitly hits the allocator wrapper
+/// that references it.
+pub static GLOBAL_TILEMALLOC: TileAllocator = TileAllocator::new();

--- a/core/src/tilemalloc/mod.rs
+++ b/core/src/tilemalloc/mod.rs
@@ -36,6 +36,16 @@
 //! — **no additional `memory.grow()` calls** past the initial extent
 //! fills.
 //!
+//! - **trim** (`TileAllocator::trim`, on demand): the steady state above
+//!   is grow-only — extents are never given back. A *one-off* spike (e.g.
+//!   millions of short-lived objects in one size class faster than the GC
+//!   reclaims them) would otherwise strand its extents forever. `trim`
+//!   sweeps the free lists and hands every fully-empty extent back to the
+//!   system allocator, so any class or the fallback can reuse it. It is
+//!   allocation-free and runs only when called (a memory-pressure or
+//!   post-GC hook), never on the hot path; it also fires automatically as
+//!   a last resort when a fallback allocation would otherwise OOM.
+//!
 //! ## How to use
 //!
 //! Install as the binary's global allocator:
@@ -48,7 +58,9 @@
 //! ```
 //!
 //! Inspect at runtime via `GLOBAL.snapshot_stats()` (cheap; copies
-//! a handful of `usize`s per class).
+//! a handful of `usize`s per class), and reclaim a transient spike via
+//! `GLOBAL.trim()` (the web binary re-exports both as wasm-bindgen JS
+//! functions — `tilemallocStats` / `tilemallocTrim`).
 //!
 //! ## How to tune
 //!

--- a/core/src/tilemalloc/stats.rs
+++ b/core/src/tilemalloc/stats.rs
@@ -49,8 +49,15 @@ pub struct TileClassStats {
     /// addition adds `tiles_per_extent` to capacity. Growth in this
     /// counter between snapshots means the working set for this class
     /// is exceeding the extent pool — consider increasing `extent_mb`
-    /// in the config.
+    /// in the config. The current `extent_count` is
+    /// `extents_added - extents_released`.
     pub extents_added: usize,
+
+    /// Cumulative count of extents handed back to the system allocator
+    /// by `TileAllocator::trim` since boot. Non-zero only after a trim
+    /// reclaimed a transient spike; `extent_count = extents_added -
+    /// extents_released`.
+    pub extents_released: usize,
 
     /// Cumulative alloc calls served by this class (does NOT count
     /// allocations that fell back to the system allocator).
@@ -226,7 +233,9 @@ impl TileAllocatorStats {
     /// schema where applicable):
     /// - `class` = `size_max` (the tile size of the class).
     /// - `free` / `alive` = `free_tiles` / `alive_tiles`.
-    /// - `ext` / `added` = `extent_count` / `extents_added`.
+    /// - `ext` / `added` / `released` = `extent_count` / `extents_added`
+    ///   / `extents_released` (so `ext = added - released`; `released`
+    ///   is non-zero only after a `trim` reclaimed empty extents).
     /// - `alloc` / `dealloc` = `alloc_total` / `dealloc_total`.
     /// - `peak` = lifetime peak of `alive_tiles` (sizing hint for `extent_mb`).
     /// - `live_mb` = `alive_tiles * size_max / 1 MiB` (the working set
@@ -271,12 +280,13 @@ impl TileAllocatorStats {
                 live_bytes as f64 * 100.0 / c.extent_bytes as f64
             };
             s.push_str(&format!(
-                "{{class={} free={} alive={} ext={} added={} alloc={} dealloc={} peak={} live_mb={:.2} util_pct={:.1} waste_pct={:.1}}}",
+                "{{class={} free={} alive={} ext={} added={} released={} alloc={} dealloc={} peak={} live_mb={:.2} util_pct={:.1} waste_pct={:.1}}}",
                 c.size_max,
                 c.free_tiles,
                 c.alive_tiles,
                 c.extent_count,
                 c.extents_added,
+                c.extents_released,
                 c.alloc_total,
                 c.dealloc_total,
                 c.peak_alive_tiles,
@@ -354,6 +364,7 @@ impl TileAllocatorStats {
     ///     { "size_min": N, "size_max": N,
     ///       "free_tiles": N, "alive_tiles": N,
     ///       "extent_bytes": N, "extent_count": N, "extents_added": N,
+    ///       "extents_released": N,
     ///       "alloc_total": N, "dealloc_total": N,
     ///       "peak_alive_tiles": N,
     ///       "wasted_bytes_total": N, "requested_bytes_total": N,
@@ -380,6 +391,7 @@ impl TileAllocatorStats {
     /// All `*_total` and `*_histogram` values are **live** (= reflecting
     /// the current pool state, alloc-minus-dealloc), except for
     /// `alloc_total`, `dealloc_total`, `extents_added`,
+    /// `extents_released`,
     /// `inplace_realloc_total`, `inbound_realloc_total_{grow,shrink}`,
     /// `outbound_realloc_total_{grow,shrink}`,
     /// `cross_class_realloc_total`, and `peak_alive_tiles`, which are
@@ -437,6 +449,7 @@ impl TileAllocatorStats {
             s.push_str(&format!("\"extent_bytes\":{},", c.extent_bytes));
             s.push_str(&format!("\"extent_count\":{},", c.extent_count));
             s.push_str(&format!("\"extents_added\":{},", c.extents_added));
+            s.push_str(&format!("\"extents_released\":{},", c.extents_released));
             s.push_str(&format!("\"alloc_total\":{},", c.alloc_total));
             s.push_str(&format!("\"dealloc_total\":{},", c.dealloc_total));
             s.push_str(&format!("\"peak_alive_tiles\":{},", c.peak_alive_tiles));

--- a/core/src/tilemalloc/stats.rs
+++ b/core/src/tilemalloc/stats.rs
@@ -1,0 +1,509 @@
+//! Runtime statistics for the tile allocator.
+//!
+//! Snapshots are read-only views taken at a single point in time. They
+//! are produced by `TileAllocator::snapshot_stats` and rendered into
+//! two transport formats — `to_json` (machine-readable, the stable
+//! schema for tooling) and `to_table` (human-readable, fixed-width
+//! columns for direct diff between snapshots). Both are surfaced
+//! to JavaScript via wasm-bindgen exports in `web/src/lib.rs`.
+
+use super::config::ENABLE_HISTOGRAMS;
+
+/// Per–size-class snapshot.
+#[derive(Clone, Debug, Default)]
+pub struct TileClassStats {
+    /// Minimum request size (in bytes) routed to this class
+    /// (inclusive). Equals the previous class's `size_max + 1`, or `1`
+    /// for the first class. Together with `size_max` it defines the
+    /// closed interval `[size_min, size_max]` of `layout.size()` values
+    /// that this class absorbs, and indexes `size_histogram` via
+    /// `requested_size = size_min + i`.
+    pub size_min: usize,
+
+    /// Maximum request size (in bytes) served by this class — the tile
+    /// size from the config. Allocations with
+    /// `layout.size() <= size_max` (and `layout.align() <= tile_align`)
+    /// are routed here.
+    pub size_max: usize,
+
+    /// Tiles currently sitting on this class's free list, immediately
+    /// reusable on the next `alloc` for this class. Sum of
+    /// `alive_tiles` and `free_tiles` is the total tile capacity
+    /// across all extents currently held for this class.
+    pub free_tiles: usize,
+
+    /// Currently alive tiles (`alloc_total - dealloc_total`).
+    pub alive_tiles: usize,
+
+    /// Total bytes the extents of this class are currently occupying
+    /// in the WASM linear memory. Equals
+    /// `extent_count * size_max * tiles_per_extent`.
+    pub extent_bytes: usize,
+
+    /// Extents currently held for this class. Each extent contributes
+    /// `tiles_per_extent` tile slots to capacity.
+    pub extent_count: usize,
+
+    /// Cumulative count of extents added to this class since boot
+    /// (= calls to the system allocator to grow capacity). Each
+    /// addition adds `tiles_per_extent` to capacity. Growth in this
+    /// counter between snapshots means the working set for this class
+    /// is exceeding the extent pool — consider increasing `extent_mb`
+    /// in the config.
+    pub extents_added: usize,
+
+    /// Cumulative alloc calls served by this class (does NOT count
+    /// allocations that fell back to the system allocator).
+    pub alloc_total: usize,
+
+    /// Cumulative dealloc calls served by this class.
+    pub dealloc_total: usize,
+
+    /// Peak `alive_tiles` ever observed for this class. Cumulative
+    /// high-water mark across the lifetime of the allocator. Useful
+    /// to decide whether the configured `extent_mb` is sized
+    /// appropriately for the class — if `peak_alive_tiles >
+    /// tiles_per_extent` (= `extent_bytes / size_max` per extent),
+    /// the class needed more than one extent at some point.
+    pub peak_alive_tiles: usize,
+
+    /// **Live** internal-fragmentation bytes currently held by this
+    /// class: sum of `(size_max - layout.size())` over every tile
+    /// currently alive. Incremented in `class_alloc`, decremented in
+    /// `class_dealloc` using `layout.size()` (which Rust's `GlobalAlloc`
+    /// contract guarantees is the same value at alloc and dealloc).
+    /// Reflects the present state of the pool, not a lifetime total.
+    /// Pair with `requested_bytes_total` for the live waste-as-percent.
+    pub wasted_bytes_total: u64,
+
+    /// **Live** bytes actually requested by callers and currently held
+    /// by tiles in this class: sum of `layout.size()` over the alive
+    /// tiles. Same alloc/dealloc symmetry as `wasted_bytes_total`.
+    pub requested_bytes_total: u64,
+
+    /// Cumulative in-place realloc fast-path hits served by this
+    /// class: `realloc` calls where both old and new `layout.size()`
+    /// landed here, so we returned the same pointer without copy.
+    /// Pair with `TileAllocatorStats::cross_class_realloc_total` to
+    /// gauge how often the fast path actually kicks in.
+    pub inplace_realloc_total: u64,
+
+    /// Cross-class realloc **arrivals from a smaller origin** (grow
+    /// landed here). `new_size > old_size` and `new_layout` lives in
+    /// this class. Always 0 for the smallest pool class.
+    pub inbound_realloc_total_grow: u64,
+
+    /// Cross-class realloc **arrivals from a larger origin** (shrink
+    /// landed here). `new_size < old_size` and `new_layout` lives in
+    /// this class.
+    pub inbound_realloc_total_shrink: u64,
+
+    /// Cross-class realloc **departures toward a larger destination**
+    /// (this class was outgrown). `new_size > old_size` and `layout`
+    /// lived here.
+    pub outbound_realloc_total_grow: u64,
+
+    /// Cross-class realloc **departures toward a smaller destination**
+    /// (this class lost a buffer to a smaller one). `new_size <
+    /// old_size` and `layout` lived here. Always 0 for the smallest
+    /// pool class.
+    pub outbound_realloc_total_shrink: u64,
+
+    /// **Live** histogram: one counter per `layout.size()` value in
+    /// `size_min..=size_max`. Index `i` corresponds to
+    /// `requested_size = size_min + i`. Length =
+    /// `size_max - size_min + 1`. Each bucket counts the tiles of
+    /// that requested size **currently alive** in the pool (not all
+    /// allocs ever made). Diff between snapshots reveals which sizes
+    /// grew or shrank over the window.
+    pub size_histogram: Vec<u64>,
+
+    /// **Live** histogram of `layout.align()` for tiles currently alive
+    /// in this class. Buckets:
+    /// - `[0]` → `align == 1` (e.g. `Box<u8>`, `Vec<u8>`, `String` backing)
+    /// - `[1]` → `align == 2` (e.g. `Box<u16>`)
+    /// - `[2]` → `align == 4` (structs with `u32` / `usize` / pointer on wasm32)
+    /// - `[3]` → `align == 8` (structs containing `u64`)
+    /// - `[4]` → `align == 16` (SIMD `v128`, some allocator metadata)
+    /// - `[5]` → `align == 32` (rare; some `#[repr(align(32))]`)
+    /// - `[6]` → `align == 64` (cache-line padding, anti-false-sharing)
+    /// - `[7]` → `align ≥ 128` (saturating; very rare in Rust user code)
+    ///
+    /// The bucket sum equals `alive_tiles` (every alive tile counted
+    /// once). Cross-reference with `size_histogram` to tell apart
+    /// "this size lands here because of size alone — a smaller class
+    /// with align ≥ requested would have fit" from "this size lands
+    /// here because no smaller class has enough align".
+    pub align_histogram: [u64; 8],
+}
+
+/// Statistics for allocations that bypassed the tile pools and went
+/// straight to the system allocator (dlmalloc on wasm32). These are
+/// the "long tail" — sizes larger than the biggest class, or
+/// over-aligned requests.
+#[derive(Clone, Debug, Default)]
+pub struct TileFallbackStats {
+    pub alloc_total: usize,
+    pub dealloc_total: usize,
+
+    /// Approximate live bytes in fallback path (`alloc_bytes -
+    /// dealloc_bytes`). Useful to see if the long tail is itself
+    /// growing.
+    pub bytes_alive: usize,
+
+    /// **Live** histogram of fallback allocations currently outstanding,
+    /// bucketed log-style by `layout.size()`. Boundaries (inclusive
+    /// upper): `[0]=512, [1]=1024, [2]=2048, [3]=4096, [4]=8192,
+    /// [5]=16384, [6]=32768, [7]=65536, [8]=131072, [9]=∞`. Each bucket
+    /// counts fallback allocations of that size class that are
+    /// currently alive (the alloc/dealloc symmetry is preserved).
+    /// A sustained large count in some bucket signals a hot fallback
+    /// path worth absorbing by adding a tile size class above the
+    /// current ceiling.
+    pub size_histogram: [u64; 10],
+}
+
+/// Top-level snapshot.
+#[derive(Clone, Debug, Default)]
+pub struct TileAllocatorStats {
+    pub classes: Vec<TileClassStats>,
+    pub fallback: TileFallbackStats,
+
+    /// Cumulative count of realloc calls that could not be served by
+    /// the in-place fast path. Sum of: tile-to-tile cross-class
+    /// transitions, tile-to-fallback transitions, fallback-to-tile
+    /// transitions, and fallback-to-fallback transitions. Compare
+    /// against the sum of `TileClassStats::inplace_realloc_total`
+    /// across all classes to compute the fast-path hit ratio.
+    pub cross_class_realloc_total: u64,
+}
+
+impl TileAllocatorStats {
+    /// Total bytes currently held by all extents combined. Together
+    /// with `fallback.bytes_alive` this is the tile allocator's net
+    /// contribution to the WASM linear memory footprint.
+    pub fn total_extent_bytes(&self) -> usize {
+        self.classes.iter().map(|c| c.extent_bytes).sum()
+    }
+
+    /// Total live bytes across all tile pools (= sum of
+    /// `alive_tiles * size_bytes`). This is the working set actually
+    /// in use, distinct from `total_extent_bytes` which is the
+    /// reserved capacity (live + free).
+    pub fn total_tile_alive_bytes(&self) -> usize {
+        self.classes
+            .iter()
+            .map(|c| c.alive_tiles * c.size_max)
+            .sum()
+    }
+
+    /// Aggregate live waste across all classes (in bytes). This is the
+    /// total internal-fragmentation overhead currently consumed by
+    /// alive tiles — i.e. how many bytes the pool is rounding up
+    /// "right now". Diff between snapshots reveals where rounding is
+    /// growing or shrinking.
+    pub fn total_wasted_bytes(&self) -> u64 {
+        self.classes.iter().map(|c| c.wasted_bytes_total).sum()
+    }
+
+    /// Aggregate live requested bytes across all classes.
+    pub fn total_requested_bytes(&self) -> u64 {
+        self.classes.iter().map(|c| c.requested_bytes_total).sum()
+    }
+
+    /// Pretty-print the snapshot as a single line. The whole snapshot
+    /// is wrapped in `[...]`; each record (one per size class plus
+    /// fallback and totals) is wrapped in `{...}` and carries
+    /// `key=value` pairs inline. Designed to be emitted as a String.
+    ///
+    /// Output shape (one line):
+    ///
+    /// ```text
+    /// [{class=8 free=63391 alive=985185 ext=1 added=1 alloc=1123812 dealloc=138627 peak=985300 live_mb=7.52 util_pct=92.5 waste_pct=0.0}...{fallback alloc=190934 dealloc=134793 alive_mb=144.66}{totals pool_mb=192.00 tile_live_mb=80.74 live_tot_mb=225.40 waste_mb=6.8 waste_pct=8.4 realloc_inplace=12345 realloc_inbound_grow=54 realloc_inbound_shrink=35 realloc_outbound_grow=42 realloc_outbound_shrink=35 realloc_cross=678}]
+    /// ```
+    ///
+    /// Per-class fields (in the order they appear, matching the JSON
+    /// schema where applicable):
+    /// - `class` = `size_max` (the tile size of the class).
+    /// - `free` / `alive` = `free_tiles` / `alive_tiles`.
+    /// - `ext` / `added` = `extent_count` / `extents_added`.
+    /// - `alloc` / `dealloc` = `alloc_total` / `dealloc_total`.
+    /// - `peak` = lifetime peak of `alive_tiles` (sizing hint for `extent_mb`).
+    /// - `live_mb` = `alive_tiles * size_max / 1 MiB` (the working set
+    ///   actually used).
+    /// - `util_pct` = current `alive_bytes * 100 / extent_bytes`
+    ///   (= how much of the reserved capacity is actually live now).
+    ///   Low util_pct means over-allocated extents; consider shrinking
+    ///   `extent_mb`.
+    /// - `waste_pct` = live `wasted / (wasted + requested) * 100`
+    ///   (= internal-fragmentation share for tiles **currently alive**
+    ///   in this class). Differs between snapshots iff the alive size
+    ///   distribution changes.
+    ///
+    /// Totals fields:
+    /// - `waste_mb` = aggregate live waste in MiB across all classes.
+    /// - `waste_pct` = aggregate over all classes.
+    /// - `realloc_inplace` = sum of all classes' fast-path realloc hits.
+    /// - `realloc_inbound_grow` / `realloc_inbound_shrink` = sums of
+    ///   cross-class realloc arrivals into pool classes, split by
+    ///   whether the call was a grow (`new > old`) or shrink. Both
+    ///   `≤ realloc_cross`; the gap vs `realloc_cross` is the
+    ///   contribution of reallocs whose destination was the fallback.
+    /// - `realloc_outbound_grow` / `realloc_outbound_shrink` =
+    ///   mirror pair: sums of cross-class realloc departures from
+    ///   pool classes, split the same way.
+    /// - `realloc_cross` = realloc calls that needed alloc+copy+dealloc.
+    ///
+    /// The per-class `size_histogram` and `size_min` are intentionally
+    /// NOT emitted here (too verbose / derivable from `class` — find
+    /// them in `to_json`). Same for the fallback `size_histogram`.
+    pub fn to_table(&self) -> String {
+        const MIB: f64 = 1024.0 * 1024.0;
+        let mut s = String::with_capacity(180 * (self.classes.len() + 3));
+        s.push('[');
+        for c in &self.classes {
+            let live_bytes = c.alive_tiles * c.size_max;
+            let live_mib = live_bytes as f64 / MIB;
+            let waste_pct = waste_percent(c.wasted_bytes_total, c.requested_bytes_total);
+            let util_pct = if c.extent_bytes == 0 {
+                0.0
+            } else {
+                live_bytes as f64 * 100.0 / c.extent_bytes as f64
+            };
+            s.push_str(&format!(
+                "{{class={} free={} alive={} ext={} added={} alloc={} dealloc={} peak={} live_mb={:.2} util_pct={:.1} waste_pct={:.1}}}",
+                c.size_max,
+                c.free_tiles,
+                c.alive_tiles,
+                c.extent_count,
+                c.extents_added,
+                c.alloc_total,
+                c.dealloc_total,
+                c.peak_alive_tiles,
+                live_mib,
+                util_pct,
+                waste_pct,
+            ));
+        }
+        let tile_live = self.total_tile_alive_bytes();
+        let pool = self.total_extent_bytes();
+        let fb_alive = self.fallback.bytes_alive;
+        let live_tot = tile_live + fb_alive;
+        let total_wasted = self.total_wasted_bytes();
+        let total_requested = self.total_requested_bytes();
+        let waste_pct_tot = waste_percent(total_wasted, total_requested);
+        let total_inplace: u64 = self.classes.iter().map(|c| c.inplace_realloc_total).sum();
+        let total_inbound_grow: u64 = self
+            .classes
+            .iter()
+            .map(|c| c.inbound_realloc_total_grow)
+            .sum();
+        let total_inbound_shrink: u64 = self
+            .classes
+            .iter()
+            .map(|c| c.inbound_realloc_total_shrink)
+            .sum();
+        let total_outbound_grow: u64 = self
+            .classes
+            .iter()
+            .map(|c| c.outbound_realloc_total_grow)
+            .sum();
+        let total_outbound_shrink: u64 = self
+            .classes
+            .iter()
+            .map(|c| c.outbound_realloc_total_shrink)
+            .sum();
+        s.push_str(&format!(
+            "{{fallback alloc={} dealloc={} alive_mb={:.2}}}",
+            self.fallback.alloc_total,
+            self.fallback.dealloc_total,
+            fb_alive as f64 / MIB,
+        ));
+        s.push_str(&format!(
+            "{{totals pool_mb={:.2} tile_live_mb={:.2} live_tot_mb={:.2} waste_mb={:.2} waste_pct={:.1} realloc_inplace={} realloc_inbound_grow={} realloc_inbound_shrink={} realloc_outbound_grow={} realloc_outbound_shrink={} realloc_cross={}}}",
+            pool as f64 / MIB,
+            tile_live as f64 / MIB,
+            live_tot as f64 / MIB,
+            total_wasted as f64 / MIB,
+            waste_pct_tot,
+            total_inplace,
+            total_inbound_grow,
+            total_inbound_shrink,
+            total_outbound_grow,
+            total_outbound_shrink,
+            self.cross_class_realloc_total,
+        ));
+        s.push(']');
+        s
+    }
+
+    /// Serialize the snapshot as a compact JSON string for tooling
+    /// (machine-readable contract). No whitespace, no escaping needed
+    /// (all values are non-negative integers). Schema:
+    ///
+    /// ```json
+    /// {
+    ///   "fallback": { "alloc_total": N, "dealloc_total": N,
+    ///                 "bytes_alive": N,
+    ///                 "size_histogram": [N, ...]  // gated, see note },
+    ///   "totals":   { "extent_bytes": N, "class_count": N,
+    ///                 "wasted_bytes_total": N, "requested_bytes_total": N,
+    ///                 "inplace_realloc_total": N,
+    ///                 "cross_class_realloc_total": N },
+    ///   "classes":  [
+    ///     { "size_min": N, "size_max": N,
+    ///       "free_tiles": N, "alive_tiles": N,
+    ///       "extent_bytes": N, "extent_count": N, "extents_added": N,
+    ///       "alloc_total": N, "dealloc_total": N,
+    ///       "peak_alive_tiles": N,
+    ///       "wasted_bytes_total": N, "requested_bytes_total": N,
+    ///       "inplace_realloc_total": N,
+    ///       "inbound_realloc_total_grow": N,
+    ///       "inbound_realloc_total_shrink": N,
+    ///       "outbound_realloc_total_grow": N,
+    ///       "outbound_realloc_total_shrink": N,
+    ///       "size_histogram": [N, ...],            // see note below
+    ///       "align_histogram": [N, N, ..., N] },   // see note below
+    ///     ...
+    ///   ]
+    /// }
+    /// ```
+    ///
+    /// **Histograms gating**: the per-class `size_histogram` /
+    /// `align_histogram` and the fallback `size_histogram` are
+    /// emitted only when the build-time const
+    /// `config::ENABLE_HISTOGRAMS` is `true`. When it's `false`, those
+    /// fields are omitted entirely from their parent object — not
+    /// emitted as empty arrays — so the schema is conditional on the
+    /// build configuration.
+    ///
+    /// All `*_total` and `*_histogram` values are **live** (= reflecting
+    /// the current pool state, alloc-minus-dealloc), except for
+    /// `alloc_total`, `dealloc_total`, `extents_added`,
+    /// `inplace_realloc_total`, `inbound_realloc_total_{grow,shrink}`,
+    /// `outbound_realloc_total_{grow,shrink}`,
+    /// `cross_class_realloc_total`, and `peak_alive_tiles`, which are
+    /// lifetime cumulative / high-water.
+    ///
+    /// `size_histogram[i]` for a class corresponds to
+    /// `requested_size = size_min + i`; for fallback, see
+    /// `TileFallbackStats::size_histogram` for the bucket boundaries.
+    pub fn to_json(&self) -> String {
+        let mut s = String::with_capacity(256 + self.classes.len() * 320);
+        s.push('{');
+
+        s.push_str("\"fallback\":{");
+        s.push_str(&format!("\"alloc_total\":{},", self.fallback.alloc_total));
+        s.push_str(&format!(
+            "\"dealloc_total\":{},",
+            self.fallback.dealloc_total
+        ));
+        s.push_str(&format!("\"bytes_alive\":{}", self.fallback.bytes_alive));
+        if ENABLE_HISTOGRAMS {
+            s.push_str(",\"size_histogram\":");
+            append_u64_array(&mut s, &self.fallback.size_histogram);
+        }
+        s.push_str("},");
+
+        let total_inplace: u64 = self.classes.iter().map(|c| c.inplace_realloc_total).sum();
+        s.push_str("\"totals\":{");
+        s.push_str(&format!("\"extent_bytes\":{},", self.total_extent_bytes()));
+        s.push_str(&format!("\"class_count\":{},", self.classes.len()));
+        s.push_str(&format!(
+            "\"wasted_bytes_total\":{},",
+            self.total_wasted_bytes()
+        ));
+        s.push_str(&format!(
+            "\"requested_bytes_total\":{},",
+            self.total_requested_bytes()
+        ));
+        s.push_str(&format!("\"inplace_realloc_total\":{},", total_inplace));
+        s.push_str(&format!(
+            "\"cross_class_realloc_total\":{}",
+            self.cross_class_realloc_total
+        ));
+        s.push_str("},");
+
+        s.push_str("\"classes\":[");
+        for (i, c) in self.classes.iter().enumerate() {
+            if i > 0 {
+                s.push(',');
+            }
+            s.push('{');
+            s.push_str(&format!("\"size_min\":{},", c.size_min));
+            s.push_str(&format!("\"size_max\":{},", c.size_max));
+            s.push_str(&format!("\"free_tiles\":{},", c.free_tiles));
+            s.push_str(&format!("\"alive_tiles\":{},", c.alive_tiles));
+            s.push_str(&format!("\"extent_bytes\":{},", c.extent_bytes));
+            s.push_str(&format!("\"extent_count\":{},", c.extent_count));
+            s.push_str(&format!("\"extents_added\":{},", c.extents_added));
+            s.push_str(&format!("\"alloc_total\":{},", c.alloc_total));
+            s.push_str(&format!("\"dealloc_total\":{},", c.dealloc_total));
+            s.push_str(&format!("\"peak_alive_tiles\":{},", c.peak_alive_tiles));
+            s.push_str(&format!("\"wasted_bytes_total\":{},", c.wasted_bytes_total));
+            s.push_str(&format!(
+                "\"requested_bytes_total\":{},",
+                c.requested_bytes_total
+            ));
+            s.push_str(&format!(
+                "\"inplace_realloc_total\":{},",
+                c.inplace_realloc_total
+            ));
+            s.push_str(&format!(
+                "\"inbound_realloc_total_grow\":{},",
+                c.inbound_realloc_total_grow
+            ));
+            s.push_str(&format!(
+                "\"inbound_realloc_total_shrink\":{},",
+                c.inbound_realloc_total_shrink
+            ));
+            s.push_str(&format!(
+                "\"outbound_realloc_total_grow\":{},",
+                c.outbound_realloc_total_grow
+            ));
+            s.push_str(&format!(
+                "\"outbound_realloc_total_shrink\":{}",
+                c.outbound_realloc_total_shrink
+            ));
+            // Histograms are emitted only when `config::ENABLE_HISTOGRAMS`
+            // is `true` at build time. When off, `size_histogram` is
+            // an empty `Vec::new()` and `align_histogram` is all-zero;
+            // emitting them would waste bytes and lie about the data.
+            if ENABLE_HISTOGRAMS {
+                s.push_str(",\"size_histogram\":");
+                append_u64_array(&mut s, &c.size_histogram);
+                s.push_str(",\"align_histogram\":");
+                append_u64_array(&mut s, &c.align_histogram);
+            }
+            s.push('}');
+        }
+        s.push(']');
+
+        s.push('}');
+        s
+    }
+}
+
+/// Append a `[1,2,3,...]` JSON array of u64 to `s`. Compact, no
+/// whitespace. Used for the per-class and fallback size histograms.
+fn append_u64_array(s: &mut String, arr: &[u64]) {
+    s.push('[');
+    for (i, v) in arr.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&v.to_string());
+    }
+    s.push(']');
+}
+
+/// Compute `wasted / (wasted + requested) * 100`, returning 0.0 when
+/// the denominator is zero (= no alloc routed through this class yet).
+fn waste_percent(wasted: u64, requested: u64) -> f64 {
+    let denom = wasted + requested;
+    if denom == 0 {
+        0.0
+    } else {
+        wasted as f64 * 100.0 / denom as f64
+    }
+}

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -16,6 +16,36 @@ use external_interface::{external_to_js_value, js_to_external_value};
 use input::{web_input_to_ruffle_key_descriptor, web_to_ruffle_text_control};
 use js_sys::{Error as JsError, Uint8Array};
 use ruffle_core::context::UpdateContext;
+use std::alloc::{GlobalAlloc, Layout};
+
+/// Thin wrapper that forwards every `GlobalAlloc` call to the shared
+/// `GLOBAL_TILEMALLOC` instance defined in `ruffle_core::tilemalloc`.
+///
+/// `#[global_allocator]` requires a `static` in the current crate, so we
+/// can't tag `GLOBAL_TILEMALLOC` directly. Forwarding here keeps a single
+/// allocator instance shared between the web binary's allocation path and
+/// any in-`ruffle_core` code that wants to read its stats (snapshot via
+/// `ruffle_core::tilemalloc::GLOBAL_TILEMALLOC.snapshot_stats()`).
+struct GlobalTilemallocRef;
+
+unsafe impl GlobalAlloc for GlobalTilemallocRef {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        unsafe { ruffle_core::tilemalloc::GLOBAL_TILEMALLOC.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { ruffle_core::tilemalloc::GLOBAL_TILEMALLOC.dealloc(ptr, layout) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        unsafe { ruffle_core::tilemalloc::GLOBAL_TILEMALLOC.alloc_zeroed(layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        unsafe { ruffle_core::tilemalloc::GLOBAL_TILEMALLOC.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: GlobalTilemallocRef = GlobalTilemallocRef;
+
 use ruffle_core::context_menu::ContextMenuCallback;
 use ruffle_core::events::{GamepadButton, MouseButton, MouseWheelDelta, TextControlCode};
 use ruffle_core::tag_utils::SwfMovie;
@@ -1356,6 +1386,28 @@ fn parse_movie_parameters(input: &JsValue) -> Vec<(String, String)> {
     params
 }
 
+/// Returns a JSON snapshot of the tilemalloc state for tooling.
+/// Per-size-class counters (alive/free tiles, extent count, extents
+/// added, alloc/dealloc totals) plus fallback (dlmalloc) totals.
+/// Schema is the stable machine-readable contract — see
+/// `ruffle_core::tilemalloc::stats::TileAllocatorStats::to_json`.
+#[wasm_bindgen(js_name = "tilemallocStats")]
+pub fn tilemalloc_stats() -> String {
+    ruffle_core::tilemalloc::GLOBAL_TILEMALLOC
+        .snapshot_stats()
+        .to_json()
+}
+
+/// Emits a single-line snapshot of the tilemalloc state to the
+/// browser console as a String. Designed for direct visual
+/// diff between snapshots in DevTools without a JSON parser.
+#[wasm_bindgen(js_name = "tilemallocTable")]
+pub fn tilemalloc_table() -> String {
+    ruffle_core::tilemalloc::GLOBAL_TILEMALLOC
+        .snapshot_stats()
+        .to_table()
+}
+
 #[wasm_bindgen(start)]
 fn global_init() {
     // Redirect Log to Tracing
@@ -1412,6 +1464,42 @@ fn global_init() {
             });
         });
     }));
+
+    // Expose tilemalloc diagnostic helpers as plain functions on the
+    // browser `window`, so they can be invoked directly from the
+    // DevTools console:
+    //
+    //     window.tilemallocStats()   → returns JSON snapshot
+    //     window.tilemallocTable()   → returns String snapshot
+    //
+    // No JS import wiring is required by the host page. The closures
+    // are intentionally leaked via `forget()`: they live for the
+    // module's lifetime, same as any global helper.
+    if let Some(window) = web_sys::window() {
+        let stats_cb = Closure::<dyn Fn() -> String>::new(|| {
+            ruffle_core::tilemalloc::GLOBAL_TILEMALLOC
+                .snapshot_stats()
+                .to_json()
+        });
+        let _ = js_sys::Reflect::set(
+            &window,
+            &JsValue::from_str("tilemallocStats"),
+            stats_cb.as_ref(),
+        );
+        stats_cb.forget();
+
+        let table_cb = Closure::<dyn Fn() -> String>::new(|| {
+            ruffle_core::tilemalloc::GLOBAL_TILEMALLOC
+                .snapshot_stats()
+                .to_table()
+        });
+        let _ = js_sys::Reflect::set(
+            &window,
+            &JsValue::from_str("tilemallocTable"),
+            table_cb.as_ref(),
+        );
+        table_cb.forget();
+    }
 
     tracing::info!("Ruffle WASM module has been initialized");
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1408,6 +1408,19 @@ pub fn tilemalloc_table() -> String {
         .to_table()
 }
 
+/// Release every fully-empty tilemalloc pool extent back to the system
+/// allocator (dlmalloc) and return the bytes reclaimed (no logging). Call it
+/// from an idle or post-GC hook — when the GC has just freed a transient
+/// spike's objects, the extents that held only that garbage become fully free
+/// and can be handed back, so later allocations (including the fallback path)
+/// reuse the memory instead of growing past the WASM cap. Inspect the effect
+/// via `tilemallocTable` (the `released` counter / dropping `ext`). See
+/// `TileAllocator::trim`.
+#[wasm_bindgen(js_name = "tilemallocTrim")]
+pub fn tilemalloc_trim() -> f64 {
+    ruffle_core::tilemalloc::GLOBAL_TILEMALLOC.trim() as f64
+}
+
 #[wasm_bindgen(start)]
 fn global_init() {
     // Redirect Log to Tracing
@@ -1471,6 +1484,7 @@ fn global_init() {
     //
     //     window.tilemallocStats()   → returns JSON snapshot
     //     window.tilemallocTable()   → returns String snapshot
+    //     window.tilemallocTrim()    → releases empty extents, returns bytes freed
     //
     // No JS import wiring is required by the host page. The closures
     // are intentionally leaked via `forget()`: they live for the
@@ -1499,6 +1513,16 @@ fn global_init() {
             table_cb.as_ref(),
         );
         table_cb.forget();
+
+        let trim_cb = Closure::<dyn Fn() -> f64>::new(|| {
+            ruffle_core::tilemalloc::GLOBAL_TILEMALLOC.trim() as f64
+        });
+        let _ = js_sys::Reflect::set(
+            &window,
+            &JsValue::from_str("tilemallocTrim"),
+            trim_cb.as_ref(),
+        );
+        trim_cb.forget();
     }
 
     tracing::info!("Ruffle WASM module has been initialized");


### PR DESCRIPTION
## What

Adds **tilemalloc**, a size-class memory allocator that replaces dlmalloc as the global
allocator on `wasm32-unknown-unknown`. It targets the small-allocation churn that
dominates long-running ActionScript workloads, turning per-call allocator cost
into O(1) push/pop on per-class intrusive free lists. The same pool counters are
then used to back the `flash.system.System` memory-introspection getters with
real numbers.

For further information, please see the attached document:
[tilemalloc.pdf](https://github.com/user-attachments/files/29025016/tilemalloc.pdf)

## Why — impact

Enterprise Flex / AS3 apps that load large XML into data grids are the worst case
for a general-purpose allocator: an `AdvancedDataGrid` bound to an E4X document
materialises hundreds of thousands of tiny, short-lived heap objects per load,
and dlmalloc's free-list traversal + coalescing cost scales with the live set.
Measured end-to-end on a real enterprise form (XML → Flex `AdvancedDataGrid`):

| Workload | dlmalloc (stock) | tilemalloc | Result |
|---|---|---|---|
| ~100 000-row XML into a grid | ~30 s first load | ~15 s | ~2× faster |
| ~250 000-row XML into a grid | did not finish (aborted after 5 min) | ~40 s | unusable → practical |
| Per-GC cost / repeated `dataProvider` refresh | heavy stutter, grows with working set | fast, flat | drastically lower |

The ~30 s → ~15 s gap appears on the **first** load against a fresh heap, which
isolates the cost as per-`malloc` free-list work rather than fragmentation. The
250k case is the headline: it changes which documents the player can open at all.

## How it works

- **alloc**: pop an intrusive free list (O(1)), else carve one tile off a bump
  pointer into the current extent.
- **dealloc**: push onto the free-list head (O(1)). **No coalescing** — freed
  tiles stay carved at their size and are reused by the next same-shaped alloc, so
  a construct/destruct workload reaches steady state with no extra `memory.grow`.
- **add_extent** (rare): grab one ~`extent_mb` region and install it as the bump
  range — two stores, no per-tile setup loop (the eager alternative would be ~1 M
  page-touching stores for the 8-byte class).
- **realloc**: in-place fast path when the new size stays in the same class (no
  alloc/copy/dealloc, no two-tiles-alive transient).
- **fallback**: anything over the largest class, or over-aligned, transparently
  goes to dlmalloc and is tracked separately.

Size classes are configured in one file (`core/src/tilemalloc/config.rs`); the
default covers 8–256 B at sub-pow2 granularity. Tile alignment is auto-derived
(greatest pow2 divisor of the size), not a knob. The allocator is `Sync` without
locking — sound on the single-threaded WASM runtime (documented; wasm-threads
would need a `Mutex`).

## Also included

- **Built-in diagnostics** — a low-overhead counter suite (per-class waste, peak
  alive, utilisation, in-place / cross-class realloc with grow/shrink split,
  optional size/align/fallback histograms gated by a build-time
  `ENABLE_HISTOGRAMS`). Exposed to JS as `window.tilemallocStats()` (JSON) and
  `window.tilemallocTable()` (single-line), auto-installed at module start. These
  are what make the class set tunable for a given workload.
- **`flash.system.System` memory getters** — `freeMemory`, `totalMemory`,
  `totalMemoryNumber`, `privateMemory` change from hard-coded stubs to real values
  derived from the WASM linear memory size, the `__heap_base` symbol, and the live
  pool counters.
- **wasm64-ready** — the memory helpers are gated on `target_family = "wasm"` with
  a separate `wasm64::memory_size` arm, so a future `wasm64-unknown-unknown` build
  works unchanged. The lone nightly gate (`simd_wasm64`) is `cfg_attr`-scoped to
  wasm64 only and inert everywhere else.

## Scope / notes

- Self-contained: new `core/src/tilemalloc/` module + a thin `#[global_allocator]`
  wrapper in `web/src/lib.rs`. No new dependencies. No added AS3 surface — the
  getters were already declared; only their bodies changed.
- Grow-only by design (extents are not returned); tune `extent_mb` and the class
  set per workload.
- Detailed design, the full statistics schema, and a "how to read the stats to
  choose the class configuration" guide are in the attached document.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
