### PR TITLE
ci: Minor tweaks to Discord notification action parameters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,8 +354,8 @@ jobs:
           message: |
             Notarize macOS universal binary bundle step failed
             [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          username: ${{ github.actor }}
-          colour: "#e5534b"
+          username: "GitHub Actions"
+          colour: "#fc2929"
 
       - name: Package macOS
         run: |

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -108,5 +108,5 @@ jobs:
           message: |
             ${{ github.workflow }} run completed with status: ${{ needs.test-dockerfile.result }}
             [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          username: ${{ github.actor }}
-          colour: ${{ needs.test-dockerfile.result == 'success' && '#57ab5a' || '#e5534b' }}
+          username: "GitHub Actions"
+          colour: ${{ needs.test-dockerfile.result == 'success' && '#009800' || '#fc2929' }}


### PR DESCRIPTION
## Description

Another minor follow-up to https://github.com/ruffle-rs/ruffle/pull/24145.

Set username to a fixed string (the last committer or who triggered the action doesn't really matter here), and tweaked colors to match existing notifications, based on:

<img src="https://github.com/user-attachments/assets/4a819b6d-69f7-4ac2-9db7-de4bbf2eea42" />

## Testing

In prod!

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
