### PR TITLE
avm1: Remove stub from `Sound.setPosition()` to act as a no-op

### DIFF
--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -791,10 +791,9 @@ fn stop<'gc>(
 }
 
 fn set_position<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm1_stub!(activation, "Sound", "setPosition");
     Ok(Value::Undefined)
 }


### PR DESCRIPTION
## Description

I've been trying a bunch of different things, but it doesn't appear that this function does anything in Flash Player. Probably a similar case to `setDuration()`, which itself is already a no-op.

## Testing

Pretty sure this is N/A

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
