### PR TITLE
swf: Add regression test for DefineFont2/3 glyph offset table panic

### DIFF
--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -3059,6 +3059,35 @@ pub mod tests {
         }
     }
 
+    /// Regression test for a corrupt/hostile `DefineFont2`/`DefineFont3` glyph
+    /// offset table. Before the offset table was read with `seek_absolute`
+    /// (rather than assumed to already be at the right position), an offset
+    /// that did not match the reader's actual position triggered
+    /// `debug_assert_eq!` and panicked debug builds; on release builds the
+    /// `available_bytes` subtraction wrapped on a decreasing offset. Neither
+    /// is exercised anymore, since `read_define_font_2` no longer computes
+    /// `available_bytes` at all -- it must return an `Err` (from running past
+    /// the end of the malformed data) rather than panic.
+    #[test]
+    fn read_define_font_2_with_out_of_range_glyph_offset_does_not_panic() {
+        let mut data = vec![];
+        data.extend_from_slice(&1u16.to_le_bytes()); // character id
+        data.push(0); // flags: no wide offsets/codes, no layout
+        data.push(0); // language: Unknown
+        data.push(0); // font name length: 0
+        data.extend_from_slice(&1u16.to_le_bytes()); // num_glyphs: 1
+                                                       // OffsetTable[0]: points far past the end of `data`, which a
+                                                       // corrupt or hostile SWF can freely claim.
+        data.extend_from_slice(&0xffffu16.to_le_bytes());
+        data.extend_from_slice(&0u16.to_le_bytes()); // CodeTableOffset
+
+        let result = reader(&data).read_define_font_2(2);
+        assert!(
+            result.is_err(),
+            "expected an error for an out-of-range glyph offset, got {result:?}"
+        );
+    }
+
     #[test]
     fn read_tag_list() {
         {


### PR DESCRIPTION
## Summary
- 8a25f7b55 ("swf: Seek to glyph shape offsets when reading DefineFont2/3") fixed a real panic in `read_define_font_2`: an out-of-range or decreasing glyph offset in a `DefineFont2`/`DefineFont3` tag used to hit `debug_assert_eq!` on debug builds, or wrap an unchecked `u32` subtraction on release builds. The fix (seeking to each claimed offset via `seek_absolute` instead of asserting the reader is already there) landed without a regression test.
- This adds that test: a minimal single-glyph `DefineFont2` whose only offset table entry points past the end of the tag data, asserting `read_define_font_2` returns `Err` rather than panicking.

## How I found this
I maintain a downstream SWF decompiler CLI. Its own adversarial fuzz suite (byte-mutating real corpus files and requiring every parse path to error rather than panic) caught this on swf 0.2.2 -- 21 of ~300 single-byte mutations of one sample SWF panicked inside this exact function. While investigating whether to carry a local patch, I found 8a25f7b55 already fixes it on `master`, just not yet published to crates.io. Since the fix itself needed nothing further, I'm contributing the regression test it was missing instead of a duplicate fix.

## Test plan
- [x] `cargo test -p swf --lib read::tests::read_define_font_2_with_out_of_range_glyph_offset_does_not_panic` passes on current `master` (after 8a25f7b55).
- [x] Confirmed the same test panics (`debug_assert_eq!` at the old `read.rs:1029`) when run against a standalone build of the unpatched swf 0.2.2 crate, i.e. it is a real regression guard and not vacuous.
- [x] `cargo test -p swf --lib` (full crate test suite) passes.