### PR TITLE
swf: Add dedicated error types `Avm1ParseError` and `UnexpectedEof`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5602,7 +5602,6 @@ version = "0.2.2"
 dependencies = [
  "bitflags 2.13.1",
  "bitstream-io 4.10.0",
- "byteorder",
  "encoding_rs",
  "enum-map",
  "flate2",

--- a/core/src/avm1/error.rs
+++ b/core/src/avm1/error.rs
@@ -22,8 +22,8 @@ pub enum Error<'gc> {
     #[error("Property recursion limit has been hit.")]
     PropertyRecursionLimit,
 
-    #[error("Couldn't parse SWF")]
-    InvalidSwf(#[from] swf::error::Error),
+    #[error("Couldn't parse AVM1 bytecode")]
+    InvalidBytecode(#[from] swf::error::Avm1ParseError),
 
     #[error("A script has thrown a custom error.")]
     ThrownValue(Value<'gc>),

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -683,7 +683,7 @@ impl<'gc> Avm1<'gc> {
                 // Continue execution without halting.
                 return;
             }
-            Error::InvalidSwf(swf_error) => {
+            Error::InvalidBytecode(swf_error) => {
                 tracing::error!("{}: {}", error, swf_error);
             }
             _ => {

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -26,6 +26,12 @@ pub enum Error {
     InvalidSwfUrl,
 }
 
+impl From<swf::error::UnexpectedEof> for Error {
+    fn from(_: swf::error::UnexpectedEof) -> Error {
+        Error::IOError(std::io::ErrorKind::UnexpectedEof.into())
+    }
+}
+
 /// Whether or not to end tag decoding.
 pub enum ControlFlow {
     /// Stop decoding after this tag.

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 bitflags = { workspace = true }
 bitstream-io = { workspace = true }
-byteorder = { workspace = true }
 encoding_rs = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -1,7 +1,10 @@
-use crate::avm1::{opcode::OpCode, types::*};
-use crate::error::{Error, Result};
+use crate::avm1::opcode::OpCode;
+use crate::avm1::types::*;
+use crate::error::{Avm1ParseError, UnexpectedEof};
 use crate::extensions::ReadSwfExt;
 use std::num::NonZeroU8;
+
+type Result<T, E = UnexpectedEof> = std::result::Result<T, E>;
 
 pub struct Reader<'a> {
     input: &'a [u8],
@@ -50,15 +53,15 @@ impl<'a> Reader<'a> {
     }
 
     #[inline]
-    pub fn read_action(&mut self) -> Result<Action<'a>> {
-        let (opcode, mut length) = self.read_opcode_and_length()?;
+    pub fn read_action(&mut self) -> Result<Action<'a>, Avm1ParseError> {
+        let (opcode, mut length) = self
+            .read_opcode_and_length()
+            .map_err(|source| Avm1ParseError::new(None, source))?;
+
         let start = self.input;
-
-        let action = self.read_op(opcode, &mut length);
-
-        if let Err(e) = action {
-            return Err(Error::avm1_parse_error_with_source(opcode, e));
-        }
+        let action = self
+            .read_op(opcode, &mut length)
+            .map_err(|source| Avm1ParseError::new(Some(opcode), source));
 
         // Verify that we parsed the correct amount of data.
         let end_pos = (start.as_ptr() as usize + length) as *const u8;
@@ -72,7 +75,7 @@ impl<'a> Reader<'a> {
         action
     }
 
-    pub fn read_opcode_and_length(&mut self) -> Result<(u8, usize)> {
+    fn read_opcode_and_length(&mut self) -> Result<(u8, usize)> {
         let opcode = self.read_u8()?;
         let length = if opcode >= 0x80 {
             self.read_u16()?.into()
@@ -443,7 +446,7 @@ pub mod tests {
         let action_bytes = [0xff, 0xff, 0xff, 0x00, 0x00];
         let mut reader = Reader::new(&action_bytes[..], 5);
         match reader.read_action() {
-            Err(crate::error::Error::Avm1ParseError { .. }) => (),
+            Err(_) => (),
             result => {
                 panic!("Expected Avm1ParseError, got {result:?}");
             }

--- a/swf/src/avm1/write.rs
+++ b/swf/src/avm1/write.rs
@@ -1,8 +1,6 @@
 use crate::avm1::opcode::OpCode;
 use crate::avm1::types::*;
-use crate::string::SwfStr;
 use crate::write::SwfWriteExt;
-use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{Result, Write};
 
 pub struct Writer<W: Write> {
@@ -13,54 +11,8 @@ pub struct Writer<W: Write> {
 
 impl<W: Write> SwfWriteExt for Writer<W> {
     #[inline]
-    fn write_u8(&mut self, n: u8) -> Result<()> {
-        self.output.write_u8(n)
-    }
-
-    #[inline]
-    fn write_u16(&mut self, n: u16) -> Result<()> {
-        self.output.write_u16::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_u32(&mut self, n: u32) -> Result<()> {
-        self.output.write_u32::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_u64(&mut self, n: u64) -> Result<()> {
-        self.output.write_u64::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_i8(&mut self, n: i8) -> Result<()> {
-        self.output.write_i8(n)
-    }
-
-    #[inline]
-    fn write_i16(&mut self, n: i16) -> Result<()> {
-        self.output.write_i16::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_i32(&mut self, n: i32) -> Result<()> {
-        self.output.write_i32::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_f32(&mut self, n: f32) -> Result<()> {
-        self.output.write_f32::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_f64(&mut self, n: f64) -> Result<()> {
-        self.output.write_f64::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_string(&mut self, s: &'_ SwfStr) -> Result<()> {
-        self.output.write_all(s.as_bytes())?;
-        self.write_u8(0)
+    fn as_writer(&mut self) -> &mut impl Write {
+        &mut self.output
     }
 }
 

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -99,7 +99,7 @@ impl<'a> Reader<'a> {
     }
 
     fn read_u30(&mut self) -> Result<u32> {
-        self.read_encoded_u32()
+        Ok(self.read_encoded_u32()?)
     }
 
     fn read_i24(&mut self) -> Result<i32> {

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -1,9 +1,7 @@
 use crate::avm2::opcode::OpCode;
 use crate::avm2::types::*;
-use crate::string::SwfStr;
 use crate::write::SwfWriteExt;
-use byteorder::{LittleEndian, WriteBytesExt};
-use std::io::{self, Result, Write};
+use std::io::{Result, Write};
 
 pub struct Writer<W: Write> {
     output: W,
@@ -11,54 +9,8 @@ pub struct Writer<W: Write> {
 
 impl<W: Write> SwfWriteExt for Writer<W> {
     #[inline]
-    fn write_u8(&mut self, n: u8) -> io::Result<()> {
-        self.output.write_u8(n)
-    }
-
-    #[inline]
-    fn write_u16(&mut self, n: u16) -> io::Result<()> {
-        self.output.write_u16::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_u32(&mut self, n: u32) -> io::Result<()> {
-        self.output.write_u32::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_u64(&mut self, n: u64) -> io::Result<()> {
-        self.output.write_u64::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_i8(&mut self, n: i8) -> io::Result<()> {
-        self.output.write_i8(n)
-    }
-
-    #[inline]
-    fn write_i16(&mut self, n: i16) -> io::Result<()> {
-        self.output.write_i16::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_i32(&mut self, n: i32) -> io::Result<()> {
-        self.output.write_i32::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_f32(&mut self, n: f32) -> io::Result<()> {
-        self.output.write_f32::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_f64(&mut self, n: f64) -> io::Result<()> {
-        self.output.write_f64::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_string(&mut self, s: &'_ SwfStr) -> io::Result<()> {
-        self.output.write_all(s.as_bytes())?;
-        self.write_u8(0)
+    fn as_writer(&mut self) -> &mut impl Write {
+        &mut self.output
     }
 }
 

--- a/swf/src/error.rs
+++ b/swf/src/error.rs
@@ -3,16 +3,13 @@ use crate::tag_code::TagCode;
 use std::{borrow, error, fmt, io};
 
 /// A `Result` from reading SWF data.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug)]
 pub enum Error {
     /// An error occurred while parsing an AVM1 action.
     /// This can contain sub-errors with further information (`Error::source`)
-    Avm1ParseError {
-        opcode: u8,
-        source: Option<Box<dyn error::Error + Send + Sync + 'static>>,
-    },
+    Avm1ParseError(Avm1ParseError),
 
     // An error occurred while parsing ABC.
     AbcParseError(AbcParseError),
@@ -35,27 +32,6 @@ pub enum Error {
 }
 
 impl Error {
-    /// Helper method to create `Error::Avm1ParseError`.
-    #[inline]
-    pub fn avm1_parse_error(opcode: u8) -> Self {
-        Self::Avm1ParseError {
-            opcode,
-            source: None,
-        }
-    }
-
-    /// Helper method to create `Error::Avm1ParseError`.
-    #[inline]
-    pub fn avm1_parse_error_with_source(
-        opcode: u8,
-        source: impl error::Error + Send + Sync + 'static,
-    ) -> Self {
-        Self::Avm1ParseError {
-            opcode,
-            source: Some(Box::new(source)),
-        }
-    }
-
     /// Helper method to create `Error::InvalidData`.
     #[inline]
     pub fn invalid_data(message: impl Into<borrow::Cow<'static, str>>) -> Self {
@@ -84,12 +60,8 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Avm1ParseError { opcode, source } => {
-                write!(f, "Error parsing AVM1 action {}", OpCode::format(*opcode))?;
-                if let Some(source) = source {
-                    write!(f, ": {source}")?;
-                }
-                Ok(())
+            Self::Avm1ParseError(error) => {
+                write!(f, "Error parsing AVM1 bytecode: {}", error)
             }
             Self::AbcParseError(error) => {
                 write!(f, "Error parsing ABC: {}", error)
@@ -112,10 +84,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Avm1ParseError { source, .. } => match source {
-                Some(s) => Some(s.as_ref()),
-                None => None,
-            },
+            Self::Avm1ParseError(e) => e.source(),
             Self::AbcParseError(e) => e.source(),
             Self::IoError(e) => e.source(),
             Self::InvalidData(_) => None,
@@ -128,6 +97,41 @@ impl error::Error for Error {
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {
         Self::IoError(error)
+    }
+}
+
+#[derive(Debug)]
+pub struct Avm1ParseError {
+    // opcodes < 0x80 always have zero length, so we use 0 to mean 'incomplete action header'.
+    pub(crate) opcode: u8,
+    pub(crate) source: UnexpectedEof,
+}
+
+impl From<Avm1ParseError> for Error {
+    fn from(e: Avm1ParseError) -> Error {
+        Error::Avm1ParseError(e)
+    }
+}
+
+impl Avm1ParseError {
+    pub(crate) fn new(opcode: Option<u8>, source: UnexpectedEof) -> Self {
+        let opcode = opcode.unwrap_or(0);
+        Self { opcode, source }
+    }
+}
+
+impl fmt::Display for Avm1ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.opcode {
+            op @ 0x80.. => write!(f, "unterminated action {}", OpCode::format(op)),
+            _ => write!(f, "incomplete action header"),
+        }
+    }
+}
+
+impl std::error::Error for Avm1ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
     }
 }
 
@@ -167,6 +171,23 @@ impl error::Error for AbcParseError {
         }
     }
 }
+
+#[derive(Copy, Clone, Debug)]
+pub struct UnexpectedEof(pub(crate) ());
+
+impl From<UnexpectedEof> for Error {
+    fn from(_: UnexpectedEof) -> Error {
+        Error::IoError(io::ErrorKind::UnexpectedEof.into())
+    }
+}
+
+impl fmt::Display for UnexpectedEof {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("unexpected end of SWF or tag")
+    }
+}
+
+impl error::Error for UnexpectedEof {}
 
 #[cfg(test)]
 #[test]

--- a/swf/src/extensions.rs
+++ b/swf/src/extensions.rs
@@ -1,7 +1,15 @@
 use crate::error::Result;
 use crate::string::SwfStr;
-use byteorder::{LittleEndian, ReadBytesExt};
 use std::io;
+
+macro_rules! impl_read_little_endian {
+    ( $($name:ident for $ty:ty;)* ) => {$(
+        #[inline]
+        fn $name(&mut self) -> Result<$ty> {
+            self.read_array().map(<$ty>::from_le_bytes)
+        }
+    )*}
+}
 
 pub trait ReadSwfExt<'a> {
     fn as_mut_slice(&mut self) -> &mut &'a [u8];
@@ -26,48 +34,35 @@ pub trait ReadSwfExt<'a> {
     }
 
     #[inline]
-    fn read_u8(&mut self) -> Result<u8> {
-        Ok(ReadBytesExt::read_u8(self.as_mut_slice())?)
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N]> {
+        use std::io::Read as _;
+
+        let mut buf = [0u8; N];
+        self.as_mut_slice().read_exact(&mut buf)?;
+        Ok(buf)
     }
 
     #[inline]
-    fn read_u16(&mut self) -> Result<u16> {
-        Ok(ReadBytesExt::read_u16::<LittleEndian>(self.as_mut_slice())?)
+    fn read_slice(&mut self, len: usize) -> Result<&'a [u8]> {
+        let slice = self.as_mut_slice();
+        if let Some((bytes, rest)) = slice.split_at_checked(len) {
+            *slice = rest;
+            Ok(bytes)
+        } else {
+            Err(io::Error::new(io::ErrorKind::UnexpectedEof, "Not enough data for slice").into())
+        }
     }
 
-    #[inline]
-    fn read_u32(&mut self) -> Result<u32> {
-        Ok(ReadBytesExt::read_u32::<LittleEndian>(self.as_mut_slice())?)
-    }
-
-    #[inline]
-    fn read_u64(&mut self) -> Result<u64> {
-        Ok(ReadBytesExt::read_u64::<LittleEndian>(self.as_mut_slice())?)
-    }
-
-    #[inline]
-    fn read_i8(&mut self) -> Result<i8> {
-        Ok(ReadBytesExt::read_i8(self.as_mut_slice())?)
-    }
-
-    #[inline]
-    fn read_i16(&mut self) -> Result<i16> {
-        Ok(ReadBytesExt::read_i16::<LittleEndian>(self.as_mut_slice())?)
-    }
-
-    #[inline]
-    fn read_i32(&mut self) -> Result<i32> {
-        Ok(ReadBytesExt::read_i32::<LittleEndian>(self.as_mut_slice())?)
-    }
-
-    #[inline]
-    fn read_f32(&mut self) -> Result<f32> {
-        Ok(ReadBytesExt::read_f32::<LittleEndian>(self.as_mut_slice())?)
-    }
-
-    #[inline]
-    fn read_f64(&mut self) -> Result<f64> {
-        Ok(ReadBytesExt::read_f64::<LittleEndian>(self.as_mut_slice())?)
+    impl_read_little_endian! {
+        read_u8 for u8;
+        read_u16 for u16;
+        read_u32 for u32;
+        read_u64 for u64;
+        read_i8 for i8;
+        read_i16 for i16;
+        read_i32 for i32;
+        read_f32 for f32;
+        read_f64 for f64;
     }
 
     #[inline]
@@ -81,17 +76,6 @@ pub trait ReadSwfExt<'a> {
             }
         }
         Ok(val)
-    }
-
-    fn read_slice(&mut self, len: usize) -> Result<&'a [u8]> {
-        let slice = self.as_mut_slice();
-        if slice.len() >= len {
-            let new_slice = &slice[..len];
-            *slice = &slice[len..];
-            Ok(new_slice)
-        } else {
-            Err(io::Error::new(io::ErrorKind::UnexpectedEof, "Not enough data for slice").into())
-        }
     }
 
     fn read_slice_to_end(&mut self) -> &'a [u8] {

--- a/swf/src/extensions.rs
+++ b/swf/src/extensions.rs
@@ -1,6 +1,7 @@
-use crate::error::Result;
+use crate::error::UnexpectedEof;
 use crate::string::SwfStr;
-use std::io;
+
+type Result<T> = std::result::Result<T, UnexpectedEof>;
 
 macro_rules! impl_read_little_endian {
     ( $($name:ident for $ty:ty;)* ) => {$(
@@ -35,11 +36,13 @@ pub trait ReadSwfExt<'a> {
 
     #[inline]
     fn read_array<const N: usize>(&mut self) -> Result<[u8; N]> {
-        use std::io::Read as _;
-
-        let mut buf = [0u8; N];
-        self.as_mut_slice().read_exact(&mut buf)?;
-        Ok(buf)
+        let slice = self.as_mut_slice();
+        if let Some((bytes, rest)) = slice.split_first_chunk::<N>() {
+            *slice = rest;
+            Ok(*bytes)
+        } else {
+            Err(UnexpectedEof(()))
+        }
     }
 
     #[inline]
@@ -49,7 +52,7 @@ pub trait ReadSwfExt<'a> {
             *slice = rest;
             Ok(bytes)
         } else {
-            Err(io::Error::new(io::ErrorKind::UnexpectedEof, "Not enough data for slice").into())
+            Err(UnexpectedEof(()))
         }
     }
 
@@ -88,9 +91,7 @@ pub trait ReadSwfExt<'a> {
     #[inline]
     fn read_str(&mut self) -> Result<&'a SwfStr> {
         let slice = self.as_mut_slice();
-        let s = SwfStr::from_bytes_null_terminated(slice).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::UnexpectedEof, "Not enough data for string")
-        })?;
+        let s = SwfStr::from_bytes_null_terminated(slice).ok_or(UnexpectedEof(()))?;
         *slice = &slice[s.len() + 1..];
         Ok(s)
     }

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -6,7 +6,6 @@ use crate::{
     types::*,
 };
 use bitstream_io::BitRead;
-use byteorder::{LittleEndian, ReadBytesExt};
 use simple_asn1::ASN1Block;
 use std::borrow::Cow;
 use std::io::{self, Read};
@@ -73,8 +72,12 @@ pub fn extract_swz(input: &[u8]) -> Result<Vec<u8>> {
 pub fn decompress_swf<'a, R: Read + 'a>(mut input: R) -> Result<SwfBuf> {
     // Read SWF header.
     let compression = read_compression_type(&mut input)?;
-    let version = input.read_u8()?;
-    let uncompressed_len = input.read_u32::<LittleEndian>()?;
+
+    let mut raw_header = [0u8; 5];
+    input.read_exact(&mut raw_header)?;
+
+    let version = raw_header[0];
+    let uncompressed_len = u32::from_le_bytes(*raw_header.split_last_chunk::<4>().unwrap().1);
 
     // Check whether the SWF version is 0.
     // Note that the behavior should actually vary, depending on the player version:
@@ -220,7 +223,7 @@ fn make_lzma_reader<'a, R: Read + 'a>(
     // To deal with the mangled header, use lzma_rs options to manually provide uncompressed length.
 
     // Read compressed length (ignored)
-    let _ = input.read_u32::<LittleEndian>()?;
+    input.read_exact(&mut [0; 4])?;
 
     // TODO: Switch to lzma-rs streaming API when stable.
     let mut output = Vec::with_capacity(unpacked_size.min(MAX_DATA_CAPACITY) as usize);

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -400,11 +400,13 @@ impl<'a> Reader<'a> {
     pub fn read_tag(&mut self) -> Result<Tag<'a>> {
         let (tag_code, length) = self.read_tag_code_and_length()?;
 
-        if let Some(tag_code) = TagCode::from_u16(tag_code) {
-            self.read_tag_with_code(tag_code, length)
+        if let Some(code) = TagCode::from_u16(tag_code) {
+            self.read_tag_with_code(code, length)
         } else {
-            self.read_slice(length)
-                .map(|data| Tag::Unknown { tag_code, data })
+            match self.read_slice(length) {
+                Ok(data) => Ok(Tag::Unknown { tag_code, data }),
+                Err(e) => Err(Error::from(e)),
+            }
         }
         .map_err(|e| Error::swf_parse_error(tag_code, e))
     }
@@ -1024,7 +1026,7 @@ impl<'a> Reader<'a> {
             let offsets_ref = self.get_ref();
 
             // OffsetTable
-            let offsets: Result<Vec<_>> = (0..num_glyphs)
+            let offsets = (0..num_glyphs)
                 .map(|_| {
                     if flags.contains(FontFlag::HAS_WIDE_OFFSETS) {
                         self.read_u32()
@@ -1032,8 +1034,7 @@ impl<'a> Reader<'a> {
                         self.read_u16().map(u32::from)
                     }
                 })
-                .collect();
-            let offsets = offsets?;
+                .collect::<Result<Vec<_>, _>>()?;
 
             // CodeTableOffset
             let code_table_offset = if flags.contains(FontFlag::HAS_WIDE_OFFSETS) {

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -5,7 +5,6 @@ use crate::{
     types::*,
 };
 use bitstream_io::BitWrite;
-use byteorder::{LittleEndian, WriteBytesExt};
 use std::cmp::max;
 use std::io::{self, Write};
 
@@ -47,13 +46,12 @@ pub fn write_swf<W: Write>(header: &Header, tags: &[Tag<'_>], output: W) -> Resu
 /// Writes a SWF to the output stream, where the tag list has already been serialized to bytes.
 /// This still appends other header information such as stage size.
 pub fn write_swf_raw_tags<W: Write>(header: &Header, tags: &[u8], mut output: W) -> Result<()> {
-    let signature = match header.compression {
+    output.write_all(match header.compression {
         Compression::None => b"FWS",
         Compression::Zlib => b"CWS",
         Compression::Lzma => b"ZWS",
-    };
-    output.write_all(&signature[..])?;
-    output.write_u8(header.version)?;
+    })?;
+    output.write_all(&[header.version])?;
 
     // Write SWF body.
     let mut swf_body = Vec::new();
@@ -68,7 +66,8 @@ pub fn write_swf_raw_tags<W: Write>(header: &Header, tags: &[u8], mut output: W)
 
     // Write SWF header.
     // Uncompressed SWF length.
-    output.write_u32::<LittleEndian>(swf_body.len() as u32 + 8)?;
+    let swf_len = swf_body.len() as u32 + 8;
+    output.write_all(&u32::to_le_bytes(swf_len))?;
 
     // Compress SWF body.
     match header.compression {
@@ -111,7 +110,8 @@ fn write_lzma_swf<W: Write>(mut output: W, mut swf_body: &[u8]) -> Result<()> {
 
     // Flash uses a mangled LZMA header, so we have to massage it into the SWF format.
     // https://helpx.adobe.com/flash-player/kb/exception-thrown-you-decompress-lzma-compressed.html
-    output.write_u32::<LittleEndian>(data.len() as u32 - 13)?; // Compressed length (- 13 to not include lzma header)
+    let adjusted_len = data.len() as u32 - 13; // Compressed length (- 13 to not include lzma header)
+    output.write_all(&u32::to_le_bytes(adjusted_len))?;
     output.write_all(&data[0..5])?; // LZMA properties
     output.write_all(&data[13..])?; // Data
     Ok(())
@@ -124,17 +124,36 @@ fn write_lzma_swf<W: Write>(_output: W, _swf_body: &[u8]) -> Result<()> {
     ))
 }
 
+macro_rules! impl_write_little_endian {
+    ( $($name:ident for $ty:ty;)* ) => {$(
+        #[inline]
+        fn $name(&mut self, n: $ty) -> io::Result<()> {
+            self.as_writer().write_all(&n.to_le_bytes())
+        }
+    )*}
+}
+
 pub trait SwfWriteExt {
-    fn write_u8(&mut self, n: u8) -> io::Result<()>;
-    fn write_u16(&mut self, n: u16) -> io::Result<()>;
-    fn write_u32(&mut self, n: u32) -> io::Result<()>;
-    fn write_u64(&mut self, n: u64) -> io::Result<()>;
-    fn write_i8(&mut self, n: i8) -> io::Result<()>;
-    fn write_i16(&mut self, n: i16) -> io::Result<()>;
-    fn write_i32(&mut self, n: i32) -> io::Result<()>;
-    fn write_f32(&mut self, n: f32) -> io::Result<()>;
-    fn write_f64(&mut self, n: f64) -> io::Result<()>;
-    fn write_string(&mut self, s: &'_ SwfStr) -> io::Result<()>;
+    fn as_writer(&mut self) -> &mut impl Write;
+
+    impl_write_little_endian! {
+        write_u8 for u8;
+        write_u16 for u16;
+        write_u32 for u32;
+        write_u64 for u64;
+        write_i8 for i8;
+        write_i16 for i16;
+        write_i32 for i32;
+        write_i64 for i64;
+        write_f32 for f32;
+        write_f64 for f64;
+    }
+
+    #[inline]
+    fn write_string(&mut self, s: &'_ SwfStr) -> io::Result<()> {
+        self.as_writer().write_all(s.as_bytes())?;
+        self.write_u8(0)
+    }
 }
 
 pub struct BitWriter<W: Write> {
@@ -219,54 +238,8 @@ struct Writer<W: Write> {
 
 impl<W: Write> SwfWriteExt for Writer<W> {
     #[inline]
-    fn write_u8(&mut self, n: u8) -> io::Result<()> {
-        self.output.write_u8(n)
-    }
-
-    #[inline]
-    fn write_u16(&mut self, n: u16) -> io::Result<()> {
-        self.output.write_u16::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_u32(&mut self, n: u32) -> io::Result<()> {
-        self.output.write_u32::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_u64(&mut self, n: u64) -> io::Result<()> {
-        self.output.write_u64::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_i8(&mut self, n: i8) -> io::Result<()> {
-        self.output.write_i8(n)
-    }
-
-    #[inline]
-    fn write_i16(&mut self, n: i16) -> io::Result<()> {
-        self.output.write_i16::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_i32(&mut self, n: i32) -> io::Result<()> {
-        self.output.write_i32::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_f32(&mut self, n: f32) -> io::Result<()> {
-        self.output.write_f32::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_f64(&mut self, n: f64) -> io::Result<()> {
-        self.output.write_f64::<LittleEndian>(n)
-    }
-
-    #[inline]
-    fn write_string(&mut self, s: &'_ SwfStr) -> io::Result<()> {
-        self.output.write_all(s.as_bytes())?;
-        self.write_u8(0)
+    fn as_writer(&mut self) -> &mut impl Write {
+        &mut self.output
     }
 }
 


### PR DESCRIPTION
## Description

Currently, parsing AVM1 bytecode returns a `swf::error::Error` on failure, even though it can only fail in a single way (running out of input). This is a fairly chonky type (32 bytes on x64 archs) which `ruffle_core:: avm1::Error` stores inline, so passing it around can be somewhat expensive.

This PR improves the situation by introducing two new error types:
- `UnexpectedEof`, a ZST returned from the `SwfReadExt` methods; as `byteorder`'s API depends on the `io::Error` type, it is replaced with std APIs.
- `Avm1ParseError`, a 1-byte struct returned from `swf::avm1::read::Reader::parse_action`.

This brings significant (~5% and higher) performance improvements on AVM1 benchmarks, and a ~60 kB reduction in binary size on the desktop release build.


I'll probably follow this up with separate PRs to do the equivalent changes for ABC parsing and general tag parsing for consistency's sake, but I don't expect drastic performance improvements here (`ruffle_core::avm2::Error` is already boxed, and ABC/tag parsing only happen at load-time anyways).

## Testing

This has no functional changes (except slightly different error messages).

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
