### PR TITLE
swf: Read decompressed data to header-declared length

### DIFF
--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -86,8 +86,14 @@ pub fn decompress_swf<'a, R: Read + 'a>(mut input: R) -> Result<SwfBuf> {
         return Err(Error::invalid_data("Invalid SWF version"));
     }
 
+    // Uncompressed length includes the 4-byte header and 4-byte uncompressed length itself,
+    // subtract it here.
+    let body_len = uncompressed_len
+        .checked_sub(8)
+        .ok_or_else(|| Error::invalid_data("Malformed SWF length"))?;
+
     // Now the SWF switches to a compressed stream.
-    let mut decompress_stream: Box<dyn Read> = match compression {
+    let decompress_stream: Box<dyn Read> = match compression {
         Compression::None => Box::new(input),
         Compression::Zlib => {
             if version < 6 {
@@ -99,18 +105,17 @@ pub fn decompress_swf<'a, R: Read + 'a>(mut input: R) -> Result<SwfBuf> {
             if version < 13 {
                 log::warn!("LZMA compressed SWF is version {version} but minimum version is 13");
             }
-            // Uncompressed length includes the 4-byte header and 4-byte uncompressed length itself,
-            // subtract it here.
-            let unpacked_size = uncompressed_len
-                .checked_sub(8)
-                .ok_or_else(|| Error::invalid_data("Malformed LZMA length"))?;
-            make_lzma_reader(input, unpacked_size)?
+            make_lzma_reader(input, body_len)?
         }
     };
 
-    // Decompress the entire SWF.
-    let mut data = Vec::with_capacity(uncompressed_len.min(MAX_DATA_CAPACITY) as usize);
-    if let Err(e) = decompress_stream.read_to_end(&mut data) {
+    // Flash Player allocates a fixed buffer based on the header length and
+    // never accesses data beyond it. Match that behavior by capping reads here.
+    let mut data = Vec::with_capacity(body_len.min(MAX_DATA_CAPACITY) as usize);
+    if let Err(e) = decompress_stream
+        .take(body_len as u64)
+        .read_to_end(&mut data)
+    {
         log::error!("Error decompressing SWF: {e}");
     }
 

--- a/tests/tests/swfs/swf/swf_length_too_short_no_second_frame/test.toml
+++ b/tests/tests/swfs/swf/swf_length_too_short_no_second_frame/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 16
-known_failure.panic = "attempt to subtract with overflow"

--- a/tests/tests/swfs/swf/swf_length_zero/test.toml
+++ b/tests/tests/swfs/swf/swf_length_zero/test.toml
@@ -1,5 +1,9 @@
 num_ticks = 16
-known_failure.panic = "attempt to subtract with overflow"
+
+# FIXME Reading the SWF file currently errors out, and we do not have a way of
+# asserting on that. Maybe move this test to swf crate's tests? Add a way of
+# asserting on error?
+ignore = true
 
 [[compilers]]
 type = "Rascal"


### PR DESCRIPTION

## Description

Flash Player allocates a fixed buffer based on the uncompressed_len field in the SWF header and never accesses data beyond it. Match that behavior by reading the decompressed data up to the header-declared length only.

This fixes a panic---subtraction overflow in loaded_bytes.

Partially overlaps with https://github.com/ruffle-rs/ruffle/pull/23324.

## Testing

Makes an existing test pass.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
