### PR TITLE
avm2: Properly stub IME.isSupported

### DIFF
--- a/core/src/avm2/globals/flash/system/IME.as
+++ b/core/src/avm2/globals/flash/system/IME.as
@@ -9,7 +9,6 @@ package flash.system {
     public final class IME extends EventDispatcher {
         private static var _conversionMode:String = "ALPHANUMERIC_HALF";
         private static var _enabled:Boolean;
-        private static var _isSupported:Boolean;
 
         public static function compositionAbandoned():void {
             stub_method("flash.system.IME", "compositionAbandoned");
@@ -27,8 +26,8 @@ package flash.system {
             stub_method("flash.system.IME", "setCompositionString");
         }
 
-        public function get isSupported():Boolean {
-            return _isSupported;
+        public static function get isSupported():Boolean {
+            return false;
         }
 
         public static function get enabled():Boolean {


### PR DESCRIPTION
## Description

`IME.isSupported` returned `undefined` and not `false`.

## Testing


## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
