### PR TITLE
Revert "chore: Bump wgpu to 28, switch egui to git"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
-name = "accesskit"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
-dependencies = [
- "uuid",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,15 +745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,7 +1382,8 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "ecolor"
 version = "0.33.3"
-source = "git+https://github.com/emilk/egui.git?rev=b077cf910297884a4f1b431e8da99806ae925168#b077cf910297884a4f1b431e8da99806ae925168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ddb8ac7643d1dba1bb02110e804406dd459a838efcb14011ced10556711a8e"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1409,9 +1392,9 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.33.3"
-source = "git+https://github.com/emilk/egui.git?rev=b077cf910297884a4f1b431e8da99806ae925168#b077cf910297884a4f1b431e8da99806ae925168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9b567d356674e9a5121ed3fedfb0a7c31e059fe71f6972b691bcd0bfc284e3"
 dependencies = [
- "accesskit",
  "ahash",
  "bitflags 2.13.0",
  "emath",
@@ -1426,7 +1409,8 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.33.3"
-source = "git+https://github.com/emilk/egui.git?rev=b077cf910297884a4f1b431e8da99806ae925168#b077cf910297884a4f1b431e8da99806ae925168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4d209971c84b2352a06174abdba701af1e552ce56b144d96f2bd50a3c91236"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1445,7 +1429,8 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.33.3"
-source = "git+https://github.com/emilk/egui.git?rev=b077cf910297884a4f1b431e8da99806ae925168#b077cf910297884a4f1b431e8da99806ae925168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec6687e5bb551702f4ad10ac428bab12acf9d53047ebb1082d4a0ed8c6251a29"
 dependencies = [
  "arboard",
  "bytemuck",
@@ -1465,7 +1450,8 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.33.3"
-source = "git+https://github.com/emilk/egui.git?rev=b077cf910297884a4f1b431e8da99806ae925168#b077cf910297884a4f1b431e8da99806ae925168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01d34e845f01c62e3fded726961092e70417d66570c499b9817ab24674ca4ed"
 dependencies = [
  "ahash",
  "egui",
@@ -1484,7 +1470,8 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "emath"
 version = "0.33.3"
-source = "git+https://github.com/emilk/egui.git?rev=b077cf910297884a4f1b431e8da99806ae925168#b077cf910297884a4f1b431e8da99806ae925168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "491bdf728bf25ddd9ad60d4cf1c48588fa82c013a2440b91aa7fc43e34a07c32"
 dependencies = [
  "bytemuck",
 ]
@@ -1598,28 +1585,26 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.33.3"
-source = "git+https://github.com/emilk/egui.git?rev=b077cf910297884a4f1b431e8da99806ae925168#b077cf910297884a4f1b431e8da99806ae925168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009d0dd3c2163823a0abdb899451ecbc78798dec545ee91b43aff1fa790bab62"
 dependencies = [
+ "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
  "epaint_default_fonts",
- "font-types",
  "log",
  "nohash-hasher",
  "parking_lot",
  "profiling",
- "self_cell",
- "skrifa",
- "smallvec",
- "vello_cpu",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
 version = "0.33.3"
-source = "git+https://github.com/emilk/egui.git?rev=b077cf910297884a4f1b431e8da99806ae925168#b077cf910297884a4f1b431e8da99806ae925168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fbe202b6578d3d56428fa185cdf114a05e49da05f477b3c7f0fbb221f1862"
 
 [[package]]
 name = "equivalent"
@@ -1728,15 +1713,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "fearless_simd"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -1892,15 +1868,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "font-types"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "fontconfig"
@@ -2304,17 +2271,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-allocator"
-version = "0.28.0"
+name = "gpu-alloc"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "ash",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
  "log",
  "presser",
- "thiserror 2.0.18",
- "windows 0.62.2",
+ "thiserror 1.0.69",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -2874,18 +2858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
-name = "kurbo"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
-dependencies = [
- "arrayvec",
- "euclid",
- "polycool",
- "smallvec",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,12 +2941,6 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "linebender_resource_handle"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linkme"
@@ -3188,9 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.33.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
+checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
  "bitflags 2.13.0",
  "block",
@@ -3257,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "28.0.0"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618f667225063219ddfc61251087db8a9aec3c3f0950c916b614e403486f1135"
+checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -4027,19 +3993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
-name = "peniko"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
-dependencies = [
- "bytemuck",
- "color",
- "kurbo",
- "linebender_resource_handle",
- "smallvec",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4191,15 +4144,6 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
-name = "polycool"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -4497,16 +4441,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "read-fonts"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
-dependencies = [
- "bytemuck",
- "font-types",
 ]
 
 [[package]]
@@ -5528,16 +5462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "skrifa"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
-dependencies = [
- "bytemuck",
- "read-fonts",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6528,32 +6452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
-name = "vello_common"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
-dependencies = [
- "bytemuck",
- "fearless_simd",
- "hashbrown 0.16.1",
- "log",
- "peniko",
- "skrifa",
- "smallvec",
-]
-
-[[package]]
-name = "vello_cpu"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
-dependencies = [
- "bytemuck",
- "hashbrown 0.16.1",
- "vello_common",
-]
-
-[[package]]
 name = "vergen"
 version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6878,13 +6776,12 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "28.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
+checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
- "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -6908,9 +6805,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "28.0.1"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f4642f53f666adcfd2d3218ab174d1e6681101aef18696b90cbe64d1c10f9"
+checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -6941,45 +6838,45 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "28.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b7b696b918f337c486bf93142454080a32a37832ba8a31e4f48221890047da"
+checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "28.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b251c331f84feac147de3c4aa3aa45112622a95dd7ee1b74384fa0458dbd79"
+checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "28.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a2cf578ce8d7d50d0e63ddc2345c7dcb599f6eb90b888813406ea78b9b7010"
+checksum = "9b1027dcf3b027a877e44819df7ceb0e2e98578830f8cd34cd6c3c7c2a7a50b7"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "28.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca976e72b2c9964eb243e281f6ce7f14a514e409920920dcda12ae40febaae"
+checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "28.0.1"
+version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d6cb474beb218824dcc9e1ce679d973f719262789bfb27407da560cac20eeb"
+checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6993,6 +6890,7 @@ dependencies = [
  "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
+ "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
@@ -7019,20 +6917,21 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "28.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
+ "thiserror 2.0.18",
  "web-sys",
 ]
 
@@ -7089,6 +6988,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
@@ -7120,15 +7029,28 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -7144,9 +7066,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7188,7 +7132,7 @@ checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -7202,11 +7146,30 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ version = "0.3.0"
 [workspace.dependencies]
 tracing = "0.1.43"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-naga = { version = "28.0.0", features = ["wgsl-out"] }
-wgpu = "28.0.0"
-egui = { git = "https://github.com/emilk/egui.git", rev = "b077cf910297884a4f1b431e8da99806ae925168" }
+naga = { version = "27.0.3", features = ["wgsl-out"] }
+wgpu = "27.0.1"
+egui = "0.33.3"
 clap = { version = "4.6.1", features = ["derive"] }
 cpal = "0.16.0"
 anyhow = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -56,7 +56,7 @@ hashbrown = { workspace = true }
 scopeguard = "1.2.0"
 fluent-templates = { workspace = true }
 egui = { workspace = true, optional = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "b077cf910297884a4f1b431e8da99806ae925168", default-features = false, optional = true }
+egui_extras = { version = "0.33.3", default-features = false, optional = true }
 png = { version = "0.18.1", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -85,7 +85,6 @@ unknown-git = "deny"
 github = [
     "ruffle-rs",
     "kyren", # for `gc-arena`
-    "emilk", # for `egui`
 ]
 
 [advisories]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 clap = { workspace = true }
 cpal = { workspace = true }
 egui = { workspace = true }
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "b077cf910297884a4f1b431e8da99806ae925168", default-features = false, features = ["image"] }
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "b077cf910297884a4f1b431e8da99806ae925168", features = ["winit"] }
+egui_extras = { version = "0.33.3", default-features = false, features = ["image"] }
+egui-wgpu = { version = "0.33.3", features = ["winit"] }
 image = { workspace = true, features = ["png"] }
-egui-winit = { git = "https://github.com/emilk/egui.git", rev = "b077cf910297884a4f1b431e8da99806ae925168" }
+egui-winit = "0.33.3"
 fontdb = "0.23"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "aac", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -84,7 +84,6 @@ impl RuffleGui {
     fn update(
         &mut self,
         egui_ctx: &egui::Context,
-        egui_ui: &mut egui::Ui,
         show_menu: bool,
         mut player: Option<&mut Player>,
         menu_height_offset: f64,
@@ -95,7 +94,7 @@ impl RuffleGui {
             .consume_shortcuts(egui_ctx, &mut self.dialogs, player.as_deref_mut());
         if show_menu {
             self.menu_bar
-                .show(&locale, egui_ui, &mut self.dialogs, player.as_deref_mut());
+                .show(&locale, egui_ctx, &mut self.dialogs, player.as_deref_mut());
         }
 
         self.dialogs.show(&locale, egui_ctx, player.as_deref_mut());

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -338,10 +338,9 @@ impl GuiController {
 
         let raw_input = self.egui_winit.take_egui_input(&self.window);
         let show_menu = self.window.fullscreen().is_none() && !self.no_gui;
-        let mut full_output = self.egui_winit.egui_ctx().run_ui(raw_input, |ui| {
+        let mut full_output = self.egui_winit.egui_ctx().run(raw_input, |context| {
             self.gui.update(
-                self.egui_winit.egui_ctx(),
-                ui,
+                context,
                 show_menu,
                 player.as_deref_mut(),
                 if show_menu {
@@ -358,7 +357,7 @@ impl GuiController {
             .repaint_delay;
 
         // If we're not in a UI, tell egui which cursor we prefer to use instead
-        if !self.egui_winit.egui_ctx().egui_wants_pointer_input()
+        if !self.egui_winit.egui_ctx().wants_pointer_input()
             && let Some(player) = player.as_deref()
         {
             full_output.platform_output.cursor_icon =
@@ -543,7 +542,7 @@ fn select_wgpu_backend(
 
 fn try_wgpu_backend(backend: wgpu::Backends) -> Option<wgpu::Instance> {
     let instance = create_wgpu_instance(backend, wgpu::BackendOptions::default());
-    if futures::executor::block_on(instance.enumerate_adapters(backend)).is_empty() {
+    if instance.enumerate_adapters(backend).is_empty() {
         None
     } else {
         Some(instance)

--- a/desktop/src/gui/dialogs/bookmarks_dialog.rs
+++ b/desktop/src/gui/dialogs/bookmarks_dialog.rs
@@ -135,9 +135,9 @@ impl BookmarksDialog {
             .default_width(600.0)
             .default_height(400.0)
             .show(egui_ctx, |ui| {
-                egui::Panel::top("bookmark-dialog-top-panel")
+                egui::TopBottomPanel::top("bookmark-dialog-top-panel")
                     .resizable(true)
-                    .min_size(100.0)
+                    .min_height(100.0)
                     .show_inside(ui, |ui| {
                         if self.preferences.have_bookmarks() {
                             should_close = self.show_bookmark_table(locale, ui);

--- a/desktop/src/gui/dialogs/preferences_dialog.rs
+++ b/desktop/src/gui/dialogs/preferences_dialog.rs
@@ -465,7 +465,7 @@ impl PreferencesDialog {
             if ui.small_button(text(locale, "show-license")).clicked() {
                 self.openh264_license_visible = true;
             };
-            let available_size = egui_ctx.content_rect().size();
+            let available_size = egui_ctx.available_rect().size();
             egui::Window::new(text(locale, "openh264-license"))
                 .collapsible(false)
                 .resizable(false)
@@ -701,7 +701,7 @@ fn ime_enabled_name(locale: &LanguageIdentifier, ime_enabled: Option<bool>) -> C
 }
 
 fn backend_availability(instance: &wgpu::Instance, backend: wgpu::Backends) -> wgpu::Backends {
-    if futures::executor::block_on(instance.enumerate_adapters(backend)).is_empty() {
+    if instance.enumerate_adapters(backend).is_empty() {
         wgpu::Backends::empty()
     } else {
         backend

--- a/desktop/src/gui/dialogs/select_path_dialog.rs
+++ b/desktop/src/gui/dialogs/select_path_dialog.rs
@@ -103,13 +103,13 @@ impl SelectPathDialog {
     pub fn render_window_contents(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) -> bool {
         let mut should_close = false;
 
-        egui::Panel::top("top").show_inside(ui, |ui| {
+        egui::TopBottomPanel::top("top").show_inside(ui, |ui| {
             if let Some(ref message) = self.config.message {
                 ui.label(message.localize(locale));
             }
         });
 
-        egui::Panel::bottom("bottom").show_inside(ui, |ui| {
+        egui::TopBottomPanel::bottom("bottom").show_inside(ui, |ui| {
             ui.horizontal(|ui| {
                 if self.config.extension.is_some() {
                     ui.checkbox(

--- a/desktop/src/gui/menu_bar.rs
+++ b/desktop/src/gui/menu_bar.rs
@@ -93,11 +93,11 @@ impl MenuBar {
     pub fn show(
         &mut self,
         locale: &LanguageIdentifier,
-        egui_ui: &mut egui::Ui,
+        egui_ctx: &egui::Context,
         dialogs: &mut Dialogs,
         mut player: Option<&mut Player>,
     ) {
-        egui::Panel::top("menu_bar").show_inside(egui_ui, |ui| {
+        egui::TopBottomPanel::top("menu_bar").show(egui_ctx, |ui| {
              egui::MenuBar::new().ui(ui, |ui| {
                 self.file_menu(locale, ui, dialogs, player.is_some());
                 self.view_menu(locale, ui, &mut player);

--- a/desktop/src/gui/movie.rs
+++ b/desktop/src/gui/movie.rs
@@ -72,7 +72,7 @@ impl MovieViewRenderer {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
             bind_group_layouts: &[&bind_group_layout],
-            immediate_size: 0,
+            push_constant_ranges: &[],
         });
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: None,
@@ -119,7 +119,7 @@ impl MovieViewRenderer {
                 })],
                 compilation_options: Default::default(),
             }),
-            multiview_mask: None,
+            multiview: None,
             cache: None,
         });
         let vertices = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -621,7 +621,6 @@ impl<'a> NagaBuilder<'a> {
                             interpolation: None,
                             sampling: None,
                             blend_src: None,
-                            per_primitive: false,
                         }),
                         offset: 0,
                     }],
@@ -645,7 +644,6 @@ impl<'a> NagaBuilder<'a> {
                         interpolation: None,
                         sampling: None,
                         blend_src: None,
-                        per_primitive: false,
                     }),
                 });
             }
@@ -759,7 +757,6 @@ impl<'a> NagaBuilder<'a> {
                     interpolation: None,
                     sampling: None,
                     blend_src: None,
-                    per_primitive: false,
                 }),
             });
 
@@ -1792,8 +1789,6 @@ impl<'a> NagaBuilder<'a> {
             workgroup_size: [0; 3],
             workgroup_size_overrides: None,
             function: self.func,
-            mesh_info: None,
-            task_payload: None,
         };
 
         self.module.entry_points.push(entry_point);

--- a/render/naga-agal/src/varying.rs
+++ b/render/naga-agal/src/varying.rs
@@ -60,7 +60,6 @@ impl NagaBuilder<'_> {
                                     interpolation: Some(naga::Interpolation::Perspective),
                                     sampling: None,
                                     blend_src: None,
-                                    per_primitive: false,
                                 }),
                                 offset: 0,
                             });
@@ -87,7 +86,6 @@ impl NagaBuilder<'_> {
                             interpolation: Some(Interpolation::Perspective),
                             sampling: None,
                             blend_src: None,
-                            per_primitive: false,
                         }),
                     });
                     let arg_index = self.func.arguments.len() - 1;

--- a/render/naga-pixelbender/src/lib.rs
+++ b/render/naga-pixelbender/src/lib.rs
@@ -240,7 +240,6 @@ impl ShaderBuilder<'_> {
                 interpolation: Some(naga::Interpolation::Perspective),
                 sampling: Some(naga::Sampling::Center),
                 blend_src: None,
-                per_primitive: false,
             }),
         });
 
@@ -251,7 +250,6 @@ impl ShaderBuilder<'_> {
                 interpolation: None,
                 sampling: None,
                 blend_src: None,
-                per_primitive: false,
             }),
         });
 
@@ -443,8 +441,6 @@ impl ShaderBuilder<'_> {
             workgroup_size: [0; 3],
             workgroup_size_overrides: None,
             function: builder.func,
-            mesh_info: None,
-            task_payload: None,
         });
 
         Ok(NagaModules {

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -1239,7 +1239,7 @@ impl ActiveFrame {
             command_encoder: descriptors
                 .device
                 .create_command_encoder(&Default::default()),
-            staging_belt: wgpu::util::StagingBelt::new(descriptors.device.clone(), 65536),
+            staging_belt: wgpu::util::StagingBelt::new(65536),
             draws_since_flush: 0,
         }
     }

--- a/render/wgpu/src/bitmaps.rs
+++ b/render/wgpu/src/bitmaps.rs
@@ -35,11 +35,7 @@ fn create_sampler(
         address_mode_w: wgpu::AddressMode::Repeat,
         mag_filter: filter,
         min_filter: filter,
-        mipmap_filter: if filter == wgpu::FilterMode::Linear {
-            wgpu::MipmapFilterMode::Linear
-        } else {
-            wgpu::MipmapFilterMode::Nearest
-        },
+        mipmap_filter: filter,
         lod_min_clamp: 0.0,
         lod_max_clamp: 100.0,
         compare: None,

--- a/render/wgpu/src/buffer_builder.rs
+++ b/render/wgpu/src/buffer_builder.rs
@@ -82,12 +82,18 @@ impl BufferBuilder {
     pub fn copy_to(
         self,
         staging_belt: &mut wgpu::util::StagingBelt,
+        device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         buffer: &wgpu::Buffer,
     ) {
         if let Some(length) = wgpu::BufferSize::new(self.inner.len() as u64) {
-            let mut view =
-                staging_belt.write_buffer(encoder, buffer, BufferAddress::default(), length);
+            let mut view = staging_belt.write_buffer(
+                encoder,
+                buffer,
+                BufferAddress::default(),
+                length,
+                device,
+            );
             view.copy_from_slice(&self.inner);
         }
     }

--- a/render/wgpu/src/context3d/current_pipeline.rs
+++ b/render/wgpu/src/context3d/current_pipeline.rs
@@ -403,7 +403,7 @@ impl CurrentPipeline {
                 .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: pipeline_layout_label.as_deref(),
                     bind_group_layouts: &[&compiled_shaders.bind_group_layout],
-                    immediate_size: 0,
+                    push_constant_ranges: &[],
                 });
 
         let bind_group = descriptors
@@ -572,7 +572,7 @@ impl CurrentPipeline {
                     mask: !0,
                     alpha_to_coverage_enabled: false,
                 },
-                multiview_mask: None,
+                multiview: Default::default(),
                 cache: None,
             });
         Some((compiled, bind_group))

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -122,7 +122,7 @@ impl WgpuContext3D {
         let front_buffer_raw_texture_handle = make_dummy_handle();
 
         // FIXME - determine the best chunk size for this
-        let buffer_staging_belt = StagingBelt::new(descriptors.device.clone(), 1024);
+        let buffer_staging_belt = StagingBelt::new(1024);
         let current_pipeline = CurrentPipeline::new(&descriptors);
 
         let buffer_command_encoder =
@@ -708,6 +708,7 @@ impl Context3D for WgpuContext3D {
                         &buffer.buffer,
                         rounded_down_offset as u64,
                         NonZeroU64::new(rounded_up_length as u64).unwrap(),
+                        &self.descriptors.device,
                     )
                     .copy_from_slice(
                         &buffer.data
@@ -736,6 +737,7 @@ impl Context3D for WgpuContext3D {
                     (start_vertex * (data32_per_vertex as usize) * std::mem::size_of::<f32>())
                         as u64,
                     NonZeroU64::new(data.len() as u64).unwrap(),
+                    &self.descriptors.device,
                 )[..data.len()]
                     .copy_from_slice(data);
             }
@@ -948,6 +950,7 @@ impl Context3D for WgpuContext3D {
                     offset,
                     NonZeroU64::new(std::mem::size_of_val(matrix_raw_data_column_major) as u64)
                         .unwrap(),
+                    &self.descriptors.device,
                 );
                 // Despite what the docs claim, we copy in *column* major order, rather than *row* major order.
                 // See this code in OpenFL: https://github.com/openfl/openfl/blob/971a4c9e43b5472fd84d73920a2b7c1b3d8d9257/src/openfl/display3D/Context3D.hx#L1532-L1550

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -87,7 +87,7 @@ impl Descriptors {
                                 &self.bind_layouts.transforms,
                                 &self.bind_layouts.bitmap,
                             ],
-                            immediate_size: 0,
+                            push_constant_ranges: &[],
                         });
                 self.device
                     .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -126,7 +126,7 @@ impl Descriptors {
                             mask: !0,
                             alpha_to_coverage_enabled: false,
                         },
-                        multiview_mask: None,
+                        multiview: None,
                         cache: None,
                     })
             })

--- a/render/wgpu/src/filters/bevel.rs
+++ b/render/wgpu/src/filters/bevel.rs
@@ -96,7 +96,7 @@ impl BevelFilter {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
             bind_group_layouts: &[&bind_group_layout],
-            immediate_size: 0,
+            push_constant_ranges: &[],
         });
 
         Self {
@@ -145,7 +145,7 @@ impl BevelFilter {
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
                         compilation_options: Default::default(),
                     }),
-                    multiview_mask: None,
+                    multiview: None,
                     cache: None,
                 })
         })
@@ -217,7 +217,13 @@ impl BevelFilter {
         shadow_color[1] *= shadow_color[3];
         shadow_color[2] *= shadow_color[3];
         staging_belt
-            .write_buffer(draw_encoder, &self.uniform_buffer, 0, self.uniform_size)
+            .write_buffer(
+                draw_encoder,
+                &self.uniform_buffer,
+                0,
+                self.uniform_size,
+                &descriptors.device,
+            )
             .copy_from_slice(bytemuck::cast_slice(&[BevelUniform {
                 highlight_color,
                 shadow_color,
@@ -233,7 +239,13 @@ impl BevelFilter {
                 composite_source: 1,
             }]));
         staging_belt
-            .write_buffer(draw_encoder, &self.vertex_buffer, 0, self.vertices_size)
+            .write_buffer(
+                draw_encoder,
+                &self.vertex_buffer,
+                0,
+                self.vertices_size,
+                &descriptors.device,
+            )
             .copy_from_slice(bytemuck::cast_slice(&[
                 source.vertices_with_highlight_and_shadow(blur_offset)
             ]));

--- a/render/wgpu/src/filters/blur.rs
+++ b/render/wgpu/src/filters/blur.rs
@@ -91,7 +91,7 @@ impl BlurFilter {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
             bind_group_layouts: &[&bind_group_layout],
-            immediate_size: 0,
+            push_constant_ranges: &[],
         });
 
         Self {
@@ -140,7 +140,7 @@ impl BlurFilter {
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
                         compilation_options: Default::default(),
                     }),
-                    multiview_mask: None,
+                    multiview: None,
                     cache: None,
                 })
         })
@@ -187,7 +187,13 @@ impl BlurFilter {
         );
 
         staging_belt
-            .write_buffer(draw_encoder, &self.vertex_buffer, 0, self.vertices_size)
+            .write_buffer(
+                draw_encoder,
+                &self.vertex_buffer,
+                0,
+                self.vertices_size,
+                &descriptors.device,
+            )
             .copy_from_slice(bytemuck::cast_slice(&[source.vertices()]));
 
         let source_view = source.texture.create_view(&Default::default());
@@ -264,7 +270,13 @@ impl BlurFilter {
                     last_weight,
                 };
                 staging_belt
-                    .write_buffer(draw_encoder, &self.uniform_buffer, 0, self.uniform_size)
+                    .write_buffer(
+                        draw_encoder,
+                        &self.uniform_buffer,
+                        0,
+                        self.uniform_size,
+                        &descriptors.device,
+                    )
                     .copy_from_slice(bytemuck::cast_slice(&[uniform]));
 
                 self.render_with_uniform_buffers(

--- a/render/wgpu/src/filters/color_matrix.rs
+++ b/render/wgpu/src/filters/color_matrix.rs
@@ -65,7 +65,7 @@ impl ColorMatrixFilter {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
             bind_group_layouts: &[&bind_group_layout],
-            immediate_size: 0,
+            push_constant_ranges: &[],
         });
 
         let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
@@ -121,7 +121,7 @@ impl ColorMatrixFilter {
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
                         compilation_options: Default::default(),
                     }),
-                    multiview_mask: None,
+                    multiview: None,
                     cache: None,
                 })
         })
@@ -155,10 +155,22 @@ impl ColorMatrixFilter {
         );
         let source_view = source.texture.create_view(&Default::default());
         staging_belt
-            .write_buffer(draw_encoder, &self.uniform_buffer, 0, self.uniform_size)
+            .write_buffer(
+                draw_encoder,
+                &self.uniform_buffer,
+                0,
+                self.uniform_size,
+                &descriptors.device,
+            )
             .copy_from_slice(bytemuck::cast_slice(&filter.matrix));
         staging_belt
-            .write_buffer(draw_encoder, &self.vertex_buffer, 0, self.vertices_size)
+            .write_buffer(
+                draw_encoder,
+                &self.vertex_buffer,
+                0,
+                self.vertices_size,
+                &descriptors.device,
+            )
             .copy_from_slice(bytemuck::cast_slice(&[source.vertices()]));
         let filter_group = descriptors
             .device

--- a/render/wgpu/src/filters/displacement_map.rs
+++ b/render/wgpu/src/filters/displacement_map.rs
@@ -102,7 +102,7 @@ impl DisplacementMapFilter {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
             bind_group_layouts: &[&bind_group_layout],
-            immediate_size: 0,
+            push_constant_ranges: &[],
         });
 
         let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
@@ -158,7 +158,7 @@ impl DisplacementMapFilter {
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
                         compilation_options: Default::default(),
                     }),
-                    multiview_mask: None,
+                    multiview: None,
                     cache: None,
                 })
         })
@@ -195,7 +195,13 @@ impl DisplacementMapFilter {
         let map_texture = as_texture(&map_handle);
         let map_view = map_texture.texture.create_view(&Default::default());
         staging_belt
-            .write_buffer(draw_encoder, &self.uniform_buffer, 0, self.uniform_size)
+            .write_buffer(
+                draw_encoder,
+                &self.uniform_buffer,
+                0,
+                self.uniform_size,
+                &descriptors.device,
+            )
             .copy_from_slice(bytemuck::cast_slice(&[DisplacementMapUniform {
                 color: [
                     f32::from(filter.color.r) / 255.0,
@@ -222,7 +228,13 @@ impl DisplacementMapFilter {
                 viewscale_y: filter.viewscale_y,
             }]));
         staging_belt
-            .write_buffer(draw_encoder, &self.vertex_buffer, 0, self.vertices_size)
+            .write_buffer(
+                draw_encoder,
+                &self.vertex_buffer,
+                0,
+                self.vertices_size,
+                &descriptors.device,
+            )
             .copy_from_slice(bytemuck::cast_slice(&[source.vertices()]));
         let filter_group = descriptors
             .device

--- a/render/wgpu/src/filters/glow.rs
+++ b/render/wgpu/src/filters/glow.rs
@@ -95,7 +95,7 @@ impl GlowFilter {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
             bind_group_layouts: &[&bind_group_layout],
-            immediate_size: 0,
+            push_constant_ranges: &[],
         });
 
         Self {
@@ -144,7 +144,7 @@ impl GlowFilter {
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
                         compilation_options: Default::default(),
                     }),
-                    multiview_mask: None,
+                    multiview: None,
                     cache: None,
                 })
         })
@@ -196,7 +196,13 @@ impl GlowFilter {
             draw_encoder,
         );
         staging_belt
-            .write_buffer(draw_encoder, &self.uniform_buffer, 0, self.uniform_size)
+            .write_buffer(
+                draw_encoder,
+                &self.uniform_buffer,
+                0,
+                self.uniform_size,
+                &descriptors.device,
+            )
             .copy_from_slice(bytemuck::cast_slice(&[GlowUniform {
                 color: [
                     f32::from(filter.color.r) / 255.0,
@@ -210,7 +216,13 @@ impl GlowFilter {
                 composite_source: if filter.composite_source() { 1 } else { 0 },
             }]));
         staging_belt
-            .write_buffer(draw_encoder, &self.vertex_buffer, 0, self.vertices_size)
+            .write_buffer(
+                draw_encoder,
+                &self.vertex_buffer,
+                0,
+                self.vertices_size,
+                &descriptors.device,
+            )
             .copy_from_slice(bytemuck::cast_slice(&[
                 source.vertices_with_blur_offset(blur_offset)
             ]));

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -91,7 +91,7 @@ impl Pipelines {
             &VERTEX_BUFFERS_DESCRIPTION_COLOR,
             &colort_bindings,
             BlendState::PREMULTIPLIED_ALPHA_BLENDING,
-            0,
+            &[],
             PrimitiveTopology::TriangleList,
         );
 
@@ -104,7 +104,7 @@ impl Pipelines {
             &VERTEX_BUFFERS_DESCRIPTION_COLOR,
             &colort_bindings,
             BlendState::PREMULTIPLIED_ALPHA_BLENDING,
-            0,
+            &[],
             PrimitiveTopology::LineStrip,
         );
 
@@ -123,7 +123,7 @@ impl Pipelines {
             &VERTEX_BUFFERS_DESCRIPTION_POS,
             &gradient_bindings,
             BlendState::PREMULTIPLIED_ALPHA_BLENDING,
-            0,
+            &[],
             PrimitiveTopology::TriangleList,
         );
 
@@ -143,7 +143,7 @@ impl Pipelines {
                 &VERTEX_BUFFERS_DESCRIPTION_POS,
                 &complex_blend_bindings,
                 BlendState::REPLACE,
-                0,
+                &[],
                 PrimitiveTopology::TriangleList,
             )
         };
@@ -164,7 +164,7 @@ impl Pipelines {
                 &VERTEX_BUFFERS_DESCRIPTION_POS,
                 &bitmap_blend_bindings,
                 blend.blend_state(),
-                0,
+                &[],
                 PrimitiveTopology::TriangleList,
             )
         });
@@ -175,7 +175,7 @@ impl Pipelines {
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: bitmap_opaque_pipeline_layout_label.as_deref(),
                 bind_group_layouts: &bitmap_blend_bindings,
-                immediate_size: 0,
+                push_constant_ranges: &[],
             });
 
         let bitmap_opaque = device.create_render_pipeline(&create_pipeline_descriptor(
@@ -238,7 +238,7 @@ impl Pipelines {
             &VERTEX_BUFFERS_DESCRIPTION_POS,
             &alpha_mask_bindings,
             BlendState::PREMULTIPLIED_ALPHA_BLENDING,
-            0,
+            &[],
             PrimitiveTopology::TriangleList,
         );
 
@@ -301,7 +301,7 @@ fn create_pipeline_descriptor<'a>(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     }
 }
@@ -316,14 +316,14 @@ fn create_shape_pipeline(
     vertex_buffers_layout: &[wgpu::VertexBufferLayout<'_>],
     bind_group_layouts: &[&wgpu::BindGroupLayout],
     blend: BlendState,
-    immediate_size: u32,
+    push_constant_ranges: &[wgpu::PushConstantRange],
     primitive_topology: PrimitiveTopology,
 ) -> ShapePipeline {
     let pipeline_layout_label = create_debug_label!("{} shape pipeline layout", name);
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: pipeline_layout_label.as_deref(),
         bind_group_layouts,
-        immediate_size,
+        push_constant_ranges,
     });
 
     let mask_render_state = |mask_name, stencil_state, write_mask| {

--- a/render/wgpu/src/pixel_bender.rs
+++ b/render/wgpu/src/pixel_bender.rs
@@ -87,7 +87,7 @@ impl PixelBenderWgpuShader {
                             mask: !0,
                             alpha_to_coverage_enabled: false,
                         },
-                        multiview_mask: None,
+                        multiview: Default::default(),
                         cache: None,
                     })
             })
@@ -195,7 +195,7 @@ impl PixelBenderWgpuShader {
                 .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: pipeline_layout_label.as_deref(),
                     bind_group_layouts: &[&bind_group_layout],
-                    immediate_size: 0,
+                    push_constant_ranges: &[],
                 });
 
         let shaders =
@@ -256,7 +256,7 @@ impl PixelBenderWgpuShader {
             int_parameters_buffer_size: shaders.int_parameters_buffer_size,
             zeroed_out_of_range_mode,
             // FIXME - come up with a good chunk size
-            staging_belt: RefCell::new(StagingBelt::new(descriptors.device.clone(), 8)),
+            staging_belt: RefCell::new(StagingBelt::new(8)),
         }
     }
 }
@@ -412,6 +412,7 @@ pub(super) fn run_pixelbender_shader_impl(
         &compiled_shader.zeroed_out_of_range_mode,
         0,
         NonZeroU64::new(std::mem::size_of::<f32>() as u64 * 4).unwrap(),
+        &descriptors.device,
     );
 
     // This would ideally be a single f32, but web requires at least 16 bytes
@@ -590,6 +591,7 @@ pub(super) fn run_pixelbender_shader_impl(
                     buffer,
                     vec4_count as u64 * 4 * component_size_bytes,
                     NonZeroU64::new(num_vec4s as u64 * 4 * component_size_bytes).unwrap(),
+                    &descriptors.device,
                 );
                 match value_vec {
                     FloatOrInt::Float(v) => {

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -151,7 +151,12 @@ impl Surface {
                     needs_stencil,
                     transforms,
                 } => {
-                    transforms.copy_to(staging_belt, draw_encoder, &dynamic_transforms.buffer);
+                    transforms.copy_to(
+                        staging_belt,
+                        &descriptors.device,
+                        draw_encoder,
+                        &dynamic_transforms.buffer,
+                    );
                     let mut render_pass =
                         draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                             label: create_debug_label!(


### PR DESCRIPTION
Reverts ruffle-rs/ruffle#23274

It appears the egui bump caused buttons in games (such as SM63, as mentioned on Discord) to fail to work on the Desktop app. This is a temporary revert before a proper fix in #24229