### PR TITLE
web: Add more Twitch domains to extension blocklist

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -18,6 +18,11 @@
                 "https://sso.godaddy.com/*", // See https://github.com/ruffle-rs/ruffle/pull/7146
                 "https://authentication.td.com/*", // See https://github.com/ruffle-rs/ruffle/issues/2158
                 "https://*.twitch.tv/*", // See https://github.com/ruffle-rs/ruffle/pull/8150
+                "https://*.twitchcdn.net/*", // See https://github.com/ruffle-rs/ruffle/issues/23929
+                "https://*.ext-twitch.tv/*", // See https://github.com/ruffle-rs/ruffle/issues/23929
+                "https://*.jtvnw.net/*", // See https://github.com/ruffle-rs/ruffle/issues/23929
+                "https://*.ttvnw.net/*", // See https://github.com/ruffle-rs/ruffle/issues/23929
+                "https://*.live-video.net/*", // See https://github.com/ruffle-rs/ruffle/issues/23929
                 "https://www.tuxedocomputers.com/*", // See https://github.com/ruffle-rs/ruffle/issues/11906
                 "https://*.taobao.com/*", // See https://github.com/ruffle-rs/ruffle/pull/12650
                 "https://*.time4learning.com/*", // See https://github.com/ruffle-rs/ruffle/pull/16186


### PR DESCRIPTION

## Description

* Fixes https://github.com/ruffle-rs/ruffle/issues/23929

Running Ruffle on *.twitchcdn.net caused Twitch to misbehave.

This patch also adds other Twitch domains just in case.

## Testing

Without this patch, Twitch says my browser is unsupported when trying to log in. With `*.twitchcdn.net` on the blocklist the error is gone.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
