### PR TITLE
swf: Parse `DefineFontAlignZones` tag using zerocopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5615,6 +5615,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "simple_asn1",
+ "zerocopy",
 ]
 
 [[package]]
@@ -7649,18 +7650,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ tempfile = "3.27.0"
 tracing-wasm = "0.2.1"
 rascal = "0.3.4"
 jpegxr = { git = "https://github.com/ruffle-rs/jpegxr", rev = "5281b4ae42be742779269a9f1a986101f101f32f" }
+zerocopy = { version = "0.8.52", features = ["derive"] }
 
 [workspace.lints.rust]
 # Clippy nightly often adds new/buggy lints that we want to ignore.

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -23,6 +23,7 @@ flate2 = { workspace = true, optional = true }
 lzma-rs = { workspace = true, optional = true }
 enum-map = { workspace = true }
 simple_asn1 = "0.6.4"
+zerocopy = { workspace = true }
 
 [features]
 default = ["flate2", "lzma"]

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -10,6 +10,7 @@ use byteorder::{LittleEndian, ReadBytesExt};
 use simple_asn1::ASN1Block;
 use std::borrow::Cow;
 use std::io::{self, Read};
+use zerocopy::FromBytes;
 
 /// Maximum buffer capacity for reading the SWF.
 ///
@@ -1154,27 +1155,15 @@ impl<'a> Reader<'a> {
         let id = self.read_character_id()?;
         let thickness = FontThickness::from_u8(self.read_u8()? >> 6)
             .ok_or_else(|| Error::invalid_data("Invalid font thickness type."))?;
-        let mut zones = vec![];
-        while let Ok(zone) = self.read_font_align_zone() {
-            zones.push(zone);
-        }
+        let (zones, rest) = <[FontAlignZone]>::ref_from_prefix(self.get_ref())
+            .map_err(|_| Error::invalid_data("Invalid DefineFontAlignZones payload."))?;
+        *self.get_mut() = rest;
+
         Ok(Tag::DefineFontAlignZones {
             id,
             thickness,
             zones,
         })
-    }
-
-    fn read_font_align_zone(&mut self) -> Result<FontAlignZone> {
-        self.read_u8()?; // Always 2.
-        let zone = FontAlignZone {
-            left: self.read_i16()?,
-            width: self.read_i16()?,
-            bottom: self.read_i16()?,
-            height: self.read_i16()?,
-        };
-        self.read_u8()?; // Always 0b000000_11 (2 dimensions).
-        Ok(zone)
     }
 
     fn read_define_font_info(&mut self, version: u8) -> Result<FontInfo<'a>> {

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -603,20 +603,30 @@ pub fn tag_tests() -> Vec<TagTestData> {
             Tag::DefineFontAlignZones {
                 id: 1,
                 thickness: FontThickness::Thin,
-                zones: vec![
-                    FontAlignZone {
-                        left: 13098,
-                        width: 0,
-                        bottom: 0,
-                        height: 17102,
-                    },
-                    FontAlignZone {
-                        left: 15333,
-                        width: 0,
-                        bottom: 0,
-                        height: 17102,
-                    },
-                ],
+                zones: {
+                    use zerocopy::I16;
+
+                    static ZONES: [FontAlignZone; 2] = [
+                        FontAlignZone {
+                            num_zones: 2,
+                            left: I16::new(13098),
+                            width: I16::new(0),
+                            bottom: I16::new(0),
+                            height: I16::new(17102),
+                            zone_mask: 0b11,
+                        },
+                        FontAlignZone {
+                            num_zones: 2,
+                            left: I16::new(15333),
+                            width: I16::new(0),
+                            bottom: I16::new(0),
+                            height: I16::new(17102),
+                            zone_mask: 0b11,
+                        },
+                    ];
+
+                    &ZONES
+                },
             },
             read_tag_bytes_from_file(
                 "tests/swfs/DefineFont3-CS6.swf",

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -11,6 +11,7 @@ use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 use std::num::NonZeroU8;
 use std::str::FromStr;
+use zerocopy::{FromBytes, I16, Immutable, IntoBytes, KnownLayout, LE, Unaligned};
 
 mod bevel_filter;
 mod blur_filter;
@@ -541,7 +542,7 @@ pub enum Tag<'a> {
     DefineFontAlignZones {
         id: CharacterId,
         thickness: FontThickness,
-        zones: Vec<FontAlignZone>,
+        zones: &'a [FontAlignZone],
     },
     DefineFontInfo(Box<FontInfo<'a>>),
     DefineFontName {
@@ -1655,13 +1656,22 @@ impl TextAlign {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, KnownLayout, Immutable, Unaligned, FromBytes, IntoBytes,
+)]
+#[repr(C)]
 pub struct FontAlignZone {
+    /// Number of `ZoneData` entries that follow. Per the spec this is variable,
+    /// but Flash should always emit 2. Currently not validated when parsing.
+    pub num_zones: u8,
     // TODO(Herschel): Read these as f16s.
-    pub left: i16,
-    pub width: i16,
-    pub bottom: i16,
-    pub height: i16,
+    pub left: I16<LE>,
+    pub width: I16<LE>,
+    pub bottom: I16<LE>,
+    pub height: I16<LE>,
+    /// Bit 0 = has X-zone, bit 1 = has Y-zone.
+    /// Currently not used.
+    pub zone_mask: u8,
 }
 
 #[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -666,23 +666,16 @@ impl<W: Write> Writer<W> {
             Tag::DefineFont2(ref font) => self.write_define_font_2(font)?,
             Tag::DefineFont4(ref font) => self.write_define_font_4(font)?,
 
-            #[expect(clippy::unusual_byte_groupings)]
             Tag::DefineFontAlignZones {
                 id,
                 thickness,
-                ref zones,
+                zones,
             } => {
                 self.write_tag_header(TagCode::DefineFontAlignZones, 3 + 10 * zones.len() as u32)?;
                 self.write_character_id(id)?;
                 self.write_u8((thickness as u8) << 6)?;
-                for zone in zones {
-                    self.write_u8(2)?; // Always 2 dimensions.
-                    self.write_i16(zone.left)?;
-                    self.write_i16(zone.width)?;
-                    self.write_i16(zone.bottom)?;
-                    self.write_i16(zone.height)?;
-                    self.write_u8(0b000000_11)?; // Always 2 dimensions.
-                }
+                let bytes = zerocopy::IntoBytes::as_bytes(zones);
+                self.output.write_all(bytes)?;
             }
 
             Tag::DefineFontInfo(ref font_info) => self.write_define_font_info(font_info)?,


### PR DESCRIPTION
## Description

No need to allocate memory here. Zerocopy is already a transitive dependency.

## Testing

I could make tests for this if they are deemed necessary. 

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
