### PR TITLE
core: Make `DisplayObject::ptr_eq` take any TDisplayObject parameter

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -2896,7 +2896,7 @@ macro_rules! impl_downcast_methods {
 }
 
 impl<'gc> DisplayObject<'gc> {
-    pub fn ptr_eq(a: DisplayObject<'gc>, b: DisplayObject<'gc>) -> bool {
+    pub fn ptr_eq<T: TDisplayObject<'gc>>(a: T, b: T) -> bool {
         std::ptr::eq(a.as_ptr(), b.as_ptr())
     }
 
@@ -3080,7 +3080,7 @@ impl<'gc> Avm1TextFieldBinding<'gc> {
     /// Caller is responsible for placing the text field on the unbound list, if necessary.
     pub fn clear_binding(dobj: DisplayObject<'gc>, text_field: EditText<'gc>, mc: &Mutation<'gc>) {
         if let Some(mut bindings) = dobj.avm1_text_field_bindings_mut(mc) {
-            bindings.retain(|b| !DisplayObject::ptr_eq(text_field.into(), b.text_field.into()));
+            bindings.retain(|b| !DisplayObject::ptr_eq(text_field, b.text_field));
         }
     }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -856,7 +856,7 @@ impl<'gc> EditText<'gc> {
             activation
                 .context
                 .unbound_text_fields
-                .retain(|&text_field| !DisplayObject::ptr_eq(text_field.into(), self.into()));
+                .retain(|&text_field| !DisplayObject::ptr_eq(text_field, self));
         }
 
         // Setup new binding.
@@ -2795,7 +2795,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         if self.variable().is_some() {
             context
                 .unbound_text_fields
-                .retain(|&text_field| !DisplayObject::ptr_eq(text_field.into(), self.into()));
+                .retain(|&text_field| !DisplayObject::ptr_eq(text_field, self));
         }
 
         self.set_avm1_removed(true);

--- a/core/src/display_object/text_line.rs
+++ b/core/src/display_object/text_line.rs
@@ -121,7 +121,7 @@ impl<'gc> TextLine<'gc> {
         let next_line = self.next_line();
 
         // If this line was the text block's first line, set it to the next line
-        if DisplayObject::ptr_eq(self.into(), block_first_line.into()) {
+        if DisplayObject::ptr_eq(self, block_first_line) {
             block.set_first_line(next_line, mc);
         }
 
@@ -245,7 +245,7 @@ impl<'gc> TextLine<'gc> {
         let mut result = Vec::new();
         result.push(self);
 
-        if DisplayObject::ptr_eq(self.into(), other.into()) {
+        if DisplayObject::ptr_eq(self, other) {
             // There is only one line, `self`
             return result;
         }
@@ -253,7 +253,7 @@ impl<'gc> TextLine<'gc> {
         // Try going forwards...
         for line in self.next_lines() {
             result.push(line);
-            if DisplayObject::ptr_eq(line.into(), other.into()) {
+            if DisplayObject::ptr_eq(line, other) {
                 return result;
             }
         }
@@ -264,7 +264,7 @@ impl<'gc> TextLine<'gc> {
 
         for line in self.previous_lines() {
             result.push(line);
-            if DisplayObject::ptr_eq(line.into(), other.into()) {
+            if DisplayObject::ptr_eq(line, other) {
                 return result;
             }
         }


### PR DESCRIPTION
## Description

This makes it work like how `avm2::object::Object::ptr_eq` works, allowing it to take any `DisplayObject` variant directly.

## Testing

No functional changes

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
