### PR TITLE
swf: Return `AbcParseError` on error for AVM2 bytecode parsing.

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -512,10 +512,10 @@ impl<'gc> Avm2<'gc> {
         let mut reader = Reader::new(data);
         let abc = match reader.read() {
             Ok(abc) => abc,
-            Err(swf::error::Error::AbcParseError(AbcParseError::MethodInfoOutOfBounds {
+            Err(AbcParseError::MethodInfoOutOfBounds {
                 method_count,
                 method_index,
-            })) => {
+            }) => {
                 let mut activation = Activation::from_nothing(context);
                 return Err(make_error_1027(&mut activation, method_index, method_count));
             }

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -12,6 +12,8 @@ use crate::string::{AvmString, WString};
 
 use naga_agal::AgalError;
 use ruffle_macros::istr;
+use swf::avm2::types::{Index, Method as AbcMethod};
+
 use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 use std::mem::size_of;
@@ -451,12 +453,12 @@ pub fn make_error_1026<'gc>(
 #[cold]
 pub fn make_error_1027<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    method_index: usize,
-    method_count: usize,
+    method_index: Index<AbcMethod>,
+    method_count: u32,
 ) -> Error<'gc> {
     make_error!(verify_error(
         activation,
-        error_message!(1027, method_index, method_count),
+        error_message!(1027, method_index.0, method_count),
         1027
     ))
 }

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -166,7 +166,11 @@ impl<'gc> Method<'gc> {
         let abc = txunit.abc();
 
         let Some(method) = abc.methods.get(method_index) else {
-            return Err(make_error_1027(activation, method_index, abc.methods.len()));
+            return Err(make_error_1027(
+                activation,
+                abc_method,
+                abc.methods.len() as u32,
+            ));
         };
 
         let mut signature = Vec::new();

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -18,7 +18,7 @@ use swf::avm2::read::Reader;
 use swf::avm2::types::{
     Index, MethodFlags as AbcMethodFlags, Multiname as AbcMultiname, Op as AbcOp,
 };
-use swf::error::{AbcParseError, Error as AbcReadError};
+use swf::error::AbcParseError;
 
 #[derive(Collect)]
 #[collect(no_drop)]
@@ -113,7 +113,7 @@ pub fn verify_method<'gc>(
             let op = match reader.read_op() {
                 Ok(op) => op,
 
-                Err(AbcReadError::AbcParseError(AbcParseError::IllegalOpcode { opcode })) => {
+                Err(AbcParseError::IllegalOpcode { opcode }) => {
                     return Err(make_error_1011(
                         activation,
                         method,
@@ -121,7 +121,7 @@ pub fn verify_method<'gc>(
                         previous_position,
                     ));
                 }
-                Err(AbcReadError::IoError(_)) => {
+                Err(AbcParseError::UnexpectedEof(_)) => {
                     // Code flow continued past end of method
                     return Err(make_error_1020(activation));
                 }

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -76,8 +76,9 @@ impl<'a> Reader<'a> {
                 }));
             };
             if dst.body.is_some() {
-                // TODO: this should somehow throw error 1121 in FP.
-                return Err(Error::invalid_data("Duplicate method body"));
+                return Err(Error::AbcParseError(AbcParseError::DuplicateMethodBody {
+                    method_index: body.method,
+                }));
             }
             dst.body = Some(Index::new(body_idx));
             method_bodies.push(body);
@@ -137,7 +138,11 @@ impl<'a> Reader<'a> {
             0x18 => Namespace::Protected(name),
             0x19 => Namespace::Explicit(name),
             0x1a => Namespace::StaticProtected(name),
-            _ => return Err(Error::invalid_data("Invalid namespace kind")),
+            _ => {
+                return Err(Error::AbcParseError(AbcParseError::InvalidNamespace {
+                    kind,
+                }));
+            }
         })
     }
 
@@ -197,7 +202,11 @@ impl<'a> Reader<'a> {
                     parameters,
                 }
             }
-            _ => return Err(Error::invalid_data("Invalid multiname kind")),
+            _ => {
+                return Err(Error::AbcParseError(AbcParseError::InvalidMultiname {
+                    kind,
+                }));
+            }
         })
     }
 
@@ -270,13 +279,16 @@ impl<'a> Reader<'a> {
         let flags = MethodFlags::from_bits_truncate(self.read_u8()?);
 
         if flags.contains(MethodFlags::HAS_OPTIONAL) {
-            let num_optional_params = self.read_u30()? as usize;
-            if let Some(start) = params.len().checked_sub(num_optional_params) {
-                for param in &mut params[start..] {
+            let num_optional_params = self.read_u30()?;
+            if let Some(start) = num_params.checked_sub(num_optional_params) {
+                for param in &mut params[(start as usize)..] {
                     param.default_value = Some(self.read_constant_value()?);
                 }
             } else {
-                return Err(Error::invalid_data("Too many optional parameters"));
+                return Err(Error::AbcParseError(AbcParseError::TooManyOptionalParams {
+                    num_params,
+                    num_optional_params,
+                }));
             }
         }
 
@@ -297,7 +309,21 @@ impl<'a> Reader<'a> {
 
     fn read_constant_value(&mut self) -> Result<DefaultValue> {
         let index = self.read_u30()?;
-        Ok(match self.read_u8()? {
+        self.read_default_value_with_index(index)
+    }
+
+    fn read_optional_value(&mut self) -> Result<Option<DefaultValue>> {
+        let index = self.read_u30()?;
+        if index == 0 {
+            Ok(None)
+        } else {
+            self.read_default_value_with_index(index).map(Some)
+        }
+    }
+
+    fn read_default_value_with_index(&mut self, index: u32) -> Result<DefaultValue> {
+        let kind = self.read_u8()?;
+        Ok(match kind {
             0x00 => DefaultValue::Undefined,
             0x01 => DefaultValue::String(Index::new(index)),
             0x03 => DefaultValue::Int(Index::new(index)),
@@ -313,34 +339,12 @@ impl<'a> Reader<'a> {
             0x18 => DefaultValue::Protected(Index::new(index)),
             0x19 => DefaultValue::Explicit(Index::new(index)),
             0x1a => DefaultValue::StaticProtected(Index::new(index)),
-            _ => return Err(Error::invalid_data("Invalid default value")),
+            _ => {
+                return Err(Error::AbcParseError(AbcParseError::InvalidNamespace {
+                    kind,
+                }));
+            }
         })
-    }
-
-    fn read_optional_value(&mut self) -> Result<Option<DefaultValue>> {
-        let index = self.read_u30()?;
-        if index == 0 {
-            Ok(None)
-        } else {
-            Ok(Some(match self.read_u8()? {
-                0x00 => DefaultValue::Undefined,
-                0x01 => DefaultValue::String(Index::new(index)),
-                0x03 => DefaultValue::Int(Index::new(index)),
-                0x04 => DefaultValue::Uint(Index::new(index)),
-                0x05 => DefaultValue::Private(Index::new(index)),
-                0x06 => DefaultValue::Double(Index::new(index)),
-                0x08 => DefaultValue::Namespace(Index::new(index)),
-                0x0a => DefaultValue::False,
-                0x0b => DefaultValue::True,
-                0x0c => DefaultValue::Null,
-                0x16 => DefaultValue::Package(Index::new(index)),
-                0x17 => DefaultValue::PackageInternal(Index::new(index)),
-                0x18 => DefaultValue::Protected(Index::new(index)),
-                0x19 => DefaultValue::Explicit(Index::new(index)),
-                0x1a => DefaultValue::StaticProtected(Index::new(index)),
-                _ => return Err(Error::invalid_data("Invalid default value")),
-            }))
-        }
     }
 
     fn read_metadata(&mut self, len: u32) -> Result<Vec<Metadata>> {
@@ -437,7 +441,8 @@ impl<'a> Reader<'a> {
     fn read_trait(&mut self) -> Result<Trait> {
         let name = self.read_index()?;
         let flags = self.read_u8()?;
-        let kind = match flags & 0b1111 {
+        let raw_kind = flags & 0b1111;
+        let kind = match raw_kind {
             0 => TraitKind::Slot {
                 slot_id: self.read_u30()?,
                 type_name: self.read_index()?,
@@ -468,7 +473,11 @@ impl<'a> Reader<'a> {
                 type_name: self.read_index()?,
                 value: self.read_optional_value()?,
             },
-            _ => return Err(Error::invalid_data("Invalid trait kind")),
+            _ => {
+                return Err(Error::AbcParseError(AbcParseError::InvalidTraitKind {
+                    kind: raw_kind,
+                }));
+            }
         };
 
         let mut metadata = vec![];

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -1,7 +1,8 @@
 use crate::avm2::types::*;
-use crate::error::{AbcParseError, Error, Result};
+use crate::error::AbcParseError;
 use crate::extensions::ReadSwfExt;
-use std::io::Read;
+
+type Result<T, E = AbcParseError> = std::result::Result<T, E>;
 
 pub struct Reader<'a> {
     input: &'a [u8],
@@ -70,15 +71,15 @@ impl<'a> Reader<'a> {
         for body_idx in 0..len {
             let body = self.read_method_body()?;
             let Some(dst) = methods.get_mut(body.method.0 as usize) else {
-                return Err(Error::AbcParseError(AbcParseError::MethodInfoOutOfBounds {
+                return Err(AbcParseError::MethodInfoOutOfBounds {
                     method_count: methods.len() as u32,
                     method_index: body.method,
-                }));
+                });
             };
             if dst.body.is_some() {
-                return Err(Error::AbcParseError(AbcParseError::DuplicateMethodBody {
+                return Err(AbcParseError::DuplicateMethodBody {
                     method_index: body.method,
-                }));
+                });
             }
             dst.body = Some(Index::new(body_idx));
             method_bodies.push(body);
@@ -115,9 +116,8 @@ impl<'a> Reader<'a> {
     fn read_string(&mut self) -> Result<Vec<u8>> {
         let len = self.read_u30()?;
         // TODO: Avoid allocating a String.
-        let mut s = Vec::with_capacity(len as usize);
-        self.read_slice(len as usize)?.read_to_end(&mut s)?;
-        Ok(s)
+        let s = self.read_slice(len as usize)?;
+        Ok(s.to_vec())
     }
 
     fn read_index<T>(&mut self) -> Result<Index<T>> {
@@ -139,9 +139,7 @@ impl<'a> Reader<'a> {
             0x19 => Namespace::Explicit(name),
             0x1a => Namespace::StaticProtected(name),
             _ => {
-                return Err(Error::AbcParseError(AbcParseError::InvalidNamespace {
-                    kind,
-                }));
+                return Err(AbcParseError::InvalidNamespace { kind });
             }
         })
     }
@@ -203,9 +201,7 @@ impl<'a> Reader<'a> {
                 }
             }
             _ => {
-                return Err(Error::AbcParseError(AbcParseError::InvalidMultiname {
-                    kind,
-                }));
+                return Err(AbcParseError::InvalidMultiname { kind });
             }
         })
     }
@@ -285,10 +281,10 @@ impl<'a> Reader<'a> {
                     param.default_value = Some(self.read_constant_value()?);
                 }
             } else {
-                return Err(Error::AbcParseError(AbcParseError::TooManyOptionalParams {
+                return Err(AbcParseError::TooManyOptionalParams {
                     num_params,
                     num_optional_params,
-                }));
+                });
             }
         }
 
@@ -340,9 +336,7 @@ impl<'a> Reader<'a> {
             0x19 => DefaultValue::Explicit(Index::new(index)),
             0x1a => DefaultValue::StaticProtected(Index::new(index)),
             _ => {
-                return Err(Error::AbcParseError(AbcParseError::InvalidNamespace {
-                    kind,
-                }));
+                return Err(AbcParseError::InvalidNamespace { kind });
             }
         })
     }
@@ -474,9 +468,7 @@ impl<'a> Reader<'a> {
                 value: self.read_optional_value()?,
             },
             _ => {
-                return Err(Error::AbcParseError(AbcParseError::InvalidTraitKind {
-                    kind: raw_kind,
-                }));
+                return Err(AbcParseError::InvalidTraitKind { kind: raw_kind });
             }
         };
 
@@ -542,9 +534,7 @@ impl<'a> Reader<'a> {
         let opcode = match OpCode::from_u8(byte) {
             Some(o) => o,
             None => {
-                return Err(Error::AbcParseError(AbcParseError::IllegalOpcode {
-                    opcode: byte,
-                }));
+                return Err(AbcParseError::IllegalOpcode { opcode: byte });
             }
         };
 

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -69,18 +69,17 @@ impl<'a> Reader<'a> {
         let mut method_bodies = Vec::with_capacity(len as usize);
         for body_idx in 0..len {
             let body = self.read_method_body()?;
-            let index = body.method.0 as usize;
-            if index >= methods.len() {
+            let Some(dst) = methods.get_mut(body.method.0 as usize) else {
                 return Err(Error::AbcParseError(AbcParseError::MethodInfoOutOfBounds {
-                    method_count: methods.len(),
-                    method_index: index,
+                    method_count: methods.len() as u32,
+                    method_index: body.method,
                 }));
-            }
-            if methods[index].body.is_some() {
+            };
+            if dst.body.is_some() {
                 // TODO: this should somehow throw error 1121 in FP.
                 return Err(Error::invalid_data("Duplicate method body"));
             }
-            methods[index].body = Some(Index::new(body_idx));
+            dst.body = Some(Index::new(body_idx));
             method_bodies.push(body);
         }
 

--- a/swf/src/error.rs
+++ b/swf/src/error.rs
@@ -1,4 +1,5 @@
 use crate::avm1::opcode::OpCode;
+use crate::avm2::types as avm2;
 use crate::tag_code::TagCode;
 use std::{borrow, error, fmt, io};
 
@@ -138,8 +139,8 @@ impl std::error::Error for Avm1ParseError {
 #[derive(Debug)]
 pub enum AbcParseError {
     MethodInfoOutOfBounds {
-        method_count: usize,
-        method_index: usize,
+        method_count: u32,
+        method_index: avm2::Index<avm2::Method>,
     },
     IllegalOpcode {
         opcode: u8,
@@ -151,14 +152,12 @@ impl fmt::Display for AbcParseError {
         match self {
             AbcParseError::MethodInfoOutOfBounds {
                 method_count,
-                method_index,
+                method_index: avm2::Index(index, _),
             } => write!(
                 f,
-                "Method body refers to index {method_index} but there are only {method_count} method infos"
+                "Method body refers to index {index} but there are only {method_count} method infos"
             ),
-            AbcParseError::IllegalOpcode { opcode } => {
-                write!(f, "Illegal opcode {opcode:#x}")
-            }
+            AbcParseError::IllegalOpcode { opcode } => write!(f, "Illegal opcode {opcode:#x}"),
         }
     }
 }

--- a/swf/src/error.rs
+++ b/swf/src/error.rs
@@ -166,6 +166,13 @@ pub enum AbcParseError {
     IllegalOpcode {
         opcode: u8,
     },
+    UnexpectedEof(UnexpectedEof),
+}
+
+impl From<AbcParseError> for Error {
+    fn from(e: AbcParseError) -> Error {
+        Error::AbcParseError(e)
+    }
 }
 
 impl fmt::Display for AbcParseError {
@@ -199,13 +206,17 @@ impl fmt::Display for AbcParseError {
             }
             AbcParseError::InvalidTraitKind { kind } => write!(f, "Invalid trait kind {kind:#x}"),
             AbcParseError::IllegalOpcode { opcode } => write!(f, "Illegal opcode {opcode:#x}"),
+            AbcParseError::UnexpectedEof(_) => write!(f, "Unexpected end of bytecode"),
         }
     }
 }
 
 impl error::Error for AbcParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
+        match self {
+            AbcParseError::UnexpectedEof(e) => Some(e),
+            _ => None,
+        }
     }
 }
 
@@ -215,6 +226,12 @@ pub struct UnexpectedEof(pub(crate) ());
 impl From<UnexpectedEof> for Error {
     fn from(_: UnexpectedEof) -> Error {
         Error::IoError(io::ErrorKind::UnexpectedEof.into())
+    }
+}
+
+impl From<UnexpectedEof> for AbcParseError {
+    fn from(e: UnexpectedEof) -> Self {
+        Self::UnexpectedEof(e)
     }
 }
 

--- a/swf/src/error.rs
+++ b/swf/src/error.rs
@@ -137,10 +137,31 @@ impl std::error::Error for Avm1ParseError {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum AbcParseError {
     MethodInfoOutOfBounds {
         method_count: u32,
         method_index: avm2::Index<avm2::Method>,
+    },
+    // TODO: this should throw error 1121 in FP.
+    DuplicateMethodBody {
+        method_index: avm2::Index<avm2::Method>,
+    },
+    TooManyOptionalParams {
+        num_params: u32,
+        num_optional_params: u32,
+    },
+    InvalidNamespace {
+        kind: u8,
+    },
+    InvalidMultiname {
+        kind: u8,
+    },
+    InvalidDefaultValue {
+        kind: u8,
+    },
+    InvalidTraitKind {
+        kind: u8,
     },
     IllegalOpcode {
         opcode: u8,
@@ -157,6 +178,26 @@ impl fmt::Display for AbcParseError {
                 f,
                 "Method body refers to index {index} but there are only {method_count} method infos"
             ),
+            AbcParseError::DuplicateMethodBody {
+                method_index: avm2::Index(index, _),
+            } => write!(f, "Duplicate method body for method #{index}"),
+            AbcParseError::TooManyOptionalParams {
+                num_params,
+                num_optional_params,
+            } => write!(
+                f,
+                "Method declares {num_optional_params} optional parameters but only has {num_params} parameters in total"
+            ),
+            AbcParseError::InvalidNamespace { kind } => {
+                write!(f, "Invalid namespace kind {kind:#x}")
+            }
+            AbcParseError::InvalidMultiname { kind } => {
+                write!(f, "Invalid multiname kind {kind:#x}")
+            }
+            AbcParseError::InvalidDefaultValue { kind } => {
+                write!(f, "Invalid default value kind {kind:#x}")
+            }
+            AbcParseError::InvalidTraitKind { kind } => write!(f, "Invalid trait kind {kind:#x}"),
             AbcParseError::IllegalOpcode { opcode } => write!(f, "Illegal opcode {opcode:#x}"),
         }
     }
@@ -164,10 +205,7 @@ impl fmt::Display for AbcParseError {
 
 impl error::Error for AbcParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            AbcParseError::MethodInfoOutOfBounds { .. } => None,
-            AbcParseError::IllegalOpcode { .. } => None,
-        }
+        None
     }
 }
 


### PR DESCRIPTION
## Description

Like #24334 but for AVM2; the custom error type was already there (`AbcParseError`), so I added more variants to cover all the error cases.

Unlike the AVM1 PR, there's no real performance gains as ABC parsing isn't on the hot path, but it's still nice for code consistency.

## Testing

No functional changes.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
