### PR TITLE
desktop: Implement FreeType device font renderer

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -14,7 +14,7 @@ env:
   FEATURES: lzma,jpegxr
   TEST_OPTS: --workspace --locked --no-fail-fast -j 4
   LLVM_COV_OPTS: --branch --profile ci
-  LLVM_COV_TEST_OPTS: ${LLVM_COV_OPTS} ${TEST_OPTS} --features ${FEATURES},imgtests
+  LLVM_COV_TEST_OPTS: ${LLVM_COV_OPTS} ${TEST_OPTS} --features ${FEATURES},imgtests,freetype
 
   LINUX_DEPENDENCIES: libasound2-dev mesa-vulkan-drivers libudev-dev libfontconfig-dev
 
@@ -89,6 +89,11 @@ jobs:
         if: runner.os != 'macOS'
         shell: bash
         run: echo FEATURES=${FEATURES},imgtests | tee -a $GITHUB_ENV
+
+      - name: Enable freetype tests
+        if: runner.os == 'Linux'
+        shell: bash
+        run: echo FEATURES=${FEATURES},freetype | tee -a $GITHUB_ENV
 
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5034,6 +5034,7 @@ dependencies = [
  "rascal",
  "regex",
  "ruffle_core",
+ "ruffle_frontend_utils",
  "ruffle_input_format",
  "ruffle_render",
  "ruffle_socket_format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,6 +1953,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "freetype-rs"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d228d6de56c90dd7585341f341849441b3490180c62d27133e525eb726809b4"
+dependencies = [
+ "bitflags 2.13.1",
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab537ce43cab850c64b4cdc390ce7e4f47f877485ddc323208e268280c308ae"
+dependencies = [
+ "cc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +2967,18 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4815,6 +4849,7 @@ dependencies = [
  "async-io",
  "bytemuck",
  "cpal",
+ "freetype-rs",
  "futures-lite",
  "macro_rules_attribute",
  "reqwest",

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -985,7 +985,11 @@ impl SwfGlyphOrShape {
 #[derive(Clone, Debug)]
 pub enum GlyphRenderData {
     Shape(ShapeHandle),
-    Bitmap { handle: BitmapHandle, tx: Twips },
+    Bitmap {
+        handle: BitmapHandle,
+        tx: Twips,
+        ty: Twips,
+    },
 }
 
 impl GlyphRenderData {
@@ -993,10 +997,11 @@ impl GlyphRenderData {
         Self::Shape(shape_handle)
     }
 
-    pub fn from_bitmap(bitmap_handle: BitmapHandle, tx: Twips) -> Self {
+    pub fn from_bitmap(bitmap_handle: BitmapHandle, tx: Twips, ty: Twips) -> Self {
         Self::Bitmap {
             handle: bitmap_handle,
             tx,
+            ty,
         }
     }
 }
@@ -1050,7 +1055,7 @@ impl GlyphShape {
                 })
                 .ok()
                 .cloned()
-                .map(|handle| GlyphRenderData::from_bitmap(handle, bitmap.tx)),
+                .map(|handle| GlyphRenderData::from_bitmap(handle, bitmap.tx, bitmap.ty)),
             GlyphShape::None => None,
         }
     }
@@ -1063,6 +1068,9 @@ struct GlyphBitmap<'a> {
 
     /// Translation in x to be applied before rendering the glyph.
     tx: Twips,
+
+    /// Translation in y to be applied before rendering the glyph.
+    ty: Twips,
 }
 
 impl<'a> std::fmt::Debug for GlyphBitmap<'a> {
@@ -1074,11 +1082,12 @@ impl<'a> std::fmt::Debug for GlyphBitmap<'a> {
 }
 
 impl<'a> GlyphBitmap<'a> {
-    pub fn new(bitmap: Bitmap<'a>, tx: Twips) -> Self {
+    pub fn new(bitmap: Bitmap<'a>, tx: Twips, ty: Twips) -> Self {
         Self {
             bitmap: Cell::new(Some(bitmap)),
             handle: OnceCell::new(),
             tx,
+            ty,
         }
     }
 
@@ -1120,9 +1129,10 @@ impl Glyph {
         bitmap: Bitmap<'static>,
         advance: Twips,
         tx: Twips,
+        ty: Twips,
     ) -> Self {
         Self {
-            shape: GlyphShape::Bitmap(Rc::new(GlyphBitmap::new(bitmap, tx))),
+            shape: GlyphShape::Bitmap(Rc::new(GlyphBitmap::new(bitmap, tx, ty))),
             advance,
             character,
         }
@@ -1174,9 +1184,9 @@ impl Glyph {
                     .commands
                     .render_shape(shape_handle, context.transform_stack.transform());
             }
-            GlyphRenderData::Bitmap { handle, tx } => {
+            GlyphRenderData::Bitmap { handle, tx, ty } => {
                 context.transform_stack.push(&Transform {
-                    matrix: Matrix::translate(tx, Twips::ZERO),
+                    matrix: Matrix::translate(tx, ty),
                     ..Default::default()
                 });
 

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -60,6 +60,7 @@ fontconfig = { version = "0.11.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = "0.12.1"
+ruffle_frontend_utils = { path = "../frontend-utils", features = ["freetype"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_System_Console", "Win32_Storage_FileSystem"] }

--- a/desktop/assets/texts/en-US/preferences_dialog.ftl
+++ b/desktop/assets/texts/en-US/preferences_dialog.ftl
@@ -47,3 +47,9 @@ ime-enabled = Input Method
 ime-enabled-experimental = (experimental)
 ime-enabled-tooltip = An input method allows inputting characters that are not available on the keyboard, for instance Chinese, Japanese, or Korean characters.
 ime-enabled-default = Default
+
+device-font-renderer = Device Font Renderer
+device-font-renderer-tooltip = Selects the backend used to render device fonts.
+device-font-renderer-default = Default
+device-font-renderer-embedded = Embedded
+device-font-renderer-freetype = FreeType

--- a/desktop/src/backends.rs
+++ b/desktop/src/backends.rs
@@ -8,3 +8,4 @@ pub use fscommand::DesktopFSCommandProvider;
 pub use navigator::DesktopNavigatorInterface;
 pub use navigator::PathAllowList;
 pub use ui::DesktopUiBackend;
+pub use ui::DeviceFontRenderer;

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -19,12 +19,40 @@ use ruffle_core::font::{FontFileData, FontQuery};
 use std::fs::File;
 use std::path::Path;
 use std::rc::Rc;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::io::AsyncReadExt;
 use url::Url;
 use winit::event_loop::EventLoopProxy;
 use winit::raw_window_handle::HasDisplayHandle;
 use winit::window::{Fullscreen, Window};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeviceFontRenderer {
+    Embedded,
+    Freetype,
+}
+
+impl DeviceFontRenderer {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DeviceFontRenderer::Embedded => "embedded",
+            DeviceFontRenderer::Freetype => "freetype",
+        }
+    }
+}
+
+impl FromStr for DeviceFontRenderer {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "embedded" => Ok(DeviceFontRenderer::Embedded),
+            "freetype" => Ok(DeviceFontRenderer::Freetype),
+            _ => Err(()),
+        }
+    }
+}
 
 pub struct DesktopFileSelection {
     handle: FileHandle,
@@ -130,6 +158,10 @@ pub struct DesktopUiBackend {
     preferred_cursor: MouseCursor,
     font_database: Rc<fontdb::Database>,
     file_picker: FilePicker,
+
+    // It's non-trivial to invalidate all fonts and change the renderer, so
+    // do not allow changing it in runtime.
+    device_font_renderer: DeviceFontRenderer,
 }
 
 impl DesktopUiBackend {
@@ -148,10 +180,11 @@ impl DesktopUiBackend {
             event_loop,
             cursor_visible: true,
             clipboard,
-            preferences,
             preferred_cursor: MouseCursor::Arrow,
             font_database,
             file_picker,
+            device_font_renderer: DeviceFontRenderer::Embedded,
+            preferences,
         })
     }
 
@@ -307,7 +340,7 @@ impl UiBackend for DesktopUiBackend {
                 face.post_script_name
             );
 
-            match load_fontdb_font(name.to_string(), face) {
+            match load_fontdb_font(name.to_string(), face, self.device_font_renderer) {
                 Ok(font_definition) => register(font_definition),
                 Err(error) => tracing::error!("Error loading font from fontdb: {error}"),
             }
@@ -321,9 +354,11 @@ impl UiBackend for DesktopUiBackend {
         register: &mut dyn FnMut(FontDefinition),
     ) -> Vec<FontQuery> {
         cfg_select! {
-            all(unix, feature = "fontconfig") => fontconfig::sort_device_fonts(query, register)
-                .inspect_err(|err| tracing::error!("Cannot sort device fonts: {err}"))
-                .unwrap_or_default(),
+            all(unix, feature = "fontconfig") => {
+                fontconfig::sort_device_fonts(query, register, self.device_font_renderer)
+                    .inspect_err(|err| tracing::error!("Cannot sort device fonts: {err}"))
+                    .unwrap_or_default()
+            }
             _ => Vec::new(),
         }
     }
@@ -399,36 +434,62 @@ fn load_font_from_file(
     index: u32,
     is_bold: bool,
     is_italic: bool,
+    device_font_renderer: DeviceFontRenderer,
 ) -> Result<FontDefinition<'static>> {
-    let file = File::open(path).map_err(|e| anyhow!("Couldn't open font file at {path:?}: {e}"))?;
+    match device_font_renderer {
+        #[cfg(target_os = "linux")]
+        DeviceFontRenderer::Freetype => {
+            use ruffle_frontend_utils::backends::ui::FreetypeFontRenderer;
 
-    // SAFETY: We have to assume that the font file won't change.
-    // This assumption is realistic, as we're using system fonts only.
-    // However, we never store other references to this data, and we reparse
-    // the whole file each time we're accessing any font data.
-    // Realistically, when the underlying file or memory region changes,
-    // we can expect Ruffle to crash due to SIGBUS or errors when parsing.
-    let mmap = unsafe { memmap2::Mmap::map(&file) };
+            Ok(FontDefinition::ExternalRenderer {
+                name,
+                is_bold,
+                is_italic,
+                font_renderer: Box::new(FreetypeFontRenderer::new(path, index)?),
+            })
+        }
+        _ => {
+            let file = File::open(path)
+                .map_err(|e| anyhow!("Couldn't open font file at {path:?}: {e}"))?;
 
-    let mmap = mmap.map_err(|e| anyhow!("Failed to mmap font file at {path:?}: {e}"))?;
-    let data = FontFileData::new(mmap);
-    Ok(FontDefinition::FontFile {
-        name,
-        is_bold,
-        is_italic,
-        data,
-        index,
-    })
+            // SAFETY: We have to assume that the font file won't change.
+            // This assumption is realistic, as we're using system fonts only.
+            // However, we never store other references to this data, and we reparse
+            // the whole file each time we're accessing any font data.
+            // Realistically, when the underlying file or memory region changes,
+            // we can expect Ruffle to crash due to SIGBUS or errors when parsing.
+            let mmap = unsafe { memmap2::Mmap::map(&file) };
+
+            let mmap = mmap.map_err(|e| anyhow!("Failed to mmap font file at {path:?}: {e}"))?;
+            let data = FontFileData::new(mmap);
+            Ok(FontDefinition::FontFile {
+                name,
+                is_bold,
+                is_italic,
+                data,
+                index,
+            })
+        }
+    }
 }
 
-fn load_fontdb_font(name: String, face: &FaceInfo) -> Result<FontDefinition<'static>> {
+fn load_fontdb_font(
+    name: String,
+    face: &FaceInfo,
+    device_font_renderer: DeviceFontRenderer,
+) -> Result<FontDefinition<'static>> {
     let is_bold = face.weight > fontdb::Weight::NORMAL;
     let is_italic = face.style != fontdb::Style::Normal;
 
     match &face.source {
-        fontdb::Source::File(path) => {
-            load_font_from_file(path, name, face.index, is_bold, is_italic)
-        }
+        fontdb::Source::File(path) => load_font_from_file(
+            path,
+            name,
+            face.index,
+            is_bold,
+            is_italic,
+            device_font_renderer,
+        ),
 
         fontdb::Source::Binary(bin) | fontdb::Source::SharedFile(_, bin) => {
             Ok(FontDefinition::FontFile {
@@ -444,7 +505,7 @@ fn load_fontdb_font(name: String, face: &FaceInfo) -> Result<FontDefinition<'sta
 
 #[cfg(all(unix, feature = "fontconfig"))]
 mod fontconfig {
-    use crate::backends::ui::load_font_from_file;
+    use crate::backends::ui::{DeviceFontRenderer, load_font_from_file};
     use ruffle_core::backend::ui::FontDefinition;
     use ruffle_core::font::FontQuery;
     use std::path::Path;
@@ -460,6 +521,7 @@ mod fontconfig {
     pub fn sort_device_fonts(
         query: &FontQuery,
         register: &mut dyn FnMut(FontDefinition),
+        device_font_renderer: DeviceFontRenderer,
     ) -> Result<Vec<FontQuery>, FontconfigError> {
         use fontconfig::{FontFormat, Pattern};
         use std::sync::LazyLock;
@@ -532,6 +594,7 @@ mod fontconfig {
                 index,
                 is_bold,
                 is_italic,
+                device_font_renderer,
             ) {
                 Ok(definition) => register(definition),
                 Err(err) => {

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -183,7 +183,9 @@ impl DesktopUiBackend {
             preferred_cursor: MouseCursor::Arrow,
             font_database,
             file_picker,
-            device_font_renderer: DeviceFontRenderer::Embedded,
+            device_font_renderer: preferences
+                .device_font_renderer()
+                .unwrap_or(DeviceFontRenderer::Embedded),
             preferences,
         })
     }

--- a/desktop/src/gui/dialogs/preferences_dialog.rs
+++ b/desktop/src/gui/dialogs/preferences_dialog.rs
@@ -1,3 +1,4 @@
+use crate::backends::DeviceFontRenderer;
 use crate::cli::{GameModePreference, OpenUrlMode};
 use crate::gui::{ThemePreference, available_languages, optional_text, text};
 use crate::log::FilenamePattern;
@@ -55,6 +56,9 @@ pub struct PreferencesDialog {
 
     ime_enabled: Option<bool>,
     ime_enabled_changed: bool,
+
+    device_font_renderer: Option<DeviceFontRenderer>,
+    device_font_renderer_changed: bool,
 }
 
 impl PreferencesDialog {
@@ -116,6 +120,9 @@ impl PreferencesDialog {
             ime_enabled: preferences.ime_enabled(),
             ime_enabled_changed: false,
 
+            device_font_renderer: preferences.device_font_renderer(),
+            device_font_renderer_changed: false,
+
             preferences,
         }
     }
@@ -145,6 +152,10 @@ impl PreferencesDialog {
                             self.show_open_url_mode_preferences(locale, &locked_text, ui);
 
                             self.show_ime_preferences(locale, ui);
+
+                            if cfg!(target_os = "linux") {
+                                self.show_font_renderer_preferences(locale, ui);
+                            }
 
                             self.show_language_preferences(locale, ui);
 
@@ -425,6 +436,32 @@ impl PreferencesDialog {
         ui.end_row();
     }
 
+    fn show_font_renderer_preferences(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) {
+        ui.label(text(locale, "device-font-renderer"))
+            .on_hover_text_at_pointer(text(locale, "device-font-renderer-tooltip"));
+        let previous = self.device_font_renderer;
+        ComboBox::from_id_salt("device-font-renderer")
+            .selected_text(device_font_renderer_name(locale, self.device_font_renderer))
+            .show_ui(ui, |ui| {
+                let values = [
+                    None,
+                    Some(DeviceFontRenderer::Embedded),
+                    Some(DeviceFontRenderer::Freetype),
+                ];
+                for value in values {
+                    ui.selectable_value(
+                        &mut self.device_font_renderer,
+                        value,
+                        device_font_renderer_name(locale, value),
+                    );
+                }
+            });
+        if self.device_font_renderer != previous {
+            self.device_font_renderer_changed = true;
+        }
+        ui.end_row();
+    }
+
     fn show_audio_preferences(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) {
         ui.label(text(locale, "audio-output-device"));
 
@@ -604,6 +641,9 @@ impl PreferencesDialog {
             if self.ime_enabled_changed {
                 preferences.set_ime_enabled(self.ime_enabled);
             }
+            if self.device_font_renderer_changed {
+                preferences.set_device_font_renderer(self.device_font_renderer);
+            }
         }) {
             // [NA] TODO: Better error handling... everywhere in desktop, really
             tracing::error!("Could not save preferences: {e}");
@@ -697,6 +737,17 @@ fn ime_enabled_name(locale: &LanguageIdentifier, ime_enabled: Option<bool>) -> C
         None => text(locale, "ime-enabled-default"),
         Some(true) => text(locale, "enable"),
         Some(false) => text(locale, "disable"),
+    }
+}
+
+fn device_font_renderer_name(
+    locale: &LanguageIdentifier,
+    device_font_renderer: Option<DeviceFontRenderer>,
+) -> Cow<'_, str> {
+    match device_font_renderer {
+        None => text(locale, "device-font-renderer-default"),
+        Some(DeviceFontRenderer::Embedded) => text(locale, "device-font-renderer-embedded"),
+        Some(DeviceFontRenderer::Freetype) => text(locale, "device-font-renderer-freetype"),
     }
 }
 

--- a/desktop/src/preferences.rs
+++ b/desktop/src/preferences.rs
@@ -3,6 +3,7 @@ mod write;
 
 pub mod storage;
 
+use crate::backends::DeviceFontRenderer;
 use crate::cli::{GameModePreference, OpenUrlMode, Opt};
 use crate::gui::ThemePreference;
 use crate::log::FilenamePattern;
@@ -229,6 +230,13 @@ impl GlobalPreferences {
             .ime_enabled
     }
 
+    pub fn device_font_renderer(&self) -> Option<DeviceFontRenderer> {
+        self.preferences
+            .lock()
+            .expect("Non-poisoned preferences")
+            .device_font_renderer
+    }
+
     pub fn recents<R>(&self, fun: impl FnOnce(&Recents) -> R) -> R {
         fun(&self.recents.lock().expect("Recents is not reentrant"))
     }
@@ -287,6 +295,7 @@ pub struct SavedGlobalPreferences {
     pub theme_preference: ThemePreference,
     pub open_url_mode: OpenUrlMode,
     pub ime_enabled: Option<bool>,
+    pub device_font_renderer: Option<DeviceFontRenderer>,
 }
 
 impl Default for SavedGlobalPreferences {
@@ -311,6 +320,7 @@ impl Default for SavedGlobalPreferences {
             theme_preference: Default::default(),
             open_url_mode: Default::default(),
             ime_enabled: None,
+            device_font_renderer: None,
         }
     }
 }

--- a/desktop/src/preferences/read.rs
+++ b/desktop/src/preferences/read.rs
@@ -71,6 +71,10 @@ pub fn read_preferences(input: &str) -> ParseDetails<SavedGlobalPreferences> {
         result.open_url_mode = value;
     }
 
+    if let Some(value) = document.parse_from_str(&mut cx, "device_font_renderer") {
+        result.device_font_renderer = Some(value);
+    }
+
     document.get_table_like(&mut cx, "log", |cx, log| {
         if let Some(value) = log.parse_from_str(cx, "filename_pattern") {
             result.log.filename_pattern = value;
@@ -96,6 +100,7 @@ pub fn read_preferences(input: &str) -> ParseDetails<SavedGlobalPreferences> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backends::DeviceFontRenderer;
     use crate::cli::{GameModePreference, OpenUrlMode};
     use crate::gui::ThemePreference;
     use crate::log::FilenamePattern;
@@ -710,6 +715,62 @@ mod tests {
                 expected: "string",
                 actual: "integer",
                 path: "open_url_mode".to_string(),
+            }],
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn device_font_renderer() {
+        let result = read_preferences("device_font_renderer = \"embedded\"");
+        assert_eq!(
+            &SavedGlobalPreferences {
+                device_font_renderer: Some(DeviceFontRenderer::Embedded),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+        let result = read_preferences("device_font_renderer = \"freetype\"");
+        assert_eq!(
+            &SavedGlobalPreferences {
+                device_font_renderer: Some(DeviceFontRenderer::Freetype),
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(Vec::<ParseWarning>::new(), result.warnings);
+
+        let result = read_preferences("device_font_renderer = \"nonsense\"");
+        assert_eq!(
+            &SavedGlobalPreferences {
+                device_font_renderer: None,
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(
+            vec![ParseWarning::UnsupportedValue {
+                value: "nonsense".to_string(),
+                path: "device_font_renderer".to_string(),
+            }],
+            result.warnings
+        );
+
+        let result = read_preferences("device_font_renderer = 1");
+        assert_eq!(
+            &SavedGlobalPreferences {
+                device_font_renderer: None,
+                ..Default::default()
+            },
+            result.values()
+        );
+        assert_eq!(
+            vec![ParseWarning::UnexpectedType {
+                expected: "string",
+                actual: "integer",
+                path: "device_font_renderer".to_string(),
             }],
             result.warnings
         );

--- a/desktop/src/preferences/write.rs
+++ b/desktop/src/preferences/write.rs
@@ -1,3 +1,4 @@
+use crate::backends::DeviceFontRenderer;
 use crate::cli::{GameModePreference, OpenUrlMode};
 use crate::gui::ThemePreference;
 use crate::log::FilenamePattern;
@@ -140,6 +141,17 @@ impl<'a> PreferencesWriter<'a> {
                 toml_document["ime"]["enabled"] = toml_edit::Item::None;
             }
             values.ime_enabled = ime_enabled;
+        });
+    }
+
+    pub fn set_device_font_renderer(&mut self, device_font_renderer: Option<DeviceFontRenderer>) {
+        self.0.edit(|values, toml_document| {
+            if let Some(device_font_renderer) = device_font_renderer {
+                toml_document["device_font_renderer"] = value(device_font_renderer.as_str());
+            } else {
+                toml_document.remove("device_font_renderer");
+            }
+            values.device_font_renderer = device_font_renderer;
         });
     }
 }
@@ -354,6 +366,25 @@ mod tests {
         test(
             "ime.enabled = false",
             |writer| writer.set_ime_enabled(None),
+            "",
+        );
+    }
+
+    #[test]
+    fn set_device_font_renderer() {
+        test(
+            "",
+            |writer| writer.set_device_font_renderer(Some(DeviceFontRenderer::Embedded)),
+            "device_font_renderer = \"embedded\"\n",
+        );
+        test(
+            "device_font_renderer = \"embedded\"",
+            |writer| writer.set_device_font_renderer(Some(DeviceFontRenderer::Freetype)),
+            "device_font_renderer = \"freetype\"\n",
+        );
+        test(
+            "device_font_renderer = \"freetype\"",
+            |writer| writer.set_device_font_renderer(None),
             "",
         );
     }

--- a/frontend-utils/Cargo.toml
+++ b/frontend-utils/Cargo.toml
@@ -15,6 +15,8 @@ default = ["native-tls"]
 cpal = ["dep:cpal", "dep:bytemuck", "ruffle_core/audio"]
 fs = []
 navigator = ["fs", "dep:async-io", "dep:tokio"]
+ui = []
+freetype = ["ui", "dep:freetype-rs"]
 
 # TLS backend for reqwest. `native-tls` is enabled by default; it uses the
 # system TLS component (OpenSSL/SChannel/SecureTransport) and keeps the binary
@@ -50,6 +52,7 @@ reqwest = { workspace = true, features = [
 tokio = { workspace = true, features = ["net", "macros"], optional = true }
 cpal = { workspace = true, optional = true }
 bytemuck = { workspace = true, optional = true }
+freetype-rs = { version = "0.38.0", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/frontend-utils/src/backends.rs
+++ b/frontend-utils/src/backends.rs
@@ -4,3 +4,5 @@ pub mod audio;
 pub mod navigator;
 #[cfg(feature = "fs")]
 pub mod storage;
+#[cfg(feature = "ui")]
+pub mod ui;

--- a/frontend-utils/src/backends/ui.rs
+++ b/frontend-utils/src/backends/ui.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "freetype")]
+mod freetype_font_renderer;
+
+#[cfg(feature = "freetype")]
+pub use freetype_font_renderer::FreetypeFontRenderer;

--- a/frontend-utils/src/backends/ui/freetype_font_renderer.rs
+++ b/frontend-utils/src/backends/ui/freetype_font_renderer.rs
@@ -1,0 +1,178 @@
+use freetype::bitmap::PixelMode;
+use freetype::face::KerningMode;
+use freetype::face::LoadFlag;
+use std::ffi::OsStr;
+use thiserror::Error;
+
+use ruffle_core::font::FontMetrics;
+use ruffle_core::font::FontRenderer;
+use ruffle_core::font::Glyph;
+use ruffle_core::swf::Twips;
+use ruffle_render::bitmap::Bitmap;
+use ruffle_render::bitmap::BitmapFormat;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Missing glyph: {0}")]
+    MissingGlyph(char),
+
+    #[error("FreeType error: {0}")]
+    FreetypeError(#[from] freetype::Error),
+}
+
+#[derive(Debug)]
+pub struct FreetypeFontRenderer {
+    face: freetype::Face,
+}
+
+impl FreetypeFontRenderer {
+    /// Render fonts with size 64px. It affects the bitmap size.
+    const SIZE_PX: f64 = 64.0;
+
+    /// Divide each pixel into 20 (use twips precision). It affects metrics.
+    const SCALE: f64 = 20.0;
+
+    pub fn new<P>(path: P, face_index: u32) -> Result<Self, Error>
+    where
+        P: AsRef<OsStr>,
+    {
+        let ft = freetype::Library::init()?;
+        let face = ft.new_face(path, face_index as isize)?;
+        face.set_char_size((Self::SIZE_PX * 64.0) as isize, 0, 0, 0)?;
+        Ok(Self { face })
+    }
+
+    fn size_metrics(&self) -> freetype::ffi::FT_Size_Metrics {
+        self.face
+            .size_metrics()
+            .expect("face should have a char size set")
+    }
+
+    fn ascent(&self) -> Twips {
+        convert_26_6_to_twips(self.size_metrics().ascender)
+    }
+
+    fn descent(&self) -> Twips {
+        // FreeType's `descender` is a signed distance from the baseline
+        // (negative since it points below it); this returns the positive
+        // magnitude expected by `FontMetrics::descent`.
+        convert_26_6_to_twips(-self.size_metrics().descender)
+    }
+
+    fn render_glyph_internal(&self, character: char) -> Result<Glyph, Error> {
+        let index = self
+            .face
+            .get_char_index(character as usize)
+            .ok_or(Error::MissingGlyph(character))?;
+
+        self.face
+            .load_glyph(index, LoadFlag::NO_BITMAP | LoadFlag::RENDER)?;
+        let glyph = self.face.glyph();
+        let bitmap = glyph.bitmap();
+        let advance = convert_26_6_to_twips(glyph.advance().x);
+        let tx = Twips::from_pixels(glyph.bitmap_left() as f64);
+
+        // `bitmap_top` is the distance from the baseline up to the top of
+        // the bitmap. Glyph bitmaps are positioned relative to the top of
+        // the line, not the baseline, so convert it into a downward offset
+        // from the top of the line.
+        let bitmap_top = Twips::from_pixels(glyph.bitmap_top() as f64);
+        let ty = self.ascent() - bitmap_top;
+
+        // Glyphs with no ink (e.g. space) have an empty bitmap, but a
+        // zero-sized texture isn't allowed, so clamp to at least 1x1.
+        let bitmap = Bitmap::new(
+            (bitmap.width() as u32).max(1),
+            (bitmap.rows() as u32).max(1),
+            BitmapFormat::Rgba,
+            convert_bitmap(&bitmap)?,
+        );
+
+        Ok(Glyph::from_bitmap(character, bitmap, advance, tx, ty))
+    }
+
+    fn calculate_kerning_internal(&self, left: char, right: char) -> Result<Twips, Error> {
+        if !self.face.has_kerning() {
+            return Ok(Twips::ZERO);
+        }
+
+        let left_index = self
+            .face
+            .get_char_index(left as usize)
+            .ok_or(Error::MissingGlyph(left))?;
+        let right_index = self
+            .face
+            .get_char_index(right as usize)
+            .ok_or(Error::MissingGlyph(right))?;
+
+        let kerning =
+            self.face
+                .get_kerning(left_index, right_index, KerningMode::KerningDefault)?;
+
+        Ok(convert_26_6_to_twips(kerning.x))
+    }
+}
+
+impl FontRenderer for FreetypeFontRenderer {
+    fn scale(&self) -> f32 {
+        (Self::SIZE_PX * Self::SCALE) as f32
+    }
+
+    fn get_font_metrics(&self) -> FontMetrics {
+        FontMetrics {
+            scale: self.scale(),
+            ascent: self.ascent().get(),
+            descent: self.descent().get(),
+            leading: 0,
+        }
+    }
+
+    fn has_kerning_info(&self) -> bool {
+        self.face.has_kerning()
+    }
+
+    fn render_glyph(&self, character: char) -> Option<Glyph> {
+        self.render_glyph_internal(character)
+            .map_err(|err| tracing::error!("Failed to render a glyph: {err:?}"))
+            .ok()
+    }
+
+    fn calculate_kerning(&self, left: char, right: char) -> Twips {
+        self.calculate_kerning_internal(left, right)
+            .map_err(|err| tracing::error!("Failed to calculate kerning: {err:?}"))
+            .unwrap_or(Twips::ZERO)
+    }
+}
+
+/// Converts a FreeType 26.6 fixed-point value (1/64th of a pixel) to Twips
+/// (1/20th of a pixel), rounding to the nearest twip.
+fn convert_26_6_to_twips(value_26_6: i64) -> Twips {
+    let whole_pixels = (value_26_6 / 64) as i32;
+
+    let fractional_twips = (value_26_6 % 64) as f64 / 64.0 * 20.0;
+    let fractional_twips = fractional_twips.round_ties_even() as i32;
+
+    Twips::new(fractional_twips + whole_pixels * 20)
+}
+
+fn convert_bitmap(bitmap: &freetype::Bitmap) -> Result<Vec<u8>, Error> {
+    let pixel_mode = bitmap.pixel_mode()?;
+    let buffer = bitmap.buffer();
+
+    match pixel_mode {
+        PixelMode::Gray => {
+            let mut result = Vec::with_capacity(buffer.len() * 4);
+
+            // TODO Add support for num_grays.
+            for &pixel in buffer {
+                result.push(pixel);
+                result.push(pixel);
+                result.push(pixel);
+                result.push(pixel);
+            }
+
+            Ok(result)
+        }
+        m => panic!("FreeType pixel mode unsupported: {m:?}"),
+    }
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -19,6 +19,7 @@ imgtests = [
     "ruffle_test_framework/ruffle_video_software",
     "ruffle_test_framework/ruffle_video_external",
 ]
+freetype = ["ruffle_test_framework/freetype"]
 jpegxr = ["ruffle_test_framework/jpegxr"]
 lzma = ["ruffle_test_framework/lzma"]
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -118,6 +118,9 @@ version = 32
 # in behavior between Ruffle and Flash.
 with_default_font = false
 
+# Which backend should be used for device font rendering.
+device_font_renderer = "freetype"
+
 # A list of image comparisons to perform during the test. This block is repeatable infinitely, as long as each name is unique.
 # The comparison part of a test is optional and only runs when `imgtests` feature is enabled
 # This requires a render to be setup for this test

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -37,6 +37,12 @@ sha2 = { workspace = true }
 clap = { workspace = true, optional = true }
 tempfile = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+ruffle_frontend_utils = { path = "../../frontend-utils", default-features = false, features = [
+    "freetype",
+], optional = true }
+
 [features]
 jpegxr = ["ruffle_core/jpegxr"]
 lzma = ["ruffle_core/lzma"]
+freetype = ["dep:ruffle_frontend_utils"]

--- a/tests/framework/src/backends.rs
+++ b/tests/framework/src/backends.rs
@@ -8,4 +8,5 @@ pub use audio::TestAudioBackend;
 pub use log::TestLogBackend;
 pub use navigator::TestNavigatorBackend;
 pub use storage::TestStorageBackend;
+pub use ui::FontRendererKind;
 pub use ui::TestUiBackend;

--- a/tests/framework/src/backends/ui.rs
+++ b/tests/framework/src/backends/ui.rs
@@ -8,7 +8,22 @@ use ruffle_core::backend::ui::{
     MultiFileDialogResult, US_ENGLISH, UiBackend,
 };
 use ruffle_core::font::{FontFileData, FontQuery};
+use serde::Deserialize;
 use url::Url;
+
+#[derive(Deserialize, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FontRendererKind {
+    #[default]
+    Embedded,
+    Freetype,
+}
+
+impl FontRendererKind {
+    pub fn can_run(self) -> bool {
+        !matches!(self, Self::Freetype) || cfg!(feature = "freetype")
+    }
+}
 
 /// A simulated file selection, for use in tests.
 pub struct TestFileSelection {
@@ -66,6 +81,7 @@ impl FileDialogSelection for TestFileSelection {
 pub struct TestUiBackend {
     fonts: HashMap<FontQuery, Font>,
     font_sorts: HashMap<FontQuery, Vec<FontQuery>>,
+    device_font_renderer: FontRendererKind,
     clipboard: String,
 }
 
@@ -73,10 +89,12 @@ impl TestUiBackend {
     pub fn new(
         fonts: HashMap<FontQuery, Font>,
         font_sorts: HashMap<FontQuery, Vec<FontQuery>>,
+        device_font_renderer: FontRendererKind,
     ) -> Self {
         Self {
             fonts,
             font_sorts,
+            device_font_renderer,
             clipboard: "".to_string(),
         }
     }
@@ -123,13 +141,33 @@ impl UiBackend for TestUiBackend {
             return;
         };
 
-        register(FontDefinition::FontFile {
-            name: font.family.to_owned(),
-            is_bold: font.bold,
-            is_italic: font.italic,
-            data: FontFileData::new(font.bytes.clone()),
-            index: 0,
-        });
+        match self.device_font_renderer {
+            FontRendererKind::Embedded => {
+                register(FontDefinition::FontFile {
+                    name: font.family.to_owned(),
+                    is_bold: font.bold,
+                    is_italic: font.italic,
+                    data: FontFileData::new(font.bytes.clone()),
+                    index: 0,
+                });
+            }
+            #[cfg(feature = "freetype")]
+            FontRendererKind::Freetype => {
+                let font_renderer = freetype_renderer(font).unwrap_or_else(|e| {
+                    panic!("Couldn't create FreeType renderer for {}: {e}", font.family)
+                });
+                register(FontDefinition::ExternalRenderer {
+                    name: font.family.to_owned(),
+                    is_bold: font.bold,
+                    is_italic: font.italic,
+                    font_renderer: Box::new(font_renderer),
+                });
+            }
+            #[cfg(not(feature = "freetype"))]
+            FontRendererKind::Freetype => {
+                unreachable!("tests requiring freetype should be skipped when it's unavailable");
+            }
+        }
     }
 
     fn sort_device_fonts(
@@ -203,4 +241,15 @@ impl UiBackend for TestUiBackend {
     }
 
     fn close_file_dialog(&mut self) {}
+}
+
+#[cfg(feature = "freetype")]
+fn freetype_renderer(
+    font: &Font,
+) -> anyhow::Result<ruffle_frontend_utils::backends::ui::FreetypeFontRenderer> {
+    use std::io::Write;
+
+    let mut file = tempfile::NamedTempFile::new()?;
+    file.write_all(&font.bytes)?;
+    Ok(ruffle_frontend_utils::backends::ui::FreetypeFontRenderer::new(file.path(), 0)?)
 }

--- a/tests/framework/src/options/player.rs
+++ b/tests/framework/src/options/player.rs
@@ -1,4 +1,4 @@
-use crate::backends::TestAudioBackend;
+use crate::backends::{FontRendererKind, TestAudioBackend};
 use crate::environment::{Environment, RenderInterface};
 use crate::options::RenderOptions;
 use ruffle_core::tag_utils::SwfMovie;
@@ -19,6 +19,7 @@ pub struct PlayerOptions {
     version: Option<u8>,
     mode: Option<PlayerMode>,
     with_default_font: bool,
+    device_font_renderer: FontRendererKind,
 }
 
 impl PlayerOptions {
@@ -79,7 +80,11 @@ impl PlayerOptions {
                 return false;
             }
         }
-        true
+        self.device_font_renderer.can_run()
+    }
+
+    pub fn device_font_renderer(&self) -> FontRendererKind {
+        self.device_font_renderer
     }
 
     pub fn viewport_dimensions(&self, movie: &SwfMovie) -> ViewportDimensions {

--- a/tests/framework/src/runner.rs
+++ b/tests/framework/src/runner.rs
@@ -99,7 +99,11 @@ impl TestRunner {
             .with_storage(Box::new(TestStorageBackend::new()))
             .with_max_execution_duration(Duration::from_secs(300))
             .with_fs_commands(Box::new(fs_command_provider))
-            .with_ui(TestUiBackend::new(test.fonts()?, test.font_sorts()))
+            .with_ui(TestUiBackend::new(
+                test.fonts()?,
+                test.font_sorts(),
+                test.options.player_options.device_font_renderer(),
+            ))
             .with_viewport_dimensions(
                 viewport_dimensions.width,
                 viewport_dimensions.height,

--- a/tests/tests/swfs/visual/edittext/edittext_device_transform_basic/output.freetype.ruffle.txt
+++ b/tests/tests/swfs/visual/edittext/edittext_device_transform_basic/output.freetype.ruffle.txt
@@ -1,0 +1,24 @@
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = width=16
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = width=16
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = width=16
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = width=16
+false = 16
+true = (x=2, y=2, w=8, h=10.1),(x=10, y=2, w=8, h=10.1)
+true = width=16
+true = 16
+true = (x=2, y=2, w=4, h=10.1),(x=6, y=2, w=4, h=10.1)
+true = width=8
+true = 8
+true = (x=2, y=2, w=16, h=10.1),(x=18, y=2, w=16, h=10.1)
+true = width=32
+true = 32
+true = (x=2, y=2, w=8, h=10.1),(x=10, y=2, w=8, h=10.1)
+true = width=16
+true = 16

--- a/tests/tests/swfs/visual/edittext/edittext_device_transform_basic/output.freetype.txt
+++ b/tests/tests/swfs/visual/edittext/edittext_device_transform_basic/output.freetype.txt
@@ -1,0 +1,24 @@
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = width=16
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = width=16
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = width=16
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = width=16
+false = 16
+true = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+true = width=16
+true = 16
+true = (x=2, y=2, w=4, h=10),(x=6, y=2, w=4, h=10)
+true = width=8
+true = 8
+true = (x=2, y=2, w=16, h=10),(x=18, y=2, w=16, h=10)
+true = width=32
+true = 32
+true = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+true = width=16
+true = 16

--- a/tests/tests/swfs/visual/edittext/edittext_device_transform_basic/test.toml
+++ b/tests/tests/swfs/visual/edittext/edittext_device_transform_basic/test.toml
@@ -1,13 +1,5 @@
 num_ticks = 1
 
-[[image_comparisons.output.checks]]
-tolerance = 0
-max_outliers = 90
-
-[[image_comparisons.output.checks]]
-tolerance = 128
-max_outliers = 14
-
 [player_options]
 with_renderer = { optional = true, quality = "high" }
 
@@ -16,3 +8,32 @@ family = "TestFont"
 path = "TestFont.ttf"
 bold = false
 italic = false
+
+[subtests.embedded.player_options]
+device_font_renderer = "embedded"
+
+[[subtests.embedded.image_comparisons.output.checks]]
+tolerance = 0
+max_outliers = 90
+
+[[subtests.embedded.image_comparisons.output.checks]]
+tolerance = 128
+max_outliers = 14
+
+[subtests.freetype]
+output_path = "output.freetype.txt"
+
+# TODO It currently fails because glyph scaling is not implemented properly.
+known_failure = true
+
+[subtests.freetype.player_options]
+device_font_renderer = "freetype"
+
+[[subtests.freetype.image_comparisons.output.checks]]
+tolerance = 0
+# TODO This is so high because glyph scaling is not implemented properly.
+max_outliers = 550
+
+[[subtests.freetype.image_comparisons.output.checks]]
+tolerance = 128
+max_outliers = 14

--- a/web/src/ui/font_renderer.rs
+++ b/web/src/ui/font_renderer.rs
@@ -125,7 +125,13 @@ impl CanvasFontRenderer {
 
         let bitmap = Bitmap::new(width, height, BitmapFormat::Rgba, pixels);
         let bitmap_tx = Twips::from_pixels(-metrics.actual_bounding_box_left());
-        Ok(Glyph::from_bitmap(character, bitmap, advance, bitmap_tx))
+        Ok(Glyph::from_bitmap(
+            character,
+            bitmap,
+            advance,
+            bitmap_tx,
+            Twips::ZERO,
+        ))
     }
 
     fn calculate_kerning_internal(&self, left: char, right: char) -> Result<Twips, JsValue> {


### PR DESCRIPTION
## Description

It's our second font renderer, this time for desktop, which allows using
the OS glyph rendering capabilities for displaying fonts in Ruffle.

It doesn't impact font selection (we still use fontconfig for that),
only font rendering (rasterization). It's supported only for Linux at
this moment (similarly to fontconfig). In theory it's possible to use
FreeType on other OSes, but people don't have that installed. We can
think about bundling FreeType for other OSes in the future.

Why am I doing this? Two reasons.

1. Fonts will look nicer on desktop (in the future, currently they look
   terrible). FreeType can render fonts at different resolutions and can
   provide high quality fonts even when their height is small. The
   embedded renderer renders fonts just like any other shape, which is
   not legible.

2. This will FINALLY allow testing font renderers. Previously we only
   had the web font renderer, and testing it ranged from difficult to
   impossible. Now we can easily test FreeType renderer and the whole
   bitmap glyphs machinery (which is also used on web).

Currently the renderer does the same hack as the web renderer, which
renders glyphs at a static resolution and scales bitmaps. This causes
fonts to look absolutely terrible, but having tests will allow to change
that in the near future.

## Testing

One test converted to test both embedded and freetype renderers.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.

The LLM was used to write preferences & tests, and debug FreeType not working properly.
