### PR TITLE
tests: Use `known_failure.panic` instead of `ignore = true` for PR #24116's tests

### DIFF
--- a/tests/tests/swfs/swf/swf_length_too_short_no_second_frame/test.toml
+++ b/tests/tests/swfs/swf/swf_length_too_short_no_second_frame/test.toml
@@ -1,3 +1,2 @@
 num_ticks = 16
-# TODO This test panics.
-ignore = true
+known_failure.panic = "attempt to subtract with overflow"

--- a/tests/tests/swfs/swf/swf_length_zero/test.toml
+++ b/tests/tests/swfs/swf/swf_length_zero/test.toml
@@ -1,6 +1,5 @@
 num_ticks = 16
-# TODO This test panics.
-ignore = true
+known_failure.panic = "attempt to subtract with overflow"
 
 [[compilers]]
 type = "Rascal"


### PR DESCRIPTION
The less ignored tests, the better!

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
