### PR TITLE
avm2: Normalize flash.globalization.Collator.compare to -1/0/1

### DIFF
--- a/core/src/avm2/globals/flash/globalization/Collator.as
+++ b/core/src/avm2/globals/flash/globalization/Collator.as
@@ -83,7 +83,13 @@ package flash.globalization {
 
         public function compare(string1:String, string2:String):int {
             stub_method("flash.globalization.Collator", "compare");
-            return string1.localeCompare(string2);
+            // Flash Player normalizes the result to exactly -1, 0, or 1.
+            // Some callers rely on this: mx/spark collections' Sort.findItem
+            // does `switch (compareResult) { case -1: ...; case 1: ... }`, so a
+            // raw comparison delta (e.g. a character-code difference) would
+            // match no case and spin the binary search forever.
+            var result:int = string1.localeCompare(string2);
+            return (result < 0) ? -1 : ((result > 0) ? 1 : 0);
         }
 
         public function equals(string1:String, string2:String):Boolean {


### PR DESCRIPTION
## Summary

`flash.globalization.Collator.compare()` returned a raw character-code delta instead of a
normalized `-1` / `0` / `1`. Flash Player's `Collator.compare` always returns exactly the sign,
and the Flex framework's collection sorting relies on that: the mismatch drives
`spark.collections.Sort.findItem()`'s binary search into an **infinite loop**, freezing any app
that sorts a Spark `DataGrid` string column by clicking its header (CPU pegged, no error thrown).

## Root cause

Ruffle's `Collator.compare` stub delegated to `String.localeCompare`, which returns a
character-code difference rather than a normalized result:

```as
"Rossi".localeCompare("Bianchi") // 'R'(82) - 'B'(66) == 16, not 1
```

`spark.collections.Sort.findItem()` (the binary search used when the collection view resolves an
item's index) branches on the comparison result with an **exact** switch:

```as
switch (direction) {
    case -1: upperBound = index - 1; break;
    case  0: /* found */            break;
    case  1: lowerBound = index + 1; break;
}
```

A delta such as `16` matches none of these cases, so neither bound is updated,
`lowerBound <= upperBound` stays true forever, and the comparator
(`SortField.stringCompare` → `Collator.compare`) is called endlessly.

The path reached from a header click is:

```
DataGrid.sortByColumns → ListCollectionView.refresh
  → Grid.dataProvider_collectionChangeHandler → updateCaretForDataProviderChange
    → ListCollectionView.getItemIndex → Sort.findItem
      → Sort.internalCompare → SortField.stringCompare → Collator.compare   // spins here
```

## Reproduction

A minimal Spark `DataGrid` with inline data. Compile with the Flex 4.6 SDK and open the SWF in
Ruffle, then click the **Name** column header to sort. Before this patch the player hangs; after
it, the column sorts normally.

```xml
<?xml version="1.0" encoding="utf-8"?>
<s:Application xmlns:fx="http://ns.adobe.com/mxml/2009"
              xmlns:s="library://ns.adobe.com/flex/spark"
              xmlns:mx="library://ns.adobe.com/flex/mx">

    <fx:Declarations>
        <mx:ArrayCollection id="people">
            <fx:Object name="Rossi"/>
            <fx:Object name="Bianchi"/>
            <fx:Object name="Verdi"/>
        </mx:ArrayCollection>
    </fx:Declarations>

    <s:DataGrid dataProvider="{people}" width="300" height="120">
        <s:columns>
            <s:ArrayList>
                <s:GridColumn dataField="name" headerText="Name"/>
            </s:ArrayList>
        </s:columns>
    </s:DataGrid>

</s:Application>
```

Any string values whose comparison delta is not exactly `±1` reproduce it (i.e. almost all real
data — here `'R' - 'B' == 16`).

## Fix

Normalize the comparison result to its sign in `Collator.compare`, matching Flash Player:

```as
var result:int = string1.localeCompare(string2);
return (result < 0) ? -1 : ((result > 0) ? 1 : 0);
```

## Notes

- `Collator.compare` is still a stub for locale-aware collation (it uses code-point ordering);
  this change only corrects the *shape* of the return value, which is what the framework depends on.
- Custom `sortCompareFunction`s that already return `-1/0/1` were unaffected and keep working; this
  fixes the default string-sort path that goes through the `Collator`.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
