### PR TITLE
tests: Add context for SWF parsing errors

### DIFF
--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -82,7 +82,7 @@ impl Test {
             false,
             None,
         )
-        .map_err(|e| anyhow!(e.to_string()))?;
+        .map_err(|e| anyhow!("Error parsing SWF: {e}"))?;
         Ok(movie)
     }
 


### PR DESCRIPTION

## Description
Without it, it just printed a generic message without indicating what's the issue.

## Testing

Tested manually by providing a SWF that fails to parse.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
