### PR TITLE
chore: Fix some lints and remove unused #[allow]s

### DIFF
--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -1,8 +1,5 @@
 //! `flash.display.Graphics` builtin/prototype
 
-// See: https://github.com/rust-lang/rust-clippy/issues/12917
-#![allow(clippy::doc_lazy_continuation)]
-
 use crate::avm2::activation::Activation;
 use crate::avm2::error::{Error2004Type, make_error_2004, make_error_2007, make_error_2008};
 use crate::avm2::globals::flash::geom::transform::object_to_matrix;

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -2219,9 +2219,6 @@ fn optimize_get_property<'gc>(
     multiname: Gc<'gc, Multiname<'gc>>,
     stack_value: OptValue<'gc>,
 ) -> Result<Option<(Op<'gc>, Option<Class<'gc>>)>, Error<'gc>> {
-    // Makes the code less readable
-    #![allow(clippy::collapsible_if)]
-
     if let Some(vtable) = stack_value.vtable() {
         match vtable.get_trait(&multiname) {
             Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
@@ -2276,9 +2273,6 @@ fn optimize_call_property<'gc>(
     passed_args: &[OptValue<'gc>],
     push_return_value: bool,
 ) -> Result<Option<(Op<'gc>, Option<Class<'gc>>)>, Error<'gc>> {
-    // Makes the code less readable
-    #![allow(clippy::collapsible_if)]
-
     let num_args = passed_args.len() as u32;
 
     if let Some(vtable) = stack_value.vtable() {
@@ -2311,38 +2305,33 @@ fn optimize_call_property<'gc>(
             #[allow(clippy::collapsible_match)]
             Some(Property::Slot { slot_id } | Property::ConstSlot { slot_id }) => {
                 // Don't optimize this for `callpropvoid`
-                if push_return_value {
-                    if stack_value.not_null() {
-                        if num_args == 1 {
-                            let mut value_class =
-                                vtable.slot_class(slot_id).expect("Slot should exist");
-                            let resolved_value_class = value_class.get_class(activation)?;
+                if push_return_value && stack_value.not_null() && num_args == 1 {
+                    let mut value_class = vtable.slot_class(slot_id).expect("Slot should exist");
+                    let resolved_value_class = value_class.get_class(activation)?;
 
-                            if let Some(slot_class) = resolved_value_class {
-                                if let Some(called_class) = slot_class.i_class() {
-                                    // Calling a c_class will perform a simple coercion to the class
-                                    let result = if called_class.call_handler().is_none() {
-                                        Some((
-                                            Op::CoerceSwapPop {
-                                                class: called_class,
-                                            },
-                                            called_class,
-                                        ))
-                                    } else if called_class == types.int {
-                                        Some((Op::CoerceISwapPop, types.int))
-                                    } else if called_class == types.uint {
-                                        Some((Op::CoerceUSwapPop, types.uint))
-                                    } else if called_class == types.number {
-                                        Some((Op::CoerceDSwapPop, types.number))
-                                    } else {
-                                        None
-                                    };
+                    if let Some(slot_class) = resolved_value_class
+                        && let Some(called_class) = slot_class.i_class()
+                    {
+                        // Calling a c_class will perform a simple coercion to the class
+                        let result = if called_class.call_handler().is_none() {
+                            Some((
+                                Op::CoerceSwapPop {
+                                    class: called_class,
+                                },
+                                called_class,
+                            ))
+                        } else if called_class == types.int {
+                            Some((Op::CoerceISwapPop, types.int))
+                        } else if called_class == types.uint {
+                            Some((Op::CoerceUSwapPop, types.uint))
+                        } else if called_class == types.number {
+                            Some((Op::CoerceDSwapPop, types.number))
+                        } else {
+                            None
+                        };
 
-                                    if let Some((new_op, return_type)) = result {
-                                        return Ok(Some((new_op, Some(return_type))));
-                                    }
-                                }
-                            }
+                        if let Some((new_op, return_type)) = result {
+                            return Ok(Some((new_op, Some(return_type))));
                         }
                     }
                 }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1059,10 +1059,6 @@ impl<'gc> EditText<'gc> {
     /// Returns the selection, but takes into account whether the selection should be rendered.
     fn visible_selection(self) -> Option<TextSelection> {
         let selection = self.0.selection.get()?;
-        // TODO: Remove this #[allow] once Rust 1.94 is released.
-        // Clippy 0.1.94+ (PR #16286) no longer fires collapsible_else_if when both
-        // branches contain if-else expressions, recognizing the parallel structure.
-        #[allow(clippy::collapsible_else_if)]
         if selection.is_caret() {
             if self.has_focus() && !self.0.flags.get().contains(EditTextFlag::READ_ONLY) {
                 Some(selection)


### PR DESCRIPTION

## Description

This patch applies some clippy lints in type_aware.rs that make the code more readable, and removes #[allow]s which are not necessary anymore.

## Testing

N/A

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
