### PR TITLE
core: Optimize GPU-to-CPU BitmapData pixel copy

### DIFF
--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -970,27 +970,26 @@ fn copy_pixels_to_bitmapdata(
     area: PixelRegion,
 ) {
     let buffer_width_pixels = buffer_width / 4;
+    let row_width = area.width() as usize;
+    let transparency = write.transparency();
 
     for y in area.y_min..area.y_max {
-        for x in area.x_min..area.x_max {
-            // note: this order of conversions helps llvm realize the index is 4-byte-aligned
-            let ind = (((x - area.x_min) + (y - area.y_min) * buffer_width_pixels) as usize) * 4;
+        let src_row_start = (((y - area.y_min) * buffer_width_pixels) as usize) * 4;
+        let src_row = &buffer[src_row_start..src_row_start + row_width * 4];
+        let dst_start = (area.x_min + y * write.width()) as usize;
+        let dst_row = &mut write.pixels[dst_start..dst_start + row_width];
 
-            // TODO(mid): optimize this A LOT
-            let r = buffer[ind];
-            let g = buffer[ind + 1usize];
-            let b = buffer[ind + 2usize];
-            let a = if write.transparency() {
-                buffer[ind + 3usize]
-            } else {
-                255
+        if transparency {
+            // SAFETY: Color is #[repr(C)] with Rgba8 layout; transparent bitmaps store
+            // premultiplied RGBA bytes matching the GPU readback buffer format.
+            let dst_bytes = unsafe {
+                std::slice::from_raw_parts_mut(dst_row.as_mut_ptr().cast::<u8>(), row_width * 4)
             };
-
-            let nc = Color::rgba(r, g, b, a);
-
-            // Ignore the original color entirely - the blending (including alpha)
-            // was done by the renderer when it wrote over the previous texture contents.
-            write.set_pixel32_raw(x, y, nc);
+            dst_bytes.copy_from_slice(src_row);
+        } else {
+            for (dst, src) in dst_row.iter_mut().zip(src_row.chunks_exact(4)) {
+                *dst = Color::rgba(src[0], src[1], src[2], 0xFF);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Optimizes `copy_pixels_to_bitmapdata`, which copies GPU readback bytes into CPU-side `BitmapData` during sync. The previous implementation called `set_pixel32_raw` once per pixel; the new implementation copies each row with `copy_from_slice` for transparent bitmaps (the common collision-map case).

This is a behavior-preserving performance change on the path used after offscreen `BitmapData.draw` / `applyFilter` when `hitTest` forces a GPU→CPU sync. Related investigation in #24032.

## Testing

```
cargo test -p tests bitmapdata_hittest
cargo test -p tests --features imgtests bitmapdata_applyfilter
```

The `bitmapdata_applyfilter` image tests compare Ruffle output against Flash Player reference screenshots.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
