### PR TITLE
avm2: Move TextLine's fields to the native object

### DIFF
--- a/core/src/avm2/globals/flash/text/engine/TextBlock.as
+++ b/core/src/avm2/globals/flash/text/engine/TextBlock.as
@@ -123,7 +123,7 @@ package flash.text.engine {
                 return;
             }
             this.firstLine.validity = "invalid";
-            this.firstLine._textBlock = null;
+            this.firstLine.setTextBlock(null);
         }
     }
 }

--- a/core/src/avm2/globals/flash/text/engine/TextLine.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLine.as
@@ -19,11 +19,6 @@ package flash.text.engine {
         [Ruffle(NativeAccessible)]
         private var _lineIndex:int = 0;
         [Ruffle(NativeAccessible)]
-        private var _beginIndex:int = 0;
-        [Ruffle(NativeAccessible)]
-        private var _endIndex:int = 0;
-
-        [Ruffle(NativeAccessible)]
         private var _previousLine:TextLine = null;
         [Ruffle(NativeAccessible)]
         private var _nextLine:TextLine = null;
@@ -34,9 +29,7 @@ package flash.text.engine {
 
         public native function get rawTextLength():int;
 
-        public function get textBlockBeginIndex():int {
-            return this._beginIndex;
-        }
+        public native function get textBlockBeginIndex():int;
 
         public native function get specifiedWidth():Number;
 

--- a/core/src/avm2/globals/flash/text/engine/TextLine.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLine.as
@@ -17,9 +17,6 @@ package flash.text.engine {
     [API("662")]
     public final class TextLine extends DisplayObjectContainer {
         [Ruffle(NativeAccessible)]
-        private var _specifiedWidth:Number = 0.0;
-
-        [Ruffle(NativeAccessible)]
         private var _rawTextLength:int = 0;
 
         [Ruffle(NativeAccessible)]
@@ -46,9 +43,7 @@ package flash.text.engine {
             return this._beginIndex;
         }
 
-        public function get specifiedWidth():Number {
-            return this._specifiedWidth;
-        }
+        public native function get specifiedWidth():Number;
 
         public native function get textBlock():TextBlock;
 
@@ -80,7 +75,7 @@ package flash.text.engine {
 
         public function get unjustifiedTextWidth():Number {
             stub_getter("flash.text.engine.TextLine", "unjustifiedTextWidth");
-            return this._specifiedWidth;
+            return this.specifiedWidth;
         }
 
         public native function get textWidth():Number;

--- a/core/src/avm2/globals/flash/text/engine/TextLine.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLine.as
@@ -17,8 +17,6 @@ package flash.text.engine {
     [API("662")]
     public final class TextLine extends DisplayObjectContainer {
         [Ruffle(NativeAccessible)]
-        private var _lineIndex:int = 0;
-        [Ruffle(NativeAccessible)]
         private var _previousLine:TextLine = null;
         [Ruffle(NativeAccessible)]
         private var _nextLine:TextLine = null;

--- a/core/src/avm2/globals/flash/text/engine/TextLine.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLine.as
@@ -20,9 +20,6 @@ package flash.text.engine {
         private var _specifiedWidth:Number = 0.0;
 
         [Ruffle(NativeAccessible)]
-        internal var _textBlock:TextBlock = null;
-
-        [Ruffle(NativeAccessible)]
         private var _rawTextLength:int = 0;
 
         [Ruffle(NativeAccessible)]
@@ -53,9 +50,11 @@ package flash.text.engine {
             return this._specifiedWidth;
         }
 
-        public function get textBlock():TextBlock {
-            return this._textBlock;
-        }
+        public native function get textBlock():TextBlock;
+
+        // TODO: remove this setter once releaseLines() is implemented natively;
+        // it only exists so AS-side releaseLines() can clear textBlock.
+        internal native function setTextBlock(value:TextBlock):void;
 
         public function get ascent():Number {
             stub_getter("flash.text.engine.TextLine", "ascent");

--- a/core/src/avm2/globals/flash/text/engine/TextLine.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLine.as
@@ -17,9 +17,6 @@ package flash.text.engine {
     [API("662")]
     public final class TextLine extends DisplayObjectContainer {
         [Ruffle(NativeAccessible)]
-        private var _rawTextLength:int = 0;
-
-        [Ruffle(NativeAccessible)]
         private var _lineIndex:int = 0;
         [Ruffle(NativeAccessible)]
         private var _beginIndex:int = 0;
@@ -35,9 +32,7 @@ package flash.text.engine {
 
         public var userData;
 
-        public function get rawTextLength():int {
-            return this._rawTextLength;
-        }
+        public native function get rawTextLength():int;
 
         public function get textBlockBeginIndex():int {
             return this._beginIndex;
@@ -91,7 +86,7 @@ package flash.text.engine {
 
         public function get atomCount():int {
             stub_getter("flash.text.engine.TextLine", "atomCount");
-            return this._rawTextLength;
+            return this.rawTextLength;
         }
 
         public function get nextLine():TextLine {

--- a/core/src/avm2/globals/flash/text/engine/TextLine.as
+++ b/core/src/avm2/globals/flash/text/engine/TextLine.as
@@ -16,11 +16,6 @@ package flash.text.engine {
     [Ruffle(Abstract)]
     [API("662")]
     public final class TextLine extends DisplayObjectContainer {
-        [Ruffle(NativeAccessible)]
-        private var _previousLine:TextLine = null;
-        [Ruffle(NativeAccessible)]
-        private var _nextLine:TextLine = null;
-
         public static const MAX_LINE_WIDTH:int = 1000000;
 
         public var userData;
@@ -80,13 +75,8 @@ package flash.text.engine {
             return this.rawTextLength;
         }
 
-        public function get nextLine():TextLine {
-            return this._nextLine;
-        }
-
-        public function get previousLine():TextLine {
-            return this._previousLine;
-        }
+        public native function get previousLine():TextLine;
+        public native function get nextLine():TextLine;
 
         public function getBaselinePosition(baseline:String):Number {
             stub_method("flash.text.engine.TextLine", "getBaselinePosition");

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -322,8 +322,9 @@ pub fn create_text_line<'gc>(
     let instance = initialize_for_allocator(activation.context, text_line.into(), class);
     let instance: Object<'gc> = instance.into();
 
+    text_line.set_text_block(Some(block), activation.gc());
+
     use crate::avm2::globals::slots::flash_text_engine_text_line as line_slots;
-    instance.set_slot(line_slots::_TEXT_BLOCK, this, activation)?;
     instance.set_slot(line_slots::_SPECIFIED_WIDTH, args.get_value(1), activation)?;
     instance.set_slot(
         line_slots::_RAW_TEXT_LENGTH,

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -6,7 +6,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::error::{Error, Error2004Type, make_error_2004, make_error_2008};
 use crate::avm2::globals::flash::display::display_object::initialize_for_allocator;
 use crate::avm2::globals::methods::flash_text_engine_content_element as element_methods;
-use crate::avm2::object::{Object, TObject, VectorObject};
+use crate::avm2::object::{Object, VectorObject};
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
 use crate::avm2_stub_method;
@@ -337,20 +337,14 @@ pub fn create_text_line<'gc>(
     text_line.set_end_index(next_position as u32);
     text_line.set_line_index(line_index);
 
-    use crate::avm2::globals::slots::flash_text_engine_text_line as line_slots;
-
     if let Some(previous_text_line) = previous_text_line {
-        instance.set_slot(
-            line_slots::_PREVIOUS_LINE,
-            previous_text_line.into(),
-            activation,
-        )?;
-        previous_text_line.set_slot(
-            //
-            line_slots::_NEXT_LINE,
-            instance.into(),
-            activation,
-        )?;
+        let previous_line = previous_text_line
+            .as_display_object()
+            .unwrap()
+            .as_text_line()
+            .unwrap();
+        text_line.set_previous_line(Some(previous_line), activation.gc());
+        previous_line.set_next_line(Some(text_line), activation.gc());
     }
 
     block.set_text_line_creation_result(Some(TextLineCreationResultValue::Success));

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -267,7 +267,12 @@ pub fn create_text_line<'gc>(
     let width = args.get_f64(1);
 
     let previous_position = if let Some(previous_text_line) = previous_text_line {
-        previous_text_line.get_slot(line_slots::_END_INDEX).as_u32() as usize
+        previous_text_line
+            .as_display_object()
+            .unwrap()
+            .as_text_line()
+            .unwrap()
+            .end_index() as usize
     } else {
         0
     };
@@ -325,18 +330,10 @@ pub fn create_text_line<'gc>(
     text_line.set_text_block(Some(block), activation.gc());
     text_line.set_specified_width(width);
     text_line.set_raw_text_length(text.len() as u32);
+    text_line.set_begin_index(previous_position as u32);
+    text_line.set_end_index(next_position as u32);
 
     use crate::avm2::globals::slots::flash_text_engine_text_line as line_slots;
-    instance.set_slot(
-        line_slots::_BEGIN_INDEX,
-        Value::from_usize_lossy(previous_position),
-        activation,
-    )?;
-    instance.set_slot(
-        line_slots::_END_INDEX,
-        Value::from_usize_lossy(next_position),
-        activation,
-    )?;
     instance.set_slot(line_slots::_LINE_INDEX, line_index.into(), activation)?;
 
     if let Some(previous_text_line) = previous_text_line {

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -323,9 +323,9 @@ pub fn create_text_line<'gc>(
     let instance: Object<'gc> = instance.into();
 
     text_line.set_text_block(Some(block), activation.gc());
+    text_line.set_specified_width(width);
 
     use crate::avm2::globals::slots::flash_text_engine_text_line as line_slots;
-    instance.set_slot(line_slots::_SPECIFIED_WIDTH, args.get_value(1), activation)?;
     instance.set_slot(
         line_slots::_RAW_TEXT_LENGTH,
         Value::from_usize_lossy(text.len()),

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -263,16 +263,15 @@ pub fn create_text_line<'gc>(
 
     avm2_stub_method!(activation, "flash.text.TextBlock", "createTextLine");
 
-    let previous_text_line = args.try_get_object(0);
+    let previous_text_line = args
+        .try_get_object(0)
+        .and_then(|o| o.as_display_object())
+        .and_then(|o| o.as_text_line());
+
     let width = args.get_f64(1);
 
     let previous_position = if let Some(previous_text_line) = previous_text_line {
-        previous_text_line
-            .as_display_object()
-            .unwrap()
-            .as_text_line()
-            .unwrap()
-            .end_index() as usize
+        previous_text_line.end_index() as usize
     } else {
         0
     };
@@ -294,13 +293,7 @@ pub fn create_text_line<'gc>(
     }
 
     let line_index = if let Some(previous_text_line) = previous_text_line {
-        previous_text_line
-            .as_display_object()
-            .unwrap()
-            .as_text_line()
-            .unwrap()
-            .line_index()
-            + 1
+        previous_text_line.line_index() + 1
     } else {
         0
     };
@@ -337,12 +330,7 @@ pub fn create_text_line<'gc>(
     text_line.set_end_index(next_position as u32);
     text_line.set_line_index(line_index);
 
-    if let Some(previous_text_line) = previous_text_line {
-        let previous_line = previous_text_line
-            .as_display_object()
-            .unwrap()
-            .as_text_line()
-            .unwrap();
+    if let Some(previous_line) = previous_text_line {
         text_line.set_previous_line(Some(previous_line), activation.gc());
         previous_line.set_next_line(Some(text_line), activation.gc());
     }

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -324,13 +324,9 @@ pub fn create_text_line<'gc>(
 
     text_line.set_text_block(Some(block), activation.gc());
     text_line.set_specified_width(width);
+    text_line.set_raw_text_length(text.len() as u32);
 
     use crate::avm2::globals::slots::flash_text_engine_text_line as line_slots;
-    instance.set_slot(
-        line_slots::_RAW_TEXT_LENGTH,
-        Value::from_usize_lossy(text.len()),
-        activation,
-    )?;
     instance.set_slot(
         line_slots::_BEGIN_INDEX,
         Value::from_usize_lossy(previous_position),

--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -295,8 +295,11 @@ pub fn create_text_line<'gc>(
 
     let line_index = if let Some(previous_text_line) = previous_text_line {
         previous_text_line
-            .get_slot(line_slots::_LINE_INDEX)
-            .as_u32()
+            .as_display_object()
+            .unwrap()
+            .as_text_line()
+            .unwrap()
+            .line_index()
             + 1
     } else {
         0
@@ -332,9 +335,9 @@ pub fn create_text_line<'gc>(
     text_line.set_raw_text_length(text.len() as u32);
     text_line.set_begin_index(previous_position as u32);
     text_line.set_end_index(next_position as u32);
+    text_line.set_line_index(line_index);
 
     use crate::avm2::globals::slots::flash_text_engine_text_line as line_slots;
-    instance.set_slot(line_slots::_LINE_INDEX, line_index.into(), activation)?;
 
     if let Some(previous_text_line) = previous_text_line {
         instance.set_slot(

--- a/core/src/avm2/globals/flash/text/engine/text_line.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_line.rs
@@ -134,6 +134,22 @@ pub fn get_raw_text_length<'gc>(
     Ok(this.raw_text_length().into())
 }
 
+pub fn get_text_block_begin_index<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this
+        .as_object()
+        .unwrap()
+        .as_display_object()
+        .unwrap()
+        .as_text_line()
+        .unwrap();
+
+    Ok(this.begin_index().into())
+}
+
 pub fn get_text_height<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,

--- a/core/src/avm2/globals/flash/text/engine/text_line.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_line.rs
@@ -118,6 +118,22 @@ pub fn get_specified_width<'gc>(
     Ok(this.specified_width().into())
 }
 
+pub fn get_raw_text_length<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this
+        .as_object()
+        .unwrap()
+        .as_display_object()
+        .unwrap()
+        .as_text_line()
+        .unwrap();
+
+    Ok(this.raw_text_length().into())
+}
+
 pub fn get_text_height<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,

--- a/core/src/avm2/globals/flash/text/engine/text_line.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_line.rs
@@ -2,6 +2,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::error::{Error, make_error_2008};
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
+use crate::display_object::TDisplayObject;
 use crate::fte::TextLineValidity;
 
 pub fn get_text_width<'gc>(
@@ -148,6 +149,46 @@ pub fn get_text_block_begin_index<'gc>(
         .unwrap();
 
     Ok(this.begin_index().into())
+}
+
+pub fn get_previous_line<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this
+        .as_object()
+        .unwrap()
+        .as_display_object()
+        .unwrap()
+        .as_text_line()
+        .unwrap();
+
+    Ok(this
+        .previous_line()
+        .and_then(|line| line.object2())
+        .map(Value::from)
+        .unwrap_or(Value::Null))
+}
+
+pub fn get_next_line<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this
+        .as_object()
+        .unwrap()
+        .as_display_object()
+        .unwrap()
+        .as_text_line()
+        .unwrap();
+
+    Ok(this
+        .next_line()
+        .and_then(|line| line.object2())
+        .map(Value::from)
+        .unwrap_or(Value::Null))
 }
 
 pub fn get_text_height<'gc>(

--- a/core/src/avm2/globals/flash/text/engine/text_line.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_line.rs
@@ -66,6 +66,42 @@ pub fn set_validity<'gc>(
     Ok(Value::Undefined)
 }
 
+pub fn get_text_block<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this
+        .as_object()
+        .unwrap()
+        .as_display_object()
+        .unwrap()
+        .as_text_line()
+        .unwrap();
+
+    Ok(this.text_block().map(Value::from).unwrap_or(Value::Null))
+}
+
+pub fn set_text_block<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this
+        .as_object()
+        .unwrap()
+        .as_display_object()
+        .unwrap()
+        .as_text_line()
+        .unwrap();
+
+    let text_block = args
+        .try_get_object(0)
+        .and_then(|o| o.as_text_block_object());
+    this.set_text_block(text_block, activation.gc());
+    Ok(Value::Undefined)
+}
+
 pub fn get_text_height<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,

--- a/core/src/avm2/globals/flash/text/engine/text_line.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_line.rs
@@ -102,6 +102,22 @@ pub fn set_text_block<'gc>(
     Ok(Value::Undefined)
 }
 
+pub fn get_specified_width<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this
+        .as_object()
+        .unwrap()
+        .as_display_object()
+        .unwrap()
+        .as_text_line()
+        .unwrap();
+
+    Ok(this.specified_width().into())
+}
+
 pub fn get_text_height<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,

--- a/core/src/display_object/text_line.rs
+++ b/core/src/display_object/text_line.rs
@@ -58,6 +58,7 @@ pub struct TextLineData<'gc> {
 
     begin_index: Cell<u32>,
     end_index: Cell<u32>,
+    line_index: Cell<u32>,
 }
 
 impl<'gc> TextLine<'gc> {
@@ -79,6 +80,7 @@ impl<'gc> TextLine<'gc> {
                 raw_text_length: Cell::new(0),
                 begin_index: Cell::new(0),
                 end_index: Cell::new(0),
+                line_index: Cell::new(0),
             },
         ))
     }
@@ -134,6 +136,14 @@ impl<'gc> TextLine<'gc> {
     pub fn set_end_index(self, value: u32) {
         self.0.end_index.set(value);
     }
+
+    pub fn line_index(self) -> u32 {
+        self.0.line_index.get()
+    }
+
+    pub fn set_line_index(self, value: u32) {
+        self.0.line_index.set(value);
+    }
 }
 
 impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
@@ -156,6 +166,7 @@ impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
                 raw_text_length: Cell::new(self.0.raw_text_length.get()),
                 begin_index: Cell::new(self.0.begin_index.get()),
                 end_index: Cell::new(self.0.end_index.get()),
+                line_index: Cell::new(self.0.line_index.get()),
             },
         ))
         .into()

--- a/core/src/display_object/text_line.rs
+++ b/core/src/display_object/text_line.rs
@@ -59,6 +59,9 @@ pub struct TextLineData<'gc> {
     begin_index: Cell<u32>,
     end_index: Cell<u32>,
     line_index: Cell<u32>,
+
+    previous_line: Lock<Option<TextLine<'gc>>>,
+    next_line: Lock<Option<TextLine<'gc>>>,
 }
 
 impl<'gc> TextLine<'gc> {
@@ -81,6 +84,8 @@ impl<'gc> TextLine<'gc> {
                 begin_index: Cell::new(0),
                 end_index: Cell::new(0),
                 line_index: Cell::new(0),
+                previous_line: Lock::new(None),
+                next_line: Lock::new(None),
             },
         ))
     }
@@ -144,6 +149,22 @@ impl<'gc> TextLine<'gc> {
     pub fn set_line_index(self, value: u32) {
         self.0.line_index.set(value);
     }
+
+    pub fn previous_line(self) -> Option<TextLine<'gc>> {
+        self.0.previous_line.get()
+    }
+
+    pub fn set_previous_line(self, value: Option<TextLine<'gc>>, mc: &Mutation<'gc>) {
+        unlock!(Gc::write(mc, self.0), TextLineData, previous_line).set(value);
+    }
+
+    pub fn next_line(self) -> Option<TextLine<'gc>> {
+        self.0.next_line.get()
+    }
+
+    pub fn set_next_line(self, value: Option<TextLine<'gc>>, mc: &Mutation<'gc>) {
+        unlock!(Gc::write(mc, self.0), TextLineData, next_line).set(value);
+    }
 }
 
 impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
@@ -167,6 +188,8 @@ impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
                 begin_index: Cell::new(self.0.begin_index.get()),
                 end_index: Cell::new(self.0.end_index.get()),
                 line_index: Cell::new(self.0.line_index.get()),
+                previous_line: Lock::new(self.0.previous_line.get()),
+                next_line: Lock::new(self.0.next_line.get()),
             },
         ))
         .into()

--- a/core/src/display_object/text_line.rs
+++ b/core/src/display_object/text_line.rs
@@ -55,6 +55,9 @@ pub struct TextLineData<'gc> {
     specified_width: Cell<f64>,
 
     raw_text_length: Cell<u32>,
+
+    begin_index: Cell<u32>,
+    end_index: Cell<u32>,
 }
 
 impl<'gc> TextLine<'gc> {
@@ -74,6 +77,8 @@ impl<'gc> TextLine<'gc> {
                 text_block: Lock::new(None),
                 specified_width: Cell::new(0.0),
                 raw_text_length: Cell::new(0),
+                begin_index: Cell::new(0),
+                end_index: Cell::new(0),
             },
         ))
     }
@@ -113,6 +118,22 @@ impl<'gc> TextLine<'gc> {
     pub fn set_raw_text_length(self, value: u32) {
         self.0.raw_text_length.set(value);
     }
+
+    pub fn begin_index(self) -> u32 {
+        self.0.begin_index.get()
+    }
+
+    pub fn set_begin_index(self, value: u32) {
+        self.0.begin_index.set(value);
+    }
+
+    pub fn end_index(self) -> u32 {
+        self.0.end_index.get()
+    }
+
+    pub fn set_end_index(self, value: u32) {
+        self.0.end_index.set(value);
+    }
 }
 
 impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
@@ -133,6 +154,8 @@ impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
                 text_block: Lock::new(self.0.text_block.get()),
                 specified_width: Cell::new(self.0.specified_width.get()),
                 raw_text_length: Cell::new(self.0.raw_text_length.get()),
+                begin_index: Cell::new(self.0.begin_index.get()),
+                end_index: Cell::new(self.0.end_index.get()),
             },
         ))
         .into()

--- a/core/src/display_object/text_line.rs
+++ b/core/src/display_object/text_line.rs
@@ -20,6 +20,7 @@ use gc_arena::{Collect, Gc, Mutation};
 use ruffle_common::avm_string::AvmString;
 use ruffle_common::utils::HasPrefixField;
 use ruffle_macros::istr;
+use std::cell::Cell;
 use std::sync::Arc;
 
 #[derive(Clone, Collect, Copy)]
@@ -50,6 +51,8 @@ pub struct TextLineData<'gc> {
     validity: Lock<AvmString<'gc>>,
 
     text_block: Lock<Option<TextBlockObject<'gc>>>,
+
+    specified_width: Cell<f64>,
 }
 
 impl<'gc> TextLine<'gc> {
@@ -67,6 +70,7 @@ impl<'gc> TextLine<'gc> {
                 movie,
                 validity: Lock::new(istr!(context, "valid")),
                 text_block: Lock::new(None),
+                specified_width: Cell::new(0.0),
             },
         ))
     }
@@ -90,6 +94,14 @@ impl<'gc> TextLine<'gc> {
     pub fn set_text_block(self, text_block: Option<TextBlockObject<'gc>>, mc: &Mutation<'gc>) {
         unlock!(Gc::write(mc, self.0), TextLineData, text_block).set(text_block);
     }
+
+    pub fn specified_width(self) -> f64 {
+        self.0.specified_width.get()
+    }
+
+    pub fn set_specified_width(self, value: f64) {
+        self.0.specified_width.set(value);
+    }
 }
 
 impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
@@ -108,6 +120,7 @@ impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
                 movie: self.0.movie.clone(),
                 validity: Lock::new(self.0.validity.get()),
                 text_block: Lock::new(self.0.text_block.get()),
+                specified_width: Cell::new(self.0.specified_width.get()),
             },
         ))
         .into()

--- a/core/src/display_object/text_line.rs
+++ b/core/src/display_object/text_line.rs
@@ -53,6 +53,8 @@ pub struct TextLineData<'gc> {
     text_block: Lock<Option<TextBlockObject<'gc>>>,
 
     specified_width: Cell<f64>,
+
+    raw_text_length: Cell<u32>,
 }
 
 impl<'gc> TextLine<'gc> {
@@ -71,6 +73,7 @@ impl<'gc> TextLine<'gc> {
                 validity: Lock::new(istr!(context, "valid")),
                 text_block: Lock::new(None),
                 specified_width: Cell::new(0.0),
+                raw_text_length: Cell::new(0),
             },
         ))
     }
@@ -102,6 +105,14 @@ impl<'gc> TextLine<'gc> {
     pub fn set_specified_width(self, value: f64) {
         self.0.specified_width.set(value);
     }
+
+    pub fn raw_text_length(self) -> u32 {
+        self.0.raw_text_length.get()
+    }
+
+    pub fn set_raw_text_length(self, value: u32) {
+        self.0.raw_text_length.set(value);
+    }
 }
 
 impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
@@ -121,6 +132,7 @@ impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
                 validity: Lock::new(self.0.validity.get()),
                 text_block: Lock::new(self.0.text_block.get()),
                 specified_width: Cell::new(self.0.specified_width.get()),
+                raw_text_length: Cell::new(self.0.raw_text_length.get()),
             },
         ))
         .into()

--- a/core/src/display_object/text_line.rs
+++ b/core/src/display_object/text_line.rs
@@ -2,6 +2,7 @@
 
 use crate::avm1::Object as Avm1Object;
 use crate::avm2::StageObject as Avm2StageObject;
+use crate::avm2::object::TextBlockObject;
 use crate::backend::ui::MouseCursor;
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::interactive::{InteractiveObjectBase, TInteractiveObject};
@@ -47,6 +48,8 @@ pub struct TextLineData<'gc> {
     ///
     /// See [`TextLineValidity`] for the known values of validity.
     validity: Lock<AvmString<'gc>>,
+
+    text_block: Lock<Option<TextBlockObject<'gc>>>,
 }
 
 impl<'gc> TextLine<'gc> {
@@ -63,6 +66,7 @@ impl<'gc> TextLine<'gc> {
                 fallback,
                 movie,
                 validity: Lock::new(istr!(context, "valid")),
+                text_block: Lock::new(None),
             },
         ))
     }
@@ -77,6 +81,14 @@ impl<'gc> TextLine<'gc> {
 
     pub fn set_validity(self, validity: AvmString<'gc>, context: &mut UpdateContext<'gc>) {
         unlock!(Gc::write(context.gc(), self.0), TextLineData, validity).set(validity);
+    }
+
+    pub fn text_block(self) -> Option<TextBlockObject<'gc>> {
+        self.0.text_block.get()
+    }
+
+    pub fn set_text_block(self, text_block: Option<TextBlockObject<'gc>>, mc: &Mutation<'gc>) {
+        unlock!(Gc::write(mc, self.0), TextLineData, text_block).set(text_block);
     }
 }
 
@@ -95,6 +107,7 @@ impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
                 fallback: self.0.fallback,
                 movie: self.0.movie.clone(),
                 validity: Lock::new(self.0.validity.get()),
+                text_block: Lock::new(self.0.text_block.get()),
             },
         ))
         .into()


### PR DESCRIPTION
## Description

A simple refactor that moves TextLine's fields from slots to the native objects.

## Testing

Already covered by tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
