### PR TITLE
avm2: Remove Error.getErrorMessage()'s stub call

### DIFF
--- a/core/src/avm2/globals/error.rs
+++ b/core/src/avm2/globals/error.rs
@@ -1,3 +1,4 @@
+use crate::PlayerMode;
 use crate::avm2::activation::Activation;
 use crate::avm2::error::Error;
 use crate::avm2::error_messages::raw_error_message;
@@ -5,7 +6,6 @@ use crate::avm2::object::ErrorObject;
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
 use crate::string::{AvmString, WString};
-use crate::{PlayerMode, avm2_stub_method};
 
 pub use crate::avm2::object::error_allocator;
 
@@ -29,8 +29,6 @@ pub fn get_error_message<'gc>(
     _this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm2_stub_method!(activation, "Error", "getErrorMessage");
-
     let id = args.get_i32(0);
 
     let prefix = format!("Error #{id}");


### PR DESCRIPTION

## Description

Forgot to remove it when implementing Error.getErrorMessage().

## Testing

N/A
## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
