### PR TITLE
desktop: Fix unused_async denial on non-Linux builds

### DIFF
--- a/desktop/src/gui/theme.rs
+++ b/desktop/src/gui/theme.rs
@@ -150,6 +150,10 @@ impl ThemeController {
         Ok(scheme_to_theme(scheme))
     }
 
+    // Nothing to await here, but the Linux variant above does, and the caller
+    // awaits unconditionally -- so this has to stay `async` to keep one call
+    // site working on every platform.
+    #[allow(clippy::unused_async)]
     #[cfg(not(target_os = "linux"))]
     pub async fn get_system_theme(&self) -> Result<Theme, Box<dyn Error>> {
         #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
## Description

`cargo clippy -p ruffle_desktop` currently fails to build on Windows and macOS
on master:

```
error: unused `async` for function with no await statements
   --> desktop\src\gui\theme.rs:154:5
```

`ThemeController::get_system_theme` has two `cfg` variants. The Linux one
awaits a freedesktop settings lookup; the other reads the theme straight off
the window and awaits nothing. Both are `async` so that the single caller in
`set_theme_preference` can `.await` it without platform-specific code. Since
884adb31f turned on `unused_async = "deny"` workspace-wide, the non-Linux
variant has tripped that lint. CI lints on Linux, where the awaiting variant is
the one compiled, so it hasn't shown up there.

This allows the lint on that variant, with a comment saying why the `async` is
deliberate. Dropping `async` instead would work, but then the call site would
have to diverge per platform for no gain.

## Testing

On Windows, `cargo clippy -p ruffle_desktop --all-targets --release` goes from
failing with that error to clean, and `cargo fmt --all --check` is clean. No
behaviour change — the attribute is the entire diff.

(Unrelated, and left alone: the same clippy run reports `unneeded return
statement` in `ruffle_frontend_utils`. Happy to fix that too if you'd like it,
but it's a warning rather than a build failure so I've kept this PR to one
thing.)

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
