### PR TITLE
fuzzer: Replace local-dir corpus prep with git-based corpus management

### DIFF
--- a/fuzz/corpuses.toml
+++ b/fuzz/corpuses.toml
@@ -1,1 +1,1 @@
-parse_swf = "swf"
+parse_swf = "parse_swf"

--- a/tools/fuzzer/src/corpus.rs
+++ b/tools/fuzzer/src/corpus.rs
@@ -1,0 +1,101 @@
+use anyhow::anyhow;
+use std::{
+    path::Path,
+    path::PathBuf,
+    process::{Command, Output},
+};
+
+use crate::fuzz_dir;
+
+pub fn corpus_dir() -> PathBuf {
+    fuzz_dir().join("corpus")
+}
+
+fn git(dir: &Path, args: &[&str]) -> std::io::Result<Output> {
+    Command::new("git").args(args).current_dir(dir).output()
+}
+
+pub fn prepare_corpus() -> anyhow::Result<()> {
+    prepare_corpus_repo()?;
+    Ok(())
+}
+
+fn prepare_corpus_repo() -> anyhow::Result<()> {
+    let corpus_dir = corpus_dir();
+
+    if !corpus_dir.join(".git").exists() {
+        if corpus_dir.exists() {
+            return Err(anyhow!(
+                "The corpus directory exists but is not a git repository"
+            ));
+        }
+
+        let output = Command::new("git")
+            .args([
+                "clone",
+                "https://github.com/ruffle-rs/fuzz-corpus.git",
+                corpus_dir.to_str().unwrap(),
+            ])
+            .output()?;
+        if !output.status.success() {
+            eprintln!("git stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+            eprintln!("git stdout:\n{}", String::from_utf8_lossy(&output.stdout));
+            return Err(anyhow!("Failed to clone the corpus"));
+        }
+    }
+
+    let has_upstream = git(
+        &corpus_dir,
+        &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+    )?
+    .status
+    .success();
+    if !has_upstream {
+        eprintln!("Warning: The corpus repository has no upstream configured; skipping pull");
+        return Ok(());
+    }
+
+    let clean = git(&corpus_dir, &["status", "--porcelain"])?
+        .stdout
+        .is_empty();
+    if !clean {
+        eprintln!("Warning: The corpus repository has local changes; skipping pull");
+        return Ok(());
+    }
+
+    let ahead = git(&corpus_dir, &["rev-list", "--count", "@{u}..HEAD"])?;
+    let ahead: u32 = String::from_utf8_lossy(&ahead.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0);
+    if ahead > 0 {
+        eprintln!("Warning: The corpus repository has {ahead} local commit(s); skipping pull");
+        return Ok(());
+    }
+
+    let head_before = git(&corpus_dir, &["rev-parse", "HEAD"])?;
+    let head_before = String::from_utf8_lossy(&head_before.stdout)
+        .trim()
+        .to_owned();
+
+    let pull = git(&corpus_dir, &["pull"])?;
+    if !pull.status.success() {
+        return Err(anyhow!(
+            "Failed to pull the corpus:\n{}{}",
+            String::from_utf8_lossy(&pull.stdout),
+            String::from_utf8_lossy(&pull.stderr),
+        ));
+    }
+
+    let pulled = git(
+        &corpus_dir,
+        &["rev-list", "--count", &format!("{head_before}..HEAD")],
+    )?;
+    let pulled: u32 = String::from_utf8_lossy(&pulled.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0);
+    eprintln!("Pulled {pulled} commit(s) into the corpus");
+
+    Ok(())
+}

--- a/tools/fuzzer/src/lib.rs
+++ b/tools/fuzzer/src/lib.rs
@@ -6,6 +6,8 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 
+pub mod corpus;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum)]
 pub enum Fuzzer {
     Afl,
@@ -74,38 +76,6 @@ pub fn fuzz_dir() -> PathBuf {
     let dir = std::env::var("LOCAL_RUFFLE_FUZZ_WORKSPACE_DIR")
         .expect("LOCAL_RUFFLE_FUZZ_WORKSPACE_DIR is not defined");
     PathBuf::from(dir)
-}
-
-pub fn swf_tests_dir() -> PathBuf {
-    let dir = std::env::var("LOCAL_RUFFLE_TESTS_SWFS_DIR")
-        .expect("LOCAL_RUFFLE_TESTS_SWFS_DIR is not defined");
-    PathBuf::from(dir)
-}
-
-pub fn prepare_swf_tests_corpus() {
-    let swf_tests_dir = swf_tests_dir();
-    let dest = fuzz_dir().join("corpus").join("swf").join("swf_tests");
-
-    if dest.exists() {
-        fs::remove_dir_all(&dest).unwrap();
-    }
-
-    fs::create_dir_all(&dest).unwrap();
-
-    for entry in walkdir::WalkDir::new(&swf_tests_dir)
-        .follow_links(false)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "swf"))
-    {
-        let relative = entry.path().strip_prefix(&swf_tests_dir).unwrap();
-        let flat_name = relative
-            .components()
-            .map(|c| c.as_os_str().to_string_lossy())
-            .collect::<Vec<_>>()
-            .join("_");
-        fs::copy(entry.path(), dest.join(flat_name)).unwrap();
-    }
 }
 
 fn corpus_for(target: &str) -> PathBuf {

--- a/tools/fuzzer/src/main.rs
+++ b/tools/fuzzer/src/main.rs
@@ -1,8 +1,6 @@
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
-use ruffle_fuzzer::{
-    Fuzzer, build_fuzz_targets, check_fuzzers, list_targets, prepare_swf_tests_corpus,
-    run_fuzz_targets,
-};
+use ruffle_fuzzer::corpus::prepare_corpus;
+use ruffle_fuzzer::{Fuzzer, build_fuzz_targets, check_fuzzers, list_targets, run_fuzz_targets};
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -102,7 +100,7 @@ fn main() -> Result<(), anyhow::Error> {
             }
         }
         Commands::Prepare => {
-            prepare_swf_tests_corpus();
+            prepare_corpus()?;
         }
         Commands::Build { target, fuzzer } => {
             check_fuzzers(&fuzzer)?;
@@ -118,7 +116,7 @@ fn main() -> Result<(), anyhow::Error> {
             check_fuzzers(&fuzzer)?;
 
             if !no_prepare {
-                prepare_swf_tests_corpus();
+                prepare_corpus()?;
             }
 
             if !no_build {


### PR DESCRIPTION

## Description

Remove `prepare_swf_tests_corpus` which copied SWF files from a local directory pointed to by `LOCAL_RUFFLE_TESTS_SWFS_DIR`. Replace it with a `corpus` module that clones `ruffle-rs/fuzz-corpus` from GitHub and pulls updates if the working tree is clean and has no unpushed commits.

Also fix the `parse_swf` corpus key in `corpuses.toml` to match the actual fuzz target name.

## Testing

N/A

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
