### PR TITLE
core: Add Avm1Enum/Avm2Enum macro derives

### DIFF
--- a/core/common/src/avm_string/common.rs
+++ b/core/common/src/avm_string/common.rs
@@ -119,6 +119,7 @@ ruffle_macros::define_common_strings! {
     "declaredBy",
     "decode",
     "default",
+    "deflate",
     "descent",
     "description",
     "device",
@@ -186,6 +187,7 @@ ruffle_macros::define_common_strings! {
     "loop",
     "lowercase",
     "lr",
+    "lzma",
     "macType",
     "matrixType",
     "menu",
@@ -357,5 +359,6 @@ ruffle_macros::define_common_strings! {
     "year",
     "yMax",
     "yMin",
+    "zlib",
     "zoom",
 }

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -6,8 +6,8 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::{
-    DeriveInput, FnArg, ImplItem, ImplItemFn, ItemEnum, ItemTrait, LitStr, Meta, Pat, TraitItem,
-    Visibility, parse_macro_input, parse_quote,
+    Data, DeriveInput, FnArg, ImplItem, ImplItemFn, ItemEnum, ItemTrait, LitStr, Meta, Pat,
+    TraitItem, Visibility, parse_macro_input, parse_quote,
 };
 
 /// Define an enum whose variants each implement a trait.
@@ -464,4 +464,118 @@ fn atom_internal(
     }
 
     transform(atom).into()
+}
+
+struct AvmEnumConfig {
+    attr_name: &'static str,
+    trait_path: TokenStream2,
+    from_method: &'static str,
+    as_method: &'static str,
+}
+
+fn derive_avm_enum_impl(input: DeriveInput, config: AvmEnumConfig) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+
+    let variants = match &input.data {
+        Data::Enum(data) => &data.variants,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                "can only be derived for enums",
+            ));
+        }
+    };
+
+    let mut str_vals: Vec<LitStr> = Vec::new();
+    let mut variant_idents: Vec<&syn::Ident> = Vec::new();
+
+    for variant in variants {
+        if !variant.fields.is_empty() {
+            return Err(syn::Error::new_spanned(
+                variant,
+                "variants with fields are not supported",
+            ));
+        }
+        let attr = variant
+            .attrs
+            .iter()
+            .find(|a| a.path().is_ident(config.attr_name));
+        match attr {
+            Some(a) => {
+                str_vals.push(a.parse_args::<LitStr>()?);
+                variant_idents.push(&variant.ident);
+            }
+            None => {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    format!("missing `#[{}(\"...\")]` attribute", config.attr_name),
+                ));
+            }
+        }
+    }
+
+    let byte_strs: Vec<syn::LitByteStr> = str_vals
+        .iter()
+        .map(|s| syn::LitByteStr::new(s.value().as_bytes(), s.span()))
+        .collect();
+
+    let trait_path = &config.trait_path;
+    let from_method = format_ident!("{}", config.from_method);
+    let as_method = format_ident!("{}", config.as_method);
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics #trait_path for #name #ty_generics #where_clause {
+            fn #from_method(s: &::ruffle_wstr::WStr) -> ::core::option::Option<Self> {
+                #(if s == #byte_strs { return ::core::option::Option::Some(Self::#variant_idents); })*
+                ::core::option::Option::None
+            }
+
+            fn #as_method<'gc>(&self, context: &impl crate::string::HasStringContext<'gc>) -> crate::string::AvmString<'gc> {
+                match self {
+                    #(Self::#variant_idents => ::ruffle_macros::istr!(context, #str_vals),)*
+                }
+            }
+        }
+    })
+}
+
+/// Derives [`crate::avm1::Avm1StrRepresentable`] for an enum.
+///
+/// Each variant must be annotated with `#[avm1_variant("string")]`.
+#[proc_macro_derive(Avm1Enum, attributes(avm1_variant))]
+pub fn derive_avm1_enum(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    derive_avm_enum_impl(
+        input,
+        AvmEnumConfig {
+            attr_name: "avm1_variant",
+            trait_path: quote!(crate::avm1::Avm1StrRepresentable),
+            from_method: "from_avm1_str",
+            as_method: "as_avm1_str",
+        },
+    )
+    .unwrap_or_else(|e| e.to_compile_error())
+    .into()
+}
+
+/// Derives [`crate::avm2::Avm2StrRepresentable`] for an enum.
+///
+/// Each variant must be annotated with `#[avm2_variant("string")]`.
+#[proc_macro_derive(Avm2Enum, attributes(avm2_variant))]
+pub fn derive_avm2_enum(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    derive_avm_enum_impl(
+        input,
+        AvmEnumConfig {
+            attr_name: "avm2_variant",
+            trait_path: quote!(crate::avm2::Avm2StrRepresentable),
+            from_method: "from_avm2_str",
+            as_method: "as_avm2_str",
+        },
+    )
+    .unwrap_or_else(|e| e.to_compile_error())
+    .into()
 }

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -38,6 +38,8 @@ pub use globals::sound::start as start_sound;
 pub use object::{NativeObject, Object, ObjectHandle, ObjectPtr};
 pub use property::Attribute;
 pub use property_map::PropertyMap;
+use ruffle_common::avm_string::AvmString;
+use ruffle_wstr::WStr;
 pub use runtime::Avm1;
 pub use value::Value;
 
@@ -97,4 +99,13 @@ macro_rules! avm1_stub {
         };
         $activation.context.stub_tracker.encounter(&STUB);
     }};
+}
+
+pub trait Avm1StrRepresentable: Sized {
+    fn from_avm1_str(s: &WStr) -> Option<Self>;
+
+    fn as_avm1_str<'gc>(
+        &self,
+        context: &impl crate::string::HasStringContext<'gc>,
+    ) -> AvmString<'gc>;
 }

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -2,17 +2,20 @@
 
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{DeclContext, PropertyOrder, StaticDeclarations, SystemClass};
-use crate::avm1::{Activation, Error, Object, Value};
+use crate::avm1::{Activation, Avm1StrRepresentable, Error, Object, Value};
 use gc_arena::{Collect, Gc, Mutation};
-use ruffle_macros::istr;
+use ruffle_macros::Avm1Enum;
 use std::cell::Cell;
 use swf::{BevelFilterFlags, Color, Fixed8, Fixed16, GradientFilterFlags};
 
-#[derive(Copy, Clone, Debug, Collect)]
+#[derive(Copy, Clone, Debug, Collect, Avm1Enum)]
 #[collect(no_drop)]
 pub enum BevelFilterType {
+    #[avm1_variant("inner")]
     Inner,
+    #[avm1_variant("outer")]
     Outer,
+    #[avm1_variant("full")]
     Full,
 }
 
@@ -364,13 +367,7 @@ impl<'gc> BevelFilter<'gc> {
         if let Some(value) = value {
             let type_ = value.coerce_to_string(activation)?;
 
-            let type_ = if &type_ == b"inner" {
-                BevelFilterType::Inner
-            } else if &type_ == b"outer" {
-                BevelFilterType::Outer
-            } else {
-                BevelFilterType::Full
-            };
+            let type_ = BevelFilterType::from_avm1_str(&type_).unwrap_or(BevelFilterType::Full);
 
             self.0.type_.set(type_);
         }
@@ -514,15 +511,7 @@ pub fn method<'gc>(
             this.set_blur_y(activation, args.get(0))?;
             Value::Undefined
         }
-        GET_TYPE => {
-            let type_ = match this.type_() {
-                BevelFilterType::Inner => istr!("inner"),
-                BevelFilterType::Outer => istr!("outer"),
-                BevelFilterType::Full => istr!("full"),
-            };
-
-            type_.into()
-        }
+        GET_TYPE => this.type_().as_avm1_str(activation).into(),
         SET_TYPE => {
             this.set_type(activation, args.get(0))?;
             Value::Undefined

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -27,6 +27,7 @@ use crate::tag_utils::SwfMovie;
 use fnv::FnvHashMap;
 use gc_arena::lock::GcRefLock;
 use gc_arena::{Collect, Gc, Mutation};
+use ruffle_wstr::WStr;
 use std::sync::Arc;
 use swf::DoAbc2Flag;
 use swf::avm2::read::Reader;
@@ -686,4 +687,13 @@ impl<'gc> Avm2<'gc> {
 
         // TODO: push the error onto `loaderInfo.uncaughtErrorEvents`
     }
+}
+
+pub trait Avm2StrRepresentable: Sized {
+    fn from_avm2_str(s: &WStr) -> Option<Self>;
+
+    fn as_avm2_str<'gc>(
+        &self,
+        context: &impl crate::string::HasStringContext<'gc>,
+    ) -> AvmString<'gc>;
 }

--- a/core/src/avm2/bytearray.rs
+++ b/core/src/avm2/bytearray.rs
@@ -2,13 +2,12 @@ use crate::avm2::Activation;
 use crate::avm2::Error;
 use crate::avm2::error::{Error2006Type, make_error_2006, make_error_2030};
 use crate::context::UpdateContext;
-use crate::string::{FromWStr, WStr};
 use flate2::Compression;
 use flate2::read::*;
 use gc_arena::Collect;
+use ruffle_macros::Avm2Enum;
 use std::cell::Cell;
 use std::cmp;
-use std::fmt::{self, Display, Formatter};
 use std::io::prelude::*;
 use std::io::{self, SeekFrom};
 
@@ -19,10 +18,13 @@ pub enum Endian {
     Little,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Avm2Enum)]
 pub enum CompressionAlgorithm {
+    #[avm2_variant("zlib")]
     Zlib,
+    #[avm2_variant("deflate")]
     Deflate,
+    #[avm2_variant("lzma")]
     Lzma,
 }
 
@@ -40,33 +42,6 @@ impl ByteArrayError {
             ByteArrayError::IndexOutOfBounds => {
                 make_error_2006(activation, Error2006Type::RangeError)
             }
-        }
-    }
-}
-
-impl Display for CompressionAlgorithm {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let s = match *self {
-            CompressionAlgorithm::Zlib => "zlib",
-            CompressionAlgorithm::Deflate => "deflate",
-            CompressionAlgorithm::Lzma => "lzma",
-        };
-        f.write_str(s)
-    }
-}
-
-impl FromWStr for CompressionAlgorithm {
-    type Err = ();
-
-    fn from_wstr(s: &WStr) -> Result<Self, Self::Err> {
-        if s == b"zlib" {
-            Ok(CompressionAlgorithm::Zlib)
-        } else if s == b"deflate" {
-            Ok(CompressionAlgorithm::Deflate)
-        } else if s == b"lzma" {
-            Ok(CompressionAlgorithm::Lzma)
-        } else {
-            Err(())
         }
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/element_format.rs
+++ b/core/src/avm2/globals/flash/text/engine/element_format.rs
@@ -1,8 +1,8 @@
-use crate::avm2::Error;
 use crate::avm2::activation::Activation;
 use crate::avm2::error::{Error2004Type, make_error_2004, make_error_2007, make_error_2008};
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
+use crate::avm2::{Avm2StrRepresentable, Error};
 use crate::fte::{
     BreakOpportunityValue, DigitCaseValue, DigitWidthValue, KerningValue, LigatureLevelValue,
     TextBaselineValue, TextRotationValue, TypographicCaseValue,
@@ -20,7 +20,7 @@ pub fn get_alignment_baseline<'gc>(
         .unwrap()
         .as_element_format_object()
         .unwrap();
-    Ok(this.alignment_baseline().as_string(activation).into())
+    Ok(this.alignment_baseline().as_avm2_str(activation).into())
 }
 
 pub fn set_alignment_baseline<'gc>(
@@ -34,7 +34,7 @@ pub fn set_alignment_baseline<'gc>(
         .as_element_format_object()
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "alignmentBaseline")?;
-    let Some(value) = TextBaselineValue::parse_string(&s) else {
+    let Some(value) = TextBaselineValue::from_avm2_str(&s) else {
         return Err(make_error_2008(activation, "alignmentBaseline"));
     };
     this.set_alignment_baseline(value);
@@ -105,7 +105,7 @@ pub fn get_break_opportunity<'gc>(
         .unwrap()
         .as_element_format_object()
         .unwrap();
-    Ok(this.break_opportunity().as_string(activation).into())
+    Ok(this.break_opportunity().as_avm2_str(activation).into())
 }
 
 pub fn set_break_opportunity<'gc>(
@@ -119,7 +119,7 @@ pub fn set_break_opportunity<'gc>(
         .as_element_format_object()
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "breakOpportunity")?;
-    let Some(value) = BreakOpportunityValue::parse_string(&s) else {
+    let Some(value) = BreakOpportunityValue::from_avm2_str(&s) else {
         return Err(make_error_2008(activation, "breakOpportunity"));
     };
     this.set_break_opportunity(value);
@@ -163,7 +163,7 @@ pub fn get_digit_case<'gc>(
         .unwrap()
         .as_element_format_object()
         .unwrap();
-    Ok(this.digit_case().as_string(activation).into())
+    Ok(this.digit_case().as_avm2_str(activation).into())
 }
 
 pub fn set_digit_case<'gc>(
@@ -177,7 +177,7 @@ pub fn set_digit_case<'gc>(
         .as_element_format_object()
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "digitCase")?;
-    let Some(value) = DigitCaseValue::parse_string(&s) else {
+    let Some(value) = DigitCaseValue::from_avm2_str(&s) else {
         return Err(make_error_2008(activation, "digitCase"));
     };
     this.set_digit_case(value);
@@ -194,7 +194,7 @@ pub fn get_digit_width<'gc>(
         .unwrap()
         .as_element_format_object()
         .unwrap();
-    Ok(this.digit_width().as_string(activation).into())
+    Ok(this.digit_width().as_avm2_str(activation).into())
 }
 
 pub fn set_digit_width<'gc>(
@@ -208,7 +208,7 @@ pub fn set_digit_width<'gc>(
         .as_element_format_object()
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "digitWidth")?;
-    let Some(value) = DigitWidthValue::parse_string(&s) else {
+    let Some(value) = DigitWidthValue::from_avm2_str(&s) else {
         return Err(make_error_2008(activation, "digitWidth"));
     };
     this.set_digit_width(value);
@@ -225,7 +225,7 @@ pub fn get_dominant_baseline<'gc>(
         .unwrap()
         .as_element_format_object()
         .unwrap();
-    Ok(this.dominant_baseline().as_string(activation).into())
+    Ok(this.dominant_baseline().as_avm2_str(activation).into())
 }
 
 pub fn set_dominant_baseline<'gc>(
@@ -239,7 +239,7 @@ pub fn set_dominant_baseline<'gc>(
         .as_element_format_object()
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "dominantBaseline")?;
-    let Some(value) = TextBaselineValue::parse_string(&s) else {
+    let Some(value) = TextBaselineValue::from_avm2_str(&s) else {
         return Err(make_error_2008(activation, "dominantBaseline"));
     };
     if value == TextBaselineValue::UseDominantBaseline {
@@ -327,7 +327,7 @@ pub fn get_kerning<'gc>(
         .unwrap()
         .as_element_format_object()
         .unwrap();
-    Ok(this.kerning().as_string(activation).into())
+    Ok(this.kerning().as_avm2_str(activation).into())
 }
 
 pub fn set_kerning<'gc>(
@@ -341,7 +341,7 @@ pub fn set_kerning<'gc>(
         .as_element_format_object()
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "kerning")?;
-    let Some(value) = KerningValue::parse_string(&s) else {
+    let Some(value) = KerningValue::from_avm2_str(&s) else {
         return Err(make_error_2008(activation, "kerning"));
     };
     this.set_kerning(value);
@@ -358,7 +358,7 @@ pub fn get_ligature_level<'gc>(
         .unwrap()
         .as_element_format_object()
         .unwrap();
-    Ok(this.ligature_level().as_string(activation).into())
+    Ok(this.ligature_level().as_avm2_str(activation).into())
 }
 
 pub fn set_ligature_level<'gc>(
@@ -372,7 +372,7 @@ pub fn set_ligature_level<'gc>(
         .as_element_format_object()
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "ligatureLevel")?;
-    let Some(value) = LigatureLevelValue::parse_string(&s) else {
+    let Some(value) = LigatureLevelValue::from_avm2_str(&s) else {
         return Err(make_error_2008(activation, "ligatureLevel"));
     };
     this.set_ligature_level(value);
@@ -417,7 +417,7 @@ pub fn get_text_rotation<'gc>(
         .unwrap()
         .as_element_format_object()
         .unwrap();
-    Ok(this.text_rotation().as_string(activation).into())
+    Ok(this.text_rotation().as_avm2_str(activation).into())
 }
 
 pub fn set_text_rotation<'gc>(
@@ -431,7 +431,7 @@ pub fn set_text_rotation<'gc>(
         .as_element_format_object()
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "textRotation")?;
-    let Some(value) = TextRotationValue::parse_string(&s) else {
+    let Some(value) = TextRotationValue::from_avm2_str(&s) else {
         return Err(make_error_2008(activation, "textRotation"));
     };
     this.set_text_rotation(value);
@@ -502,7 +502,7 @@ pub fn get_typographic_case<'gc>(
         .unwrap()
         .as_element_format_object()
         .unwrap();
-    Ok(this.typographic_case().as_string(activation).into())
+    Ok(this.typographic_case().as_avm2_str(activation).into())
 }
 
 pub fn set_typographic_case<'gc>(
@@ -516,7 +516,7 @@ pub fn set_typographic_case<'gc>(
         .as_element_format_object()
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "typographicCase")?;
-    let Some(value) = TypographicCaseValue::parse_avm2_string(&s) else {
+    let Some(value) = TypographicCaseValue::from_avm2_str(&s) else {
         return Err(make_error_2008(activation, "typographicCase"));
     };
     this.set_typographic_case(value);

--- a/core/src/avm2/globals/flash/text/engine/font_description.rs
+++ b/core/src/avm2/globals/flash/text/engine/font_description.rs
@@ -1,3 +1,4 @@
+use crate::avm2::Avm2StrRepresentable;
 use crate::avm2::Error;
 use crate::avm2::activation::Activation;
 use crate::avm2::error::make_error_2008;
@@ -47,7 +48,7 @@ pub fn get_font_weight<'gc>(
         .unwrap()
         .as_font_description_object()
         .unwrap();
-    Ok(this.font_weight().as_string(activation).into())
+    Ok(this.font_weight().as_avm2_str(activation).into())
 }
 
 pub fn set_font_weight<'gc>(
@@ -62,7 +63,7 @@ pub fn set_font_weight<'gc>(
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "fontWeight")?;
     this.set_font_weight(
-        FontWeightValue::parse_string(&s)
+        FontWeightValue::from_avm2_str(&s)
             .ok_or_else(|| make_error_2008(activation, "fontWeight"))?,
     );
     Ok(Value::Undefined)
@@ -78,7 +79,7 @@ pub fn get_font_posture<'gc>(
         .unwrap()
         .as_font_description_object()
         .unwrap();
-    Ok(this.font_posture().as_string(activation).into())
+    Ok(this.font_posture().as_avm2_str(activation).into())
 }
 
 pub fn set_font_posture<'gc>(
@@ -93,7 +94,7 @@ pub fn set_font_posture<'gc>(
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "fontPosture")?;
     this.set_font_posture(
-        FontPostureValue::parse_string(&s)
+        FontPostureValue::from_avm2_str(&s)
             .ok_or_else(|| make_error_2008(activation, "fontPosture"))?,
     );
     Ok(Value::Undefined)
@@ -109,7 +110,7 @@ pub fn get_font_lookup<'gc>(
         .unwrap()
         .as_font_description_object()
         .unwrap();
-    Ok(this.font_lookup().as_string(activation).into())
+    Ok(this.font_lookup().as_avm2_str(activation).into())
 }
 
 pub fn set_font_lookup<'gc>(
@@ -124,7 +125,7 @@ pub fn set_font_lookup<'gc>(
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "fontLookup")?;
     this.set_font_lookup(
-        FontLookupValue::parse_string(&s)
+        FontLookupValue::from_avm2_str(&s)
             .ok_or_else(|| make_error_2008(activation, "fontLookup"))?,
     );
     Ok(Value::Undefined)
@@ -140,7 +141,7 @@ pub fn get_rendering_mode<'gc>(
         .unwrap()
         .as_font_description_object()
         .unwrap();
-    Ok(this.rendering_mode().as_string(activation).into())
+    Ok(this.rendering_mode().as_avm2_str(activation).into())
 }
 
 pub fn set_rendering_mode<'gc>(
@@ -155,7 +156,7 @@ pub fn set_rendering_mode<'gc>(
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "renderingMode")?;
     this.set_rendering_mode(
-        RenderingModeValue::parse_string(&s)
+        RenderingModeValue::from_avm2_str(&s)
             .ok_or_else(|| make_error_2008(activation, "renderingMode"))?,
     );
     Ok(Value::Undefined)
@@ -171,7 +172,7 @@ pub fn get_cff_hinting<'gc>(
         .unwrap()
         .as_font_description_object()
         .unwrap();
-    Ok(this.cff_hinting().as_string(activation).into())
+    Ok(this.cff_hinting().as_avm2_str(activation).into())
 }
 
 pub fn set_cff_hinting<'gc>(
@@ -186,7 +187,7 @@ pub fn set_cff_hinting<'gc>(
         .unwrap();
     let s = args.get_string_non_null(activation, 0, "cffHinting")?;
     this.set_cff_hinting(
-        CffHintingValue::parse_string(&s)
+        CffHintingValue::from_avm2_str(&s)
             .ok_or_else(|| make_error_2008(activation, "cffHinting"))?,
     );
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/utils/byte_array.rs
+++ b/core/src/avm2/globals/flash/utils/byte_array.rs
@@ -1,8 +1,9 @@
 use std::rc::Rc;
 
+use crate::avm2::Avm2StrRepresentable;
 use crate::avm2::Error;
 use crate::avm2::activation::Activation;
-use crate::avm2::bytearray::{Endian, ObjectEncoding};
+use crate::avm2::bytearray::{CompressionAlgorithm, Endian, ObjectEncoding};
 use crate::avm2::error::{make_error_2008, make_error_2058};
 use crate::avm2::object::Object;
 use crate::avm2::parameters::ParametersExt;
@@ -735,9 +736,9 @@ pub fn compress<'gc>(
 
     if let Some(mut bytearray) = this.as_bytearray_mut() {
         let algorithm = args.get_string_non_null(activation, 0, "algorithm")?;
-        let algorithm = match algorithm.parse() {
-            Ok(algorithm) => algorithm,
-            Err(_) => return Err(make_error_2058(activation)),
+        let algorithm = match CompressionAlgorithm::from_avm2_str(&algorithm) {
+            Some(algorithm) => algorithm,
+            None => return Err(make_error_2058(activation)),
         };
         let buffer = bytearray.compress(algorithm);
         bytearray.clear();
@@ -759,9 +760,9 @@ pub fn uncompress<'gc>(
 
     if let Some(mut bytearray) = this.as_bytearray_mut() {
         let algorithm = args.get_string_non_null(activation, 0, "algorithm")?;
-        let algorithm = match algorithm.parse() {
-            Ok(algorithm) => algorithm,
-            Err(_) => return Err(make_error_2058(activation)),
+        let algorithm = match CompressionAlgorithm::from_avm2_str(&algorithm) {
+            Some(algorithm) => algorithm,
+            None => return Err(make_error_2058(activation)),
         };
         let buffer = match bytearray.decompress(algorithm) {
             Some(buffer) => buffer,

--- a/core/src/fte.rs
+++ b/core/src/fte.rs
@@ -1,431 +1,166 @@
 //! Various structs related to FTE used across the whole codebase.
 
-use crate::avm2::activation::Activation;
-use crate::string::AvmString;
 use gc_arena::Collect;
-use ruffle_macros::istr;
+use ruffle_macros::Avm2Enum;
 use ruffle_wstr::WStr;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum FontWeightValue {
+    #[avm2_variant("normal")]
     Normal,
+    #[avm2_variant("bold")]
     Bold,
 }
 
-impl FontWeightValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"normal" {
-            Self::Normal
-        } else if s == b"bold" {
-            Self::Bold
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Normal => istr!("normal"),
-            Self::Bold => istr!("bold"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum FontPostureValue {
+    #[avm2_variant("normal")]
     Normal,
+    #[avm2_variant("italic")]
     Italic,
 }
 
-impl FontPostureValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"normal" {
-            Self::Normal
-        } else if s == b"italic" {
-            Self::Italic
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Normal => istr!("normal"),
-            Self::Italic => istr!("italic"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum FontLookupValue {
+    #[avm2_variant("device")]
     Device,
+    #[avm2_variant("embeddedCFF")]
     EmbeddedCFF,
 }
 
-impl FontLookupValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"device" {
-            Self::Device
-        } else if s == b"embeddedCFF" {
-            Self::EmbeddedCFF
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Device => istr!("device"),
-            Self::EmbeddedCFF => istr!("embeddedCFF"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum RenderingModeValue {
+    #[avm2_variant("normal")]
     Normal,
+    #[avm2_variant("cff")]
     Cff,
 }
 
-impl RenderingModeValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"normal" {
-            Self::Normal
-        } else if s == b"cff" {
-            Self::Cff
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Normal => istr!("normal"),
-            Self::Cff => istr!("cff"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum CffHintingValue {
+    #[avm2_variant("none")]
     None,
+    #[avm2_variant("horizontalStem")]
     HorizontalStem,
 }
 
-impl CffHintingValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"none" {
-            Self::None
-        } else if s == b"horizontalStem" {
-            Self::HorizontalStem
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::None => istr!("none"),
-            Self::HorizontalStem => istr!("horizontalStem"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum TextBaselineValue {
+    #[avm2_variant("ascent")]
     Ascent,
+    #[avm2_variant("descent")]
     Descent,
+    #[avm2_variant("ideographicBottom")]
     IdeographicBottom,
+    #[avm2_variant("ideographicCenter")]
     IdeographicCenter,
+    #[avm2_variant("ideographicTop")]
     IdeographicTop,
+    #[avm2_variant("roman")]
     Roman,
+    #[avm2_variant("useDominantBaseline")]
     UseDominantBaseline,
 }
 
-impl TextBaselineValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"ascent" {
-            Self::Ascent
-        } else if s == b"descent" {
-            Self::Descent
-        } else if s == b"ideographicBottom" {
-            Self::IdeographicBottom
-        } else if s == b"ideographicCenter" {
-            Self::IdeographicCenter
-        } else if s == b"ideographicTop" {
-            Self::IdeographicTop
-        } else if s == b"roman" {
-            Self::Roman
-        } else if s == b"useDominantBaseline" {
-            Self::UseDominantBaseline
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            TextBaselineValue::Ascent => istr!("ascent"),
-            TextBaselineValue::Descent => istr!("descent"),
-            TextBaselineValue::IdeographicBottom => istr!("ideographicBottom"),
-            TextBaselineValue::IdeographicCenter => istr!("ideographicCenter"),
-            TextBaselineValue::IdeographicTop => istr!("ideographicTop"),
-            TextBaselineValue::Roman => istr!("roman"),
-            TextBaselineValue::UseDominantBaseline => istr!("useDominantBaseline"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum BreakOpportunityValue {
+    #[avm2_variant("all")]
     All,
+    #[avm2_variant("any")]
     Any,
+    #[avm2_variant("auto")]
     Auto,
+    #[avm2_variant("none")]
     None,
 }
 
-impl BreakOpportunityValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"all" {
-            Self::All
-        } else if s == b"any" {
-            Self::Any
-        } else if s == b"auto" {
-            Self::Auto
-        } else if s == b"none" {
-            Self::None
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::All => istr!("all"),
-            Self::Any => istr!("any"),
-            Self::Auto => istr!("auto"),
-            Self::None => istr!("none"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum DigitCaseValue {
+    #[avm2_variant("default")]
     Default,
+    #[avm2_variant("lining")]
     Lining,
+    #[avm2_variant("oldStyle")]
     OldStyle,
 }
 
-impl DigitCaseValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"default" {
-            Self::Default
-        } else if s == b"lining" {
-            Self::Lining
-        } else if s == b"oldStyle" {
-            Self::OldStyle
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Default => istr!("default"),
-            Self::Lining => istr!("lining"),
-            Self::OldStyle => istr!("oldStyle"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum DigitWidthValue {
+    #[avm2_variant("default")]
     Default,
+    #[avm2_variant("proportional")]
     Proportional,
+    #[avm2_variant("tabular")]
     Tabular,
 }
 
-impl DigitWidthValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"default" {
-            Self::Default
-        } else if s == b"proportional" {
-            Self::Proportional
-        } else if s == b"tabular" {
-            Self::Tabular
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Default => istr!("default"),
-            Self::Proportional => istr!("proportional"),
-            Self::Tabular => istr!("tabular"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum KerningValue {
+    #[avm2_variant("auto")]
     Auto,
+    #[avm2_variant("off")]
     Off,
+    #[avm2_variant("on")]
     On,
 }
 
-impl KerningValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"auto" {
-            Self::Auto
-        } else if s == b"off" {
-            Self::Off
-        } else if s == b"on" {
-            Self::On
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Auto => istr!("auto"),
-            Self::Off => istr!("off"),
-            Self::On => istr!("on"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum LigatureLevelValue {
+    #[avm2_variant("common")]
     Common,
+    #[avm2_variant("exotic")]
     Exotic,
+    #[avm2_variant("minimum")]
     Minimum,
+    #[avm2_variant("none")]
     None,
+    #[avm2_variant("uncommon")]
     Uncommon,
 }
 
-impl LigatureLevelValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"common" {
-            Self::Common
-        } else if s == b"exotic" {
-            Self::Exotic
-        } else if s == b"minimum" {
-            Self::Minimum
-        } else if s == b"none" {
-            Self::None
-        } else if s == b"uncommon" {
-            Self::Uncommon
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Common => istr!("common"),
-            Self::Exotic => istr!("exotic"),
-            Self::Minimum => istr!("minimum"),
-            Self::None => istr!("none"),
-            Self::Uncommon => istr!("uncommon"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum TextRotationValue {
+    #[avm2_variant("auto")]
     Auto,
+    #[avm2_variant("rotate0")]
     Rotate0,
+    #[avm2_variant("rotate180")]
     Rotate180,
+    #[avm2_variant("rotate270")]
     Rotate270,
+    #[avm2_variant("rotate90")]
     Rotate90,
 }
 
-impl TextRotationValue {
-    pub fn parse_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"auto" {
-            Self::Auto
-        } else if s == b"rotate0" {
-            Self::Rotate0
-        } else if s == b"rotate180" {
-            Self::Rotate180
-        } else if s == b"rotate270" {
-            Self::Rotate270
-        } else if s == b"rotate90" {
-            Self::Rotate90
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Auto => istr!("auto"),
-            Self::Rotate0 => istr!("rotate0"),
-            Self::Rotate180 => istr!("rotate180"),
-            Self::Rotate270 => istr!("rotate270"),
-            Self::Rotate90 => istr!("rotate90"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Collect, Avm2Enum)]
 #[collect(require_static)]
 pub enum TypographicCaseValue {
+    #[avm2_variant("caps")]
     Caps,
+    #[avm2_variant("capsAndSmallCaps")]
     CapsAndSmallCaps,
+    #[avm2_variant("default")]
     Default,
+    #[avm2_variant("lowercase")]
     Lowercase,
+    #[avm2_variant("smallCaps")]
     SmallCaps,
+    #[avm2_variant("title")]
     Title,
+    #[avm2_variant("uppercase")]
     Uppercase,
-}
-
-impl TypographicCaseValue {
-    pub fn parse_avm2_string(s: &WStr) -> Option<Self> {
-        Some(if s == b"caps" {
-            Self::Caps
-        } else if s == b"capsAndSmallCaps" {
-            Self::CapsAndSmallCaps
-        } else if s == b"default" {
-            Self::Default
-        } else if s == b"lowercase" {
-            Self::Lowercase
-        } else if s == b"smallCaps" {
-            Self::SmallCaps
-        } else if s == b"title" {
-            Self::Title
-        } else if s == b"uppercase" {
-            Self::Uppercase
-        } else {
-            return None;
-        })
-    }
-
-    pub fn as_string<'gc>(self, activation: &mut Activation<'_, 'gc>) -> AvmString<'gc> {
-        match self {
-            Self::Caps => istr!("caps"),
-            Self::CapsAndSmallCaps => istr!("capsAndSmallCaps"),
-            Self::Default => istr!("default"),
-            Self::Lowercase => istr!("lowercase"),
-            Self::SmallCaps => istr!("smallCaps"),
-            Self::Title => istr!("title"),
-            Self::Uppercase => istr!("uppercase"),
-        }
-    }
 }
 
 #[derive(Clone, Copy, Collect, PartialEq)]


### PR DESCRIPTION
## Description

Avm1Enum/Avm2Enum macro derives allow an enum to be annotated with
AVM1/AVM2 string variants, from which Avm1StrRepresentable or
Avm2StrRepresentable is being implemented.

These traits have methods for parsing and converting enums to AVM1/AVM2
strings.

This refactor reduces boilerplate in many places.

## Testing

Already covered by tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
