### PR TITLE
chore: Bump `lru` and `spin` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,6 +2406,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -3010,11 +3015,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -5539,9 +5544,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -23,7 +23,7 @@ image = { workspace = true }
 naga-agal = { path = "../naga-agal" }
 naga-pixelbender = { path = "../naga-pixelbender" }
 profiling = { version = "1.0", default-features = false, optional = true }
-lru = "0.16.2"
+lru = "0.18.2"
 naga = { workspace = true }
 indexmap = { workspace = true }
 smallvec = { workspace = true }

--- a/render/wgpu/src/context3d/shader_pair.rs
+++ b/render/wgpu/src/context3d/shader_pair.rs
@@ -56,8 +56,7 @@ impl ShaderPairAgal {
     ) -> RefMut<'_, CompiledShaderProgram> {
         let compiled = self.compiled.borrow_mut();
         RefMut::map(compiled, |compiled| {
-            // TODO: Figure out a way to avoid the clone when we have a cache hit
-            compiled.get_or_insert_mut(data.clone(), || {
+            compiled.get_or_insert_mut_with_key(data, |data| {
                 let vertex_naga_module =
                     naga_agal::agal_to_naga(&self.vertex_shader, &data.vertex_attributes).unwrap();
                 let vertex_module =


### PR DESCRIPTION
## Description

Resolves two issues flagged by `cargo-deny` in the "Check dependencies" job of our "Test Rust" CI workflow on PRs: https://github.com/ruffle-rs/ruffle/actions/runs/31498899156/job/93803517481?pr=24379#step:5:6330

Version `0.9.8` of `spin` was yanked, but thankfully there's a `0.9.9` out - bumping it was trivial.

Bumping `lru` also didn't necessitate any code changes. It bumped this indirect dep path to `hashbrown` to `0.17` - but since we already had that in the tree, that's no issue at all either. Nor are the even more indirect deps this version of `hashbrown` has gained with this, as they were all also included already.
As a bonus, bumping this allowed an easy resolution of a TODO, via a newly added method in the API: https://github.com/jeromefroe/lru-rs/blob/master/CHANGELOG.md#v0164---2026-04-13 (Granted, just bumping to `0.16.4` would also have been enough for this.) 

## Testing

See if CI is green, I suppose.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [X] An LLM was involved in the authoring of this code.
