### PR TITLE
chore: Bump webdriverio and some @wdio packages to 9.30 in web/

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,10 +16,10 @@
             ],
             "devDependencies": {
                 "@eslint/js": "^9.39.2",
-                "@wdio/browserstack-service": "^9.29.1",
-                "@wdio/cli": "^9.29.1",
-                "@wdio/local-runner": "^9.29.1",
-                "@wdio/mocha-framework": "^9.29.1",
+                "@wdio/browserstack-service": "^9.30.1",
+                "@wdio/cli": "^9.30.0",
+                "@wdio/local-runner": "^9.30.0",
+                "@wdio/mocha-framework": "^9.30.0",
                 "@wdio/spec-reporter": "^9.29.1",
                 "@wdio/static-server-service": "^9.29.1",
                 "chai": "^6.2.2",
@@ -44,7 +44,7 @@
                 "typedoc-plugin-mdn-links": "^5.1.1",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.64.0",
-                "webdriverio": "^9.29.0",
+                "webdriverio": "^9.30.0",
                 "webpack": "^5.108.4",
                 "webpack-cli": "^7.2.1",
                 "workspace-version": "^0.1.4"
@@ -336,24 +336,10 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/@browserstack/wdio-browserstack-service": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@browserstack/wdio-browserstack-service/-/wdio-browserstack-service-2.0.2.tgz",
-            "integrity": "sha512-G8QefAej1fAZwIxCF5FeM5bZVrqpWXTepokzd2clGmzi9tVrHbmR4jC1L8rRGTK2X88uym8Yzb+idw9FbkJztw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@bufbuild/protobuf": "^2.5.2",
-                "@grpc/grpc-js": "1.13.3"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@bufbuild/protobuf": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-            "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
+            "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
             "dev": true,
             "license": "(Apache-2.0 AND BSD-3-Clause)"
         },
@@ -2824,9 +2810,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-            "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+            "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
             "dev": true,
             "license": "BSD-3-Clause"
         },
@@ -3971,20 +3957,21 @@
             }
         },
         "node_modules/@wdio/browserstack-service": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/@wdio/browserstack-service/-/browserstack-service-9.29.1.tgz",
-            "integrity": "sha512-TiJJDo8UlWTerRC55Ptmc2eLxXC1CT5r0ljrlr1Z2ywc0azKIKQBgbY7mqFGhwUKRQskT6es0Odv2PJQvanhcA==",
+            "version": "9.30.1",
+            "resolved": "https://registry.npmjs.org/@wdio/browserstack-service/-/browserstack-service-9.30.1.tgz",
+            "integrity": "sha512-wJoYnfGJb9h4EoXu6SiIHpPJazp7p6GS8DQQIk8sNo+BYO/hzztjASJVxRZBjZdBiuzNSfzFmTnIUNS0knM6pg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@browserstack/ai-sdk-node": "1.5.17",
-                "@browserstack/wdio-browserstack-service": "^2.0.2",
+                "@bufbuild/protobuf": "^2.5.2",
+                "@grpc/grpc-js": "1.13.3",
                 "@percy/appium-app": "^2.0.9",
                 "@percy/selenium-webdriver": "^2.2.2",
                 "@types/gitconfiglocal": "^2.0.1",
-                "@wdio/logger": "9.29.1",
-                "@wdio/reporter": "9.29.1",
-                "@wdio/types": "9.29.1",
+                "@wdio/logger": "^9.0.0",
+                "@wdio/reporter": "^9.0.0",
+                "@wdio/types": "^9.0.0",
                 "browserstack-local": "^1.5.1",
                 "chalk": "^5.3.0",
                 "csv-writer": "^1.6.0",
@@ -3994,9 +3981,9 @@
                 "tar": "^7.5.11",
                 "undici": "^6.24.0",
                 "uuid": "^11.1.0",
-                "webdriverio": "9.29.1",
+                "webdriverio": "^9.0.0",
                 "winston-transport": "^4.5.0",
-                "yauzl": "^3.0.0"
+                "yauzl": "^3.4.0"
             },
             "engines": {
                 "node": ">=18.20.0"
@@ -4006,23 +3993,23 @@
             }
         },
         "node_modules/@wdio/cli": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.29.1.tgz",
-            "integrity": "sha512-MjRHdM5mGuibhwv+pu8rJD1Pxl6JVj4Pvy9stuj/SjbTqWRxjLauLd3i7+tIMdmrK0ajGO0n249HT8vS8Mh0Dg==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.30.0.tgz",
+            "integrity": "sha512-e5IqOvfjnyMfSYM6c++qe66kwMw24TA11b/sYDa3oPsHps06JaRzFqM4U0HZIUa+9QpNheat87VYJWrsRCKv1g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vitest/snapshot": "^2.1.1",
-                "@wdio/config": "9.29.1",
+                "@wdio/config": "9.30.0",
                 "@wdio/globals": "9.29.1",
                 "@wdio/logger": "9.29.1",
-                "@wdio/protocols": "9.29.1",
+                "@wdio/protocols": "9.30.0",
                 "@wdio/types": "9.29.1",
-                "@wdio/utils": "9.29.1",
+                "@wdio/utils": "9.30.0",
                 "async-exit-hook": "^2.0.1",
                 "chalk": "^5.4.1",
                 "chokidar": "^4.0.0",
-                "create-wdio": "9.29.1",
+                "create-wdio": "9.30.0",
                 "dotenv": "^17.2.0",
                 "import-meta-resolve": "^4.0.0",
                 "lodash.flattendeep": "^4.4.0",
@@ -4030,7 +4017,7 @@
                 "lodash.union": "^4.6.0",
                 "read-pkg-up": "^10.0.0",
                 "tsx": "^4.7.2",
-                "webdriverio": "9.29.1",
+                "webdriverio": "9.30.0",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -4041,15 +4028,15 @@
             }
         },
         "node_modules/@wdio/config": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.29.1.tgz",
-            "integrity": "sha512-8IXDiRG9wUUnpU6M/uzsVqIHJD/7o4y9RaOU2Jh/OdRJP/7rxwfGsa24Bv486rnMGdghztkwLCBJWG0jbeEtfw==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.30.0.tgz",
+            "integrity": "sha512-pH/Y1F4QVIsx33xyli8+9HCr4HRuOeUk8j/lqNBuuUzbvduYRCLmNkZqxRsLnRth8wrlPdzA8Hq+PPLwJWrceA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@wdio/logger": "9.29.1",
                 "@wdio/types": "9.29.1",
-                "@wdio/utils": "9.29.1",
+                "@wdio/utils": "9.30.0",
                 "deepmerge-ts": "^7.0.3",
                 "glob": "^10.2.2",
                 "import-meta-resolve": "^4.0.0",
@@ -4098,9 +4085,9 @@
             "license": "MIT"
         },
         "node_modules/@wdio/config/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4266,18 +4253,18 @@
             }
         },
         "node_modules/@wdio/local-runner": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.29.1.tgz",
-            "integrity": "sha512-ypgi3gTZYY3eStp1U9H6Gjl0mer55CYMdbtRQ27s6evN1QABcwkGCTuzwqHoO6RmKzwPOuht2mnWb9HwYJaNnw==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.30.0.tgz",
+            "integrity": "sha512-7W+vjAsccGXuy2g83vsc5zKwZSkmnEZDEzsORGhorJAWJPd3NwZ8LyyudBxWvSS4sLbJB0Ix4wx70lA8YoiQMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.1.0",
                 "@wdio/logger": "9.29.1",
                 "@wdio/repl": "9.16.2",
-                "@wdio/runner": "9.29.1",
+                "@wdio/runner": "9.30.0",
                 "@wdio/types": "9.29.1",
-                "@wdio/xvfb": "9.29.1",
+                "@wdio/xvfb": "9.30.0",
                 "exit-hook": "^4.0.0",
                 "expect-webdriverio": "^5.6.5",
                 "split2": "^4.1.0",
@@ -4305,9 +4292,9 @@
             }
         },
         "node_modules/@wdio/mocha-framework": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.29.1.tgz",
-            "integrity": "sha512-GG3z0OtD2eu15ql3vnI6VcLJ3INUfSrqbuop/tCAbCjkkKgpjq1JOno0lrDNKRt5Ndq4a4/c9Wu5uxfL+CItYw==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.30.0.tgz",
+            "integrity": "sha512-NhxHeIFd0iHpb8sud3ahOilE/bgm5MBBzSq+xSKW+hTUYdmeyy4w+KX5p/+AQ0dsUEIToaA4xjZRUTCwY+65Wg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4315,7 +4302,7 @@
                 "@types/node": "^20.11.28",
                 "@wdio/logger": "9.29.1",
                 "@wdio/types": "9.29.1",
-                "@wdio/utils": "9.29.1",
+                "@wdio/utils": "9.30.0",
                 "mocha": "^10.3.0"
             },
             "engines": {
@@ -4604,9 +4591,9 @@
             }
         },
         "node_modules/@wdio/protocols": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.29.1.tgz",
-            "integrity": "sha512-NFlBQOA4zDb4D/ETpVMqDgbJyEqdhGRsJWybLOXG7PGlPwfcrfmTMHC1+Boq4KODgpwbhCmI9zIk2JQmGYIttQ==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.30.0.tgz",
+            "integrity": "sha512-VDKCTw3GVdqUw1+fXAY4FUOSt+a3/r7T2O34d5HAaZLfI6QHacsU7/N0Sv3w/QgWU6yj3WkXElXq1oSWF1XcBw==",
             "dev": true,
             "license": "MIT"
         },
@@ -4641,22 +4628,22 @@
             }
         },
         "node_modules/@wdio/runner": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.29.1.tgz",
-            "integrity": "sha512-LV9+0U74J1YModG0T64Kdnh+xvOcd9MWGFlKyXnCtfFDV+47K9BpoDMrc/ng3daLrIKcZGVbym+GhEShiM0DPQ==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.30.0.tgz",
+            "integrity": "sha512-gvUExYXZtziIM4TmWMd98cvVUt2jTQ54k8gIYxBJ8w8N6BQfrko08IKWrVjoNOanJzLMHjqtCWWx4DXR3JtozQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.11.28",
-                "@wdio/config": "9.29.1",
+                "@wdio/config": "9.30.0",
                 "@wdio/dot-reporter": "9.29.1",
                 "@wdio/globals": "9.29.1",
                 "@wdio/logger": "9.29.1",
                 "@wdio/types": "9.29.1",
-                "@wdio/utils": "9.29.1",
+                "@wdio/utils": "9.30.0",
                 "deepmerge-ts": "^7.0.3",
-                "webdriver": "9.29.1",
-                "webdriverio": "9.29.1"
+                "webdriver": "9.30.0",
+                "webdriverio": "9.30.0"
             },
             "engines": {
                 "node": ">=18.20.0"
@@ -4721,9 +4708,9 @@
             }
         },
         "node_modules/@wdio/utils": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.29.1.tgz",
-            "integrity": "sha512-jyt6b6FfdYwVbMISVhuyGC1xQGZj6xM03KhTHozH7a9/zu9b++94KRdT9HRbwX8zefjW0YeIC5+qWSIf7WWHZg==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.30.0.tgz",
+            "integrity": "sha512-MhTx8jKOtspogeMUmASFsmL6vRetwCpvfcAFHauYZ62UzPjFwHThIXorzoG90mrcS9Yl+c8Sj9BfX+bdxwXfsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4733,7 +4720,7 @@
                 "decamelize": "^6.0.0",
                 "deepmerge-ts": "^7.0.3",
                 "edgedriver": "^6.1.2",
-                "geckodriver": "^6.1.0",
+                "geckodriver": "^6.1.1",
                 "get-port": "^7.0.0",
                 "import-meta-resolve": "^4.0.0",
                 "locate-app": "^2.2.24",
@@ -4747,16 +4734,16 @@
             }
         },
         "node_modules/@wdio/xvfb": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.29.1.tgz",
-            "integrity": "sha512-suC0EJcPVldpIyJA/UB9cV11PkW4sGgNmLHPhWU7NiASnbiFeHjK3EbevjzlwwBNYXx1KHO4jMY4Rep2wwVNuw==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.30.0.tgz",
+            "integrity": "sha512-v2vkweVbf1nI3lqRjVMbRyWFqHxPrDE95sLq0IZLjZ8fnXtWWIF61ZxfUhLdrMKB6s3gXnOyZuWgEJFD7iDBGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@wdio/logger": "9.29.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=18.20.0"
             }
         },
         "node_modules/@webassemblyjs/ast": {
@@ -4935,9 +4922,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@zip.js/zip.js": {
-            "version": "2.8.26",
-            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
-            "integrity": "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==",
+            "version": "2.8.33",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.33.tgz",
+            "integrity": "sha512-Mc+s4DdDl9lmhFmkOmNDryC/b4rZm7y2/qBUQTCwPYGkQ8dkCeykILqEYBd+14ATuj93XWZJBrPe2x+cF9LcGA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -6869,9 +6856,9 @@
             "license": "MIT"
         },
         "node_modules/create-wdio": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.29.1.tgz",
-            "integrity": "sha512-EWef5jtJ9pN+tYblwZvWwDEKEgZSMy8VZCUCWBIiw3Z48aDbqusxpOseZWZ/rAttsqGyntzIvHLxIo0r7kryxw==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.30.0.tgz",
+            "integrity": "sha512-rmlMhGxT+s+mnAt+GWUhwf/h9CalN1Qy/LXE6u7IUkw2HdpcimYZOFCQ15bujE+Bm0/rfH9jFz9Tn08xtln4nw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6893,7 +6880,7 @@
                 "create-wdio": "bin/wdio.js"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18.20.0"
             }
         },
         "node_modules/cross-env": {
@@ -8677,9 +8664,9 @@
             "license": "MIT"
         },
         "node_modules/filelist/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8940,9 +8927,9 @@
             }
         },
         "node_modules/geckodriver": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
-            "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.1.tgz",
+            "integrity": "sha512-/AcCyc9o9o6hUbudaSJM2iOtXbxSLqQPOb4GrPvEN40cjraUeaX/j5kH3mSgwiroyMn7qzx2wM61AQ2XY8j3sA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -8952,7 +8939,7 @@
                 "decamelize": "^6.0.1",
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.6",
-                "modern-tar": "^0.7.2"
+                "modern-tar": "^0.7.3"
             },
             "bin": {
                 "geckodriver": "bin/geckodriver.js"
@@ -11900,9 +11887,9 @@
             }
         },
         "node_modules/modern-tar": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
-            "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+            "version": "0.7.7",
+            "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+            "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13407,9 +13394,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
@@ -13968,9 +13955,9 @@
             "license": "MIT"
         },
         "node_modules/recursive-readdir/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15800,9 +15787,9 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-            "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+            "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16826,23 +16813,23 @@
             }
         },
         "node_modules/webdriver": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.29.1.tgz",
-            "integrity": "sha512-uhxYap3qQXC9H2V8SDr7vcy0blZETeri4goLwbw1TFq4EZHF1Dv503Zc0PAjfkNQJCD4/rzAyr07+EX72kx1pg==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.30.0.tgz",
+            "integrity": "sha512-DisY5E8p5zAZyl8pee08p4Vlc91c94Am9oswZaNCgZH5Ewm//FoCZ+tHNppENqooCYjfa/upATbFqGOLuXQkrw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.1.0",
                 "@types/ws": "^8.5.3",
-                "@wdio/config": "9.29.1",
+                "@wdio/config": "9.30.0",
                 "@wdio/logger": "9.29.1",
-                "@wdio/protocols": "9.29.1",
+                "@wdio/protocols": "9.30.0",
                 "@wdio/types": "9.29.1",
-                "@wdio/utils": "9.29.1",
+                "@wdio/utils": "9.30.0",
                 "deepmerge-ts": "^7.0.3",
                 "https-proxy-agent": "^7.0.6",
-                "undici": "^6.21.3",
-                "ws": "^8.8.0"
+                "undici": "^6.27.0",
+                "ws": "^8.21.0"
             },
             "engines": {
                 "node": ">=18.20.0"
@@ -16873,20 +16860,20 @@
             }
         },
         "node_modules/webdriverio": {
-            "version": "9.29.1",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.29.1.tgz",
-            "integrity": "sha512-UIplAnvbjdE0tucHVR/8Uk0Y7rz72VaEx/s0Tq91fMdXm+m+Za16e+b5tObh4xEEfyCITODPfzgBva9rA+xApQ==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.30.0.tgz",
+            "integrity": "sha512-cmV/uSbCvnJ99QejGPVGlzb9MjiSYUts8VjdESnDKvA7JvRMIJK0l807Js7HDK/g6KG7j+D2apsFHGlT7W5UeA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^20.11.30",
                 "@types/sinonjs__fake-timers": "^8.1.5",
-                "@wdio/config": "9.29.1",
+                "@wdio/config": "9.30.0",
                 "@wdio/logger": "9.29.1",
-                "@wdio/protocols": "9.29.1",
+                "@wdio/protocols": "9.30.0",
                 "@wdio/repl": "9.16.2",
                 "@wdio/types": "9.29.1",
-                "@wdio/utils": "9.29.1",
+                "@wdio/utils": "9.30.0",
                 "archiver": "^7.0.1",
                 "aria-query": "^5.3.0",
                 "cheerio": "^1.0.0-rc.12",
@@ -16903,7 +16890,7 @@
                 "rgb2hex": "0.2.5",
                 "serialize-error": "^12.0.0",
                 "urlpattern-polyfill": "^10.0.0",
-                "webdriver": "9.29.1"
+                "webdriver": "9.30.0"
             },
             "engines": {
                 "node": ">=18.20.0"
@@ -17708,27 +17695,16 @@
             }
         },
         "node_modules/yauzl": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-            "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+            "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "buffer-crc32": "~0.2.3",
                 "pend": "~1.2.0"
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/yauzl/node_modules/buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/yn": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,10 +16,10 @@
     ],
     "devDependencies": {
         "@eslint/js": "^9.39.2",
-        "@wdio/browserstack-service": "^9.29.1",
-        "@wdio/cli": "^9.29.1",
-        "@wdio/local-runner": "^9.29.1",
-        "@wdio/mocha-framework": "^9.29.1",
+        "@wdio/browserstack-service": "^9.30.1",
+        "@wdio/cli": "^9.30.0",
+        "@wdio/local-runner": "^9.30.0",
+        "@wdio/mocha-framework": "^9.30.0",
         "@wdio/spec-reporter": "^9.29.1",
         "@wdio/static-server-service": "^9.29.1",
         "chai": "^6.2.2",
@@ -44,7 +44,7 @@
         "typedoc-plugin-mdn-links": "^5.1.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.64.0",
-        "webdriverio": "^9.29.0",
+        "webdriverio": "^9.30.0",
         "webpack": "^5.108.4",
         "webpack-cli": "^7.2.1",
         "workspace-version": "^0.1.4"


### PR DESCRIPTION
## Description

Extracted from https://github.com/ruffle-rs/ruffle/pull/24275 due to https://github.com/dependabot/dependabot-core/issues/12823.
Apparently, some `@wdio` packages have `9.30.1` already, while others are still on `9.29.x`.

## Testing

Mostly, yeah.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
