### PR TITLE
avm2: Emit `native_table.rs` in a deterministic order

### DIFF
--- a/core/build_playerglobal/src/avm2.rs
+++ b/core/build_playerglobal/src/avm2.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use regex::RegexBuilder;
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
@@ -462,8 +462,8 @@ fn write_native_table(data: &[u8], out_dir: &Path) -> Result<Vec<u8>, Box<dyn st
     let mut rust_custom_constructors = vec![none_tokens; abc.classes.len()];
     let mut rust_fast_calls = vec![];
 
-    let mut rust_accessible_slots: HashMap<String, Vec<_>> = HashMap::new();
-    let mut rust_accessible_methods: HashMap<String, Vec<_>> = HashMap::new();
+    let mut rust_accessible_slots: BTreeMap<String, Vec<_>> = BTreeMap::new();
+    let mut rust_accessible_methods: BTreeMap<String, Vec<_>> = BTreeMap::new();
 
     let mut check_trait = |trait_: &Trait, parent: Option<Index<Multiname>>, is_class: bool| {
         match trait_.kind {


### PR DESCRIPTION


## Description

This change allows for reproducible builds.
See https://reproducible-builds.org/ for why this is good.

The problem was this:
`write_native_table` collected the `[NativeAccessible]` slot constants and the `[NativeCallable]` method constants into a `HashMap` keyed by module name, then iterated it to emit `pub mod slots { .. }` and `pub mod methods { .. }`.
Since HashMap iteration order differs on every run, the generated native_table.rs came out with its 45 slot modules and 6 method modules shuffled, even though the contents were always the same.

The shuffling propagated into the ruffle_desktop binary, so we got a different `ruffle` openSUSE package from every build when nothing in the inputs changed.

The solution:
Use a `BTreeMap` instead. The keys are the module names that are about to be emitted, so ordering them alphabetically both fixes the order and makes the generated file easier to read; nothing downstream depends on the previous order, as the consumers refer to the constants by path.

## Testing

_How can we test this PR?_

One could write a test to recreate the native_table.rs multiple times and check that it has the same content each time. My command of rust is not good enough for this, but I'm not even sure this is worth a test. Do you?

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code. (I still overhauled the commit message and dropped superfluous code comments)
