### PR TITLE
tests: Mention UTC timezone is necessary for amf0_serde_suite

### DIFF
--- a/tests/tests/swfs/avm1/amf0_serde_suite/README.md
+++ b/tests/tests/swfs/avm1/amf0_serde_suite/README.md
@@ -1,5 +1,6 @@
  # Running the test
 
+You need to either set your system's timezone, or if possible, Flash Player's time zone to UTC to get the right output for this test due to time zone offset information being included in AMF Date data.
 
 To verify the actual data sent over the network, run 'server.py' from this directory. Then, run 'test.swf' in either Flash Player or the Ruffle Desktop player.
 


### PR DESCRIPTION
## Description

Setting timezone is needed for this test.

## Testing

Do or do not set your time zone and see differing output.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
