### PR TITLE
core: Move `TDisplayObject::instantiate` onto each enum variant that needs it

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -2650,8 +2650,6 @@ pub trait TDisplayObject<'gc>:
         None
     }
 
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc>;
-
     /// Whether this object can be used as a mask.
     /// If this returns false and this object is used as a mask, the mask will not be applied.
     /// This is used by movie clips to disable the mask when there are no children, for example.

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -110,6 +110,10 @@ impl<'gc> Avm1Button<'gc> {
         ))
     }
 
+    pub fn instantiate(self, mc: &Mutation<'gc>) -> Self {
+        Self(Gc::new(mc, (*self.0).clone()))
+    }
+
     pub fn set_sounds(self, sounds: swf::ButtonSounds) {
         let mut shared = self.0.shared.cell.borrow_mut();
         shared.up_to_over_sound = sounds.up_to_over_sound;
@@ -247,11 +251,6 @@ impl<'gc> Avm1Button<'gc> {
 impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
     fn base(self) -> Gc<'gc, DisplayObjectBase<'gc>> {
         HasPrefixField::as_prefix_gc(self.raw_interactive())
-    }
-
-    fn instantiate(self, mc: &Mutation<'gc>) -> DisplayObject<'gc> {
-        let data: &Avm1ButtonData = &self.0;
-        Self(Gc::new(mc, data.clone())).into()
     }
 
     fn id(self) -> CharacterId {

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -157,6 +157,10 @@ impl<'gc> Avm2Button<'gc> {
         Self::from_swf_tag(&button_record, &movie.into(), context, false)
     }
 
+    pub fn instantiate(self, mc: &Mutation<'gc>) -> Self {
+        Self(Gc::new(mc, (*self.0).clone()))
+    }
+
     pub fn set_sounds(self, sounds: swf::ButtonSounds) {
         let mut shared = self.0.shared.cell.borrow_mut();
         shared.up_to_over_sound = sounds.up_to_over_sound;
@@ -413,10 +417,6 @@ impl<'gc> Avm2Button<'gc> {
 impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
     fn base(self) -> Gc<'gc, DisplayObjectBase<'gc>> {
         HasPrefixField::as_prefix_gc(self.raw_interactive())
-    }
-
-    fn instantiate(self, mc: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(mc, (*self.0).clone())).into()
     }
 
     fn id(self) -> CharacterId {

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -198,6 +198,10 @@ impl<'gc> Bitmap<'gc> {
         Self::new_with_bitmap_data(mc, id, bitmap_data, smoothing, &movie)
     }
 
+    pub fn instantiate(self, mc: &Mutation<'gc>) -> Self {
+        Self(Gc::new(mc, (*self.0).clone()))
+    }
+
     // Important - we read 'width' and 'height' from the cached
     // values on this object. See the definition of these fields
     // for more information
@@ -291,10 +295,6 @@ impl<'gc> Bitmap<'gc> {
 impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
     fn base(self) -> Gc<'gc, DisplayObjectBase<'gc>> {
         HasPrefixField::as_prefix_gc(self.0)
-    }
-
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
     fn id(self) -> CharacterId {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -409,6 +409,10 @@ impl<'gc> EditText<'gc> {
         text
     }
 
+    pub fn instantiate(self, mc: &Mutation<'gc>) -> Self {
+        Self(Gc::new(mc, (*self.0).clone()))
+    }
+
     fn contains_flag(self, flag: EditTextFlag) -> bool {
         self.0.flags.get().contains(flag)
     }
@@ -2546,10 +2550,6 @@ impl<'gc> EditText<'gc> {
 impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     fn base(self) -> Gc<'gc, DisplayObjectBase<'gc>> {
         HasPrefixField::as_prefix_gc(self.raw_interactive())
-    }
-
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
     fn id(self) -> CharacterId {

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -115,6 +115,10 @@ impl<'gc> Graphic<'gc> {
         ))
     }
 
+    pub fn instantiate(self, mc: &Mutation<'gc>) -> Self {
+        Self(Gc::new(mc, (*self.0).clone()))
+    }
+
     pub fn drawing_mut(&self) -> RefMut<'_, Drawing> {
         self.0.drawing.get_or_init(Default::default).borrow_mut()
     }
@@ -176,10 +180,6 @@ impl<'gc> Graphic<'gc> {
 impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     fn base(self) -> Gc<'gc, DisplayObjectBase<'gc>> {
         HasPrefixField::as_prefix_gc(self.0)
-    }
-
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
     fn id(self) -> CharacterId {

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -72,10 +72,6 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
         HasPrefixField::as_prefix_gc(self.raw_interactive())
     }
 
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
-    }
-
     fn id(self) -> CharacterId {
         u16::MAX
     }

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -55,15 +55,15 @@ impl<'gc> MorphShape<'gc> {
             },
         ))
     }
+
+    pub fn instantiate(self, gc_context: &Mutation<'gc>) -> Self {
+        Self(Gc::new(gc_context, (*self.0).clone()))
+    }
 }
 
 impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
     fn base(self) -> Gc<'gc, DisplayObjectBase<'gc>> {
         HasPrefixField::as_prefix_gc(self.0)
-    }
-
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
     fn id(self) -> CharacterId {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -360,6 +360,10 @@ impl<'gc> MovieClip<'gc> {
         mc
     }
 
+    pub fn instantiate(self, mc: &Mutation<'gc>) -> Self {
+        Self(Gc::new(mc, (*self.0).clone()))
+    }
+
     /// Replace the current MovieClipData with a completely new SwfMovie.
     ///
     /// If no movie is provided, then the movie clip will be replaced with an
@@ -2516,10 +2520,6 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         HasPrefixField::as_prefix_gc(self.raw_interactive())
     }
 
-    fn instantiate(self, mc: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(mc, (*self.0).clone())).into()
-    }
-
     fn id(self) -> CharacterId {
         self.0.id()
     }
@@ -4357,8 +4357,7 @@ impl<'gc, 'a> MovieClip<'gc> {
                                 // instantiations don't reflect changes made to the loaded
                                 // main timeline instance.
 
-                                let instantiated =
-                                    self.instantiate(activation.gc()).as_movie_clip().unwrap();
+                                let instantiated = self.instantiate(activation.gc());
 
                                 let library = activation
                                     .context

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -811,10 +811,6 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         HasPrefixField::as_prefix_gc(self.raw_interactive())
     }
 
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
-    }
-
     fn local_to_global_matrix(self) -> Matrix {
         // The stage is in Stage coordinates by definition
         Default::default()

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -65,6 +65,10 @@ impl<'gc> Text<'gc> {
         ))
     }
 
+    pub fn instantiate(self, mc: &Mutation<'gc>) -> Self {
+        Self(Gc::new(mc, (*self.0).clone()))
+    }
+
     fn set_shared(&self, context: &mut UpdateContext<'gc>, to: Gc<'gc, TextShared>) {
         let mc = context.gc();
         unlock!(Gc::write(mc, self.0), TextData, shared).set(to);
@@ -105,10 +109,6 @@ impl<'gc> Text<'gc> {
 impl<'gc> TDisplayObject<'gc> for Text<'gc> {
     fn base(self) -> Gc<'gc, DisplayObjectBase<'gc>> {
         HasPrefixField::as_prefix_gc(self.0)
-    }
-
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
     fn id(self) -> CharacterId {

--- a/core/src/display_object/text_line.rs
+++ b/core/src/display_object/text_line.rs
@@ -266,29 +266,6 @@ impl<'gc> TDisplayObject<'gc> for TextLine<'gc> {
         HasPrefixField::as_prefix_gc(interactive)
     }
 
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(
-            gc_context,
-            TextLineData {
-                base: Default::default(),
-                avm2_object: Lock::new(None),
-                fallback: self.0.fallback,
-                movie: self.0.movie.clone(),
-                validity: Lock::new(self.0.validity.get()),
-                text_block: Lock::new(self.0.text_block.get()),
-                hide_block_from_script: Cell::new(self.0.hide_block_from_script.get()),
-                specified_width: Cell::new(self.0.specified_width.get()),
-                raw_text_length: Cell::new(self.0.raw_text_length.get()),
-                begin_index: Cell::new(self.0.begin_index.get()),
-                end_index: Cell::new(self.0.end_index.get()),
-                line_index: Cell::new(self.0.line_index.get()),
-                previous_line: Lock::new(self.0.previous_line.get()),
-                next_line: Lock::new(self.0.next_line.get()),
-            },
-        ))
-        .into()
-    }
-
     fn id(self) -> CharacterId {
         0
     }

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -179,6 +179,10 @@ impl<'gc> Video<'gc> {
         ))
     }
 
+    pub fn instantiate(self, mc: &Mutation<'gc>) -> Self {
+        Self(Gc::new(mc, (*self.0).clone()))
+    }
+
     fn set_object(&self, context: &mut UpdateContext<'gc>, to: AvmObject<'gc>) {
         let mc = context.gc();
         unlock!(Gc::write(mc, self.0), VideoData, object).set(Some(to));
@@ -347,10 +351,6 @@ impl<'gc> Video<'gc> {
 impl<'gc> TDisplayObject<'gc> for Video<'gc> {
     fn base(self) -> Gc<'gc, DisplayObjectBase<'gc>> {
         HasPrefixField::as_prefix_gc(self.0)
-    }
-
-    fn instantiate(self, gc_context: &Mutation<'gc>) -> DisplayObject<'gc> {
-        Self(Gc::new(gc_context, self.0.as_ref().clone())).into()
     }
 
     fn post_instantiation(

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -258,16 +258,16 @@ impl<'gc> MovieLibrary<'gc> {
                 let bitmap = bitmap.compressed().decode().unwrap();
                 let bitmap = Bitmap::new(mc, id, bitmap, self.swf.clone());
                 bitmap.set_avm2_bitmapdata_class(mc, avm2_class);
-                Some(bitmap.instantiate(mc))
+                Some(bitmap.instantiate(mc).into())
             }
-            Character::EditText(edit_text) => Some(edit_text.instantiate(mc)),
-            Character::Graphic(graphic) => Some(graphic.instantiate(mc)),
-            Character::MorphShape(morph_shape) => Some(morph_shape.instantiate(mc)),
-            Character::MovieClip(movie_clip) => Some(movie_clip.instantiate(mc)),
-            Character::Avm1Button(button) => Some(button.instantiate(mc)),
-            Character::Avm2Button(button) => Some(button.instantiate(mc)),
-            Character::Text(text) => Some(text.instantiate(mc)),
-            Character::Video(video) => Some(video.instantiate(mc)),
+            Character::EditText(edit_text) => Some(edit_text.instantiate(mc).into()),
+            Character::Graphic(graphic) => Some(graphic.instantiate(mc).into()),
+            Character::MorphShape(morph_shape) => Some(morph_shape.instantiate(mc).into()),
+            Character::MovieClip(movie_clip) => Some(movie_clip.instantiate(mc).into()),
+            Character::Avm1Button(button) => Some(button.instantiate(mc).into()),
+            Character::Avm2Button(button) => Some(button.instantiate(mc).into()),
+            Character::Text(text) => Some(text.instantiate(mc).into()),
+            Character::Video(video) => Some(video.instantiate(mc).into()),
             _ => {
                 // Cannot instantiate non-display object
                 None


### PR DESCRIPTION
## Description

Previously, each `TDisplayObject` variant had to implement `instantiate`. However, some variants, such as `LoaderDisplay` and `TextLine`, don't need it. This PR removes it from them.

## Testing

No functional changes.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
