### PR TITLE
Polyfilled plugin properties remain configurable

### DIFF
--- a/web/packages/core/src/plugin-polyfill.ts
+++ b/web/packages/core/src/plugin-polyfill.ts
@@ -277,10 +277,12 @@ export function installPlugin(plugin: RufflePlugin): void {
     if (!("install" in navigator.plugins) || !navigator.plugins["install"]) {
         Object.defineProperty(window, "PluginArray", {
             value: RufflePluginArray,
+            configurable: true,
         });
         Object.defineProperty(navigator, "plugins", {
             value: new RufflePluginArray(navigator.plugins),
             writable: false,
+            configurable: true,
         });
     }
 
@@ -293,13 +295,16 @@ export function installPlugin(plugin: RufflePlugin): void {
     ) {
         Object.defineProperty(window, "MimeTypeArray", {
             value: RuffleMimeTypeArray,
+            configurable: true,
         });
         Object.defineProperty(window, "MimeType", {
             value: RuffleMimeType,
+            configurable: true,
         });
         Object.defineProperty(navigator, "mimeTypes", {
             value: new RuffleMimeTypeArray(navigator.mimeTypes),
             writable: false,
+            configurable: true,
         });
     }
 

--- a/web/packages/selfhosted/test/polyfill/spoofing/test.ts
+++ b/web/packages/selfhosted/test/polyfill/spoofing/test.ts
@@ -78,4 +78,68 @@ describe("Spoofing is not easily detectable", () => {
         });
         expect(json).to.equal('{"0":{},"1":{},"2":{},"3":{},"4":{},"5":{}}');
     });
+
+    it("Spoof of navigator.plugins configurable", async () => {
+        const configurable = await browser.execute(() => {
+            try {
+                Object.defineProperty(navigator, "plugins", { value: "test" });
+                return true;
+            } catch (_) {
+                return false;
+            }
+        });
+        expect(configurable).be.true;
+    });
+
+    it("Spoof of navigator.mimeTypes configurable", async () => {
+        const configurable = await browser.execute(() => {
+            try {
+                Object.defineProperty(navigator, "mimeTypes", {
+                    value: "test",
+                });
+                return true;
+            } catch (_) {
+                return false;
+            }
+        });
+        expect(configurable).be.true;
+    });
+
+    it("Spoof of PluginArray configurable", async () => {
+        const configurable = await browser.execute(() => {
+            try {
+                Object.defineProperty(window, "PluginArray", { value: "test" });
+                return true;
+            } catch (_) {
+                return false;
+            }
+        });
+        expect(configurable).be.true;
+    });
+
+    it("Spoof of MimeTypeArray configurable", async () => {
+        const configurable = await browser.execute(() => {
+            try {
+                Object.defineProperty(window, "MimeTypeArray", {
+                    value: "test",
+                });
+                return true;
+            } catch (_) {
+                return false;
+            }
+        });
+        expect(configurable).be.true;
+    });
+
+    it("Spoof of MimeType configurable", async () => {
+        const configurable = await browser.execute(() => {
+            try {
+                Object.defineProperty(window, "MimeType", { value: "test" });
+                return true;
+            } catch (_) {
+                return false;
+            }
+        });
+        expect(configurable).be.true;
+    });
 });


### PR DESCRIPTION

## Description

Fixes #24311. 

This allows additional plugin polyfills or additional code in general (from different scripts or browser extensions) to add to `navigator.plugins`, `navigator.mimeTypes` etc. after Ruffle (or to override the properties in any other way, as they normally can do).

## Testing

Tests added to `web/packages/selfhosted/test/polyfill/spoofing`.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
