### PR TITLE
web: Handle case for invalid URL in panic.tsx

### DIFF
--- a/web/packages/core/src/internal/errors.tsx
+++ b/web/packages/core/src/internal/errors.tsx
@@ -21,6 +21,12 @@ export class LoadRuffleWasmError extends Error {
     }
 }
 
+export class LoadBeginError extends Error {
+    constructor(message: string) {
+        super(`Failed to begin SWF load: ${message}`);
+    }
+}
+
 export class InvalidOptionsError extends Error {
     constructor(message: string) {
         super(`Invalid options: ${message}`);

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -21,6 +21,7 @@ import { RUFFLE_ORIGIN } from "../constants";
 import {
     InvalidOptionsError,
     InvalidSwfError,
+    LoadBeginError,
     LoadRuffleWasmError,
     LoadSwfError,
 } from "../errors";
@@ -1022,7 +1023,7 @@ export class InnerPlayer {
             }
         } catch (e) {
             console.error(`Serious error occurred loading SWF file: ${e}`);
-            const err = new Error(e as string);
+            const err = new LoadBeginError(e as string);
             this.panic(err);
             throw err;
         }

--- a/web/packages/core/src/internal/ui/panic.tsx
+++ b/web/packages/core/src/internal/ui/panic.tsx
@@ -5,6 +5,7 @@ import { RUFFLE_ORIGIN } from "../constants";
 import {
     InvalidOptionsError,
     InvalidSwfError,
+    LoadBeginError,
     LoadRuffleWasmError,
     LoadSwfError,
 } from "../errors";
@@ -366,6 +367,39 @@ function createPanicError(error: Error | null): {
                 CommonActions.ShowDetails,
             ],
         };
+    }
+
+    if (error instanceof LoadBeginError) {
+        const message = String(error.message).toLowerCase();
+
+        if (
+            message.includes("is not a valid url") ||
+            message.includes("invalid url") ||
+            message.includes("invalid base url")
+        ) {
+            // TODO: Switch to `URL.canParse` when support improves
+            let baseURIValid;
+            try {
+                new URL(document.baseURI);
+                baseURIValid = true;
+            } catch {
+                baseURIValid = false;
+            }
+
+            if (!baseURIValid) {
+                // Self hosted: document.baseURI is overridden and returns an invalid result
+                return {
+                    body: textAsParagraphs("error-javascript-conflict"),
+                    actions: [CommonActions.ShowDetails],
+                };
+            } else {
+                // General error: Invalid URL passed to Ruffle
+                return {
+                    body: textAsParagraphs("error-url-invalid"),
+                    actions: [CommonActions.ShowDetails],
+                };
+            }
+        }
     }
 
     return {

--- a/web/packages/core/texts/en-US/messages.ftl
+++ b/web/packages/core/texts/en-US/messages.ftl
@@ -85,6 +85,9 @@ error-csp-conflict =
     Ruffle has encountered a major issue whilst trying to initialize.
     This web server's Content Security Policy does not allow the required ".wasm" component to run.
     If you are the server administrator, please consult the Ruffle wiki for help.
+error-url-invalid =
+    Ruffle failed to load the Flash SWF file.
+    The most likely reason is that an invalid URL for the SWF file was passed to Ruffle.
 error-unknown =
     Ruffle has encountered a major issue whilst trying to display this Flash content.
     {$outdated ->


### PR DESCRIPTION
## Description

This adds handling for both a `document.baseURI` overriden by the page (e.g. #22492) and for an invalid URL being passed to `player.load`. This PR should close all the panic reports about the Wayback Machine breaking `document.baseURI` for some sites.

The first case now displays the following instead of a generic panic:
<img width="550" height="400" alt="image" src="https://github.com/user-attachments/assets/d2c8d770-e371-4391-a860-00a5fff48757" />

And for the second case:
<img width="550" height="400" alt="image" src="https://github.com/user-attachments/assets/08430e4b-f824-4a1e-93b8-3f93625c6edb" />

## Testing

I've tested an extension built with this PR myself on #22492 and a testing site.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
