### PR TITLE
avm2: Implement flash.ui.Mouse.cursor

### DIFF
--- a/core/src/avm2/globals/flash/ui/Mouse.as
+++ b/core/src/avm2/globals/flash/ui/Mouse.as
@@ -7,6 +7,9 @@ package flash.ui {
         public static native function hide():void;
         public static native function show():void;
 
+        public static native function get cursor():String;
+        public static native function set cursor(value:String):void;
+
         public static function get supportsCursor():Boolean {
             stub_getter("flash.ui.Mouse", "supportsCursor");
             return true;

--- a/core/src/avm2/globals/flash/ui/mouse.rs
+++ b/core/src/avm2/globals/flash/ui/mouse.rs
@@ -2,7 +2,11 @@
 
 use crate::avm2::Error;
 use crate::avm2::activation::Activation;
+use crate::avm2::error::make_error_2008;
+use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
+use crate::backend::ui::MouseCursor;
+use crate::string::AvmString;
 
 pub fn hide<'gc>(
     activation: &mut Activation<'_, 'gc>,
@@ -10,6 +14,40 @@ pub fn hide<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     activation.context.ui.set_mouse_visible(false);
+    Ok(Value::Undefined)
+}
+
+pub fn get_cursor<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    // The mapping mirrors `flash.ui.MouseCursor`.
+    let cursor = match activation.context.mouse_data.forced_cursor {
+        None => "auto",
+        Some(MouseCursor::Arrow) => "arrow",
+        Some(MouseCursor::Hand) => "button",
+        Some(MouseCursor::IBeam) => "ibeam",
+        Some(MouseCursor::Grab) => "hand",
+    };
+    Ok(AvmString::new_utf8(activation.gc(), cursor).into())
+}
+
+pub fn set_cursor<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Value<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let value = args.get_string_non_null(activation, 0, "cursor")?;
+    let forced = match &*value.to_utf8_lossy() {
+        "auto" => None,
+        "arrow" => Some(MouseCursor::Arrow),
+        "button" => Some(MouseCursor::Hand),
+        "ibeam" => Some(MouseCursor::IBeam),
+        "hand" => Some(MouseCursor::Grab),
+        _ => return Err(make_error_2008(activation, "cursor")),
+    };
+    activation.context.mouse_data.forced_cursor = forced;
     Ok(Value::Undefined)
 }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -119,6 +119,12 @@ pub struct MouseData<'gc> {
     pub pressed: Option<InteractiveObject<'gc>>,
     pub right_pressed: Option<InteractiveObject<'gc>>,
     pub middle_pressed: Option<InteractiveObject<'gc>>,
+
+    /// The cursor forced through `flash.ui.Mouse.cursor`. `None` corresponds to
+    /// `MouseCursor.AUTO`: the cursor is chosen automatically from the object
+    /// under the pointer. Any other value overrides that automatic choice.
+    #[collect(require_static)]
+    pub forced_cursor: Option<MouseCursor>,
 }
 
 impl<'gc> MouseData<'gc> {
@@ -1879,6 +1885,11 @@ impl Player {
                 }
                 refresh
             };
+            // A cursor forced through `flash.ui.Mouse.cursor` (any value other
+            // than `MouseCursor.AUTO`) overrides the automatic cursor.
+            if let Some(forced) = context.mouse_data.forced_cursor {
+                new_cursor = forced;
+            }
             Self::run_actions(context);
             needs_render
         });
@@ -2931,6 +2942,7 @@ impl PlayerBuilder {
                 pressed: None,
                 right_pressed: None,
                 middle_pressed: None,
+                forced_cursor: None,
             },
             avm1_shared_objects: HashMap::new(),
             avm2_shared_objects: HashMap::new(),


### PR DESCRIPTION
## Summary

`flash.ui.Mouse` was missing the `cursor` property entirely, so assignments to
`Mouse.cursor` had no effect. The Text Layout Framework sets
`Mouse.cursor = MouseCursor.IBEAM` when the pointer moves over editable text, so
Spark `TextInput` / `TextArea` (and any TLF-based content) never displayed the
I-beam cursor — the pointer stayed an arrow.

This implements `flash.ui.Mouse.cursor` (getter and setter), letting content
force a specific cursor and matching Flash Player.

## Root cause

`flash.ui.Mouse` only exposed `hide`/`show`/`supportsCursor`/`registerCursor`.
There was no `cursor` property, so:

- `Mouse.cursor = MouseCursor.IBEAM` (used by `flashx.textLayout.edit.SelectionManager.setMouseCursor`) was a no-op / illegal write, and
- reading `Mouse.cursor` was unsupported.

Ruffle already picks a cursor automatically from the object under the pointer
(arrow, button, I-beam over a `TextField`, …), but nothing let ActionScript
*force* one.

## Reproduction

Minimal AS3: a grey rectangle that requests the I-beam while hovered. Without
this patch the cursor stays an arrow (and the assignment does not take effect);
with it, the pointer becomes an I-beam over the rectangle.

```as
import flash.display.Sprite;
import flash.events.MouseEvent;
import flash.ui.Mouse;
import flash.ui.MouseCursor;

var box:Sprite = new Sprite();
box.graphics.beginFill(0xCCCCCC);
box.graphics.drawRect(0, 0, 200, 100);
addChild(box);

box.addEventListener(MouseEvent.MOUSE_OVER, function(e:MouseEvent):void {
    Mouse.cursor = MouseCursor.IBEAM;
});
box.addEventListener(MouseEvent.MOUSE_OUT, function(e:MouseEvent):void {
    Mouse.cursor = MouseCursor.AUTO;
});
```

The same path is exercised implicitly by any Flex Spark editable text control.

## Fix

- Add a `forced_cursor: Option<MouseCursor>` field to the persistent `MouseData`.
- The native `Mouse.cursor` setter stores it; the getter reads it back.
  `MouseCursor.AUTO` maps to `None` — the automatic per-object cursor is kept —
  and any other value overrides that choice. Invalid strings throw
  `ArgumentError` #2008, as in Flash Player.
- In the player's cursor update, a non-`None` `forced_cursor` replaces the
  automatically-computed cursor before it is applied.

The AS3 constant ↔ internal enum mapping: `AUTO→None`, `ARROW→Arrow`,
`BUTTON→Hand`, `IBEAM→IBeam`, `HAND→Grab`.

## Notes

- The forced cursor takes effect on the next mouse activity (the cursor is
  recomputed while processing pointer events); TLF sets it during
  `rollOver`/`mouseMove`, so it applies immediately in practice.
- Automatic cursor selection (e.g. the hand over buttons) is unchanged when
  `Mouse.cursor` is left at its default `"auto"`.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
