### PR TITLE
chore: Add ttf-parser advisory to ignored list in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -91,4 +91,5 @@ github = [
 version = 2
 
 # `paste` crate is no longer maintained https://rustsec.org/advisories/RUSTSEC-2024-0436
-ignore = ["RUSTSEC-2024-0436"]
+# `ttf-parser` crate is no longer maintained https://rustsec.org/advisories/RUSTSEC-2026-0192
+ignore = ["RUSTSEC-2024-0436", "RUSTSEC-2026-0192"]


### PR DESCRIPTION
## Description

`ttf-parser` is no longer maintained, but works fine for our usage.

## Testing

CI will stop complaining

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
