### PR TITLE
ci: Report macOS universal binary bundle notarization failure on Discord

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,6 +333,7 @@ jobs:
           codesign --verify -vvvv package/Ruffle.app
 
       - name: Notarize bundle
+        id: notarize-bundle
         continue-on-error: true
         run: |
           xcrun notarytool store-credentials "Ruffle" --apple-id ${{ secrets.APPLE_ID }} --team-id ${{ secrets.APPLE_TEAM }} --password ${{ secrets.APPLE_APP_PASSWORD }}
@@ -342,6 +343,16 @@ jobs:
           cd ..
           xcrun notarytool submit Ruffle.zip --keychain-profile Ruffle --wait
           xcrun stapler staple package/Ruffle.app
+
+      - name: Report notarization failure on Discord
+        uses: th0th/notify-discord@v0.4.1
+        if: ${{ steps.notarize-bundle.outcome == 'failure' && github.repository == 'ruffle-rs/ruffle' }}
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_JOB_NAME: "Notarize macOS universal binary bundle"
+          GITHUB_JOB_STATUS: ${{ steps.notarize-bundle.outcome }}
 
       - name: Package macOS
         run: |


### PR DESCRIPTION
## Description

Since Apple requires us to agree to their updated developer agreement from time to time, let's try to be notified about this.

Mostly copied from the Firefox extension builder Dockerfile reproducibility tester workflow.
I think this will post into the #github-updates channel, don't know how useful that is (it tends to be spammy).
Maybe we could add some pings or something...? Or set up a different webhook for a different channel...

Note: We could consider switching from https://github.com/th0th/notify-discord/ to the more recently updated https://github.com/stegzilla/discord-notify.

## Testing

Don't agree to the new Apple agreement until tomorrow, and see if a message pops up on Discord about it.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
