### PR TITLE
core: Scroll text fields horizontally to follow the caret

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1557,6 +1557,51 @@ impl<'gc> EditText<'gc> {
         self.invalidate_cached_bitmap();
     }
 
+    /// The x position of the caret in layout space.
+    ///
+    /// The caret may sit after the last character, which has no bounds of its
+    /// own, so fall back to the right edge of the character before it.
+    fn caret_layout_x(self, position: usize) -> Option<Twips> {
+        let layout = self.0.layout.borrow();
+        if let Some(bounds) = layout.char_bounds(position) {
+            Some(bounds.x_min)
+        } else {
+            layout
+                .char_bounds(position.checked_sub(1)?)
+                .map(|bounds| bounds.x_max)
+        }
+    }
+
+    /// Scroll horizontally so that the caret stays visible, like FP does while
+    /// the user types or moves through the text. Layout isn't clipped to the
+    /// field, so without this the text keeps being laid out past the right edge
+    /// and simply stops being drawn.
+    fn scroll_caret_into_view(self) {
+        // Wrapped text has nowhere to scroll to.
+        if self.0.flags.get().contains(EditTextFlag::WORD_WRAP) {
+            return;
+        }
+        let Some(selection) = self.selection() else {
+            return;
+        };
+        let Some(caret_x) = self.caret_layout_x(selection.to()) else {
+            return;
+        };
+
+        let caret_x = self.layout_width_to_local_width(caret_x);
+        let window_width = (self.0.bounds.get().width() - Self::GUTTER * 2).max(Twips::ZERO);
+        let hscroll = Twips::from_pixels(self.0.hscroll.get());
+        let new_hscroll = if caret_x < hscroll {
+            caret_x
+        } else if caret_x > hscroll + window_width {
+            caret_x - window_width
+        } else {
+            return;
+        };
+
+        self.set_hscroll(new_hscroll.to_pixels().clamp(0.0, self.maxhscroll()));
+    }
+
     pub fn scroll(self) -> usize {
         self.0.scroll.get()
     }
@@ -1823,6 +1868,9 @@ impl<'gc> EditText<'gc> {
                 }
             }
         }
+        // Also for plain caret movement, which doesn't count as a change.
+        self.scroll_caret_into_view();
+
         if changed {
             let mut activation = Avm1Activation::from_nothing(
                 context,
@@ -2086,6 +2134,7 @@ impl<'gc> EditText<'gc> {
         self.replace_text(selection.start(), selection.end(), text, context);
         let new_pos = selection.start() + text.len();
         self.set_selection(Some(TextSelection::for_position(new_pos)));
+        self.scroll_caret_into_view();
 
         let mut activation = Avm1Activation::from_nothing(
             context,


### PR DESCRIPTION
## Description

An `EditText` never scrolls horizontally on its own. Outside of `relayout`
resetting `hscroll` to zero and the ActionScript `scrollH` setter, nothing in
the codebase ever writes it — so in a field that does not word-wrap, text typed
past the right edge is laid out normally and then simply never drawn. To the
user the line looks like it vanishes as they keep typing, and the caret is gone
with it. Flash Player instead keeps the caret in view by scrolling the field.

This adds `scroll_caret_into_view()`, which shifts `hscroll` by the minimum
amount needed whenever the caret leaves the visible window, clamped to
`maxhscroll()`:

- caret left of the window → scroll to the caret;
- caret past the right edge → scroll so the caret lands on that edge;
- caret already visible → do nothing.

It runs from `text_input`, so typing follows the caret, and from
`text_control_input`, so arrows, backspace, home and end scroll back as well.
Word-wrapped fields return early — they have nowhere to scroll to.

One detail worth calling out: the caret may sit *after* the last character,
which has no bounds of its own, so `caret_layout_x` falls back to the right
edge of the preceding character.

For context: this comes out of a downstream Ruffle build I maintain for
AdventureQuest Worlds, where it has been shipping since July (see Testing).
A few of the other fixes I have there aren't game-specific either — coalescing
cursor moves to one hit-test per tick in the desktop player, invalidating an
ancestor's bitmap cache when a colour transform changes, and honouring the
`weakKeys` argument to `Dictionary`. I'd rather send those as separate,
reviewable PRs than bundle them here; happy to open them if they'd be welcome.

## Testing

`cargo test -p tests --release` passes on this branch: 4169 passed, 0 failed,
339 ignored.

This has also had real-world use rather than just a synthetic case. I maintain
a downstream Ruffle build for AdventureQuest Worlds, and this change has been
in every release of it since 2026-07-21 — six releases so far. AQW's chat is a
single-line input with `maxChars = 150`, which is exactly the case that breaks:
before this, the line looked like it vanished as you typed past the right edge,
and players reported it as text disappearing. Nothing has come back about text
input since.

I have **not** included a new automated regression test, because I don't have a
debug Flash Player available to produce a trusted `output.txt`, and I'd rather
not commit expected output I can't verify against the real player.

The behaviour is scriptable, though, and I'm happy to add a test if a reviewer
can supply or confirm the Flash Player values: `scrollH` is readable from
ActionScript, and `tests/input-format` already supports `TextInput` events, so
a test can type a string into a single-line input field and trace `scrollH`
after each character.

To verify manually, use any SWF with a single-line input `TextField` narrower
than the text being typed (an `Input` type field with `wordWrap = false`):

- **Before:** type past the right edge — the characters stop appearing, the
  caret disappears, and `scrollH` stays at `0`. Pressing Home/End or the arrow
  keys doesn't bring the text back either.
- **After:** the field scrolls to follow the caret while typing, and scrolls
  back when the caret is moved left with the arrow keys, Home, or Backspace.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
