### PR TITLE
avm2: Implement streaming flash.net.URLStream

### DIFF
--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -1046,6 +1046,16 @@ pub fn make_error_2002<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> 
 
 #[inline(never)]
 #[cold]
+pub fn make_error_2029<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
+    make_error!(io_error(
+        activation,
+        "Error #2029: This URLStream object does not have an open stream.",
+        2029,
+    ))
+}
+
+#[inline(never)]
+#[cold]
 pub fn make_error_2003<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
     make_error!(security_error(activation, error_message!(2003), 2003))
 }

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -959,6 +959,16 @@ pub fn make_error_2001<'gc>(
 make_error_fn!(make_error_2002, 2002, io_error);
 make_error_fn!(make_error_2003, 2003, security_error);
 
+#[inline(never)]
+#[cold]
+pub fn make_error_2029<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
+    make_error!(io_error(
+        activation,
+        "Error #2029: This URLStream object does not have an open stream.",
+        2029,
+    ))
+}
+
 pub enum Error2004Type {
     Error,
     ArgumentError,

--- a/core/src/avm2/globals/flash/net.rs
+++ b/core/src/avm2/globals/flash/net.rs
@@ -17,6 +17,7 @@ pub mod responder;
 pub mod shared_object;
 pub mod socket;
 pub mod url_loader;
+pub mod url_stream;
 pub mod xml_socket;
 
 fn object_to_index_map<'gc>(

--- a/core/src/avm2/globals/flash/net.rs
+++ b/core/src/avm2/globals/flash/net.rs
@@ -18,6 +18,7 @@ pub mod responder;
 pub mod shared_object;
 pub mod socket;
 pub mod url_loader;
+pub mod url_stream;
 pub mod xml_socket;
 
 fn object_to_index_map<'gc>(

--- a/core/src/avm2/globals/flash/net/URLStream.as
+++ b/core/src/avm2/globals/flash/net/URLStream.as
@@ -1,157 +1,113 @@
 package flash.net {
-    import __ruffle__.stub_constructor;
-    import __ruffle__.stub_getter;
-    import __ruffle__.stub_setter;
-
-    import flash.events.Event;
     import flash.events.EventDispatcher;
+    import flash.net.URLRequest;
+    import flash.utils.ByteArray;
     import flash.utils.Endian;
     import flash.utils.IDataInput;
-    import flash.utils.ByteArray;
-    import flash.events.Event;
-    import flash.events.HTTPStatusEvent;
-    import flash.events.IOErrorEvent;
-    import flash.events.ProgressEvent;
-    import flash.events.SecurityErrorEvent;
 
     public class URLStream extends EventDispatcher implements IDataInput {
-        private var _endian:String = Endian.BIG_ENDIAN;
+        // The internal byte buffer fed by the native loader. All reads go
+        // through this ByteArray. Native code appends bytes to it as they
+        // arrive over the network.
+        [Ruffle(NativeAccessible)]
+        private var _data:ByteArray = new ByteArray();
+
+        [Ruffle(NativeAccessible)]
         private var _connected:Boolean = false;
 
-        // FIXME - we currently implement `URLStream` using a `URLLoader`,
-        // which means that content can't actually be "streamed" (it becomes
-        // available all at once when the entire download finishes).
-        // We should write an actual "streaming" implementation that exposes
-        // content as it comes in over the network, but this will require changes
-        // to `NavigatorBackend`. See https://github.com/ruffle-rs/ruffle/pull/11046
-        private var _loader:URLLoader = new URLLoader();
+        // Set to true by close(); the native fetch loop polls this flag and
+        // stops dispatching further events once it becomes true.
+        [Ruffle(NativeAccessible)]
+        private var _closed:Boolean = false;
 
         public function URLStream() {
-            stub_constructor("flash.net.URLStream", "streaming support");
-
-            this._loader.dataFormat = URLLoaderDataFormat.BINARY;
-            var self = this;
-
-            this._loader.addEventListener(Event.OPEN, function(e:*):void {
-                self.dispatchEvent(new Event(Event.OPEN));
-            });
-            this._loader.addEventListener(Event.COMPLETE, function(e:*):void {
-                self._loader.data.endian = self._endian;
-                self.dispatchEvent(new Event(Event.COMPLETE));
-            });
-            this._loader.addEventListener(IOErrorEvent.IO_ERROR, function(e:*):void {
-                self.dispatchEvent(new IOErrorEvent(IOErrorEvent.IO_ERROR));
-            });
-            this._loader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, function(e:*):void {
-                self.dispatchEvent(new SecurityErrorEvent(SecurityErrorEvent.SECURITY_ERROR));
-            });
-            this._loader.addEventListener(ProgressEvent.PROGRESS, function(e:*):void {
-                self._loader.data.endian = self._endian;
-                self.dispatchEvent(new ProgressEvent(ProgressEvent.PROGRESS, false, false, e.bytesLoaded, e.bytesTotal));
-            });
-            this._loader.addEventListener(HTTPStatusEvent.HTTP_STATUS, function(e:*):void {
-                self.dispatchEvent(new HTTPStatusEvent(HTTPStatusEvent.HTTP_STATUS, false, false, e.status, e.redirected));
-            });
         }
 
         public function get bytesAvailable():uint {
-            if (this._loader.data) {
-                return this._loader.data.bytesAvailable;
-            }
-            return 0;
+            return this._data.bytesAvailable;
         }
 
         public function get connected():Boolean {
-            return _connected;
+            return this._connected;
         }
 
         public function get endian():String {
-            return _endian;
+            return this._data.endian;
         }
 
         public function set endian(value:String):void {
             if (value === Endian.BIG_ENDIAN || value === Endian.LITTLE_ENDIAN) {
-                this._endian = value;
-                if (this._loader.data) {
-                    this._loader.data.endian = value;
-                }
+                this._data.endian = value;
             } else {
                 throw new ArgumentError("Error #2008: Parameter endian must be one of the accepted values.", 2008);
             }
         }
 
-        public function load(request:URLRequest):void {
-            this._loader.load(request);
-            this._connected = true;
-        }
-
-        public function close():void {
-            this._loader.close();
-            this._connected = false;
-        }
-
         public function get objectEncoding():uint {
-            stub_getter("flash.net.URLStream", "objectEncoding");
-            return 0;
+            return this._data.objectEncoding;
         }
+
         public function set objectEncoding(value:uint):void {
-            stub_setter("flash.net.URLStream", "objectEncoding");
+            this._data.objectEncoding = value;
         }
+
+        public native function load(request:URLRequest):void;
+        public native function close():void;
 
         public function readBoolean():Boolean {
-            return this._loader.data.readBoolean();
+            return this._data.readBoolean();
         }
 
         public function readByte():int {
-            return this._loader.data.readByte();
+            return this._data.readByte();
         }
 
         public function readBytes(bytes:ByteArray, offset:uint = 0, length:uint = 0):void {
-            this._loader.data.readBytes(bytes, offset, length);
+            this._data.readBytes(bytes, offset, length);
         }
 
         public function readDouble():Number {
-            return this._loader.data.readDouble();
+            return this._data.readDouble();
         }
 
         public function readFloat():Number {
-            return this._loader.data.readFloat();
+            return this._data.readFloat();
         }
 
         public function readInt():int {
-            return this._loader.data.readInt();
+            return this._data.readInt();
         }
 
         public function readMultiByte(length:uint, charSet:String):String {
-            return this._loader.data.readMultiByte(length, charSet);
+            return this._data.readMultiByte(length, charSet);
         }
 
         public function readObject():* {
-            return this._loader.data.readObject();
+            return this._data.readObject();
         }
 
         public function readShort():int {
-            return this._loader.data.readShort();
+            return this._data.readShort();
         }
 
         public function readUnsignedByte():uint {
-            return this._loader.data.readUnsignedByte();
+            return this._data.readUnsignedByte();
         }
 
         public function readUnsignedInt():uint {
-            return this._loader.data.readUnsignedInt();
+            return this._data.readUnsignedInt();
         }
 
         public function readUnsignedShort():uint {
-            return this._loader.data.readUnsignedShort();
+            return this._data.readUnsignedShort();
         }
 
         public function readUTF():String {
-            return this._loader.data.readUTF();
+            return this._data.readUTF();
         }
 
         public function readUTFBytes(length:uint):String {
-            return this._loader.data.readUTFBytes(length);
+            return this._data.readUTFBytes(length);
         }
     }
 }

--- a/core/src/avm2/globals/flash/net/url_stream.rs
+++ b/core/src/avm2/globals/flash/net/url_stream.rs
@@ -1,0 +1,89 @@
+//! `flash.net.URLStream` native function definitions
+
+use crate::avm2::activation::Activation;
+use crate::avm2::error::make_error_2029;
+use crate::avm2::globals::flash::display::loader::request_from_url_request;
+use crate::avm2::globals::slots::flash_net_url_stream as url_stream_slots;
+use crate::avm2::object::TObject as _;
+use crate::avm2::parameters::ParametersExt;
+use crate::avm2::value::Value;
+use crate::avm2::{Error, Object};
+
+/// Native function definition for `URLStream.load`
+pub fn load<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this.as_object().unwrap();
+
+    let request = args.get_object(activation, 0, "request")?;
+
+    spawn_fetch(activation, this, request)
+}
+
+/// Native function definition for `URLStream.close`
+///
+/// Per the Adobe spec, `close()` "immediately closes the stream and cancels
+/// the download operation" and throws an `IOError` if the stream was not
+/// open. We model "open" via the `_connected` slot: it is set synchronously
+/// in `load()` and cleared on completion, error, or a previous `close()`.
+///
+/// Closing sets the `_closed` flag, which the async fetch loop polls after
+/// every chunk; once it sees the flag it stops dispatching further events.
+pub fn close<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this.as_object().unwrap();
+
+    let connected = matches!(
+        this.get_slot(url_stream_slots::_CONNECTED),
+        Value::Bool(true)
+    );
+    if !connected {
+        return Err(make_error_2029(activation));
+    }
+
+    this.set_slot(url_stream_slots::_CLOSED, Value::Bool(true), activation)?;
+    this.set_slot(url_stream_slots::_CONNECTED, Value::Bool(false), activation)?;
+
+    // Per the Adobe spec: "No data can be read from the stream after the
+    // close() method is called." Clear the internal buffer so subsequent
+    // reads see `bytesAvailable == 0` and throw EOFError. This matches
+    // `Socket.close()` in Ruffle, which also clears its read buffer.
+    if let Some(bytearray) = this
+        .get_slot(url_stream_slots::_DATA)
+        .as_object()
+        .and_then(|o| o.as_bytearray_object())
+    {
+        bytearray.storage_mut().clear();
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn spawn_fetch<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    stream_object: Object<'gc>,
+    url_request: Object<'gc>,
+) -> Result<Value<'gc>, Error<'gc>> {
+    let request = request_from_url_request(activation, url_request)?;
+
+    // Reset per-load state. A `close()` issued before this call must not
+    // cancel the new fetch, and the byte counters start fresh. `_connected`
+    // is set true synchronously so that a `close()` issued between now and
+    // the arrival of the first response chunk is treated as cancelling an
+    // open stream (rather than throwing error #2029).
+    stream_object.set_slot(url_stream_slots::_CLOSED, Value::Bool(false), activation)?;
+    stream_object.set_slot(url_stream_slots::_CONNECTED, Value::Bool(true), activation)?;
+
+    let future = crate::loader::load_data_into_url_stream(
+        activation.context,
+        stream_object.as_script_object().unwrap(),
+        request,
+    );
+    activation.context.navigator.spawn_future(future);
+    Ok(Value::Undefined)
+}

--- a/core/src/avm2/globals/flash/net/url_stream.rs
+++ b/core/src/avm2/globals/flash/net/url_stream.rs
@@ -1,0 +1,90 @@
+//! `flash.net.URLStream` native function definitions
+
+use crate::avm2::activation::Activation;
+use crate::avm2::error::make_error_2029;
+use crate::avm2::function::FunctionArgs;
+use crate::avm2::globals::flash::display::loader::request_from_url_request;
+use crate::avm2::globals::slots::flash_net_url_stream as url_stream_slots;
+use crate::avm2::object::TObject as _;
+use crate::avm2::parameters::ParametersExt;
+use crate::avm2::value::Value;
+use crate::avm2::{Error, Object};
+
+/// Native function definition for `URLStream.load`
+pub fn load<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    args: FunctionArgs<'_, 'gc>,
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this.as_object().unwrap();
+
+    let request = args.get_object(activation, 0, "request")?;
+
+    spawn_fetch(activation, this, request)
+}
+
+/// Native function definition for `URLStream.close`
+///
+/// Per the Adobe spec, `close()` "immediately closes the stream and cancels
+/// the download operation" and throws an `IOError` if the stream was not
+/// open. We model "open" via the `_connected` slot: it is set synchronously
+/// in `load()` and cleared on completion, error, or a previous `close()`.
+///
+/// Closing sets the `_closed` flag, which the async fetch loop polls after
+/// every chunk; once it sees the flag it stops dispatching further events.
+pub fn close<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: FunctionArgs<'_, 'gc>,
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this.as_object().unwrap();
+
+    let connected = matches!(
+        this.get_slot(url_stream_slots::_CONNECTED),
+        Value::Bool(true)
+    );
+    if !connected {
+        return Err(make_error_2029(activation));
+    }
+
+    this.set_slot(url_stream_slots::_CLOSED, Value::Bool(true), activation)?;
+    this.set_slot(url_stream_slots::_CONNECTED, Value::Bool(false), activation)?;
+
+    // Per the Adobe spec: "No data can be read from the stream after the
+    // close() method is called." Clear the internal buffer so subsequent
+    // reads see `bytesAvailable == 0` and throw EOFError. This matches
+    // `Socket.close()` in Ruffle, which also clears its read buffer.
+    if let Some(bytearray) = this
+        .get_slot(url_stream_slots::_DATA)
+        .as_object()
+        .and_then(|o| o.as_bytearray_object())
+    {
+        bytearray.storage_mut().clear();
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn spawn_fetch<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    stream_object: Object<'gc>,
+    url_request: Object<'gc>,
+) -> Result<Value<'gc>, Error<'gc>> {
+    let request = request_from_url_request(activation, url_request)?;
+
+    // Reset per-load state. A `close()` issued before this call must not
+    // cancel the new fetch, and the byte counters start fresh. `_connected`
+    // is set true synchronously so that a `close()` issued between now and
+    // the arrival of the first response chunk is treated as cancelling an
+    // open stream (rather than throwing error #2029).
+    stream_object.set_slot(url_stream_slots::_CLOSED, Value::Bool(false), activation)?;
+    stream_object.set_slot(url_stream_slots::_CONNECTED, Value::Bool(true), activation)?;
+
+    let future = crate::loader::load_data_into_url_stream(
+        activation.context,
+        stream_object.as_script_object().unwrap(),
+        request,
+    );
+    activation.context.navigator.spawn_future(future);
+    Ok(Value::Undefined)
+}

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1351,6 +1351,241 @@ pub fn load_data_into_url_loader<'gc>(
     })
 }
 
+/// Kick off an incremental data load into a `URLStream`.
+///
+/// Unlike [`load_data_into_url_loader`], this consumes the response chunk by
+/// chunk via [`SuccessResponse::next_chunk`] and feeds bytes into the
+/// stream's internal `ByteArray` as they arrive, dispatching a
+/// `ProgressEvent` after each chunk. This matches the Adobe spec for
+/// `URLStream`: "Data is made available to application code immediately as
+/// it is downloaded, instead of waiting until the entire file is complete."
+///
+/// The fetch loop polls the `_closed` slot after every chunk and after the
+/// initial response. When `close()` is called from AS3 it flips this flag
+/// and the loop exits silently without dispatching any further events.
+#[must_use]
+pub fn load_data_into_url_stream<'gc>(
+    uc: &UpdateContext<'gc>,
+    target: Avm2ScriptObject<'gc>,
+    request: Request,
+) -> OwnedFuture<(), Error> {
+    let player = uc.player_handle();
+    let target = Avm2ScriptObjectHandle::stash(uc, target);
+
+    Box::pin(async move {
+        // Use `FetchReason::UrlLoader` so the same compatibility rewrites
+        // (e.g. fpdownload.adobe.com -> cdn.ruffle.rs) apply to URLStream
+        // requests as well, since the two APIs are semantically equivalent
+        // network fetches.
+        let fetch = player
+            .lock()
+            .unwrap()
+            .fetch(request, FetchReason::UrlLoader);
+
+        // Await the initial response (headers/status). On success this
+        // yields a streamable body; on failure we go straight to the error
+        // path.
+        let initial = fetch.await;
+
+        let mut response = match initial {
+            Ok(response) => response,
+            Err(response) => {
+                tracing::error!(
+                    "Error during URLStream load of {:?}: {:?}",
+                    response.url,
+                    response.error
+                );
+
+                player.lock().unwrap().update(|uc| {
+                    let target = Avm2Object::from(target.fetch(uc));
+                    if is_url_stream_closed(uc, target) {
+                        return;
+                    }
+
+                    let mut activation = Avm2Activation::from_nothing(uc);
+
+                    let (status_code, redirected) =
+                        if let Error::HttpNotOk(_, status_code, redirected, _) = response.error {
+                            (status_code, redirected)
+                        } else {
+                            (0, false)
+                        };
+                    if status_code != 0 {
+                        let http_status_evt = Avm2EventObject::http_status_event(
+                            &mut activation,
+                            status_code,
+                            redirected,
+                        );
+                        Avm2::dispatch_event(activation.context, http_status_evt, target);
+                    }
+
+                    let io_error_evt = Avm2EventObject::io_error_event(
+                        &mut activation,
+                        "Error #2032: Stream Error",
+                        2032,
+                    );
+                    set_url_stream_disconnected(uc, target);
+                    Avm2::dispatch_event(uc, io_error_evt, target);
+                });
+
+                return Ok(());
+            }
+        };
+
+        let status = response.status();
+        let redirected = response.redirected();
+        let expected_length = response.expected_length().ok().flatten().unwrap_or(0);
+
+        // Fire the OPEN and httpStatus events as soon as the connection
+        // is established. Per Adobe docs OPEN is dispatched "when a load
+        // operation commences" and httpStatus when the status code is
+        // detected, both of which are now known.
+        let early_dispatch_ok = player.lock().unwrap().update(|uc| {
+            let target = Avm2Object::from(target.fetch(uc));
+            if is_url_stream_closed(uc, target) {
+                return false;
+            }
+
+            // `_connected` was already set true synchronously in `load()`.
+            // It stays true here through OPEN/progress and is cleared on
+            // COMPLETE, error, or close(), matching Adobe semantics.
+
+            let mut activation = Avm2Activation::from_nothing(uc);
+
+            let open_evt = Avm2EventObject::bare_default_event(activation.context, "open");
+            Avm2::dispatch_event(activation.context, open_evt, target);
+
+            if status != 0 {
+                let http_status_evt =
+                    Avm2EventObject::http_status_event(&mut activation, status, redirected);
+                Avm2::dispatch_event(activation.context, http_status_evt, target);
+            }
+
+            true
+        });
+
+        if !early_dispatch_ok {
+            return Ok(());
+        }
+
+        // Pump chunks. Each successful chunk is appended to the internal
+        // ByteArray and produces a `progress` event. We track the running
+        // count locally; `bytes_total` is the server-announced length when
+        // known, or 0 when the body length is indefinite (e.g. chunked
+        // transfer encoding). This mirrors Flash, where `bytesTotal` stays
+        // 0 for streams of unknown length.
+        let mut bytes_loaded: u64 = 0;
+        let bytes_total: u64 = expected_length;
+
+        loop {
+            let next = response.next_chunk().await;
+            match next {
+                Ok(Some(chunk)) => {
+                    bytes_loaded = bytes_loaded.saturating_add(chunk.len() as u64);
+
+                    let stop = player.lock().unwrap().update(|uc| {
+                        let target = Avm2Object::from(target.fetch(uc));
+                        if is_url_stream_closed(uc, target) {
+                            return true;
+                        }
+
+                        append_url_stream_chunk(uc, target, &chunk);
+
+                        let mut activation = Avm2Activation::from_nothing(uc);
+                        let progress_evt = Avm2EventObject::progress_event(
+                            &mut activation,
+                            "progress",
+                            bytes_loaded as usize,
+                            bytes_total as usize,
+                        );
+                        Avm2::dispatch_event(activation.context, progress_evt, target);
+
+                        false
+                    });
+
+                    if stop {
+                        return Ok(());
+                    }
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    tracing::error!("Error during URLStream chunked read: {:?}", error);
+
+                    player.lock().unwrap().update(|uc| {
+                        let target = Avm2Object::from(target.fetch(uc));
+                        if is_url_stream_closed(uc, target) {
+                            return;
+                        }
+
+                        let mut activation = Avm2Activation::from_nothing(uc);
+                        let io_error_evt = Avm2EventObject::io_error_event(
+                            &mut activation,
+                            "Error #2032: Stream Error",
+                            2032,
+                        );
+                        set_url_stream_disconnected(uc, target);
+                        Avm2::dispatch_event(uc, io_error_evt, target);
+                    });
+
+                    return Ok(());
+                }
+            }
+        }
+
+        // Success path: dispatch COMPLETE after all chunks have been
+        // appended. We also drop `connected` here per Adobe semantics.
+        player.lock().unwrap().update(|uc| {
+            let target = Avm2Object::from(target.fetch(uc));
+            if is_url_stream_closed(uc, target) {
+                return;
+            }
+
+            set_url_stream_disconnected(uc, target);
+
+            let complete_evt = Avm2EventObject::bare_default_event(uc, "complete");
+            Avm2::dispatch_event(uc, complete_evt, target);
+        });
+
+        Ok(())
+    })
+}
+
+/// Returns `true` if `close()` has been invoked on the URLStream while the
+/// fetch was in flight.
+fn is_url_stream_closed<'gc>(_uc: &UpdateContext<'gc>, target: Avm2Object<'gc>) -> bool {
+    use crate::avm2::globals::slots::flash_net_url_stream as slots;
+    matches!(target.get_slot(slots::_CLOSED), Avm2Value::Bool(true))
+}
+
+fn set_url_stream_connected<'gc>(uc: &UpdateContext<'gc>, target: Avm2Object<'gc>, value: bool) {
+    use crate::avm2::globals::slots::flash_net_url_stream as slots;
+    target.set_slot_no_coerce(slots::_CONNECTED, Avm2Value::Bool(value), uc.gc());
+}
+
+fn set_url_stream_disconnected<'gc>(uc: &UpdateContext<'gc>, target: Avm2Object<'gc>) {
+    set_url_stream_connected(uc, target, false);
+}
+
+fn append_url_stream_chunk<'gc>(_uc: &UpdateContext<'gc>, target: Avm2Object<'gc>, chunk: &[u8]) {
+    use crate::avm2::globals::slots::flash_net_url_stream as slots;
+
+    let data_value = target.get_slot(slots::_DATA);
+    let bytearray = match data_value.as_object().and_then(|o| o.as_bytearray_object()) {
+        Some(ba) => ba,
+        None => return,
+    };
+
+    let mut storage = bytearray.storage_mut();
+    // We want appends to land at the end of the buffer, not at the
+    // current read position. Save the read position, jump to the end,
+    // write, restore.
+    let saved_position = storage.position();
+    let end = storage.len();
+    storage.set_position(end);
+    let _ = storage.write_bytes(chunk);
+    storage.set_position(saved_position);
+}
+
 /// Kick off an AVM1 audio load.
 ///
 /// Returns the loader's async process, which you will need to spawn.

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1361,6 +1361,241 @@ pub fn load_data_into_url_loader<'gc>(
     })
 }
 
+/// Kick off an incremental data load into a `URLStream`.
+///
+/// Unlike [`load_data_into_url_loader`], this consumes the response chunk by
+/// chunk via [`SuccessResponse::next_chunk`] and feeds bytes into the
+/// stream's internal `ByteArray` as they arrive, dispatching a
+/// `ProgressEvent` after each chunk. This matches the Adobe spec for
+/// `URLStream`: "Data is made available to application code immediately as
+/// it is downloaded, instead of waiting until the entire file is complete."
+///
+/// The fetch loop polls the `_closed` slot after every chunk and after the
+/// initial response. When `close()` is called from AS3 it flips this flag
+/// and the loop exits silently without dispatching any further events.
+#[must_use]
+pub fn load_data_into_url_stream<'gc>(
+    uc: &UpdateContext<'gc>,
+    target: Avm2ScriptObject<'gc>,
+    request: Request,
+) -> OwnedFuture<(), Error> {
+    let player = uc.player_handle();
+    let target = Avm2ScriptObjectHandle::stash(uc, target);
+
+    Box::pin(async move {
+        // Use `FetchReason::UrlLoader` so the same compatibility rewrites
+        // (e.g. fpdownload.adobe.com -> cdn.ruffle.rs) apply to URLStream
+        // requests as well, since the two APIs are semantically equivalent
+        // network fetches.
+        let fetch = player
+            .lock()
+            .unwrap()
+            .fetch(request, FetchReason::UrlLoader);
+
+        // Await the initial response (headers/status). On success this
+        // yields a streamable body; on failure we go straight to the error
+        // path.
+        let initial = fetch.await;
+
+        let mut response = match initial {
+            Ok(response) => response,
+            Err(response) => {
+                tracing::error!(
+                    "Error during URLStream load of {:?}: {:?}",
+                    response.url,
+                    response.error
+                );
+
+                player.lock().unwrap().update(|uc| {
+                    let target = Avm2Object::from(target.fetch(uc));
+                    if is_url_stream_closed(uc, target) {
+                        return;
+                    }
+
+                    let mut activation = Avm2Activation::from_nothing(uc);
+
+                    let (status_code, redirected) =
+                        if let Error::HttpNotOk(_, status_code, redirected, _) = response.error {
+                            (status_code, redirected)
+                        } else {
+                            (0, false)
+                        };
+                    if status_code != 0 {
+                        let http_status_evt = Avm2EventObject::http_status_event(
+                            &mut activation,
+                            status_code,
+                            redirected,
+                        );
+                        Avm2::dispatch_event(activation.context, http_status_evt, target);
+                    }
+
+                    let io_error_evt = Avm2EventObject::io_error_event(
+                        &mut activation,
+                        "Error #2032: Stream Error",
+                        2032,
+                    );
+                    set_url_stream_disconnected(uc, target);
+                    Avm2::dispatch_event(uc, io_error_evt, target);
+                });
+
+                return Ok(());
+            }
+        };
+
+        let status = response.status();
+        let redirected = response.redirected();
+        let expected_length = response.expected_length().ok().flatten().unwrap_or(0);
+
+        // Fire the OPEN and httpStatus events as soon as the connection
+        // is established. Per Adobe docs OPEN is dispatched "when a load
+        // operation commences" and httpStatus when the status code is
+        // detected, both of which are now known.
+        let early_dispatch_ok = player.lock().unwrap().update(|uc| {
+            let target = Avm2Object::from(target.fetch(uc));
+            if is_url_stream_closed(uc, target) {
+                return false;
+            }
+
+            // `_connected` was already set true synchronously in `load()`.
+            // It stays true here through OPEN/progress and is cleared on
+            // COMPLETE, error, or close(), matching Adobe semantics.
+
+            let mut activation = Avm2Activation::from_nothing(uc);
+
+            let open_evt = Avm2EventObject::bare_default_event(activation.context, "open");
+            Avm2::dispatch_event(activation.context, open_evt, target);
+
+            if status != 0 {
+                let http_status_evt =
+                    Avm2EventObject::http_status_event(&mut activation, status, redirected);
+                Avm2::dispatch_event(activation.context, http_status_evt, target);
+            }
+
+            true
+        });
+
+        if !early_dispatch_ok {
+            return Ok(());
+        }
+
+        // Pump chunks. Each successful chunk is appended to the internal
+        // ByteArray and produces a `progress` event. We track the running
+        // count locally; `bytes_total` is the server-announced length when
+        // known, or 0 when the body length is indefinite (e.g. chunked
+        // transfer encoding). This mirrors Flash, where `bytesTotal` stays
+        // 0 for streams of unknown length.
+        let mut bytes_loaded: u64 = 0;
+        let bytes_total: u64 = expected_length;
+
+        loop {
+            let next = response.next_chunk().await;
+            match next {
+                Ok(Some(chunk)) => {
+                    bytes_loaded = bytes_loaded.saturating_add(chunk.len() as u64);
+
+                    let stop = player.lock().unwrap().update(|uc| {
+                        let target = Avm2Object::from(target.fetch(uc));
+                        if is_url_stream_closed(uc, target) {
+                            return true;
+                        }
+
+                        append_url_stream_chunk(uc, target, &chunk);
+
+                        let mut activation = Avm2Activation::from_nothing(uc);
+                        let progress_evt = Avm2EventObject::progress_event(
+                            &mut activation,
+                            "progress",
+                            bytes_loaded as usize,
+                            bytes_total as usize,
+                        );
+                        Avm2::dispatch_event(activation.context, progress_evt, target);
+
+                        false
+                    });
+
+                    if stop {
+                        return Ok(());
+                    }
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    tracing::error!("Error during URLStream chunked read: {:?}", error);
+
+                    player.lock().unwrap().update(|uc| {
+                        let target = Avm2Object::from(target.fetch(uc));
+                        if is_url_stream_closed(uc, target) {
+                            return;
+                        }
+
+                        let mut activation = Avm2Activation::from_nothing(uc);
+                        let io_error_evt = Avm2EventObject::io_error_event(
+                            &mut activation,
+                            "Error #2032: Stream Error",
+                            2032,
+                        );
+                        set_url_stream_disconnected(uc, target);
+                        Avm2::dispatch_event(uc, io_error_evt, target);
+                    });
+
+                    return Ok(());
+                }
+            }
+        }
+
+        // Success path: dispatch COMPLETE after all chunks have been
+        // appended. We also drop `connected` here per Adobe semantics.
+        player.lock().unwrap().update(|uc| {
+            let target = Avm2Object::from(target.fetch(uc));
+            if is_url_stream_closed(uc, target) {
+                return;
+            }
+
+            set_url_stream_disconnected(uc, target);
+
+            let complete_evt = Avm2EventObject::bare_default_event(uc, "complete");
+            Avm2::dispatch_event(uc, complete_evt, target);
+        });
+
+        Ok(())
+    })
+}
+
+/// Returns `true` if `close()` has been invoked on the URLStream while the
+/// fetch was in flight.
+fn is_url_stream_closed<'gc>(_uc: &UpdateContext<'gc>, target: Avm2Object<'gc>) -> bool {
+    use crate::avm2::globals::slots::flash_net_url_stream as slots;
+    matches!(target.get_slot(slots::_CLOSED), Avm2Value::Bool(true))
+}
+
+fn set_url_stream_connected<'gc>(uc: &UpdateContext<'gc>, target: Avm2Object<'gc>, value: bool) {
+    use crate::avm2::globals::slots::flash_net_url_stream as slots;
+    target.set_slot_no_coerce(slots::_CONNECTED, Avm2Value::Bool(value), uc.gc());
+}
+
+fn set_url_stream_disconnected<'gc>(uc: &UpdateContext<'gc>, target: Avm2Object<'gc>) {
+    set_url_stream_connected(uc, target, false);
+}
+
+fn append_url_stream_chunk<'gc>(_uc: &UpdateContext<'gc>, target: Avm2Object<'gc>, chunk: &[u8]) {
+    use crate::avm2::globals::slots::flash_net_url_stream as slots;
+
+    let data_value = target.get_slot(slots::_DATA);
+    let bytearray = match data_value.as_object().and_then(|o| o.as_bytearray_object()) {
+        Some(ba) => ba,
+        None => return,
+    };
+
+    let mut storage = bytearray.storage_mut();
+    // We want appends to land at the end of the buffer, not at the
+    // current read position. Save the read position, jump to the end,
+    // write, restore.
+    let saved_position = storage.position();
+    let end = storage.len();
+    storage.set_position(end);
+    let _ = storage.write_bytes(chunk);
+    storage.set_position(saved_position);
+}
+
 /// Kick off an AVM1 audio load.
 ///
 /// Returns the loader's async process, which you will need to spawn.


### PR DESCRIPTION
## Summary

Replaces the existing stub (a thin wrapper around `URLLoader` that delivered
the entire response body as a single `progress` event) with a true streaming
implementation conformant to the Adobe public specification.

### What changed

- **`URLStream.as`** — rewritten as `EventDispatcher implements IDataInput`
  with three `[Ruffle(NativeAccessible)]` private slots: `_data:ByteArray`
  (the read buffer), `_connected:Boolean`, `_closed:Boolean`. All
  `readXxx`, `bytesAvailable`, `endian`, and `objectEncoding` members proxy
  to `_data`. `load` and `close` are `public native function`.

- **`url_stream.rs`** (new file) — `load()` resets state, sets
  `_connected=true` **synchronously** (so `close()` called before the first
  chunk is treated as cancellation of an open stream), then spawns the async
  fetch future. `close()` throws `IOError #2029` if the stream was not open
  and clears the internal buffer per spec ("No data can be read from the
  stream after the close() method is called.").

- **`loader.rs`** — new `load_data_into_url_stream` function reuses the
  existing `SuccessResponse::next_chunk()` mechanism (already implemented
  by all backends). Per chunk: saves the read position, seeks to `len()`,
  appends the chunk, restores the position — so incremental reads inside
  `progress` listeners work correctly. The `_closed` slot is polled after
  every chunk to honour synchronous `close()` calls.

- **`error.rs`** — adds `make_error_2029` (`IOError`: "This URLStream object
  does not have an open stream."), mirroring `make_error_2002` for Socket.

### Event sequence

`open` → `httpStatus` (if HTTP and status ≠ 0) → `progress` × N → `complete`

On error: `httpStatus` (if applicable) → `ioError #2032`.
On `close()` while downloading: loop exits silently (no `complete`).

### Tested

- Existing regression test `tests/swfs/avm2/urlstream_basic` passes
  unchanged (byte-identical output).
- Manual Flex 4.6 harness covering: `IOError #2029` on premature `close()`,
  endian validation, text load (event order, `readUTFBytes`, `connected`
  flag), all typed reads (`readByte`…`readDouble`/`readUTF`/`readBoolean` +
  little-endian section), incremental streaming with per-chunk reads and
  checksum over 512 KiB, `close()` mid-download (buffer cleared,
  `EOFError #2030`), `EOFError` past EOF, and `ioError` on a missing URL.
- `cargo +beta clippy -p ruffle_core --tests -- -D warnings` → EXIT 0
- `cargo fmt --all -- --check` → clean

## Checklist
- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
