### PR TITLE
avm2: Make Matrix3D.identity()/appendTranslation() native

### DIFF
--- a/core/src/avm2/globals/flash/geom/Matrix3D.as
+++ b/core/src/avm2/globals/flash/geom/Matrix3D.as
@@ -27,21 +27,9 @@ package flash.geom {
             }
         }
 
-        public function identity():void {
-            // Note that every 4 elements is a *column*, not a row
-            this._rawData = new <Number>[
-                1, 0, 0, 0,
-                0, 1, 0, 0,
-                0, 0, 1, 0,
-                0, 0, 0, 1
-            ];
-        }
+        public native function identity():void;
 
-        public function appendTranslation(x:Number, y:Number, z:Number):void {
-            this._rawData[12] += x;
-            this._rawData[13] += y;
-            this._rawData[14] += z;
-        }
+        public native function appendTranslation(x:Number, y:Number, z:Number):void;
 
         public native function appendRotation(degrees:Number, axis:Vector3D, pivotPoint:Vector3D = null):void;
 

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -102,6 +102,48 @@ fn set_raw_data<'gc>(
     this.set_slot(matrix3d_slots::_RAW_DATA, raw_data.into(), activation)
 }
 
+/// Implements `Matrix3D.identity`.
+pub fn identity<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this.as_object().unwrap();
+
+    #[rustfmt::skip]
+    let raw_data: RawData = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 1.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+
+    set_raw_data(activation, this, raw_data)?;
+
+    Ok(Value::Undefined)
+}
+
+/// Implements `Matrix3D.appendTranslation`.
+pub fn append_translation<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this.as_object().unwrap();
+    let x = args.get_f64(0);
+    let y = args.get_f64(1);
+    let z = args.get_f64(2);
+
+    let mut raw_data = raw_data_of(this);
+    raw_data[12] += x;
+    raw_data[13] += y;
+    raw_data[14] += z;
+
+    set_raw_data(activation, this, raw_data)?;
+
+    Ok(Value::Undefined)
+}
+
 /// Implements `Matrix3D.append`.
 pub fn append<'gc>(
     activation: &mut Activation<'_, 'gc>,


### PR DESCRIPTION
## Description

This patch makes Matrix3D.identity()/appendTranslation() native without
changing any semantics.

## Testing

Already tested.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
