### PR TITLE
core: Dispatch textInput to focused non-TextField objects

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -51,7 +51,7 @@ use crate::orphan_manager::OrphanManager;
 use crate::prelude::*;
 use crate::socket::Sockets;
 use crate::streams::StreamManager;
-use crate::string::{AvmStringInterner, StringContext};
+use crate::string::{AvmString, AvmStringInterner, StringContext};
 use crate::stub::StubCollection;
 use crate::system_properties::SystemProperties;
 use crate::tag_utils::SwfMovie;
@@ -1309,15 +1309,43 @@ impl Player {
             }
 
             // KeyPress events take precedence over text input.
-            if !key_press_handled && let Some(text) = context.focus_tracker.get_as_edit_text() {
-                if let InputEvent::TextInput { codepoint } = &event {
-                    text.text_input((*codepoint).to_string(), context);
-                }
-                if let InputEvent::TextControl { code } = &event {
-                    text.text_control_input(*code, context);
-                }
-                if let InputEvent::Ime(ime) = &event {
-                    text.ime(ime.clone(), context);
+            if !key_press_handled {
+                if let Some(text) = context.focus_tracker.get_as_edit_text() {
+                    if let InputEvent::TextInput { codepoint } = &event {
+                        text.text_input((*codepoint).to_string(), context);
+                    }
+                    if let InputEvent::TextControl { code } = &event {
+                        text.text_control_input(*code, context);
+                    }
+                    if let InputEvent::Ime(ime) = &event {
+                        text.ime(ime.clone(), context);
+                    }
+                } else if let InputEvent::TextInput { codepoint } = &event
+                    && let Some(focus) = context.focus_tracker.get()
+                {
+                    // The focused object is an interactive object other than a
+                    // native text field (e.g. a Sprite hosting a Text Layout
+                    // Framework EditManager). Flash Player dispatches typed
+                    // characters as a `TextEvent` to whatever object holds
+                    // focus, which is how such components receive keyboard
+                    // input; mirror that so they can be typed into.
+                    //
+                    // TODO: Route IME composition events here as well.
+                    let target = focus.as_displayobject();
+                    if target.movie().is_action_script_3()
+                        && let Some(target_object) = target.object2()
+                    {
+                        let mut activation = Avm2Activation::from_nothing(context);
+                        let text = AvmString::new_utf8(activation.gc(), codepoint.to_string());
+                        let text_evt = Avm2EventObject::text_event(
+                            &mut activation,
+                            "textInput",
+                            text,
+                            true,
+                            true,
+                        );
+                        Avm2::dispatch_event(activation.context, text_evt, target_object.into());
+                    }
                 }
             }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1339,15 +1339,43 @@ impl Player {
             }
 
             // KeyPress events take precedence over text input.
-            if !key_press_handled && let Some(text) = context.focus_tracker.get_as_edit_text() {
-                if let InputEvent::TextInput { codepoint } = &event {
-                    text.text_input((*codepoint).to_string(), context);
-                }
-                if let InputEvent::TextControl { code } = &event {
-                    text.text_control_input(*code, context);
-                }
-                if let InputEvent::Ime(ime) = &event {
-                    text.ime(ime.clone(), context);
+            if !key_press_handled {
+                if let Some(text) = context.focus_tracker.get_as_edit_text() {
+                    if let InputEvent::TextInput { codepoint } = &event {
+                        text.text_input((*codepoint).to_string(), context);
+                    }
+                    if let InputEvent::TextControl { code } = &event {
+                        text.text_control_input(*code, context);
+                    }
+                    if let InputEvent::Ime(ime) = &event {
+                        text.ime(ime.clone(), context);
+                    }
+                } else if let InputEvent::TextInput { codepoint } = &event
+                    && let Some(focus) = context.focus_tracker.get()
+                {
+                    // The focused object is an interactive object other than a
+                    // native text field (e.g. a Sprite hosting a Text Layout
+                    // Framework EditManager). Flash Player dispatches typed
+                    // characters as a `TextEvent` to whatever object holds
+                    // focus, which is how such components receive keyboard
+                    // input; mirror that so they can be typed into.
+                    //
+                    // TODO: Route IME composition events here as well.
+                    let target = focus.as_displayobject();
+                    if target.movie().is_action_script_3()
+                        && let Some(target_object) = target.object2()
+                    {
+                        let mut activation = Avm2Activation::from_nothing(context);
+                        let text = AvmString::new_utf8(activation.gc(), codepoint.to_string());
+                        let text_evt = Avm2EventObject::text_event(
+                            &mut activation,
+                            "textInput",
+                            text,
+                            true,
+                            true,
+                        );
+                        Avm2::dispatch_event(activation.context, text_evt, target_object.into());
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Typed characters were only delivered to native text fields. When any other
interactive object held focus — in particular a `Sprite` running a Text Layout
Framework `EditManager`, as used by Flex Spark `TextInput` / `TextArea` /
`ComboBox` — the character was dropped, so those controls displayed their
content but could not be typed into.

Flash Player dispatches a `flash.events.TextEvent` of type `TEXT_INPUT` to
whatever `InteractiveObject` has focus. This makes Ruffle do the same.

## Root cause

In `player.rs`, character input, text-control and IME events were routed to the
focused object only when it was a native `EditText`:

```rust
if !key_press_handled
    && let Some(text) = context.focus_tracker.get_as_edit_text()
{
    if let InputEvent::TextInput { codepoint } = &event {
        text.text_input(codepoint.to_string(), context);
    }
    // … TextControl, Ime …
}
```

`FocusTracker::get_as_edit_text()` returns `Some` only for a native `EditText`.
When focus was on any other object the whole block was skipped and the character
was discarded — it was never dispatched anywhere. Raw `KeyboardEvent`s were not
gated this way (they already reached the focused object), so navigation keys
arrived but the character content did not.

## Reproduction

Minimal AS3: a focused `Sprite` that listens for `TEXT_INPUT`. Before this patch
typing produces nothing; after it, each keystroke is delivered.

```as
import flash.display.Sprite;
import flash.events.TextEvent;

var box:Sprite = new Sprite();
box.graphics.beginFill(0xEEEEEE);
box.graphics.drawRect(0, 0, 200, 100);
addChild(box);

// Focus a non-TextField interactive object.
stage.focus = box;

box.addEventListener(TextEvent.TEXT_INPUT, function(e:TextEvent):void {
    trace("TEXT_INPUT: " + e.text);
});
// Type on the keyboard: without the patch nothing is traced; with it,
// each character is traced. This is the mechanism TLF/Spark editing relies on.
```

## Fix

Turn the block into an `if` / `else if`: the native `EditText` path is unchanged
and still handled first; when the focused object is an ActionScript 3 interactive
object other than a text field, dispatch a bubbling, cancelable `textInput`
`TextEvent` to it (built with the same helper the native path uses). Dispatch is
gated to AS3 targets, consistent with the neighbouring `KeyboardEvent` code.

Because an `EditText` is always caught by the first branch, its native insertion,
its own `textInput` dispatch, restrict filtering and IME/text-control handling
are byte-for-byte the same as before. The new branch runs only for focused
objects that previously received nothing, so the change is strictly additive.

## Notes

- `KeyboardEvent`s already reached focused objects, so arrow/navigation keys were
  unaffected; only the character channel was missing.
- IME composition and text-control commands to non-text-field focus are left as a
  follow-up (they still take the native `EditText` path). Latin/ASCII typing — the
  reported gap — is fully covered.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
