### PR TITLE
ci: Install pinned version of Edge/Edgedriver

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -186,6 +186,23 @@ jobs:
           install-dependencies: true
           install-chromedriver: true
 
+      - name: Install pinned Edge (workaround for actions/runner-images#14223)
+        if: matrix.browser == 'edge'
+        run: |
+          # Download and install pinned Edge
+          wget https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_148.0.3967.96-1_amd64.deb
+          sudo apt-get install --allow-downgrades -y ./microsoft-edge-stable_148.0.3967.96-1_amd64.deb
+
+          # Download and extract pinned EdgeDriver
+          wget https://msedgedriver.microsoft.com/148.0.3967.96/edgedriver_linux64.zip
+          unzip edgedriver_linux64.zip
+          sudo mv msedgedriver /usr/local/bin/msedgedriver
+          sudo chmod +x /usr/local/bin/msedgedriver
+
+          # Export paths for WDIO
+          echo "EDGE_BIN=/usr/bin/microsoft-edge" >> "$GITHUB_ENV"
+          echo "EDGEWEBDRIVER=/usr/local/bin/msedgedriver" >> "$GITHUB_ENV"
+
       - name: Run browser-based tests
         working-directory: web
         shell: bash -l {0}

--- a/web/packages/selfhosted/wdio.conf.ts
+++ b/web/packages/selfhosted/wdio.conf.ts
@@ -46,14 +46,27 @@ if (edge) {
     const args = ["--disable-gpu", "--enable-unsafe-swiftshader"];
     if (headless) {
         args.push("--headless");
+        if (process.env["EDGE_BIN"]) {
+            args.push("--no-sandbox", "--disable-dev-shm-usage");
+        }
     }
-    capabilities.push({
+    const edgeOptions: { args: string[]; binary?: string } = { args };
+    if (process.env["EDGE_BIN"]) {
+        edgeOptions.binary = process.env["EDGE_BIN"];
+    }
+
+    const edgeCaps: WebdriverIO.Capabilities = {
         "wdio:maxInstances": maxInstances,
         browserName: "MicrosoftEdge",
-        "ms:edgeOptions": {
-            args,
-        },
-    });
+        "ms:edgeOptions": edgeOptions,
+    };
+    if (process.env["EDGEWEBDRIVER"]) {
+        edgeCaps["wdio:edgedriverOptions"] = {
+            binary: process.env["EDGEWEBDRIVER"],
+        };
+    }
+
+    capabilities.push(edgeCaps);
 }
 
 if (firefox) {


### PR DESCRIPTION
## Description

Install pinned Edge/Edgedriver manually (no actions exist for it: https://github.com/browser-actions/setup-edge/issues/560)

## Testing

Check CI

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code. (Gemini told me the paths of the Edge/Edgedriver installs)
