### PR TITLE
chore: Ignore cargo deny DoS errors in our outdated quick-xml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -89,7 +89,13 @@ github = [
 
 [advisories]
 version = 2
-
-# `paste` crate is no longer maintained https://rustsec.org/advisories/RUSTSEC-2024-0436
-# `ttf-parser` crate is no longer maintained https://rustsec.org/advisories/RUSTSEC-2026-0192
-ignore = ["RUSTSEC-2024-0436", "RUSTSEC-2026-0192"]
+ignore = [
+    # `paste` crate is no longer maintained https://rustsec.org/advisories/RUSTSEC-2024-0436
+    "RUSTSEC-2024-0436",
+    # `ttf-parser` crate is no longer maintained https://rustsec.org/advisories/RUSTSEC-2026-0192
+    "RUSTSEC-2026-0192",
+    # Quadratic run time when checking a start tag for duplicate attribute names https://rustsec.org/advisories/RUSTSEC-2026-0194
+    "RUSTSEC-2026-0194",
+    # Unbounded namespace-declaration allocation in NsReader enables memory-exhaustion denial of service https://rustsec.org/advisories/RUSTSEC-2026-0195
+    "RUSTSEC-2026-0195"
+]


### PR DESCRIPTION
## Description

I would argue that DoS problems aren't really that interesting for us, because there are probably tons of ways for bad Flash code to cause a DoS, so we might as well ignore it for now. 

#21107  exists to update quick-xml

In fact, I think the permanently red CI might hide other more critical advisories in the future.

## Testing


## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
