### PR TITLE
avm2: Use native Matrix3D in AVM2

### DIFF
--- a/core/src/avm2/globals/flash/display3D/context_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/context_3d.rs
@@ -7,7 +7,6 @@ use crate::avm2::error::{
     make_error_3772, make_error_3773, make_error_3780, make_error_3781,
 };
 use crate::avm2::globals::methods::flash_geom_matrix_3d as matrix3d_methods;
-use crate::avm2::globals::slots::flash_geom_matrix_3d as matrix3d_slots;
 use crate::avm2::globals::slots::flash_geom_rectangle as rectangle_slots;
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2_stub_method;
@@ -298,15 +297,12 @@ pub fn set_program_constants_from_matrix<'gc>(
         }
 
         let matrix_raw_data = matrix
-            .get_slot(matrix3d_slots::_RAW_DATA)
-            .as_object()
-            .expect("rawData cannot be null");
-
-        let matrix_raw_data = matrix_raw_data
-            .as_vector_storage()
+            .as_matrix3d_object()
             .unwrap()
+            .matrix_ref()
+            .raw_data
             .iter()
-            .map(|val| (val.as_f64() as f32).to_le_bytes())
+            .map(|val| (*val as f32).to_le_bytes())
             .collect::<Vec<[u8; 4]>>();
 
         context.set_program_constants(program_type, first_register, &matrix_raw_data);

--- a/core/src/avm2/globals/flash/geom/Matrix3D.as
+++ b/core/src/avm2/globals/flash/geom/Matrix3D.as
@@ -5,28 +5,14 @@ package flash.geom {
 
     [Ruffle(InstanceAllocator)]
     public class Matrix3D {
-        // The 4x4 matrix data, stored in column-major order
-        // This is never null.
-        [Ruffle(NativeAccessible)]
-        private var _rawData:Vector.<Number>;
-
-        public function get rawData():Vector.<Number> {
-            return this._rawData.AS3::concat();
-        }
-
-        public function set rawData(value:Vector.<Number>):void {
-            if (value != null) {
-                this._rawData = value.AS3::concat();
-            }
-        }
-
         public function Matrix3D(v:Vector.<Number> = null) {
             if (v != null && v.length == 16) {
-                this._rawData = v.AS3::concat();
-            } else {
-                this.identity();
+                this.rawData = v;
             }
         }
+
+        public native function get rawData():Vector.<Number>;
+        public native function set rawData(value:Vector.<Number>):void;
 
         public native function identity():void;
 
@@ -86,8 +72,7 @@ package flash.geom {
 
         [API("674")]
         public function copyFrom(other:Matrix3D):void {
-            // This makes a copy of other.rawData
-            this._rawData = other.rawData;
+            this.rawData = other.rawData;
         }
 
         [API("674")]
@@ -95,13 +80,11 @@ package flash.geom {
 
         [Ruffle(NativeCallable)]
         public function clone():Matrix3D {
-            // The constructor will make a copy of this._rawData
-            return new Matrix3D(this._rawData);
+            return new Matrix3D(this.rawData);
         }
 
         public function copyToMatrix3D(other:Matrix3D):void {
-            // This makes a copy of this.rawData
-            other._rawData = this.rawData;
+            other.rawData = this.rawData;
         }
 
         public function pointAt(pos:Vector3D, at:Vector3D = null, up:Vector3D = null):void {

--- a/core/src/avm2/globals/flash/geom/Matrix3D.as
+++ b/core/src/avm2/globals/flash/geom/Matrix3D.as
@@ -3,6 +3,7 @@
 package flash.geom {
     import __ruffle__.stub_method;
 
+    [Ruffle(InstanceAllocator)]
     public class Matrix3D {
         // The 4x4 matrix data, stored in column-major order
         // This is never null.

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -8,6 +8,8 @@ use crate::avm2::{Activation, Avm2StrRepresentable as _, Error, Object, TObject 
 use crate::avm2_stub_method;
 use ruffle_macros::Avm2Enum;
 
+pub use crate::avm2::object::matrix_3d_allocator;
+
 /// A 4x4 matrix, stored in column-major order, like `Matrix3D.rawData`.
 type RawData = [f64; 16];
 

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -1,5 +1,4 @@
 use crate::avm2::error::{Error2004Type, make_error_2004, make_error_2187};
-use crate::avm2::globals::slots::flash_geom_matrix_3d as matrix3d_slots;
 use crate::avm2::globals::slots::flash_geom_vector_3d as vector3d_slots;
 use crate::avm2::object::VectorObject;
 use crate::avm2::parameters::ParametersExt;
@@ -7,6 +6,7 @@ use crate::avm2::vector::VectorStorage;
 use crate::avm2::{Activation, Avm2StrRepresentable as _, Error, Object, TObject as _, Value};
 use crate::avm2_stub_method;
 use ruffle_macros::Avm2Enum;
+use ruffle_render::matrix3d::Matrix3D;
 
 pub use crate::avm2::object::matrix_3d_allocator;
 
@@ -71,46 +71,58 @@ fn multiply(lhs: &RawData, rhs: &RawData) -> RawData {
     result
 }
 
-/// Reads the `_rawData` of `this`.
-fn raw_data_of(this: Object<'_>) -> RawData {
-    let raw_data = this
-        .get_slot(matrix3d_slots::_RAW_DATA)
-        .as_object()
-        .expect("rawData is never null");
-    let raw_data = raw_data.as_vector_storage().expect("rawData is a Vector");
-
-    std::array::from_fn(|i| {
-        raw_data
-            .get_optional(i)
-            .map(|value| value.as_f64())
-            .unwrap_or(f64::NAN)
-    })
-}
-
-/// Stores `raw_data` as the new `_rawData` of `this`.
-fn set_raw_data<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    this: Object<'gc>,
-    raw_data: RawData,
-) -> Result<(), Error<'gc>> {
-    let number = activation.avm2().class_defs().number;
-    let storage = VectorStorage::from_values(
-        raw_data.iter().map(|value| (*value).into()).collect(),
-        false,
-        Some(number),
-    );
-
-    let raw_data = VectorObject::from_vector(storage, activation);
-    this.set_slot(matrix3d_slots::_RAW_DATA, raw_data.into(), activation)
-}
-
-/// Implements `Matrix3D.identity`.
-pub fn identity<'gc>(
+pub fn get_raw_data<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
+
+    let number = activation.avm2().class_defs().number;
+    let storage = VectorStorage::from_values(
+        this.matrix_ref()
+            .raw_data
+            .iter()
+            .map(|value| (*value).into())
+            .collect(),
+        false,
+        Some(number),
+    );
+
+    Ok(VectorObject::from_vector(storage, activation).into())
+}
+
+/// Implements `Matrix3D.rawData`'s setter.
+pub fn set_raw_data<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
+    let Some(value) = args.try_get_object(0) else {
+        return Ok(Value::Undefined);
+    };
+    let value = value.as_vector_storage().unwrap();
+
+    let raw_data: RawData = std::array::from_fn(|i| {
+        value
+            .get_optional(i)
+            .map(|v| v.as_f64())
+            .unwrap_or(f64::NAN)
+    });
+
+    this.replace_matrix(Matrix3D { raw_data });
+
+    Ok(Value::Undefined)
+}
+
+/// Implements `Matrix3D.identity`.
+pub fn identity<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Value<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
 
     #[rustfmt::skip]
     let raw_data: RawData = [
@@ -120,28 +132,28 @@ pub fn identity<'gc>(
         0.0, 0.0, 0.0, 1.0,
     ];
 
-    set_raw_data(activation, this, raw_data)?;
+    this.replace_matrix(Matrix3D { raw_data });
 
     Ok(Value::Undefined)
 }
 
 /// Implements `Matrix3D.appendTranslation`.
 pub fn append_translation<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let x = args.get_f64(0);
     let y = args.get_f64(1);
     let z = args.get_f64(2);
 
-    let mut raw_data = raw_data_of(this);
+    let mut raw_data = this.matrix_ref().raw_data;
     raw_data[12] += x;
     raw_data[13] += y;
     raw_data[14] += z;
 
-    set_raw_data(activation, this, raw_data)?;
+    this.replace_matrix(Matrix3D { raw_data });
 
     Ok(Value::Undefined)
 }
@@ -152,11 +164,14 @@ pub fn append<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
-    let lhs = args.get_object(activation, 0, "lhs")?;
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
+    let lhs = args
+        .get_object(activation, 0, "lhs")?
+        .as_matrix3d_object()
+        .unwrap();
 
-    let result = multiply(&raw_data_of(lhs), &raw_data_of(this));
-    set_raw_data(activation, this, result)?;
+    let result = multiply(&lhs.matrix_ref().raw_data, &this.matrix_ref().raw_data);
+    this.replace_matrix(Matrix3D { raw_data: result });
 
     Ok(Value::Undefined)
 }
@@ -167,11 +182,14 @@ pub fn prepend<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
-    let rhs = args.get_object(activation, 0, "rhs")?;
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
+    let rhs = args
+        .get_object(activation, 0, "rhs")?
+        .as_matrix3d_object()
+        .unwrap();
 
-    let result = multiply(&raw_data_of(this), &raw_data_of(rhs));
-    set_raw_data(activation, this, result)?;
+    let result = multiply(&this.matrix_ref().raw_data, &rhs.matrix_ref().raw_data);
+    this.replace_matrix(Matrix3D { raw_data: result });
 
     Ok(Value::Undefined)
 }
@@ -184,7 +202,7 @@ pub fn append_rotation<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let degrees = args.get_f64(0);
     let axis = args.get_object(activation, 1, "axis")?;
     let pivot_point = args.try_get_object(2);
@@ -237,8 +255,8 @@ pub fn append_rotation<'gc>(
         1.0,
     ];
 
-    let result = multiply(&m, &raw_data_of(this));
-    set_raw_data(activation, this, result)?;
+    let result = multiply(&m, &this.matrix_ref().raw_data);
+    this.replace_matrix(Matrix3D { raw_data: result });
 
     Ok(Value::Undefined)
 }
@@ -249,7 +267,7 @@ pub fn copy_column_to<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let column = args.get_u32(0);
     let vector3d = args.get_object(activation, 1, "vector3D")?;
 
@@ -257,7 +275,7 @@ pub fn copy_column_to<'gc>(
         return Err(make_error_2004(activation, Error2004Type::ArgumentError));
     }
 
-    let raw_data = raw_data_of(this);
+    let raw_data = this.matrix_ref().raw_data;
     let base = column as usize * 4;
 
     vector3d.set_slot(vector3d_slots::X, raw_data[base].into(), activation)?;
@@ -274,7 +292,7 @@ pub fn copy_column_from<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let column = args.get_u32(0);
     let vector3d = args.get_object(activation, 1, "vector3D")?;
 
@@ -284,14 +302,14 @@ pub fn copy_column_from<'gc>(
 
     let [x, y, z, w] = read_vector3d(vector3d);
 
-    let mut raw_data = raw_data_of(this);
+    let mut raw_data = this.matrix_ref().raw_data;
     let base = column as usize * 4;
     raw_data[base] = x;
     raw_data[base + 1] = y;
     raw_data[base + 2] = z;
     raw_data[base + 3] = w;
 
-    set_raw_data(activation, this, raw_data)?;
+    this.replace_matrix(Matrix3D { raw_data });
 
     Ok(Value::Undefined)
 }
@@ -302,7 +320,7 @@ pub fn copy_row_to<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let row = args.get_u32(0);
     let vector3d = args.get_object(activation, 1, "vector3D")?;
 
@@ -310,7 +328,7 @@ pub fn copy_row_to<'gc>(
         return Err(make_error_2004(activation, Error2004Type::ArgumentError));
     }
 
-    let raw_data = raw_data_of(this);
+    let raw_data = this.matrix_ref().raw_data;
     let base = row as usize;
 
     vector3d.set_slot(vector3d_slots::X, raw_data[base].into(), activation)?;
@@ -327,7 +345,7 @@ pub fn copy_row_from<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let row = args.get_u32(0);
     let vector3d = args.get_object(activation, 1, "vector3D")?;
 
@@ -337,14 +355,14 @@ pub fn copy_row_from<'gc>(
 
     let [x, y, z, w] = read_vector3d(vector3d);
 
-    let mut raw_data = raw_data_of(this);
+    let mut raw_data = this.matrix_ref().raw_data;
     let base = row as usize;
     raw_data[base] = x;
     raw_data[base + 4] = y;
     raw_data[base + 8] = z;
     raw_data[base + 12] = w;
 
-    set_raw_data(activation, this, raw_data)?;
+    this.replace_matrix(Matrix3D { raw_data });
 
     Ok(Value::Undefined)
 }
@@ -355,7 +373,7 @@ pub fn copy_raw_data_from<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let source = args.get_object(activation, 0, "source")?;
     let source = source.as_vector_storage().unwrap();
     let index = args.get_u32(1) as usize;
@@ -368,7 +386,7 @@ pub fn copy_raw_data_from<'gc>(
     let raw_data: RawData =
         std::array::from_fn(|i| source.get_optional(index + i).unwrap().as_f64());
 
-    set_raw_data(activation, this, raw_data)?;
+    this.replace_matrix(Matrix3D { raw_data });
 
     if do_transpose {
         transpose(activation, this.into(), &[])?;
@@ -383,7 +401,7 @@ pub fn copy_raw_data_to<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let dest = args
         .get_object(activation, 0, "dest")?
         .as_vector_object()
@@ -396,18 +414,18 @@ pub fn copy_raw_data_to<'gc>(
         storage.resize(index + 16, activation)?;
     }
 
-    let mut raw_data = raw_data_of(this);
+    let mut matrix = this.matrix();
     if do_transpose {
         // TODO Unify with transpose().
-        raw_data.swap(1, 4);
-        raw_data.swap(2, 8);
-        raw_data.swap(3, 12);
-        raw_data.swap(6, 9);
-        raw_data.swap(7, 13);
-        raw_data.swap(11, 14);
+        matrix.raw_data.swap(1, 4);
+        matrix.raw_data.swap(2, 8);
+        matrix.raw_data.swap(3, 12);
+        matrix.raw_data.swap(6, 9);
+        matrix.raw_data.swap(7, 13);
+        matrix.raw_data.swap(11, 14);
     }
 
-    for (i, value) in raw_data.into_iter().enumerate() {
+    for (i, value) in matrix.raw_data.into_iter().enumerate() {
         storage.set(index + i, value.into(), activation)?;
     }
 
@@ -420,8 +438,8 @@ pub fn get_position<'gc>(
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
-    let mr = raw_data_of(this);
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
+    let mr = this.matrix_ref().raw_data;
 
     Ok(vector3d_to_object(
         activation,
@@ -431,35 +449,35 @@ pub fn get_position<'gc>(
 
 /// Implements `Matrix3D.position`'s setter.
 pub fn set_position<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let Some(val) = args.try_get_object(0) else {
         return Ok(Value::Undefined);
     };
 
     let [x, y, z, _] = read_vector3d(val);
 
-    let mut raw_data = raw_data_of(this);
+    let mut raw_data = this.matrix_ref().raw_data;
     raw_data[12] = x;
     raw_data[13] = y;
     raw_data[14] = z;
 
-    set_raw_data(activation, this, raw_data)?;
+    this.replace_matrix(Matrix3D { raw_data });
 
     Ok(Value::Undefined)
 }
 
 /// Implements `Matrix3D.transpose`.
 pub fn transpose<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
-    let mut mr = raw_data_of(this);
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
+    let mut mr = this.matrix_ref().raw_data;
 
     mr.swap(1, 4);
     mr.swap(2, 8);
@@ -468,7 +486,7 @@ pub fn transpose<'gc>(
     mr.swap(7, 13);
     mr.swap(11, 14);
 
-    set_raw_data(activation, this, mr)?;
+    this.replace_matrix(Matrix3D { raw_data: mr });
 
     Ok(Value::Undefined)
 }
@@ -479,10 +497,10 @@ pub fn delta_transform_vector<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let v = args.get_object(activation, 0, "vector")?;
 
-    let mr = raw_data_of(this);
+    let mr = this.matrix_ref().raw_data;
     let [x, y, z, _] = read_vector3d(v);
 
     Ok(vector3d_to_object(
@@ -502,10 +520,10 @@ pub fn transform_vector<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let v = args.get_object(activation, 0, "vector")?;
 
-    let mr = raw_data_of(this);
+    let mr = this.matrix_ref().raw_data;
     let [x, y, z, _] = read_vector3d(v);
 
     Ok(vector3d_to_object(
@@ -525,7 +543,7 @@ pub fn transform_vectors<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let vin = args
         .get_object(activation, 0, "vin")?
         .as_vector_object()
@@ -544,7 +562,7 @@ pub fn transform_vectors<'gc>(
             .resize(result_vecs_length, activation)?;
     }
 
-    let mr = raw_data_of(this);
+    let mr = this.matrix_ref().raw_data;
 
     // 'vin' and 'vout' may be the same object, so borrows of their storage
     // are scoped to a single access, never held across a read and a write.
@@ -592,19 +610,19 @@ pub fn get_determinant<'gc>(
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
-    let mr = raw_data_of(this);
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
+    let mr = this.matrix_ref().raw_data;
     Ok(determinant_of(&mr).into())
 }
 
 /// Implements `Matrix3D.invert`.
 pub fn invert<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
-    let mr = raw_data_of(this);
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
+    let mr = this.matrix_ref().raw_data;
 
     let d = determinant_of(&mr);
     let invertible = d.abs() > 0.00000000001;
@@ -652,7 +670,7 @@ pub fn invert<'gc>(
          d * (m11 * (m22 * m33 - m32 * m23) - m21 * (m12 * m33 - m32 * m13) + m31 * (m12 * m23 - m22 * m13)),
     ];
 
-    set_raw_data(activation, this, result)?;
+    this.replace_matrix(Matrix3D { raw_data: result });
 
     Ok(true.into())
 }
@@ -665,7 +683,7 @@ pub fn recompose<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
 
     let components = args.get_object(activation, 0, "components")?;
     let components = components.as_vector_storage().unwrap();
@@ -766,7 +784,7 @@ pub fn recompose<'gc>(
         &multiply(&rotation_matrix, &scale_matrix),
     );
 
-    set_raw_data(activation, this, raw_data)?;
+    this.replace_matrix(Matrix3D { raw_data });
 
     Ok(true.into())
 }
@@ -779,14 +797,14 @@ pub fn decompose<'gc>(
     this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.as_object().unwrap();
+    let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
 
     let orientation = args.get_string_non_null(activation, 0, "orientationStyle")?;
     let Some(orientation) = Orientation3D::from_avm2_str(&orientation) else {
         return Err(make_error_2187(activation, orientation));
     };
 
-    let mut mr = raw_data_of(this);
+    let mut mr = this.matrix_ref().raw_data;
 
     let translation = [mr[12], mr[13], mr[14], 0.0];
 

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -564,55 +564,11 @@ pub fn invert<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
-    let mr = this.matrix_ref().raw_data;
-
-    let d = this.matrix_ref().determinant();
-    let invertible = d.abs() > 0.00000000001;
-
-    if !invertible {
+    let Some(result) = this.matrix_ref().invert() else {
         return Ok(false.into());
-    }
+    };
 
-    let d = 1.0 / d;
-
-    let m11 = mr[0];
-    let m21 = mr[4];
-    let m31 = mr[8];
-    let m41 = mr[12];
-    let m12 = mr[1];
-    let m22 = mr[5];
-    let m32 = mr[9];
-    let m42 = mr[13];
-    let m13 = mr[2];
-    let m23 = mr[6];
-    let m33 = mr[10];
-    let m43 = mr[14];
-    let m14 = mr[3];
-    let m24 = mr[7];
-    let m34 = mr[11];
-    let m44 = mr[15];
-
-    #[rustfmt::skip]
-    let result: RawData = [
-         d * (m22 * (m33 * m44 - m43 * m34) - m32 * (m23 * m44 - m43 * m24) + m42 * (m23 * m34 - m33 * m24)),
-        -d * (m12 * (m33 * m44 - m43 * m34) - m32 * (m13 * m44 - m43 * m14) + m42 * (m13 * m34 - m33 * m14)),
-         d * (m12 * (m23 * m44 - m43 * m24) - m22 * (m13 * m44 - m43 * m14) + m42 * (m13 * m24 - m23 * m14)),
-        -d * (m12 * (m23 * m34 - m33 * m24) - m22 * (m13 * m34 - m33 * m14) + m32 * (m13 * m24 - m23 * m14)),
-        -d * (m21 * (m33 * m44 - m43 * m34) - m31 * (m23 * m44 - m43 * m24) + m41 * (m23 * m34 - m33 * m24)),
-         d * (m11 * (m33 * m44 - m43 * m34) - m31 * (m13 * m44 - m43 * m14) + m41 * (m13 * m34 - m33 * m14)),
-        -d * (m11 * (m23 * m44 - m43 * m24) - m21 * (m13 * m44 - m43 * m14) + m41 * (m13 * m24 - m23 * m14)),
-         d * (m11 * (m23 * m34 - m33 * m24) - m21 * (m13 * m34 - m33 * m14) + m31 * (m13 * m24 - m23 * m14)),
-         d * (m21 * (m32 * m44 - m42 * m34) - m31 * (m22 * m44 - m42 * m24) + m41 * (m22 * m34 - m32 * m24)),
-        -d * (m11 * (m32 * m44 - m42 * m34) - m31 * (m12 * m44 - m42 * m14) + m41 * (m12 * m34 - m32 * m14)),
-         d * (m11 * (m22 * m44 - m42 * m24) - m21 * (m12 * m44 - m42 * m14) + m41 * (m12 * m24 - m22 * m14)),
-        -d * (m11 * (m22 * m34 - m32 * m24) - m21 * (m12 * m34 - m32 * m14) + m31 * (m12 * m24 - m22 * m14)),
-        -d * (m21 * (m32 * m43 - m42 * m33) - m31 * (m22 * m43 - m42 * m23) + m41 * (m22 * m33 - m32 * m23)),
-         d * (m11 * (m32 * m43 - m42 * m33) - m31 * (m12 * m43 - m42 * m13) + m41 * (m12 * m33 - m32 * m13)),
-        -d * (m11 * (m22 * m43 - m42 * m23) - m21 * (m12 * m43 - m42 * m13) + m41 * (m12 * m23 - m22 * m13)),
-         d * (m11 * (m22 * m33 - m32 * m23) - m21 * (m12 * m33 - m32 * m13) + m31 * (m12 * m23 - m22 * m13)),
-    ];
-
-    this.replace_matrix(Matrix3D { raw_data: result });
+    this.replace_matrix(result);
 
     Ok(true.into())
 }

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -140,12 +140,10 @@ pub fn append_translation<'gc>(
     let y = args.get_f64(1);
     let z = args.get_f64(2);
 
-    let mut raw_data = this.matrix_ref().raw_data;
-    raw_data[12] += x;
-    raw_data[13] += y;
-    raw_data[14] += z;
-
-    this.replace_matrix(Matrix3D { raw_data });
+    let mut matrix = this.matrix_mut();
+    matrix.raw_data[12] += x;
+    matrix.raw_data[13] += y;
+    matrix.raw_data[14] += z;
 
     Ok(Value::Undefined)
 }
@@ -294,14 +292,12 @@ pub fn copy_column_from<'gc>(
 
     let [x, y, z, w] = read_vector3d(vector3d);
 
-    let mut raw_data = this.matrix_ref().raw_data;
+    let mut matrix = this.matrix_mut();
     let base = column as usize * 4;
-    raw_data[base] = x;
-    raw_data[base + 1] = y;
-    raw_data[base + 2] = z;
-    raw_data[base + 3] = w;
-
-    this.replace_matrix(Matrix3D { raw_data });
+    matrix.raw_data[base] = x;
+    matrix.raw_data[base + 1] = y;
+    matrix.raw_data[base + 2] = z;
+    matrix.raw_data[base + 3] = w;
 
     Ok(Value::Undefined)
 }
@@ -347,14 +343,12 @@ pub fn copy_row_from<'gc>(
 
     let [x, y, z, w] = read_vector3d(vector3d);
 
-    let mut raw_data = this.matrix_ref().raw_data;
+    let mut matrix = this.matrix_mut();
     let base = row as usize;
-    raw_data[base] = x;
-    raw_data[base + 4] = y;
-    raw_data[base + 8] = z;
-    raw_data[base + 12] = w;
-
-    this.replace_matrix(Matrix3D { raw_data });
+    matrix.raw_data[base] = x;
+    matrix.raw_data[base + 4] = y;
+    matrix.raw_data[base + 8] = z;
+    matrix.raw_data[base + 12] = w;
 
     Ok(Value::Undefined)
 }
@@ -447,12 +441,10 @@ pub fn set_position<'gc>(
 
     let [x, y, z, _] = read_vector3d(val);
 
-    let mut raw_data = this.matrix_ref().raw_data;
-    raw_data[12] = x;
-    raw_data[13] = y;
-    raw_data[14] = z;
-
-    this.replace_matrix(Matrix3D { raw_data });
+    let mut matrix = this.matrix_mut();
+    matrix.raw_data[12] = x;
+    matrix.raw_data[13] = y;
+    matrix.raw_data[14] = z;
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -55,22 +55,6 @@ fn vector3d_to_object<'gc>(
         .unwrap()
 }
 
-/// Multiplies two matrices.
-fn multiply(lhs: &RawData, rhs: &RawData) -> RawData {
-    let mut result = [0.0; 16];
-
-    for column in 0..4 {
-        for row in 0..4 {
-            result[column * 4 + row] = lhs[row] * rhs[column * 4]
-                + lhs[4 + row] * rhs[column * 4 + 1]
-                + lhs[8 + row] * rhs[column * 4 + 2]
-                + lhs[12 + row] * rhs[column * 4 + 3];
-        }
-    }
-
-    result
-}
-
 pub fn get_raw_data<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
@@ -160,8 +144,8 @@ pub fn append<'gc>(
         .as_matrix3d_object()
         .unwrap();
 
-    let result = multiply(&lhs.matrix_ref().raw_data, &this.matrix_ref().raw_data);
-    this.replace_matrix(Matrix3D { raw_data: result });
+    let result = lhs.matrix_ref().multiply(&this.matrix_ref());
+    this.replace_matrix(result);
 
     Ok(Value::Undefined)
 }
@@ -178,8 +162,8 @@ pub fn prepend<'gc>(
         .as_matrix3d_object()
         .unwrap();
 
-    let result = multiply(&this.matrix_ref().raw_data, &rhs.matrix_ref().raw_data);
-    this.replace_matrix(Matrix3D { raw_data: result });
+    let result = this.matrix_ref().multiply(&rhs.matrix_ref());
+    this.replace_matrix(result);
 
     Ok(Value::Undefined)
 }
@@ -245,8 +229,8 @@ pub fn append_rotation<'gc>(
         1.0,
     ];
 
-    let result = multiply(&m, &this.matrix_ref().raw_data);
-    this.replace_matrix(Matrix3D { raw_data: result });
+    let result = Matrix3D { raw_data: m }.multiply(&this.matrix_ref());
+    this.replace_matrix(result);
 
     Ok(Value::Undefined)
 }
@@ -746,14 +730,20 @@ pub fn recompose<'gc>(
         translation_x, translation_y, translation_z, 1.0,
     ];
 
+    let translation = Matrix3D {
+        raw_data: translation_matrix,
+    };
+    let rotation = Matrix3D {
+        raw_data: rotation_matrix,
+    };
+    let scale = Matrix3D {
+        raw_data: scale_matrix,
+    };
+
     // The order of operations is observable when some of the components are not
     // finite.
-    let raw_data = multiply(
-        &translation_matrix,
-        &multiply(&rotation_matrix, &scale_matrix),
-    );
-
-    this.replace_matrix(Matrix3D { raw_data });
+    let result = translation.multiply(&rotation.multiply(&scale));
+    this.replace_matrix(result);
 
     Ok(true.into())
 }

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -547,16 +547,6 @@ pub fn transform_vectors<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Computes the determinant of a matrix.
-fn determinant_of(mr: &RawData) -> f64 {
-    (mr[0] * mr[5] - mr[4] * mr[1]) * (mr[10] * mr[15] - mr[14] * mr[11])
-        - (mr[0] * mr[9] - mr[8] * mr[1]) * (mr[6] * mr[15] - mr[14] * mr[7])
-        + (mr[0] * mr[13] - mr[12] * mr[1]) * (mr[6] * mr[11] - mr[10] * mr[7])
-        + (mr[4] * mr[9] - mr[8] * mr[5]) * (mr[2] * mr[15] - mr[14] * mr[3])
-        - (mr[4] * mr[13] - mr[12] * mr[5]) * (mr[2] * mr[11] - mr[10] * mr[3])
-        + (mr[8] * mr[13] - mr[12] * mr[9]) * (mr[2] * mr[7] - mr[6] * mr[3])
-}
-
 /// Implements `Matrix3D.determinant`'s getter.
 pub fn get_determinant<'gc>(
     _activation: &mut Activation<'_, 'gc>,
@@ -564,8 +554,7 @@ pub fn get_determinant<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
-    let mr = this.matrix_ref().raw_data;
-    Ok(determinant_of(&mr).into())
+    Ok(this.matrix_ref().determinant().into())
 }
 
 /// Implements `Matrix3D.invert`.
@@ -577,7 +566,7 @@ pub fn invert<'gc>(
     let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
     let mr = this.matrix_ref().raw_data;
 
-    let d = determinant_of(&mr);
+    let d = this.matrix_ref().determinant();
     let invertible = d.abs() > 0.00000000001;
 
     if !invertible {

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -659,17 +659,7 @@ pub fn recompose<'gc>(
     }
     rotation_matrix[15] = 1.0;
 
-    #[rustfmt::skip]
-    let translation_matrix = [
-        1.0,           0.0,           0.0,           0.0,
-        0.0,           1.0,           0.0,           0.0,
-        0.0,           0.0,           1.0,           0.0,
-        translation_x, translation_y, translation_z, 1.0,
-    ];
-
-    let translation = Matrix3D {
-        raw_data: translation_matrix,
-    };
+    let translation = Matrix3D::translate(translation_x, translation_y, translation_z);
     let rotation = Matrix3D {
         raw_data: rotation_matrix,
     };

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -660,14 +660,6 @@ pub fn recompose<'gc>(
     rotation_matrix[15] = 1.0;
 
     #[rustfmt::skip]
-    let scale_matrix = [
-        scale_x, 0.0,     0.0,     0.0,
-        0.0,     scale_y, 0.0,     0.0,
-        0.0,     0.0,     scale_z, 0.0,
-        0.0,     0.0,     0.0,     1.0,
-    ];
-
-    #[rustfmt::skip]
     let translation_matrix = [
         1.0,           0.0,           0.0,           0.0,
         0.0,           1.0,           0.0,           0.0,
@@ -681,9 +673,7 @@ pub fn recompose<'gc>(
     let rotation = Matrix3D {
         raw_data: rotation_matrix,
     };
-    let scale = Matrix3D {
-        raw_data: scale_matrix,
-    };
+    let scale = Matrix3D::scale(scale_x, scale_y, scale_z);
 
     // The order of operations is observable when some of the components are not
     // finite.

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -124,15 +124,7 @@ pub fn identity<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
 
-    #[rustfmt::skip]
-    let raw_data: RawData = [
-        1.0, 0.0, 0.0, 0.0,
-        0.0, 1.0, 0.0, 0.0,
-        0.0, 0.0, 1.0, 0.0,
-        0.0, 0.0, 0.0, 1.0,
-    ];
-
-    this.replace_matrix(Matrix3D { raw_data });
+    this.replace_matrix(Matrix3D::IDENTITY);
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/geom/matrix_3d.rs
+++ b/core/src/avm2/globals/flash/geom/matrix_3d.rs
@@ -377,12 +377,13 @@ pub fn copy_raw_data_from<'gc>(
 
     let raw_data: RawData =
         std::array::from_fn(|i| source.get_optional(index + i).unwrap().as_f64());
-
-    this.replace_matrix(Matrix3D { raw_data });
+    let mut matrix = Matrix3D { raw_data };
 
     if do_transpose {
-        transpose(activation, this.into(), &[])?;
+        matrix.transpose_in_place();
     }
+
+    this.replace_matrix(matrix);
 
     Ok(Value::Undefined)
 }
@@ -408,13 +409,7 @@ pub fn copy_raw_data_to<'gc>(
 
     let mut matrix = this.matrix();
     if do_transpose {
-        // TODO Unify with transpose().
-        matrix.raw_data.swap(1, 4);
-        matrix.raw_data.swap(2, 8);
-        matrix.raw_data.swap(3, 12);
-        matrix.raw_data.swap(6, 9);
-        matrix.raw_data.swap(7, 13);
-        matrix.raw_data.swap(11, 14);
+        matrix.transpose_in_place();
     }
 
     for (i, value) in matrix.raw_data.into_iter().enumerate() {
@@ -469,17 +464,7 @@ pub fn transpose<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = this.as_object().unwrap().as_matrix3d_object().unwrap();
-    let mut mr = this.matrix_ref().raw_data;
-
-    mr.swap(1, 4);
-    mr.swap(2, 8);
-    mr.swap(3, 12);
-    mr.swap(6, 9);
-    mr.swap(7, 13);
-    mr.swap(11, 14);
-
-    this.replace_matrix(Matrix3D { raw_data: mr });
-
+    this.matrix_mut().transpose_in_place();
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -1,6 +1,5 @@
 use crate::avm2::globals::slots::flash_geom_color_transform as ct_slots;
 use crate::avm2::globals::slots::flash_geom_matrix as matrix_slots;
-use crate::avm2::globals::slots::flash_geom_matrix_3d as matrix3d_slots;
 use crate::avm2::globals::slots::flash_geom_perspective_projection as pp_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::globals::slots::flash_geom_transform as transform_slots;
@@ -211,27 +210,6 @@ pub fn matrix3d_to_object<'gc>(
     Ok(object)
 }
 
-fn object_to_matrix3d<'gc>(
-    object: Object<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-) -> Result<Matrix3D, Error<'gc>> {
-    let raw_data = object
-        .get_slot(matrix3d_slots::_RAW_DATA)
-        .as_object()
-        .expect("rawData cannot be null");
-    let raw_data = raw_data
-        .as_vector_storage()
-        .expect("rawData is not a Vector");
-    let raw_data: Vec<f64> = (0..16)
-        .map(|i| -> Result<f64, Error<'gc>> { Ok(raw_data.get(i, activation)?.as_f64()) })
-        .collect::<Result<Vec<f64>, _>>()?;
-    let raw_data = raw_data
-        .as_slice()
-        .try_into()
-        .expect("rawData size must be 16");
-    Ok(Matrix3D { raw_data })
-}
-
 pub fn object_to_perspective_projection<'gc>(
     object: Object<'gc>,
     _activation: &mut Activation<'_, 'gc>,
@@ -353,7 +331,7 @@ pub fn set_matrix_3d<'gc>(
     let (matrix, has_matrix3d) = {
         match args.try_get_object(0) {
             Some(obj) => {
-                let matrix3d = object_to_matrix3d(obj, activation)?;
+                let matrix3d = obj.as_matrix3d_object().unwrap().matrix();
                 let matrix = matrix3d.to_matrix();
                 (matrix, true)
             }

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -3,9 +3,7 @@ use crate::avm2::globals::slots::flash_geom_matrix as matrix_slots;
 use crate::avm2::globals::slots::flash_geom_perspective_projection as pp_slots;
 use crate::avm2::globals::slots::flash_geom_point as point_slots;
 use crate::avm2::globals::slots::flash_geom_transform as transform_slots;
-use crate::avm2::object::VectorObject;
 use crate::avm2::parameters::ParametersExt;
-use crate::avm2::vector::VectorStorage;
 use crate::avm2::{Activation, Error, Object, TObject as _, Value};
 use crate::display_object::{BoundsMode, TDisplayObject};
 use crate::prelude::{DisplayObject, Matrix, Twips};
@@ -196,17 +194,17 @@ pub fn matrix3d_to_object<'gc>(
     matrix: Matrix3D,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let number = activation.avm2().class_defs().number;
-    let mut raw_data_storage = VectorStorage::new(16, true, Some(number));
-    for (i, data) in matrix.raw_data.iter().enumerate() {
-        raw_data_storage.set(i, Value::Number(*data), activation)?;
-    }
-    let vector = VectorObject::from_vector(raw_data_storage, activation).into();
     let object = activation
         .avm2()
         .classes()
         .matrix3d
-        .construct(activation, &[vector])?;
+        .construct(activation, &[])?;
+    object
+        .as_object()
+        .unwrap()
+        .as_matrix3d_object()
+        .unwrap()
+        .replace_matrix(matrix);
     Ok(object)
 }
 

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -47,6 +47,7 @@ mod function_object;
 mod index_buffer_3d_object;
 mod loaderinfo_object;
 mod local_connection_object;
+mod matrix3d_object;
 mod message_channel_object;
 mod namespace_object;
 mod net_connection_object;
@@ -120,6 +121,9 @@ pub use crate::avm2::object::loaderinfo_object::{
 };
 pub use crate::avm2::object::local_connection_object::{
     LocalConnectionObject, LocalConnectionObjectWeak, local_connection_allocator,
+};
+pub use crate::avm2::object::matrix3d_object::{
+    Matrix3DObject, Matrix3DObjectWeak, matrix_3d_allocator,
 };
 pub use crate::avm2::object::message_channel_object::{
     MessageChannelObject, MessageChannelObjectWeak,
@@ -245,6 +249,7 @@ use crate::font::Font;
         WorkerDomainObject(WorkerDomainObject<'gc>),
         MessageChannelObject(MessageChannelObject<'gc>),
         SecurityDomainObject(SecurityDomainObject<'gc>),
+        Matrix3DObject(Matrix3DObject<'gc>),
     }
 )]
 pub trait TObject<'gc>: 'gc + Collect<'gc> + Debug + Into<Object<'gc>> + Clone + Copy {
@@ -810,6 +815,7 @@ impl<'gc> Object<'gc> {
         pub fn as_shared_object for SharedObjectObject;
         pub fn as_sound_transform for SoundTransformObject;
         pub fn as_style_sheet for StyleSheetObject;
+        pub fn as_matrix3d_object for Matrix3DObject;
     }
 
     /// Unwrap this object's `Namespace`, if the object is a boxed namespace.
@@ -1018,6 +1024,7 @@ define_weak_enum! {
         WorkerDomainObject(WorkerDomainObjectWeak<'gc>),
         MessageChannelObject(MessageChannelObjectWeak<'gc>),
         SecurityDomainObject(SecurityDomainObjectWeak<'gc>),
+        Matrix3DObject(Matrix3DObjectWeak<'gc>),
     }
 }
 

--- a/core/src/avm2/object/matrix3d_object.rs
+++ b/core/src/avm2/object/matrix3d_object.rs
@@ -19,14 +19,7 @@ pub fn matrix_3d_allocator<'gc>(
         activation.gc(),
         Matrix3DObjectData {
             base,
-            matrix: RefCell::new(Matrix3D {
-                raw_data: [
-                    1.0, 0.0, 0.0, 0.0, //
-                    0.0, 1.0, 0.0, 0.0, //
-                    0.0, 0.0, 1.0, 0.0, //
-                    0.0, 0.0, 0.0, 1.0,
-                ],
-            }),
+            matrix: RefCell::new(Matrix3D::IDENTITY),
         },
     ))
     .into())

--- a/core/src/avm2/object/matrix3d_object.rs
+++ b/core/src/avm2/object/matrix3d_object.rs
@@ -1,0 +1,47 @@
+use crate::avm2::Error;
+use crate::avm2::activation::Activation;
+use crate::avm2::object::script_object::ScriptObjectData;
+use crate::avm2::object::{ClassObject, Object, TObject};
+use core::fmt;
+use gc_arena::{Collect, Gc, GcWeak};
+use ruffle_common::utils::HasPrefixField;
+
+/// A class instance allocator that allocates Matrix3D objects.
+pub fn matrix_3d_allocator<'gc>(
+    class: ClassObject<'gc>,
+    activation: &mut Activation<'_, 'gc>,
+) -> Result<Object<'gc>, Error<'gc>> {
+    let base = ScriptObjectData::new(class);
+
+    Ok(Matrix3DObject(Gc::new(activation.gc(), Matrix3DObjectData { base })).into())
+}
+
+#[derive(Clone, Collect, Copy)]
+#[collect(no_drop)]
+pub struct Matrix3DObject<'gc>(pub Gc<'gc, Matrix3DObjectData<'gc>>);
+
+#[derive(Clone, Collect, Copy, Debug)]
+#[collect(no_drop)]
+pub struct Matrix3DObjectWeak<'gc>(pub GcWeak<'gc, Matrix3DObjectData<'gc>>);
+
+impl fmt::Debug for Matrix3DObject<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Matrix3DObject")
+            .field("ptr", &Gc::as_ptr(self.0))
+            .finish()
+    }
+}
+
+#[derive(Collect, HasPrefixField)]
+#[collect(no_drop)]
+#[repr(C, align(8))]
+pub struct Matrix3DObjectData<'gc> {
+    /// Base script object.
+    base: ScriptObjectData<'gc>,
+}
+
+impl<'gc> TObject<'gc> for Matrix3DObject<'gc> {
+    fn gc_base(&self) -> Gc<'gc, ScriptObjectData<'gc>> {
+        HasPrefixField::as_prefix_gc(self.0)
+    }
+}

--- a/core/src/avm2/object/matrix3d_object.rs
+++ b/core/src/avm2/object/matrix3d_object.rs
@@ -5,6 +5,8 @@ use crate::avm2::object::{ClassObject, Object, TObject};
 use core::fmt;
 use gc_arena::{Collect, Gc, GcWeak};
 use ruffle_common::utils::HasPrefixField;
+use ruffle_render::matrix3d::Matrix3D;
+use std::cell::{Ref, RefCell, RefMut};
 
 /// A class instance allocator that allocates Matrix3D objects.
 pub fn matrix_3d_allocator<'gc>(
@@ -13,7 +15,21 @@ pub fn matrix_3d_allocator<'gc>(
 ) -> Result<Object<'gc>, Error<'gc>> {
     let base = ScriptObjectData::new(class);
 
-    Ok(Matrix3DObject(Gc::new(activation.gc(), Matrix3DObjectData { base })).into())
+    Ok(Matrix3DObject(Gc::new(
+        activation.gc(),
+        Matrix3DObjectData {
+            base,
+            matrix: RefCell::new(Matrix3D {
+                raw_data: [
+                    1.0, 0.0, 0.0, 0.0, //
+                    0.0, 1.0, 0.0, 0.0, //
+                    0.0, 0.0, 1.0, 0.0, //
+                    0.0, 0.0, 0.0, 1.0,
+                ],
+            }),
+        },
+    ))
+    .into())
 }
 
 #[derive(Clone, Collect, Copy)]
@@ -38,6 +54,26 @@ impl fmt::Debug for Matrix3DObject<'_> {
 pub struct Matrix3DObjectData<'gc> {
     /// Base script object.
     base: ScriptObjectData<'gc>,
+
+    matrix: RefCell<Matrix3D>,
+}
+
+impl<'gc> Matrix3DObject<'gc> {
+    pub fn matrix_ref(&self) -> Ref<'_, Matrix3D> {
+        self.0.matrix.borrow()
+    }
+
+    pub fn matrix_mut(&self) -> RefMut<'_, Matrix3D> {
+        self.0.matrix.borrow_mut()
+    }
+
+    pub fn matrix(self) -> Matrix3D {
+        *self.matrix_ref()
+    }
+
+    pub fn replace_matrix(self, matrix: Matrix3D) -> Matrix3D {
+        self.0.matrix.replace(matrix)
+    }
 }
 
 impl<'gc> TObject<'gc> for Matrix3DObject<'gc> {

--- a/render/src/matrix3d.rs
+++ b/render/src/matrix3d.rs
@@ -75,6 +75,57 @@ impl Matrix3D {
             + (m[8] * m[13] - m[12] * m[9]) * (m[2] * m[7] - m[6] * m[3])
     }
 
+    pub fn invert(&self) -> Option<Self> {
+        let d = self.determinant();
+        let invertible = d.abs() > 0.00000000001;
+
+        if !invertible {
+            return None;
+        }
+
+        let d = 1.0 / d;
+
+        let m = self.raw_data;
+        let m11 = m[0];
+        let m21 = m[4];
+        let m31 = m[8];
+        let m41 = m[12];
+        let m12 = m[1];
+        let m22 = m[5];
+        let m32 = m[9];
+        let m42 = m[13];
+        let m13 = m[2];
+        let m23 = m[6];
+        let m33 = m[10];
+        let m43 = m[14];
+        let m14 = m[3];
+        let m24 = m[7];
+        let m34 = m[11];
+        let m44 = m[15];
+
+        #[rustfmt::skip]
+        let raw_data = [
+             d * (m22 * (m33 * m44 - m43 * m34) - m32 * (m23 * m44 - m43 * m24) + m42 * (m23 * m34 - m33 * m24)),
+            -d * (m12 * (m33 * m44 - m43 * m34) - m32 * (m13 * m44 - m43 * m14) + m42 * (m13 * m34 - m33 * m14)),
+             d * (m12 * (m23 * m44 - m43 * m24) - m22 * (m13 * m44 - m43 * m14) + m42 * (m13 * m24 - m23 * m14)),
+            -d * (m12 * (m23 * m34 - m33 * m24) - m22 * (m13 * m34 - m33 * m14) + m32 * (m13 * m24 - m23 * m14)),
+            -d * (m21 * (m33 * m44 - m43 * m34) - m31 * (m23 * m44 - m43 * m24) + m41 * (m23 * m34 - m33 * m24)),
+             d * (m11 * (m33 * m44 - m43 * m34) - m31 * (m13 * m44 - m43 * m14) + m41 * (m13 * m34 - m33 * m14)),
+            -d * (m11 * (m23 * m44 - m43 * m24) - m21 * (m13 * m44 - m43 * m14) + m41 * (m13 * m24 - m23 * m14)),
+             d * (m11 * (m23 * m34 - m33 * m24) - m21 * (m13 * m34 - m33 * m14) + m31 * (m13 * m24 - m23 * m14)),
+             d * (m21 * (m32 * m44 - m42 * m34) - m31 * (m22 * m44 - m42 * m24) + m41 * (m22 * m34 - m32 * m24)),
+            -d * (m11 * (m32 * m44 - m42 * m34) - m31 * (m12 * m44 - m42 * m14) + m41 * (m12 * m34 - m32 * m14)),
+             d * (m11 * (m22 * m44 - m42 * m24) - m21 * (m12 * m44 - m42 * m14) + m41 * (m12 * m24 - m22 * m14)),
+            -d * (m11 * (m22 * m34 - m32 * m24) - m21 * (m12 * m34 - m32 * m14) + m31 * (m12 * m24 - m22 * m14)),
+            -d * (m21 * (m32 * m43 - m42 * m33) - m31 * (m22 * m43 - m42 * m23) + m41 * (m22 * m33 - m32 * m23)),
+             d * (m11 * (m32 * m43 - m42 * m33) - m31 * (m12 * m43 - m42 * m13) + m41 * (m12 * m33 - m32 * m13)),
+            -d * (m11 * (m22 * m43 - m42 * m23) - m21 * (m12 * m43 - m42 * m13) + m41 * (m12 * m23 - m22 * m13)),
+             d * (m11 * (m22 * m33 - m32 * m23) - m21 * (m12 * m33 - m32 * m13) + m31 * (m12 * m23 - m22 * m13)),
+        ];
+
+        Some(Self { raw_data })
+    }
+
     pub fn multiply(&self, rhs: &Self) -> Self {
         let lhs = &self.raw_data;
         let rhs = &rhs.raw_data;

--- a/render/src/matrix3d.rs
+++ b/render/src/matrix3d.rs
@@ -65,6 +65,16 @@ impl Matrix3D {
         self.raw_data.swap(11, 14);
     }
 
+    pub fn determinant(&self) -> f64 {
+        let m = &self.raw_data;
+        (m[0] * m[5] - m[4] * m[1]) * (m[10] * m[15] - m[14] * m[11])
+            - (m[0] * m[9] - m[8] * m[1]) * (m[6] * m[15] - m[14] * m[7])
+            + (m[0] * m[13] - m[12] * m[1]) * (m[6] * m[11] - m[10] * m[7])
+            + (m[4] * m[9] - m[8] * m[5]) * (m[2] * m[15] - m[14] * m[3])
+            - (m[4] * m[13] - m[12] * m[5]) * (m[2] * m[11] - m[10] * m[3])
+            + (m[8] * m[13] - m[12] * m[9]) * (m[2] * m[7] - m[6] * m[3])
+    }
+
     pub fn multiply(&self, rhs: &Self) -> Self {
         let lhs = &self.raw_data;
         let rhs = &rhs.raw_data;

--- a/render/src/matrix3d.rs
+++ b/render/src/matrix3d.rs
@@ -9,6 +9,15 @@ pub struct Matrix3D {
 }
 
 impl Matrix3D {
+    pub const IDENTITY: Self = Self {
+        raw_data: [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0,
+        ],
+    };
+
     pub fn from_matrix(matrix: Matrix) -> Self {
         Self {
             raw_data: [

--- a/render/src/matrix3d.rs
+++ b/render/src/matrix3d.rs
@@ -55,4 +55,13 @@ impl Matrix3D {
             ty: Twips::from_pixels(self.raw_data[13]),
         }
     }
+
+    pub fn transpose_in_place(&mut self) {
+        self.raw_data.swap(1, 4);
+        self.raw_data.swap(2, 8);
+        self.raw_data.swap(3, 12);
+        self.raw_data.swap(6, 9);
+        self.raw_data.swap(7, 13);
+        self.raw_data.swap(11, 14);
+    }
 }

--- a/render/src/matrix3d.rs
+++ b/render/src/matrix3d.rs
@@ -64,4 +64,21 @@ impl Matrix3D {
         self.raw_data.swap(7, 13);
         self.raw_data.swap(11, 14);
     }
+
+    pub fn multiply(&self, rhs: &Self) -> Self {
+        let lhs = &self.raw_data;
+        let rhs = &rhs.raw_data;
+        let mut result = [0.0; 16];
+
+        for column in 0..4 {
+            for row in 0..4 {
+                result[column * 4 + row] = lhs[row] * rhs[column * 4]
+                    + lhs[4 + row] * rhs[column * 4 + 1]
+                    + lhs[8 + row] * rhs[column * 4 + 2]
+                    + lhs[12 + row] * rhs[column * 4 + 3];
+            }
+        }
+
+        Self { raw_data: result }
+    }
 }

--- a/render/src/matrix3d.rs
+++ b/render/src/matrix3d.rs
@@ -29,6 +29,17 @@ impl Matrix3D {
         }
     }
 
+    pub fn translate(x: f64, y: f64, z: f64) -> Self {
+        Self {
+            raw_data: [
+                1.0, 0.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0, //
+                x, y, z, 1.0,
+            ],
+        }
+    }
+
     pub fn from_matrix(matrix: Matrix) -> Self {
         Self {
             raw_data: [

--- a/render/src/matrix3d.rs
+++ b/render/src/matrix3d.rs
@@ -18,6 +18,17 @@ impl Matrix3D {
         ],
     };
 
+    pub fn scale(x: f64, y: f64, z: f64) -> Self {
+        Self {
+            raw_data: [
+                x, 0.0, 0.0, 0.0, //
+                0.0, y, 0.0, 0.0, //
+                0.0, 0.0, z, 0.0, //
+                0.0, 0.0, 0.0, 1.0,
+            ],
+        }
+    }
+
     pub fn from_matrix(matrix: Matrix) -> Self {
         Self {
             raw_data: [


### PR DESCRIPTION
## Description

This PR makes AVM2 use the native Matrix3D as data storage (instead of a `_rawData` vector), moves some methods into that class, and simplifies existing code.

## Testing

Covered by existing tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
