### PR TITLE
ci: Update Edge wdio headless arguments for stability 

### DIFF
--- a/web/packages/selfhosted/wdio.conf.ts
+++ b/web/packages/selfhosted/wdio.conf.ts
@@ -45,7 +45,7 @@ if (chrome) {
 if (edge) {
     const args = ["--disable-gpu", "--enable-unsafe-swiftshader"];
     if (headless) {
-        args.push("--headless");
+        args.push("--headless", "--no-sandbox");
     }
     capabilities.push({
         "wdio:maxInstances": maxInstances,


### PR DESCRIPTION
## Description

Edge workers were crashing during initialization when running in headless mode.

This adds the no-sandbox argument to prevent crashes.

Note: tried doing the same for Chrome, but no such luck: https://github.com/danielhjacobs/ruffle/actions/runs/28178811519 / https://github.com/ruffle-rs/ruffle/compare/master...danielhjacobs:ruffle:refs/heads/fix-chrome?diff=split&w

## Testing

Check CI

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
