### PR TITLE
avm2: Only set `TextBlock.firstLine` when creating the first line

### DIFF
--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -426,10 +426,12 @@ pub fn do_create_text_line<'gc>(
     if let Some(previous_line) = previous_text_line {
         text_line.set_previous_line(Some(previous_line), activation.gc());
         previous_line.set_next_line(Some(text_line), activation.gc());
+    } else {
+        // If there's no previous line, then this is the first line.
+        block.set_first_line(Some(text_line), activation.gc());
     }
 
     block.set_text_line_creation_result(Some(TextLineCreationResultValue::Success));
-    block.set_first_line(Some(text_line), activation.gc());
 
     Ok(text_line_instance.into())
 }

--- a/tests/tests/swfs/avm2/textblock_line_changes/output.ruffle.txt
+++ b/tests/tests/swfs/avm2/textblock_line_changes/output.ruffle.txt
@@ -1,4 +1,4 @@
-First line in block: line-4
+First line in block: line-0
 Line #0:
     line.validity: valid
     line.textBlock: [object TextBlock]
@@ -24,7 +24,7 @@ Line #4:
     line.textBlock: [object TextBlock]
     line.previousLine: line-3
     line.nextLine: null
-First line in block: line-4
+First line in block: line-0
 Line #0:
     line.validity: valid
     line.textBlock: [object TextBlock]
@@ -50,7 +50,7 @@ Line #4:
     line.textBlock: [object TextBlock]
     line.previousLine: line-3
     line.nextLine: null
-First line in block: line-4
+First line in block: line-0
 Line #0:
     line.validity: valid
     line.textBlock: [object TextBlock]
@@ -77,7 +77,7 @@ Line #4:
     line.previousLine: line-3
     line.nextLine: null
 Calling recreateTextLine returns the same line: true
-First line in block: line-1
+First line in block: line-0
 Line #0:
     line.validity: valid
     line.textBlock: [object TextBlock]
@@ -103,7 +103,7 @@ Line #4:
     line.textBlock: [object TextBlock]
     line.previousLine: line-3
     line.nextLine: null
-First line in block: line-1
+First line in block: line-0
 Line #0:
     line.validity: valid
     line.textBlock: [object TextBlock]
@@ -130,7 +130,7 @@ Line #4:
     line.previousLine: line-3
     line.nextLine: null
 Calling createTextLine returns the same line: false
-First line in block: line-unknown
+First line in block: line-0
 Line #0:
     line.validity: valid
     line.textBlock: [object TextBlock]

--- a/tests/tests/swfs/avm2/textblock_recreateline/output.ruffle.txt
+++ b/tests/tests/swfs/avm2/textblock_recreateline/output.ruffle.txt
@@ -1,4 +1,4 @@
-First line in block: line-4
+First line in block: line-0
 Line #0:
     line.validity: valid
     line.textBlock: [object TextBlock]
@@ -55,7 +55,7 @@ line#2
 0
 Event listener called
 0
-First line in block: line-2
+First line in block: line-0
 Line #0:
     line.validity: valid
     line.textBlock: [object TextBlock]


### PR DESCRIPTION
## Description

Previously, it was being set when creating any line at all

## Testing

This improves the output of the `avm2/textblock_line_changes` and `avm2/textblock_recreateline` tests

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
