### PR TITLE
ci: Fix typo in extension builder dockerfile tester workflow

### DIFF
--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -109,4 +109,4 @@ jobs:
             ${{ github.workflow }} run completed with status: ${{ needs.test-dockerfile.result }}
             [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           username: ${{ github.actor }}
-          colour: ${{ needs.test-dockerfile.result == 'success' && '##57ab5a' || '#e5534b' }}
+          colour: ${{ needs.test-dockerfile.result == 'success' && '#57ab5a' || '#e5534b' }}


### PR DESCRIPTION
One-character follow-up to https://github.com/ruffle-rs/ruffle/pull/24145.
What a blunder! I'm so sorry.