### PR TITLE
desktop: Coalesce cursor moves into one hit-test per tick

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -29,6 +29,12 @@ struct MainWindow {
     player: PlayerController,
     minimized: bool,
     mouse_pos: PhysicalPosition<f64>,
+    /// Whether the cursor moved since the last tick. winit can deliver
+    /// `CursorMoved` at the mouse polling rate (hundreds of Hz), and each move
+    /// runs a full display-list hit-test (`run_mouse_pick`). We coalesce them
+    /// so that at most one hit-test runs per tick, which keeps a burst of OS
+    /// cursor events from stalling frames in a crowded scene.
+    mouse_move_pending: bool,
     modifiers: Modifiers,
     min_window_size: LogicalSize<u32>,
     max_window_size: PhysicalSize<u32>,
@@ -100,10 +106,10 @@ impl MainWindow {
                 }
 
                 self.mouse_pos = position;
-                let (x, y) = self.gui.window_to_movie_position(position);
-                let event = PlayerEvent::MouseMove { x, y };
-                self.player.handle_event(event);
-                self.check_redraw();
+                // Defer the actual hit-test to the next tick via `flush_mouse_move`.
+                // A burst of high-frequency cursor moves collapses into a single
+                // `run_mouse_pick` instead of one per OS event.
+                self.mouse_move_pending = true;
             }
             WindowEvent::DroppedFile(file) => {
                 if let Some(content_descriptor) = ContentDescriptor::new_local(&file, None) {
@@ -124,6 +130,10 @@ impl MainWindow {
                 if self.gui.is_context_menu_visible() {
                     return;
                 }
+
+                // Apply any pending cursor move first so the press/release uses an
+                // up-to-date hover target and preserves MouseMove -> MouseDown order.
+                self.flush_mouse_move();
 
                 use ruffle_core::events::MouseButton as RuffleMouseButton;
                 use winit::event::MouseButton;
@@ -188,6 +198,8 @@ impl MainWindow {
                 }
             }
             WindowEvent::CursorLeft { .. } => {
+                // Drop any coalesced move; the cursor is no longer in the stage.
+                self.mouse_move_pending = false;
                 if let Some(mut player) = self.player.get() {
                     player.set_mouse_in_stage(false);
                 }
@@ -369,6 +381,10 @@ impl MainWindow {
             }
         }
 
+        // Apply at most one coalesced cursor move per tick, before advancing the
+        // movie, so a burst of high-frequency cursor moves runs a single hit-test.
+        self.flush_mouse_move();
+
         // Core loop
         // [NA] This used to be called `MainEventsCleared`, but I think the behaviour is different now.
         // We should look at changing our tick to happen somewhere else if we see any behavioural problems.
@@ -384,6 +400,18 @@ impl MainWindow {
                 self.check_redraw();
             }
         }
+    }
+
+    /// Flush a coalesced cursor move, if any, running a single hit-test for the
+    /// latest cursor position. Called once per tick and before mouse clicks.
+    fn flush_mouse_move(&mut self) {
+        if !self.mouse_move_pending {
+            return;
+        }
+        self.mouse_move_pending = false;
+        let (x, y) = self.gui.window_to_movie_position(self.mouse_pos);
+        self.player.handle_event(PlayerEvent::MouseMove { x, y });
+        self.check_redraw();
     }
 
     fn check_redraw(&self) {
@@ -544,6 +572,7 @@ impl ApplicationHandler<RuffleEvent> for App {
                 loaded,
                 minimized: false,
                 mouse_pos: PhysicalPosition::new(0.0, 0.0),
+                mouse_move_pending: false,
                 modifiers: Modifiers::default(),
                 time: Instant::now(),
                 next_frame_time: None,


### PR DESCRIPTION
## Description

Every `WindowEvent::CursorMoved` synchronously ran `run_mouse_pick`, which
hit-tests the whole display list. winit delivers cursor moves at the mouse
polling rate — hundreds per second on Windows — so moving the cursor across a
busy scene fired a burst of hit-tests *in between* rendered frames. On heavy
content this is very visible: the player hitches while the cursor is moving,
and worse the more display objects are on stage.

This records the latest cursor position instead of acting on it, and flushes it
at most once per tick from `about_to_wait`. It also flushes immediately before
a mouse press, so a click still sees an up-to-date hover target and
`MouseMove` → `MouseDown` ordering is preserved. `CursorLeft` drops the pending
move. Clicks gain no latency.

**The trade-off, stated plainly:** content now sees `MouseMove` at tick rate
rather than at the OS event rate. I think that is the right call — the extra
hit-tests were computing hover state that nothing could observe until the next
frame anyway — but it is a behaviour change for content that tracks the cursor
path finely (a drawing app, say), so it's worth a maintainer's judgement rather
than mine. If you'd prefer this gated behind a flag, or flushed more than once
per tick, I'm happy to rework it.

## Testing

`cargo check -p ruffle_desktop --release` and `cargo fmt --all --check` are
clean, and clippy reports nothing against the changed file. The change is
confined to the desktop event loop, which the SWF regression suite doesn't
exercise, so I verified it by running the player rather than by adding to that
suite.

One aside I ran into while checking this, unrelated to the change:
`cargo clippy -p ruffle_desktop` currently fails on Windows on master, because
the `#[cfg(not(target_os = "linux"))]` arm of `ThemeController::get_system_theme`
is `async` with nothing to await (the Linux arm does await). CI presumably
doesn't see it because it lints on Linux. Untouched here — happy to send the
one-line fix as its own PR if that's useful.

This has had heavy real-world use rather than just a synthetic case. I maintain
a downstream Ruffle build for AdventureQuest Worlds, and this change has been
in every release of it since 2026-06-27 — thirteen releases over about six
weeks of daily play. It was originally made because click-to-move in a crowded
town stuttered badly; the game has no `MOUSE_MOVE` listener at all, so the
entire per-move cost was host-side hit-testing. No input regressions have come
back since, including from mouse-driven UI, drag interactions and text
selection.

To see the difference without that content: open any SWF with a large display
list in the desktop player and sweep the cursor across it while watching frame
pacing. Before, the burst of `run_mouse_pick` calls between frames shows up as
a stutter that tracks cursor motion; after, hover updates once per tick and the
stutter is gone.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
