### PR TITLE
avm2: Minor performance improvements

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2023,6 +2023,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                     ((n1 as i64 + n2 as i64) as f64).into()
                 }
             }
+            (Value::Integer(n1), Value::Number(n2)) => (n1 as f64 + n2).into(),
+            (Value::Number(n1), Value::Integer(n2)) => (n1 + n2 as f64).into(),
             (Value::Number(n1), Value::Number(n2)) => (n1 + n2).into(),
             (Value::String(s), value2) => Value::String(AvmString::concat(
                 self.gc(),

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2146,8 +2146,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn op_decrement(&mut self) -> Result<(), Error<'gc>> {
         let value = self.pop_stack().coerce_to_number(self)?;
+        let result = Value::from(value - 1.0);
 
-        self.push_stack(value - 1.0);
+        self.push_stack(result.try_promote_number());
 
         Ok(())
     }
@@ -2163,8 +2164,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     fn op_divide(&mut self) -> Result<(), Error<'gc>> {
         let value2 = self.pop_stack().coerce_to_number(self)?;
         let value1 = self.pop_stack().coerce_to_number(self)?;
+        let result = Value::from(value1 / value2);
 
-        self.push_stack(value1 / value2);
+        self.push_stack(result.try_promote_number());
 
         Ok(())
     }
@@ -2187,8 +2189,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn op_increment(&mut self) -> Result<(), Error<'gc>> {
         let value = self.pop_stack().coerce_to_number(self)?;
+        let result = Value::from(value + 1.0);
 
-        self.push_stack(value + 1.0);
+        self.push_stack(result.try_promote_number());
 
         Ok(())
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2284,6 +2284,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                     ((n1 as i64 - n2 as i64) as f64).into()
                 }
             }
+            (Value::Integer(n1), Value::Number(n2)) => (n1 as f64 - n2).into(),
+            (Value::Number(n1), Value::Integer(n2)) => (n1 - n2 as f64).into(),
             (Value::Number(n1), Value::Number(n2)) => (n1 - n2).into(),
             _ => {
                 let value2 = value2.coerce_to_number(self)?;

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -1878,30 +1878,62 @@ impl<'gc> Value<'gc> {
     /// This abstract relational comparison algorithm is intended to match
     /// ECMA-262 3rd edition, section 11.8.5. It returns `true`, `false`, *or*
     /// `undefined` (to signal NaN), the latter of which we represent as `None`.
+    ///
+    /// This function can be very hot, so we try to inline this fast-path and
+    /// fall back to a non-inlined slow-path if necessary.
     pub fn abstract_lt(
         &self,
         other: &Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Option<bool>, Error<'gc>> {
+        // Full abstract-lt implementation. This is the slow-path.
+        #[inline(never)]
+        fn abstract_lt_slow<'gc>(
+            self_value: &Value<'gc>,
+            other_value: &Value<'gc>,
+            activation: &mut Activation<'_, 'gc>,
+        ) -> Result<Option<bool>, Error<'gc>> {
+            let prim_self = self_value.coerce_to_primitive(Some(Hint::Number), activation)?;
+            let prim_other = other_value.coerce_to_primitive(Some(Hint::Number), activation)?;
+
+            if let (Value::String(s), Value::String(o)) = (&prim_self, &prim_other) {
+                return Ok(Some(s.as_wstr() < o.as_wstr()));
+            }
+
+            let num_self = prim_self.coerce_to_number(activation)?;
+            let num_other = prim_other.coerce_to_number(activation)?;
+
+            if num_self.is_nan() || num_other.is_nan() {
+                return Ok(None);
+            }
+
+            Ok(Some(num_self < num_other))
+        }
+
         match (self, other) {
             (Value::Integer(a), Value::Integer(b)) => Ok(Some(a < b)),
-            _ => {
-                let prim_self = self.coerce_to_primitive(Some(Hint::Number), activation)?;
-                let prim_other = other.coerce_to_primitive(Some(Hint::Number), activation)?;
-
-                if let (Value::String(s), Value::String(o)) = (&prim_self, &prim_other) {
-                    return Ok(Some(s.as_wstr() < o.as_wstr()));
-                }
-
-                let num_self = prim_self.coerce_to_number(activation)?;
-                let num_other = prim_other.coerce_to_number(activation)?;
-
-                if num_self.is_nan() || num_other.is_nan() {
+            (Value::Integer(a), Value::Number(b)) => {
+                if b.is_nan() {
                     return Ok(None);
                 }
 
-                Ok(Some(num_self < num_other))
+                Ok(Some((*a as f64) < *b))
             }
+            (Value::Number(a), Value::Integer(b)) => {
+                if a.is_nan() {
+                    return Ok(None);
+                }
+
+                Ok(Some(*a < *b as f64))
+            }
+            (Value::Number(a), Value::Number(b)) => {
+                if a.is_nan() || b.is_nan() {
+                    return Ok(None);
+                }
+
+                Ok(Some(a < b))
+            }
+            _ => abstract_lt_slow(self, other, activation),
         }
     }
 }

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -757,8 +757,9 @@ impl<'gc> Value<'gc> {
     /// ToUint32 algorithm which appears to match AVM2.
     ///
     /// This function can be very hot, so we inline a fast-path for
-    /// `Value::Number` and `Value::Integer`, and fall back to a non-inlined
-    /// slow-path handling the rest of the cases if necessary.
+    /// `Value::Integer` and fall back to a non-inlined slow path handling the
+    /// rest of the cases if necessary.
+    #[inline]
     pub fn coerce_to_u32(&self, activation: &mut Activation<'_, 'gc>) -> Result<u32, Error<'gc>> {
         // Full coerce-to-u32 implementation. This is the slow-path.
         #[inline(never)]
@@ -767,7 +768,8 @@ impl<'gc> Value<'gc> {
             activation: &mut Activation<'_, 'gc>,
         ) -> Result<u32, Error<'gc>> {
             Ok(match value {
-                Value::Integer(_) | Value::Number(_) => unreachable!("Handled by fast path"),
+                Value::Integer(_) => unreachable!("Handled by fast path"),
+                Value::Number(n) => f64_to_wrapping_u32(*n),
                 Value::Bool(b) => *b as u32,
                 Value::Undefined | Value::Null => 0,
                 Value::String(_) | Value::Object(_) => {
@@ -777,7 +779,6 @@ impl<'gc> Value<'gc> {
         }
 
         match self {
-            Value::Number(n) => Ok(f64_to_wrapping_u32(*n)),
             Value::Integer(i) => Ok(*i as u32),
             _ => {
                 // Fall back to slow path
@@ -795,8 +796,9 @@ impl<'gc> Value<'gc> {
     /// ToInt32 algorithm which appears to match AVM2.
     ///
     /// This function can be very hot, so we inline a fast-path for
-    /// `Value::Number` and `Value::Integer`, and fall back to a non-inlined
-    /// slow-path handling the rest of the cases if necessary.
+    /// `Value::Integer` and fall back to a non-inlined slow path handling the
+    /// rest of the cases if necessary.
+    #[inline]
     pub fn coerce_to_i32(&self, activation: &mut Activation<'_, 'gc>) -> Result<i32, Error<'gc>> {
         // Full coerce-to-i32 implementation. This is the slow-path.
         #[inline(never)]
@@ -805,7 +807,8 @@ impl<'gc> Value<'gc> {
             activation: &mut Activation<'_, 'gc>,
         ) -> Result<i32, Error<'gc>> {
             Ok(match value {
-                Value::Integer(_) | Value::Number(_) => unreachable!("Handled by fast path"),
+                Value::Integer(_) => unreachable!("Handled by fast path"),
+                Value::Number(n) => f64_to_wrapping_i32(*n),
                 Value::Bool(b) => *b as i32,
                 Value::Undefined | Value::Null => 0,
                 Value::String(_) | Value::Object(_) => {
@@ -815,7 +818,6 @@ impl<'gc> Value<'gc> {
         }
 
         match self {
-            Value::Number(n) => Ok(f64_to_wrapping_i32(*n)),
             Value::Integer(i) => Ok(*i),
             _ => {
                 // Fall back to slow path

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -493,6 +493,17 @@ pub fn abc_default_value<'gc>(
     }
 }
 
+/// Given an `f64`, return an `i32` value that losslessly represents it, or
+/// `None` if there is no such `i32` value.
+fn try_promote_f64(value: f64) -> Option<i32> {
+    let i = value as i32;
+    if value.to_bits() == (i as f64).to_bits() {
+        Some(i)
+    } else {
+        None
+    }
+}
+
 impl<'gc> Value<'gc> {
     /// Do the best effort of converting the [`usize`] value to [`Value`].
     ///
@@ -524,8 +535,7 @@ impl<'gc> Value<'gc> {
     pub fn normalize(self) -> Self {
         match self {
             Value::Number(n) => {
-                let i = n as i32;
-                if n.to_bits() == (i as f64).to_bits() && fits_in_value_integer_i32(i) {
+                if let Some(i) = try_promote_f64(n).filter(|i| fits_in_value_integer_i32(*i)) {
                     Value::Integer(i)
                 } else {
                     self
@@ -538,6 +548,16 @@ impl<'gc> Value<'gc> {
                     self
                 }
             }
+            _ => self,
+        }
+    }
+
+    /// If this `Value` is a `Value::Number` that can be losslessly represented
+    /// as a `Value::Integer`, return that `Value::Integer`. Otherwise return
+    /// the original value.
+    pub fn try_promote_number(self) -> Self {
+        match self {
+            Value::Number(n) if let Some(i) = try_promote_f64(n) => Value::Integer(i),
             _ => self,
         }
     }


### PR DESCRIPTION
## Description

Try to return `Value::Integer` instead of `Value::Number` from some operations when possible, add some fast paths, micro-optimize `coerce_to_u32` and `coerce_to_i32`, and prevent some `Activation::op_X` code from being inlined.

From my measurements, this is a tiny (0.5-1%) performance improvement on a few physics SWFs in my collection.

## Testing

No SWF-observable changes

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
