### PR TITLE
core: Migrate ruffle_macros to syn 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2959,7 +2959,7 @@ checksum = "77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4856,7 +4856,7 @@ version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5352,7 +5352,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5711,9 +5711,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.106"
 quote = "1.0.45"
-syn = { version = "2.0.117", features = ["extra-traits", "full"] }
+syn = { version = "3.0.3", features = ["extra-traits", "full"] }

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -104,9 +104,10 @@ pub fn enum_trait_object(args: TokenStream, item: TokenStream) -> TokenStream {
         fn adjust_method(&self, method: &mut syn::TraitItemFn) {
             let Self { mod_name, lt, .. } = self;
             let generics = &mut method.sig.generics;
-            generics
-                .params
-                .insert(0, syn::LifetimeParam::new(lt.clone()).into());
+            generics.params.insert(
+                0,
+                syn::GenericParam::Lifetime(syn::LifetimeParam::new(lt.clone())),
+            );
             generics
                 .make_where_clause()
                 .predicates
@@ -154,15 +155,10 @@ pub fn enum_trait_object(args: TokenStream, item: TokenStream) -> TokenStream {
                         .adjust_method(method);
 
                     let method_name = &method.sig.ident;
-                    let deref = if let Some(syn::Receiver {
-                        colon_token: None,
-                        reference,
-                        ..
-                    }) = method.sig.receiver()
-                    {
-                        reference.is_some().then(|| quote!(*))
-                    } else {
-                        panic!("#[no_dynamic] method `{method_name}` must take `self`, `&self`, or `&mut self`")
+                    let deref = match method.sig.receiver().map(|r| &r.kind) {
+                        Some(syn::ReceiverKind::Value) => None,
+                        Some(syn::ReceiverKind::Reference(..)) => Some(quote!(*)),
+                        _ => panic!("#[no_dynamic] method `{method_name}` must take `self`, `&self`, or `&mut self`"),
                     };
 
                     // Moves the provided default body to the enum's generated trait impl,
@@ -197,7 +193,7 @@ pub fn enum_trait_object(args: TokenStream, item: TokenStream) -> TokenStream {
                 ImplItem::Fn(ImplItemFn {
                     attrs: method.attrs.clone(),
                     vis: Visibility::Inherited,
-                    defaultness: None,
+                    modifiers: syn::FnModifiers::default(),
                     sig: method.sig.clone(),
                     block: method_block,
                 })


### PR DESCRIPTION
## Description

Motivation: https://github.com/ruffle-rs/ruffle/pull/24260#issuecomment-5047832132
The ecosystem is slowly catching up ( https://github.com/ruffle-rs/ruffle/pull/24318/changes#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87eL718-R718 ), let's try not to be the last one to migrate ourselves.

Three API changes were needed:
 - The `From<LifetimeParam> for GenericParam` impl was removed, so construct the `GenericParam::Lifetime` variant explicitly.
 - `colon_token` and `reference` in `Receiver` were replaced by `kind: ReceiverKind`, so match on that in `#[no_dynamic]` handling.
 - `ImplItemFn::defaultness` was moved into the non-exhaustive `modifiers: FnModifiers`.
 
See: https://github.com/dtolnay/syn/releases/tag/3.0.0

LLM Disclosure: Claude did this on its own first, but then I manually recreated it entirely, line by line, to make sure I understand what changed.

## Testing

_If it builds, it works!_ :crab:

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
	  **Technically the 3.0.2 -> 3.0.3 bump _could_ be separated, but ... it's trivial.**
- [X] An LLM was involved in the authoring of this code.
