### PR TITLE
avm2: Implement more of XMLList using get_property_local

### DIFF
--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -217,29 +217,17 @@ pub fn child<'gc>(
     Ok(list.into())
 }
 
+// ECMA-357 13.5.4.5 XMLList.prototype.children ( )
 pub fn children<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
-
     let list = this.as_xml_list_object().unwrap();
-    let children = list.children();
-    let mut sub_children = Vec::new();
-    for child in &*children {
-        if let E4XNodeKind::Element { children, .. } = &*child.node().kind() {
-            sub_children.extend(children.iter().map(|node| E4XOrXml::E4X(*node)));
-        }
-    }
-    // FIXME: This method should just call get_property_local with "*".
-    Ok(XmlListObject::new_with_children(
-        activation,
-        sub_children,
-        Some(list.into()),
-        Some(Multiname::any()),
-    )
-    .into())
+
+    // 1. Return the results of calling the [[Get]] method of list with argument "*"
+    list.get_property_local(&Multiname::any(), activation)
 }
 
 /// 13.5.4.8 XMLList.prototype.contains (value)

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -270,64 +270,33 @@ pub fn copy<'gc>(
     Ok(list.deep_copy(activation).into())
 }
 
+// ECMA-357 13.5.4.2 XMLList.prototype.attribute ( attributeName )
 pub fn attribute<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
-
     let list = this.as_xml_list_object().unwrap();
 
+    // 1. Let name = ToAttributeName(attributeName)
     let multiname = name_to_multiname(activation, args.get_value(0), true)?;
 
-    let children = list.children();
-    let mut sub_children = Vec::new();
-    for child in &*children {
-        if let E4XNodeKind::Element { attributes, .. } = &*child.node().kind()
-            && let Some(found) = attributes
-                .iter()
-                .find(|node| node.matches_name(&multiname))
-                .copied()
-        {
-            sub_children.push(E4XOrXml::E4X(found));
-        }
-    }
-
-    // FIXME: This should just use get_property_local with an attribute Multiname.
-    Ok(XmlListObject::new_with_children(
-        activation,
-        sub_children,
-        Some(list.into()),
-        Some(multiname),
-    )
-    .into())
+    // 2. Return the result of calling the [[Get]] method of list with argument name
+    list.get_property_local(&multiname, activation)
 }
 
+// ECMA-357 13.5.4.3 XMLList.prototype.attributes ( )
 pub fn attributes<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap();
-
     let list = this.as_xml_list_object().unwrap();
 
-    let mut child_attrs = Vec::new();
-    for child in list.children().iter() {
-        if let E4XNodeKind::Element { attributes, .. } = &*child.node().kind() {
-            child_attrs.extend(attributes.iter().map(|node| E4XOrXml::E4X(*node)));
-        }
-    }
-
-    // FIXME: This should just use get_property_local with an any attribute Multiname.
-    Ok(XmlListObject::new_with_children(
-        activation,
-        child_attrs,
-        Some(list.into()),
-        Some(Multiname::any_attribute()),
-    )
-    .into())
+    // 1. Return the result of calling the [[Get]] method of list with argument ToAttributeName("*")
+    list.get_property_local(&Multiname::any_attribute(), activation)
 }
 
 pub fn descendants<'gc>(


### PR DESCRIPTION
## Description

Implements XMLList.attribute(s) and XMLList.children using get_property_local

## Testing

Should be covered by existing tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
