### PR TITLE
frontend-utils: Don't use native certs for rustls backend of reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,10 +2523,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4636,7 +4636,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4652,6 +4651,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5254,18 +5254,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -6871,6 +6859,15 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/frontend-utils/Cargo.toml
+++ b/frontend-utils/Cargo.toml
@@ -20,11 +20,11 @@ navigator = ["fs", "dep:async-io", "dep:tokio"]
 # system TLS component (OpenSSL/SChannel/SecureTransport) and keeps the binary
 # smaller, which suits desktop targets. Platforms where native-tls is
 # unavailable or impractical (e.g. Android) should set `default-features = false`
-# and enable `rustls-tls`, which bundles a pure-Rust TLS stack (with the OS root
+# and enable `rustls-tls`, which bundles a pure-Rust TLS stack (including root
 # certificates). reqwest picks the backend automatically at runtime from
 # whichever is compiled in, so no code change is needed to switch.
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls-native-roots"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 toml_edit = { workspace = true, features = ["parse"] }


### PR DESCRIPTION
## Description

Seems like even the OS-native root certs are not working on Android.

Follow-up to https://github.com/ruffle-rs/ruffle/pull/23947.
Fixes https://github.com/ruffle-rs/ruffle-android/issues/788.
Tested using https://github.com/ruffle-rs/ruffle-android/pull/794, but I feel like this is the proper place to do it.
This proxy feature flag proxy was added for the sake of the Android app, after all.

## Testing

Download the APKs from the CI run of the linked downstream PR, and see that it is now able to load SWFs from HTTPS URLs.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.