### PR TITLE
video: Reduce allocations/copies when decoding frames

### DIFF
--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -117,6 +117,17 @@ pub struct Bitmap<'a> {
 }
 
 impl<'a> Bitmap<'a> {
+    // Produces an zero-sized image with the given format.
+    #[inline]
+    pub fn empty(format: BitmapFormat) -> Self {
+        Self {
+            width: 0,
+            height: 0,
+            format,
+            data: Cow::Borrowed(&[]),
+        }
+    }
+
     /// Ensures that `data` is the correct size for the given `width` and `height`.
     #[inline]
     pub fn new<D>(width: u32, height: u32, format: BitmapFormat, data: D) -> Self
@@ -168,6 +179,21 @@ impl<'a> Bitmap<'a> {
         if let Cow::Owned(buf) = data {
             buf.resize(expected_len, 0);
         }
+    }
+
+    #[inline]
+    pub fn reborrow(&self) -> Bitmap<'_> {
+        Bitmap {
+            width: self.width,
+            height: self.height,
+            format: self.format,
+            data: Cow::Borrowed(&self.data),
+        }
+    }
+
+    #[inline]
+    pub fn into_buf(self) -> Cow<'a, [u8]> {
+        self.data
     }
 
     pub fn to_rgb(mut self) -> Self {

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -123,31 +123,12 @@ impl<'a> Bitmap<'a> {
     where
         D: Into<Cow<'a, [u8]>>,
     {
-        Self::new_impl(width, height, format, data.into())
-    }
+        let mut data = data.into();
 
-    fn new_impl(width: u32, height: u32, format: BitmapFormat, mut data: Cow<'a, [u8]>) -> Self {
         // If the size is incorrect, either we screwed up or the decoder screwed up.
         let expected_len = format.length_for_size(width as usize, height as usize);
         if data.len() != expected_len {
-            tracing::warn!(
-                "Incorrect bitmap data size, expected {} bytes, got {}",
-                expected_len,
-                data.len(),
-            );
-
-            // Truncate or zero-pad to the expected size.
-            if let Cow::Borrowed(slice) = &data {
-                // Allocate the owned buffer ourselves instead of using `Cow::to_mut`, to avoid
-                // a reallocation if the buffer needs to be padded.
-                let mut vec = Vec::with_capacity(expected_len);
-                vec.extend_from_slice(&slice[..expected_len]);
-                data = Cow::Owned(vec);
-            }
-            match &mut data {
-                Cow::Owned(data) => data.resize(expected_len, 0),
-                Cow::Borrowed(_) => unreachable!(),
-            }
+            Self::resize_data(&mut data, expected_len);
         }
 
         Self {
@@ -155,6 +136,37 @@ impl<'a> Bitmap<'a> {
             height,
             format,
             data,
+        }
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn resize_data(data: &mut Cow<'_, [u8]>, expected_len: usize) {
+        let len = data.len();
+        assert!(len != expected_len);
+        tracing::warn!("Incorrect bitmap data size, expected {expected_len} bytes, got {len}");
+
+        match (&mut *data, expected_len.checked_sub(len)) {
+            // Not enough data: ensure we have an owned buffer with enough space to hold
+            // the extra padding.
+            (Cow::Borrowed(slice), Some(_)) => {
+                // Allocate the owned buffer ourselves instead of using `Cow::to_mut`, to avoid
+                // a reallocation if the buffer needs to be padded.
+                let mut vec = Vec::with_capacity(expected_len);
+                vec.extend_from_slice(slice);
+                *data = Cow::Owned(vec);
+            }
+            (Cow::Owned(buf), Some(extra)) => buf.reserve_exact(extra),
+
+            // Too much data: truncate the excess.
+            (Cow::Borrowed(slice), None) => *slice = &slice[..expected_len],
+            // The `resize` call just after this will take care of the truncation.
+            (Cow::Owned(_), None) => (),
+        }
+
+        // Thanks to the previous `match`, this will never have to reallocate.
+        if let Cow::Owned(buf) = data {
+            buf.resize(expected_len, 0);
         }
     }
 

--- a/video/external/src/backend.rs
+++ b/video/external/src/backend.rs
@@ -180,9 +180,7 @@ impl VideoBackend for ExternalVideoBackend {
                 self.software
                     .decode_video_stream_frame(*handle, encoded_frame, renderer)
             }
-            ProxyOrStream::Owned(stream) => {
-                let frame = stream.decoder.decode_frame(encoded_frame)?;
-
+            ProxyOrStream::Owned(stream) => stream.decoder.decode_frame(encoded_frame, |frame| {
                 let width = frame.width();
                 let height = frame.height();
 
@@ -203,7 +201,7 @@ impl VideoBackend for ExternalVideoBackend {
                     width,
                     height,
                 })
-            }
+            }),
         }
     }
 }

--- a/video/external/src/decoder/openh264.rs
+++ b/video/external/src/decoder/openh264.rs
@@ -317,7 +317,11 @@ impl VideoDecoder for H264Decoder {
         }
     }
 
-    fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error> {
+    fn decode_frame_dyn(
+        &mut self,
+        encoded_frame: EncodedFrame<'_>,
+        callback: &mut dyn FnMut(DecodedFrame<'_>),
+    ) -> Result<(), Error> {
         assert!(self.length_size > 0, "Decoder not configured");
         unsafe {
             let decoder_vtbl = (*self.decoder).as_ref().unwrap();
@@ -400,12 +404,13 @@ impl VideoDecoder for H264Decoder {
             // when encoded image size doesn't match declared video tag size.
             // NOTE: This will always use the BT.601 coefficients, which may or may
             // not be correct. So far I haven't seen anything to the contrary in FP.
-            Ok(DecodedFrame::new(
+            callback(DecodedFrame::new(
                 buffer_info.iWidth as u32,
                 buffer_info.iHeight as u32,
                 BitmapFormat::Yuv420p,
                 yuv,
-            ))
+            ));
+            Ok(())
         }
     }
 }

--- a/video/external/src/decoder/openh264.rs
+++ b/video/external/src/decoder/openh264.rs
@@ -199,6 +199,8 @@ pub struct H264Decoder {
 
     openh264: Arc<OpenH264>,
     decoder: *mut ISVCDecoder,
+
+    scratch: Vec<u8>,
 }
 
 struct OpenH264Data {
@@ -225,6 +227,7 @@ impl H264Decoder {
                 length_size: 0,
                 openh264,
                 decoder,
+                scratch: Vec::new(),
             }
         }
     }
@@ -259,7 +262,8 @@ impl VideoDecoder for H264Decoder {
             let decoder_vtbl = (*self.decoder).as_ref().unwrap();
 
             //input: encoded bitstream start position; should include start code prefix
-            let mut buffer: Vec<c_uchar> = Vec::new();
+            self.scratch.clear();
+            let buffer: &mut Vec<c_uchar> = &mut self.scratch;
 
             // Converting from AVCC to Annex B (stream-like) format,
             // putting the PPS and SPS into a NALU.
@@ -329,7 +333,11 @@ impl VideoDecoder for H264Decoder {
             // input: encoded bitstream start position; should include start code prefix
             // converting from AVCC (file-like) to Annex B (stream-like) format
             // Thankfully the start code emulation prevention is there in both.
-            let mut buffer: Vec<c_uchar> = Vec::with_capacity(encoded_frame.data.len());
+            self.scratch.clear();
+            let buffer: &mut Vec<c_uchar> = &mut self.scratch;
+            // Not `reserve_exact`; encoded len varies from frame to frame so some slack is
+            // welcome here.
+            buffer.reserve(encoded_frame.data.len());
 
             let mut i = 0;
             while i < encoded_frame.data.len() {
@@ -361,9 +369,7 @@ impl VideoDecoder for H264Decoder {
                 ));
             }
             if dest_buf_info.iBufferStatus != 1 {
-                return Err(Error::DecoderError(
-                    "No output frame produced by the decoder".into(),
-                ));
+                return Err(Error::DecoderNoOutputFrame);
             }
             let buffer_info = dest_buf_info.UsrData.sSystemBuffer;
             if buffer_info.iFormat != videoFormatI420 as c_int {
@@ -372,8 +378,11 @@ impl VideoDecoder for H264Decoder {
                 ));
             }
 
-            let mut yuv: Vec<u8> = Vec::with_capacity(
-                buffer_info.iWidth as usize * buffer_info.iHeight as usize * 3 / 2,
+            self.scratch.clear();
+            let yuv: &mut Vec<u8> = &mut self.scratch;
+            yuv.reserve_exact(
+                BitmapFormat::Yuv420p
+                    .length_for_size(buffer_info.iWidth as usize, buffer_info.iHeight as usize),
             );
 
             // Copying Y
@@ -408,7 +417,7 @@ impl VideoDecoder for H264Decoder {
                 buffer_info.iWidth as u32,
                 buffer_info.iHeight as u32,
                 BitmapFormat::Yuv420p,
-                yuv,
+                yuv.as_slice(),
             ));
             Ok(())
         }

--- a/video/external/src/decoder/webcodecs.rs
+++ b/video/external/src/decoder/webcodecs.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::mem;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -54,7 +55,7 @@ pub struct H264Decoder {
     ///
     /// This in itself results in one frame of delay (because we can't block decode_frame
     /// until the callback is invoked), but it shouldn't matter in practice.
-    last_frame: Rc<RefCell<Option<DecodedFrame<'static>>>>,
+    last_frame: Rc<RefCell<LastFrame>>,
 
     // Simply keeping these objects alive, as they are used by the JS side.
     // See: https://rustwasm.github.io/wasm-bindgen/examples/closures.html
@@ -64,75 +65,86 @@ pub struct H264Decoder {
     error_callback: Closure<dyn Fn(DomException)>,
 }
 
+struct LastFrame {
+    status: Result<(), Error>,
+    // This is kept separate from `status` so that it can be reused between frames.
+    data: DecodedFrame<'static>,
+}
+
 impl H264Decoder {
     /// `extradata` should hold "AVCC (MP4) format" decoder configuration, including PPS and SPS.
     /// Make sure it has any start code emulation prevention "three bytes" removed.
     ///
     /// The log_subscriber is needed so that we have proper logging from within the callbacks.
     pub fn new(log_subscriber: Arc<Layered<WASMLayer, Registry>>) -> Result<Self, Error> {
-        let last_frame = Rc::new(RefCell::new(None));
+        let last_frame = Rc::new(RefCell::new(LastFrame {
+            status: Err(Error::DecoderNoOutputFrame),
+            data: DecodedFrame::empty(BitmapFormat::Rgb),
+        }));
         let lf = last_frame.clone();
 
         let log_subscriber_for_output = log_subscriber.clone();
         let output = move |output: &VideoFrame| {
             let _subscriber = tracing::subscriber::set_default(log_subscriber_for_output.clone());
             let visible_rect = output.visible_rect().unwrap();
+            let (width, height) = (visible_rect.width() as u32, visible_rect.height() as u32);
 
-            match output.format().unwrap() {
-                VideoPixelFormat::I420 => {
-                    let mut data: Vec<u8> =
-                        vec![
-                            0;
-                            visible_rect.width() as usize * visible_rect.height() as usize * 3 / 2
-                        ];
-                    let _ = output.copy_to_with_u8_slice(&mut data);
-                    last_frame.replace(Some(DecodedFrame::new(
-                        visible_rect.width() as u32,
-                        visible_rect.height() as u32,
-                        BitmapFormat::Yuv420p,
-                        data,
-                    )));
-                }
-                VideoPixelFormat::Bgrx => {
-                    let mut data: Vec<u8> =
-                        vec![0; visible_rect.width() as usize * visible_rect.height() as usize * 4];
-                    let _ = output.copy_to_with_u8_slice(&mut data);
-                    for pixel in data.chunks_mut(4) {
-                        pixel.swap(0, 2);
-                        pixel[3] = 0xff;
+            type FormatProcessor<'a> = (BitmapFormat, &'a dyn Fn(&mut Vec<u8>));
+
+            let src_format = output.format().unwrap();
+            let processor: Result<FormatProcessor<'_>, _> = match src_format {
+                VideoPixelFormat::I420 => Ok((BitmapFormat::Yuv420p, &|_data| {
+                    // nothing to do
+                })),
+                VideoPixelFormat::Bgrx => Ok((BitmapFormat::Rgba, &|data| {
+                    for [b, _g, r, x] in data.as_chunks_mut::<4>().0 {
+                        std::mem::swap(b, r);
+                        *x = 0xff;
                     }
-                    last_frame.replace(Some(DecodedFrame::new(
-                        visible_rect.width() as u32,
-                        visible_rect.height() as u32,
-                        BitmapFormat::Rgba,
-                        data,
-                    )));
-                }
-                VideoPixelFormat::Nv12 => {
-                    let luma_len = visible_rect.width() as usize * visible_rect.height() as usize;
-                    let chroma_len = (visible_rect.width() as usize).div_ceil(2)
-                        * (visible_rect.height() as usize).div_ceil(2);
-                    let mut data: Vec<u8> = vec![0; luma_len + chroma_len * 2];
-                    let _ = output.copy_to_with_u8_slice(&mut data);
-                    let chroma = data.split_off(luma_len);
-                    let chroma_pairs = chroma.as_chunks::<2>().0;
-                    for uv in chroma_pairs {
-                        data.push(uv[0]);
+                })),
+                VideoPixelFormat::Nv12 => Ok((BitmapFormat::Yuv420p, &|data| {
+                    let luma_len = width as usize * height as usize;
+                    let chroma_len = width.div_ceil(2) as usize * height.div_ceil(2) as usize;
+                    assert_eq!(luma_len + 2 * chroma_len, data.len());
+
+                    // Need some scratch space to deinterlace chroma pairs
+                    let original_len = data.len();
+                    data.extend_from_within(luma_len..);
+
+                    let (dst, chroma_pairs) = data.split_at_mut(original_len);
+                    let (u_dst, v_dst) = dst[luma_len..].split_at_mut(chroma_len);
+
+                    use std::iter::zip;
+                    for ((u, v), uv) in zip(zip(u_dst, v_dst), chroma_pairs.as_chunks::<2>().0) {
+                        *u = uv[0];
+                        *v = uv[1];
                     }
-                    for uv in chroma_pairs {
-                        data.push(uv[1]);
-                    }
-                    last_frame.replace(Some(DecodedFrame::new(
-                        visible_rect.width() as u32,
-                        visible_rect.height() as u32,
-                        BitmapFormat::Yuv420p,
-                        data,
-                    )));
-                }
-                other_format => {
-                    error!("Unsupported pixel format: {:?}", other_format);
-                }
+
+                    // Clear scratch space
+                    data.truncate(original_len);
+                })),
+                other_format => Err(Error::DecoderError(
+                    format!("Unsupported pixel format: {other_format:?}").into(),
+                )),
             };
+
+            let mut frame = last_frame.borrow_mut();
+            frame.status = processor.map(|(dst_format, process_pixels)| {
+                let size_in_bytes = dst_format.length_for_size(width as usize, height as usize);
+
+                // Recycle the last frame's buffer.
+                let mut data = mem::replace(&mut frame.data, DecodedFrame::empty(dst_format))
+                    .into_buf()
+                    .into_owned();
+                data.clear();
+                data.reserve_exact(size_in_bytes);
+
+                data.resize(size_in_bytes, 0);
+                let _ = output.copy_to_with_u8_slice(&mut data);
+                process_pixels(&mut data);
+
+                frame.data = DecodedFrame::new(width, height, dst_format, data);
+            });
 
             output.close();
         };
@@ -291,14 +303,8 @@ impl VideoDecoder for H264Decoder {
             .map_err(js_error_to_decoder_error)?;
         trace!("decoder state: {:?}", self.decoder.state());
 
-        match self.last_frame.borrow_mut().take() {
-            Some(frame) => {
-                callback(frame);
-                Ok(())
-            }
-            None => Err(Error::DecoderError(
-                "No output frame produced by the decoder".into(),
-            )),
-        }
+        let mut frame = self.last_frame.borrow_mut();
+        mem::replace(&mut frame.status, Err(Error::DecoderNoOutputFrame))
+            .map(|()| callback(frame.data.reborrow()))
     }
 }

--- a/video/external/src/decoder/webcodecs.rs
+++ b/video/external/src/decoder/webcodecs.rs
@@ -54,7 +54,7 @@ pub struct H264Decoder {
     ///
     /// This in itself results in one frame of delay (because we can't block decode_frame
     /// until the callback is invoked), but it shouldn't matter in practice.
-    last_frame: Rc<RefCell<Option<DecodedFrame>>>,
+    last_frame: Rc<RefCell<Option<DecodedFrame<'static>>>>,
 
     // Simply keeping these objects alive, as they are used by the JS side.
     // See: https://rustwasm.github.io/wasm-bindgen/examples/closures.html
@@ -265,7 +265,11 @@ impl VideoDecoder for H264Decoder {
         Ok(FrameDependency::Past)
     }
 
-    fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error> {
+    fn decode_frame_dyn(
+        &mut self,
+        encoded_frame: EncodedFrame<'_>,
+        callback: &mut dyn FnMut(DecodedFrame<'_>),
+    ) -> Result<(), Error> {
         debug!("decoding frame {}", encoded_frame.frame_id);
         trace!("decoder state: {:?}", self.decoder.state());
         trace!("queue size: {}", self.decoder.decode_queue_size());
@@ -288,7 +292,10 @@ impl VideoDecoder for H264Decoder {
         trace!("decoder state: {:?}", self.decoder.state());
 
         match self.last_frame.borrow_mut().take() {
-            Some(frame) => Ok(frame),
+            Some(frame) => {
+                callback(frame);
+                Ok(())
+            }
             None => Err(Error::DecoderError(
                 "No output frame produced by the decoder".into(),
             )),

--- a/video/software/src/backend.rs
+++ b/video/software/src/backend.rs
@@ -86,23 +86,27 @@ impl VideoBackend for SoftwareVideoBackend {
             .get_mut(stream)
             .ok_or(Error::VideoStreamIsNotRegistered)?;
 
-        let frame = stream.decoder.decode_frame(encoded_frame)?;
+        stream.decoder.decode_frame(encoded_frame, |frame| {
+            let width = frame.width();
+            let height = frame.height();
 
-        let width = frame.width();
-        let height = frame.height();
+            let handle = if let Some(bitmap) = stream.bitmap.clone() {
+                renderer.update_texture(
+                    &bitmap,
+                    frame,
+                    PixelRegion::for_whole_size(width, height),
+                )?;
+                bitmap
+            } else {
+                renderer.register_bitmap(frame)?
+            };
+            stream.bitmap = Some(handle.clone());
 
-        let handle = if let Some(bitmap) = stream.bitmap.clone() {
-            renderer.update_texture(&bitmap, frame, PixelRegion::for_whole_size(width, height))?;
-            bitmap
-        } else {
-            renderer.register_bitmap(frame)?
-        };
-        stream.bitmap = Some(handle.clone());
-
-        Ok(BitmapInfo {
-            handle,
-            width,
-            height,
+            Ok(BitmapInfo {
+                handle,
+                width,
+                height,
+            })
         })
     }
 }

--- a/video/software/src/decoder.rs
+++ b/video/software/src/decoder.rs
@@ -40,7 +40,34 @@ pub trait VideoDecoder {
     /// Frames may be decoded in any order that does not violate the frame
     /// dependencies declared by the output of `preload_video_stream_frame`.
     ///
-    /// The decoded frame should be returned. An `Error` can be returned if
-    /// a drawable bitmap can not be produced.
-    fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error>;
+    /// Either calls the provided `callback` *once* with the decoded frame and
+    /// returns `Ok(())`, or returns an error if the frame could not be decoded.
+    ///
+    /// Note: this uses a callback instead of a simple return value to give
+    /// decoders full control over the lifetime of the decoded frame data.
+    fn decode_frame_dyn(
+        &mut self,
+        encoded_frame: EncodedFrame<'_>,
+        callback: &mut dyn FnMut(DecodedFrame<'_>),
+    ) -> Result<(), Error>;
+}
+
+impl dyn VideoDecoder {
+    /// Helper method to wrangle the dyn-compatible `decode_frame_dyn` API into
+    /// something friendlier.
+    pub fn decode_frame<R>(
+        &mut self,
+        encoded_frame: EncodedFrame<'_>,
+        callback: impl FnOnce(DecodedFrame<'_>) -> Result<R, Error>,
+    ) -> Result<R, Error> {
+        let mut cb = Some(callback);
+        let mut r = Err(Error::DecoderNoOutputFrame);
+        self.decode_frame_dyn(encoded_frame, &mut |decoded| {
+            r = match cb.take() {
+                Some(cb) => cb(decoded),
+                None => Err(Error::DecoderMultipleOutputFrames),
+            };
+        })?;
+        r
+    }
 }

--- a/video/software/src/decoder/h263.rs
+++ b/video/software/src/decoder/h263.rs
@@ -29,14 +29,19 @@ impl From<H263Error> for Error {
 }
 
 /// H263 video decoder.
-pub struct H263Decoder(H263State, VideoDeblocking);
+pub struct H263Decoder {
+    state: H263State,
+    deblock: VideoDeblocking,
+    scratch: Vec<u8>,
+}
 
 impl H263Decoder {
     pub fn new(deblock: VideoDeblocking) -> Self {
-        Self(
-            H263State::new(DecoderOption::SORENSON_SPARK_BITSTREAM),
+        Self {
+            state: H263State::new(DecoderOption::SORENSON_SPARK_BITSTREAM),
             deblock,
-        )
+            scratch: Vec::new(),
+        }
     }
 }
 
@@ -44,7 +49,7 @@ impl VideoDecoder for H263Decoder {
     fn preload_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<FrameDependency, Error> {
         let mut reader = H263Reader::from_source(encoded_frame.data());
         let picture = self
-            .0
+            .state
             .parse_picture(&mut reader, None)
             .map_err(H263Error::DecoderError)?
             .ok_or(H263Error::NoPictureInVideoStream)?;
@@ -64,12 +69,12 @@ impl VideoDecoder for H263Decoder {
     ) -> Result<(), Error> {
         let mut reader = H263Reader::from_source(encoded_frame.data());
 
-        self.0
+        self.state
             .decode_next_picture(&mut reader)
             .map_err(H263Error::DecoderError)?;
 
         let picture = self
-            .0
+            .state
             .get_last_picture()
             .expect("Decoding a picture should let us grab that picture");
 
@@ -79,44 +84,39 @@ impl VideoDecoder for H263Decoder {
             .ok_or(H263Error::MissingWidthHeight)?;
         let (y, b, r) = picture.as_yuv();
 
-        let hdr = picture.as_header();
+        self.scratch.clear();
+        let data = &mut self.scratch;
+        data.reserve_exact(y.len() + b.len() + r.len());
 
-        if self.1 == VideoDeblocking::Level1
-            || (self.1 == VideoDeblocking::UseVideoPacketValue
+        let hdr = picture.as_header();
+        if self.deblock == VideoDeblocking::Level1
+            || (self.deblock == VideoDeblocking::UseVideoPacketValue
                 && hdr.options.contains(PictureOption::USE_DEBLOCKER))
         {
             let chroma_width = picture.chroma_samples_per_row();
             let quantizer = hdr.quantizer as usize;
             let strength = QUANT_TO_STRENGTH[quantizer];
 
+            // TODO: it'd be nice if `h263_rs_deblock` provided in-place deblocking
             let y = deblock(y, width as usize, strength);
             let b = deblock(b, chroma_width, strength);
             let r = deblock(r, chroma_width, strength);
 
-            let mut data = Vec::with_capacity(y.len() + b.len() + r.len());
             data.extend_from_slice(&y);
             data.extend_from_slice(&b);
             data.extend_from_slice(&r);
-
-            callback(DecodedFrame::new(
-                width as u32,
-                height as u32,
-                BitmapFormat::Yuv420p,
-                data,
-            ));
         } else {
-            let mut data = Vec::with_capacity(y.len() + b.len() + r.len());
             data.extend_from_slice(y);
             data.extend_from_slice(b);
             data.extend_from_slice(r);
-
-            callback(DecodedFrame::new(
-                width as u32,
-                height as u32,
-                BitmapFormat::Yuv420p,
-                data,
-            ));
         }
+
+        callback(DecodedFrame::new(
+            width as u32,
+            height as u32,
+            BitmapFormat::Yuv420p,
+            data.as_slice(),
+        ));
         Ok(())
     }
 }

--- a/video/software/src/decoder/h263.rs
+++ b/video/software/src/decoder/h263.rs
@@ -57,7 +57,11 @@ impl VideoDecoder for H263Decoder {
         }
     }
 
-    fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error> {
+    fn decode_frame_dyn(
+        &mut self,
+        encoded_frame: EncodedFrame<'_>,
+        callback: &mut dyn FnMut(DecodedFrame<'_>),
+    ) -> Result<(), Error> {
         let mut reader = H263Reader::from_source(encoded_frame.data());
 
         self.0
@@ -94,25 +98,26 @@ impl VideoDecoder for H263Decoder {
             data.extend_from_slice(&b);
             data.extend_from_slice(&r);
 
-            Ok(DecodedFrame::new(
+            callback(DecodedFrame::new(
                 width as u32,
                 height as u32,
                 BitmapFormat::Yuv420p,
                 data,
-            ))
+            ));
         } else {
             let mut data = Vec::with_capacity(y.len() + b.len() + r.len());
             data.extend_from_slice(y);
             data.extend_from_slice(b);
             data.extend_from_slice(r);
 
-            Ok(DecodedFrame::new(
+            callback(DecodedFrame::new(
                 width as u32,
                 height as u32,
                 BitmapFormat::Yuv420p,
                 data,
-            ))
+            ));
         }
+        Ok(())
     }
 }
 

--- a/video/software/src/decoder/screen.rs
+++ b/video/software/src/decoder/screen.rs
@@ -148,7 +148,11 @@ impl VideoDecoder for ScreenVideoDecoder {
         }
     }
 
-    fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error> {
+    fn decode_frame_dyn(
+        &mut self,
+        encoded_frame: EncodedFrame<'_>,
+        callback: &mut dyn FnMut(DecodedFrame<'_>),
+    ) -> Result<(), Error> {
         let is_keyframe = encoded_frame.data[0] >> 4 == 1;
 
         if !is_keyframe && self.last_frame.is_none() {
@@ -204,12 +208,13 @@ impl VideoDecoder for ScreenVideoDecoder {
 
         self.last_frame = Some(data);
 
-        Ok(DecodedFrame::new(
+        callback(DecodedFrame::new(
             w as u32,
             h as u32,
             BitmapFormat::Rgb,
             rgb,
-        ))
+        ));
+        Ok(())
     }
 }
 

--- a/video/software/src/decoder/screen.rs
+++ b/video/software/src/decoder/screen.rs
@@ -39,9 +39,9 @@ pub struct ScreenVideoDecoder {
     block_w: usize,
     block_h: usize,
 
-    tile: Vec<u8>, // acts as a scratch buffer
+    scratch: Vec<u8>,
 
-    last_frame: Option<Vec<u8>>,
+    last_frame: Vec<u8>,
 }
 
 struct ByteReader<'a> {
@@ -86,17 +86,15 @@ impl ScreenVideoDecoder {
             h: 0,
             block_w: 0,
             block_h: 0,
-            tile: vec![],
-            last_frame: None,
+            scratch: vec![],
+            last_frame: vec![],
         }
     }
 
-    fn decode_v1(
-        &mut self,
-        src: &mut ByteReader,
-        data: &mut [u8],
-        stride: usize,
-    ) -> Result<bool, Error> {
+    fn decode_v1(&mut self, src: &mut ByteReader) -> Result<bool, Error> {
+        let stride = self.w * 3;
+        let data = self.last_frame.as_mut_slice();
+
         let mut is_intra = true;
         for (yy, row) in data.chunks_mut(stride * self.block_h).enumerate() {
             let cur_h = (self.h - yy * self.block_h).min(self.block_h);
@@ -105,18 +103,16 @@ impl ScreenVideoDecoder {
 
                 let data_size = src.read_u16be()? as usize;
                 if data_size > 0 {
+                    let tile = &mut self.scratch[..cur_w * cur_h * 3];
                     Decompress::new(true)
                         .decompress(
                             src.read_buf_ref(data_size)?,
-                            &mut self.tile[..cur_w * cur_h * 3],
+                            tile,
                             flate2::FlushDecompress::Finish,
                         )
                         .map_err(ScreenError::DecompressionError)?;
 
-                    for (dst, src) in row[x * 3..]
-                        .chunks_mut(stride)
-                        .zip(self.tile.chunks(cur_w * 3))
-                    {
+                    for (dst, src) in row[x * 3..].chunks_mut(stride).zip(tile.chunks(cur_w * 3)) {
                         dst[..cur_w * 3].copy_from_slice(src);
                     }
                 } else {
@@ -125,10 +121,6 @@ impl ScreenVideoDecoder {
             }
         }
         Ok(is_intra)
-    }
-
-    fn flush(&mut self) {
-        self.last_frame = None;
     }
 }
 
@@ -155,7 +147,7 @@ impl VideoDecoder for ScreenVideoDecoder {
     ) -> Result<(), Error> {
         let is_keyframe = encoded_frame.data[0] >> 4 == 1;
 
-        if !is_keyframe && self.last_frame.is_none() {
+        if !is_keyframe && self.last_frame.is_empty() {
             return Err(ScreenError::MissingReferenceFrame.into());
         }
 
@@ -172,31 +164,33 @@ impl VideoDecoder for ScreenVideoDecoder {
 
         debug_assert!(w != 0 && h != 0 && blk_w != 0 && blk_h != 0);
 
+        let block_size = blk_w * blk_h * 3;
+        let frame_size = w * h * 3;
+
         if self.w != w || self.h != h || self.block_w != blk_w || self.block_h != blk_h {
-            self.flush();
-            self.tile.resize(blk_w * blk_h * 3, 0);
             self.w = w;
             self.h = h;
             self.block_w = blk_w;
             self.block_h = blk_h;
+            // The scratch buffer is used for temporary tile data and the final RGB frame.
+            self.scratch
+                .resize(std::cmp::max(block_size, frame_size), 0);
+            // Flush previous frame.
+            self.last_frame.clear();
+            self.last_frame.resize(frame_size, 0);
         }
 
-        let mut data = self
-            .last_frame
-            .clone()
-            .unwrap_or_else(|| vec![0; w * h * 3]);
-
-        let stride = w * 3;
-
-        let is_intra = self.decode_v1(&mut br, data.as_mut_slice(), stride)?;
+        let is_intra = self.decode_v1(&mut br)?;
 
         if is_intra != is_keyframe {
             return Err(ScreenError::KeyframeInvalid.into());
         }
 
-        let mut rgb = vec![0u8; w * h * 3];
+        // `last_frame` was updated in-place by `decode_v1`.
+        let data = &self.last_frame[..frame_size];
 
         // convert from BGR to RGB and flip Y
+        let rgb = &mut self.scratch[..frame_size];
         for y in 0..h {
             let data_row = &data[y * w * 3..(y + 1) * w * 3];
             let rgb_row = &mut rgb[(h - y - 1) * w * 3..(h - y) * w * 3];
@@ -206,13 +200,11 @@ impl VideoDecoder for ScreenVideoDecoder {
             }
         }
 
-        self.last_frame = Some(data);
-
         callback(DecodedFrame::new(
             w as u32,
             h as u32,
             BitmapFormat::Rgb,
-            rgb,
+            &*rgb,
         ));
         Ok(())
     }

--- a/video/software/src/decoder/vp6.rs
+++ b/video/software/src/decoder/vp6.rs
@@ -112,7 +112,11 @@ impl VideoDecoder for Vp6Decoder {
         )
     }
 
-    fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error> {
+    fn decode_frame_dyn(
+        &mut self,
+        encoded_frame: EncodedFrame<'_>,
+        callback: &mut dyn FnMut(DecodedFrame<'_>),
+    ) -> Result<(), Error> {
         // If this is the first frame, the decoder needs to be initialized.
 
         if !self.init_called {
@@ -245,24 +249,25 @@ impl VideoDecoder for Vp6Decoder {
             data.extend(v);
             data.extend(a);
 
-            Ok(DecodedFrame::new(
+            callback(DecodedFrame::new(
                 width as u32,
                 height as u32,
                 BitmapFormat::Yuva420p,
                 data,
-            ))
+            ));
         } else {
             let mut data = y.to_vec();
             data.extend(u);
             data.extend(v);
 
-            Ok(DecodedFrame::new(
+            callback(DecodedFrame::new(
                 width as u32,
                 height as u32,
                 BitmapFormat::Yuv420p,
                 data,
-            ))
+            ));
         }
+        Ok(())
     }
 }
 

--- a/video/software/src/decoder/vp6.rs
+++ b/video/software/src/decoder/vp6.rs
@@ -43,6 +43,7 @@ pub struct Vp6Decoder {
     bitreader: VP6BR,
     init_called: bool,
     last_frame: Option<NABufferRef<NAVideoBuffer<u8>>>,
+    scratch: Vec<u8>,
 }
 
 impl Vp6Decoder {
@@ -65,33 +66,35 @@ impl Vp6Decoder {
             bitreader: VP6BR::new(),
             init_called: false,
             last_frame: None,
+            scratch: Vec::new(),
         }
     }
 }
 
-fn crop(data: &[u8], mut width: usize, to_size: (u16, u16)) -> Vec<u8> {
+/// Crop `data` to the requested size, and append the result to the `out` buffer.
+fn crop(out: &mut Vec<u8>, data: &[u8], width: usize, to_size: (u16, u16)) {
     debug_assert!(data.len().is_multiple_of(width));
-    let mut height = data.len() / width;
-    let mut data = data.to_vec();
+    let height = data.len() / width;
+
+    let new_width = usize::min(width, to_size.0 as usize);
+    let new_height = usize::min(height, to_size.1 as usize);
 
     if width > to_size.0 as usize {
-        // Removing the unwanted pixels on the right edge
-        // by squishing all the rows tightly next to each other.
-        let new_width = to_size.0 as usize;
-        let new_height = usize::min(height, to_size.1 as usize);
-        // no need to move the first row, nor any rows on the bottom that will end up being cropped entirely
-        for row in 1..new_height {
-            data.copy_within(row * width..(row * width + new_width), row * new_width);
+        // Removing the unwanted pixels on the right edge (most commonly: unused pieces
+        // of macroblocks) by squishing all the rows tightly next to each other.
+        // Bitmap at the moment does not allow these gaps, so we need to remove them.
+        out.reserve(new_width * new_height);
+
+        // No need to move rows on the bottom that are being cropped entirely
+        for row in 0..new_height {
+            let row_data = &data[row * width..(row * width + new_width)];
+            out.extend_from_slice(row_data);
         }
-        width = new_width;
-        height = new_height;
+    } else {
+        // Cropping unwanted rows on the bottom
+        // No horizontal squish needed, everything can be copied in one go
+        out.extend_from_slice(&data[..width * new_height]);
     }
-
-    // Cropping the unwanted rows on the bottom, also dropping any unused space at the end left by the squish above
-    height = usize::min(height, to_size.1 as usize);
-    data.truncate(width * height);
-
-    data
 }
 
 impl VideoDecoder for Vp6Decoder {
@@ -158,11 +161,9 @@ impl VideoDecoder for Vp6Decoder {
             || (self.with_alpha && encoded_frame.data.len() <= 3)
         {
             // This frame is empty, so it's a "skip frame"; reusing the last frame, if there is one.
-
-            match &self.last_frame {
-                Some(frame) => frame.clone(),
-                None => return Err(Vp6Error::UnexpectedSkipFrame.into()),
-            }
+            self.last_frame
+                .as_ref()
+                .ok_or(Vp6Error::UnexpectedSkipFrame)?
         } else {
             // Actually decoding the frame and extracting the buffer it is stored in.
 
@@ -176,9 +177,7 @@ impl VideoDecoder for Vp6Decoder {
                 _ => Err(Vp6Error::InvalidBufferType),
             }?;
 
-            self.last_frame = Some(frame.clone());
-
-            frame
+            self.last_frame.insert(frame)
         };
 
         let yuv = frame.get_data();
@@ -216,16 +215,17 @@ impl VideoDecoder for Vp6Decoder {
             // Flash Player just produces a black image in this case!
         }
 
-        //(most commonly: unused pieces of macroblocks)
-        // Bitmap at the moment does not allow these gaps, so we need to remove them.
+        self.scratch.clear();
 
-        let y = crop(y, width, bounds);
-        let u = crop(
+        crop(&mut self.scratch, y, width, bounds);
+        crop(
+            &mut self.scratch,
             u,
             chroma_width,
             (bounds.0.div_ceil(2), bounds.1.div_ceil(2)),
         );
-        let v = crop(
+        crop(
+            &mut self.scratch,
             v,
             chroma_width,
             (bounds.0.div_ceil(2), bounds.1.div_ceil(2)),
@@ -235,38 +235,26 @@ impl VideoDecoder for Vp6Decoder {
         height = bounds.1 as usize;
 
         // Adding in the alpha component, if present.
-        if self.with_alpha {
+        let format = if self.with_alpha {
             // Apparently it's possible for the alpha channel to be coded in a different size than the Y channel.
             let (alpha_width, alpha_height) = frame.get_dimensions(3);
             debug_assert!(frame.get_stride(3) == frame.get_dimensions(3).0);
 
             let alpha_offset = frame.get_offset(3);
             let alpha = &yuv[alpha_offset..alpha_offset + alpha_width * alpha_height];
-            let a = crop(alpha, alpha_width, bounds);
+            crop(&mut self.scratch, alpha, alpha_width, bounds);
 
-            let mut data = y.to_vec();
-            data.extend(u);
-            data.extend(v);
-            data.extend(a);
-
-            callback(DecodedFrame::new(
-                width as u32,
-                height as u32,
-                BitmapFormat::Yuva420p,
-                data,
-            ));
+            BitmapFormat::Yuva420p
         } else {
-            let mut data = y.to_vec();
-            data.extend(u);
-            data.extend(v);
+            BitmapFormat::Yuv420p
+        };
 
-            callback(DecodedFrame::new(
-                width as u32,
-                height as u32,
-                BitmapFormat::Yuv420p,
-                data,
-            ));
-        }
+        callback(DecodedFrame::new(
+            width as u32,
+            height as u32,
+            format,
+            self.scratch.as_slice(),
+        ));
         Ok(())
     }
 }

--- a/video/src/error.rs
+++ b/video/src/error.rs
@@ -18,6 +18,12 @@ pub enum Error {
     #[error("Video decoding isn't supported")]
     DecodingNotSupported,
 
+    #[error("Video decoder didn't produce an output frame")]
+    DecoderNoOutputFrame,
+
+    #[error("Video decoder produced multiple output frames")]
+    DecoderMultipleOutputFrames,
+
     #[error(transparent)]
     DecoderError(Box<dyn std::error::Error + Send + Sync>),
 }

--- a/video/src/frame.rs
+++ b/video/src/frame.rs
@@ -22,7 +22,7 @@ impl<'a> EncodedFrame<'a> {
 }
 
 /// A decoded frame of video. It can be in whichever format the decoder chooses.
-pub type DecodedFrame = Bitmap<'static>;
+pub type DecodedFrame<'a> = Bitmap<'a>;
 
 /// What dependencies a given video frame has on any previous frames.
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
## Description

Currently, the `VideoDecoder::decode_frame` method returns owned `Bitmap<'static>`s, forcing decoders to allocate a fresh buffer for each decoded frame.

This PR changes the API to instead provide a short-lived buffer through a callback, and updates the decoders to take advantage of this by reusing buffers more aggressively.

## Testing

All `visual/video` tests pass on native, but I still need to do a visual check with my human eyes, and properly test the web decoder.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
