### PR TITLE
ci: Switch Discord notification action to one that doesn't need Docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,14 +345,17 @@ jobs:
           xcrun stapler staple package/Ruffle.app
 
       - name: Report notarization failure on Discord
-        uses: th0th/notify-discord@v0.4.1
+        uses: stegzilla/discord-notify@v2
         if: ${{ steps.notarize-bundle.outcome == 'failure' && github.repository == 'ruffle-rs/ruffle' }}
         continue-on-error: true
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_JOB_NAME: "Notarize macOS universal binary bundle"
-          GITHUB_JOB_STATUS: ${{ steps.notarize-bundle.outcome }}
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
+          title: "macOS notarization failed"
+          message: |
+            Notarize macOS universal binary bundle step failed
+            [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          username: ${{ github.actor }}
+          colour: "#e5534b"
 
       - name: Package macOS
         run: |

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -94,11 +94,19 @@ jobs:
           name: result
           path: firefox_extensions/
 
+  report-result:
+    name: Report result to Discord
+    runs-on: ubuntu-24.04
+    needs: test-dockerfile
+    if: always() && github.repository == 'ruffle-rs/ruffle'
+    steps:
       - name: Notify Discord
-        uses: th0th/notify-discord@v0.4.1
-        if: ${{ always() && github.repository == 'ruffle-rs/ruffle' }}
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_JOB_NAME: "Build extension via Dockerfile"
-          GITHUB_JOB_STATUS: ${{ job.status }}
+        uses: stegzilla/discord-notify@v2
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
+          title: "Ruffle extension builder Dockerfile test result"
+          message: |
+            ${{ github.workflow }} run completed with status: ${{ needs.test-dockerfile.result }}
+            [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          username: ${{ github.actor }}
+          colour: ${{ needs.test-dockerfile.result == 'success' && '##57ab5a' || '#e5534b' }}


### PR DESCRIPTION
## Description

Follow-up to https://github.com/ruffle-rs/ruffle/pull/24113, as that didn't work out: https://github.com/ruffle-rs/ruffle/actions/runs/28760270801/job/85275571829#step:13:10

This action doesn't need Docker, so it has a higher chance of working on macOS - it's also more recently updated.

I split the reporting of the Dockerfile tester into its own job, because this action works a bit differently - it doesn't take a job ID in itself, so reporting the status of the main job (which can fail for multiple reasons) seemed more logical this way.

The macOS one only checks one step, not a whole job, so I kept that one as is.

As for the "outcome", and "result" mismatch, see:
 - https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context
 - https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context

## Testing

I can trigger a manual run of the Dockerfile tester workflow after merging, and the Release workflow will run anyway.
As for before merging... That would have to be done in someone's fork and their own Discord server.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
