### PR TITLE
ci: Sync bumped package versions into package-lock.json upon release

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -179,6 +179,7 @@ def bump(release_type):
     run_command(['npm', 'install', 'workspace-version'], cwd=npm_dir)
     run_command(['npm', 'version', '--no-git-tag-version', version], cwd=npm_dir)
     run_command(['./node_modules/workspace-version/dist/index.js'], cwd=npm_dir)
+    run_command(['npm', 'install', '--package-lock-only'], cwd=npm_dir)
 
     github_output('current-version', current_version)
     github_output('version', version)


### PR DESCRIPTION
## Description

This should resolve the awkwardness where Dependabot syncs internal cross-package version constraints following a new stable release.

For example, this: https://github.com/ruffle-rs/ruffle/pull/24365/changes#diff-3ebf69f247f3231fd796e60555489b4a1ed684e3ad4cb0ace460a2ed07d53a95
After this: https://github.com/ruffle-rs/ruffle/commit/a4f5b5256e245693bc9077ef6c6b6abc95490e7f#diff-3ebf69f247f3231fd796e60555489b4a1ed684e3ad4cb0ace460a2ed07d53a95

Tested locally, the newly added command reproduced the same diff on my machine that looked out of place in the Dependabot PR above.

## Testing

Run this list of commands locally in `web`, and see that the newly added one does to `package-lock.json` what it's supposed to do.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
