### PR TITLE
avm2: Remove constructors from abstract classes

### DIFF
--- a/core/src/avm2/globals/flash/display/AVM1Movie.as
+++ b/core/src/avm2/globals/flash/display/AVM1Movie.as
@@ -3,10 +3,6 @@ package flash.display {
 
     [Ruffle(Abstract)]
     public class AVM1Movie extends DisplayObject {
-        public function AVM1Movie() {
-            // Should be inaccessible
-        }
-
         public function call(functionName:String, ...rest):* {
             stub_method("flash.display.AVM1Movie", "call");
             return null;

--- a/core/src/avm2/globals/flash/display/Graphics.as
+++ b/core/src/avm2/globals/flash/display/Graphics.as
@@ -5,10 +5,6 @@ package flash.display {
 
     [Ruffle(Abstract)]
     public final class Graphics {
-        public function Graphics() {
-            throw new Error("You cannot construct Graphics directly.");
-        }
-
         public native function beginBitmapFill(
             bitmap:BitmapData,
             matrix:Matrix = null,


### PR DESCRIPTION
## Description

Constructors of abstract classes are not called anyway, so no need to have them defined.

## Testing

Should not be observable.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
