### PR TITLE
ci: Also use cargo --locked in the extension builder Dockerfile

### DIFF
--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --ta
 ENV PATH="/root/.cargo/bin:$PATH"
 # wasm-bindgen-cli version must match wasm-bindgen crate version.
 # Be sure to update in test_web.yml, release.yml, Cargo.toml, and web/README.md as well.
-RUN cargo install wasm-bindgen-cli --version 0.2.120
+RUN cargo install --locked wasm-bindgen-cli --version 0.2.120
 
 # Building Ruffle:
 COPY . ruffle


### PR DESCRIPTION
## Description

Follow-up to https://github.com/ruffle-rs/ruffle/pull/23980.

This should avoid these failures: https://github.com/ruffle-rs/ruffle/actions/runs/28267137047

The only difference between the WASM files was this metadata entry:

```
$ diff -C 7 normal.wasm.hex docker.wasm.hex 
*** normal.wasm.hex     2026-06-27 20:23:43.664304006 +0200
--- docker.wasm.hex     2026-06-27 20:23:51.595537092 +0200
***************
*** 829302,829316 ****
  00ca7750: 8f01 0970 726f 6475 6365 7273 0208 6c61  ...producers..la
  00ca7760: 6e67 7561 6765 0104 5275 7374 000c 7072  nguage..Rust..pr
  00ca7770: 6f63 6573 7365 642d 6279 0405 7275 7374  ocessed-by..rust
  00ca7780: 631d 312e 3936 2e30 2028 6163 3638 6661  c.1.96.0 (ac68fa
  00ca7790: 6132 3020 3230 3236 2d30 352d 3235 290c  a20 2026-05-25).
  00ca77a0: 5562 756e 7475 2063 6c61 6e67 1131 382e  Ubuntu clang.18.
  00ca77b0: 312e 3320 2831 7562 756e 7475 3129 0677  1.3 (1ubuntu1).w
! 00ca77c0: 616c 7275 7306 302e 3236 2e31 0c77 6173  alrus.0.26.1.was
  00ca77d0: 6d2d 6269 6e64 6765 6e07 302e 322e 3132  m-bindgen.0.2.12
  00ca77e0: 3000 9d01 0f74 6172 6765 745f 6665 6174  0....target_feat
  00ca77f0: 7572 6573 092b 0f6d 7574 6162 6c65 2d67  ures.+.mutable-g
  00ca7800: 6c6f 6261 6c73 2b13 6e6f 6e74 7261 7070  lobals+.nontrapp
  00ca7810: 696e 672d 6670 746f 696e 742b 0773 696d  ing-fptoint+.sim
  00ca7820: 6431 3238 2b0b 6275 6c6b 2d6d 656d 6f72  d128+.bulk-memor
  00ca7830: 792b 0873 6967 6e2d 6578 742b 0f72 6566  y+.sign-ext+.ref
--- 829302,829316 ----
  00ca7750: 8f01 0970 726f 6475 6365 7273 0208 6c61  ...producers..la
  00ca7760: 6e67 7561 6765 0104 5275 7374 000c 7072  nguage..Rust..pr
  00ca7770: 6f63 6573 7365 642d 6279 0405 7275 7374  ocessed-by..rust
  00ca7780: 631d 312e 3936 2e30 2028 6163 3638 6661  c.1.96.0 (ac68fa
  00ca7790: 6132 3020 3230 3236 2d30 352d 3235 290c  a20 2026-05-25).
  00ca77a0: 5562 756e 7475 2063 6c61 6e67 1131 382e  Ubuntu clang.18.
  00ca77b0: 312e 3320 2831 7562 756e 7475 3129 0677  1.3 (1ubuntu1).w
! 00ca77c0: 616c 7275 7306 302e 3236 2e34 0c77 6173  alrus.0.26.4.was
  00ca77d0: 6d2d 6269 6e64 6765 6e07 302e 322e 3132  m-bindgen.0.2.12
  00ca77e0: 3000 9d01 0f74 6172 6765 745f 6665 6174  0....target_feat
  00ca77f0: 7572 6573 092b 0f6d 7574 6162 6c65 2d67  ures.+.mutable-g
  00ca7800: 6c6f 6261 6c73 2b13 6e6f 6e74 7261 7070  lobals+.nontrapp
  00ca7810: 696e 672d 6670 746f 696e 742b 0773 696d  ing-fptoint+.sim
  00ca7820: 6431 3238 2b0b 6275 6c6b 2d6d 656d 6f72  d128+.bulk-memor
  00ca7830: 792b 0873 6967 6e2d 6578 742b 0f72 6566  y+.sign-ext+.ref
```

That is, the patch version of walrus  that processed the file (`0.26.1` vs.` 0.26.4`).
`walrus` is a `wasm-bindgen` dependency: https://crates.io/crates/walrus

## Testing

Using the CI workflow linked above.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
