### PR TITLE
ci: Fix version4 to respect extension manifest limit

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -30,9 +30,9 @@ def get_current_day_id():
 
 
 def get_max_day_id():
-    max_year = 2999
-    max_day = 999
-    return f'{max_year - 2000}{max_day}'
+    # This is the maximum value allowed in the extension's manifest.
+    # It will work till 2065, but then we can just change the format.
+    return '65535'
 
 
 def get_tag_name(version):


### PR DESCRIPTION

## Description

The previous 4th version component for stable releases (999999) exceeded 65535, the largest value allowed in the extension manifest's version format, causing errors.

This patch makes it use 65535, which will work only till 2065, but I think we'll manage.

This unfortunately makes it look uglier for people that do not appreciate round binary numbers.

## Testing

Not tested

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
