### PR TITLE
video: Add support for NV12 pixel format

### DIFF
--- a/video/external/src/decoder/webcodecs.rs
+++ b/video/external/src/decoder/webcodecs.rs
@@ -133,6 +133,8 @@ impl H264Decoder {
                     error!("Unsupported pixel format: {:?}", other_format);
                 }
             };
+
+            output.close();
         };
 
         let log_subscriber_for_error = log_subscriber.clone();

--- a/video/external/src/decoder/webcodecs.rs
+++ b/video/external/src/decoder/webcodecs.rs
@@ -108,6 +108,27 @@ impl H264Decoder {
                         data,
                     )));
                 }
+                VideoPixelFormat::Nv12 => {
+                    let luma_len = visible_rect.width() as usize * visible_rect.height() as usize;
+                    let chroma_len = (visible_rect.width() as usize).div_ceil(2)
+                        * (visible_rect.height() as usize).div_ceil(2);
+                    let mut data: Vec<u8> = vec![0; luma_len + chroma_len * 2];
+                    let _ = output.copy_to_with_u8_slice(&mut data);
+                    let chroma = data.split_off(luma_len);
+                    let chroma_pairs = chroma.as_chunks::<2>().0;
+                    for uv in chroma_pairs {
+                        data.push(uv[0]);
+                    }
+                    for uv in chroma_pairs {
+                        data.push(uv[1]);
+                    }
+                    last_frame.replace(Some(DecodedFrame::new(
+                        visible_rect.width() as u32,
+                        visible_rect.height() as u32,
+                        BitmapFormat::Yuv420p,
+                        data,
+                    )));
+                }
                 other_format => {
                     error!("Unsupported pixel format: {:?}", other_format);
                 }


### PR DESCRIPTION
## Description

Previously, the NV12 pixel format was unsupported, logging `Unsupported pixel format: Nv12` to the console. This adds support for decoding videos with NV12 pixel format in webcodecs. 

This PR also fixes video freezes. I'm not entirely sure if I should include this fix here, but without it I couldn't even test my changes properly. Looking into the console I found ruffle was spamming these: `decoding video frame XXX failed: No output frame produced by the decoder`. As far as I noticed, when one frame failed to decode in time, instead of skipping over that frame, the decoder waited until it finished decoding and only then continued decoding subsequent frames. This caused the frames to accumulate and stall, causing videos to freeze. 

## Testing

I couldn't find a way to write tests for this, as there are no reference tests for other pixel formats. One of the suggestions was to create an HTML wrapping Flash and let Ruffle polyfill it, but tests require GPU acceleration to be disabled and NV12 doesn't work without GPU acceleration.

Here's an NV12 encoded video, extracted from one of the games I was testing, which inspired me to make this PR: [pitkEqim.flv](https://github.com/user-attachments/files/30603887/pitkEqim.zip).

I'm not familiar with ActionScript, but I can probably whip up a test script that loads the video attached above to help test this. Please let me know.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
