### PR TITLE
debug_ui/avm2: Move Class information into its own window

### DIFF
--- a/core/src/debug_ui.rs
+++ b/core/src/debug_ui.rs
@@ -1,5 +1,6 @@
 mod avm1;
 mod avm2;
+mod avm2_class;
 mod common;
 mod display_object;
 mod domain;
@@ -9,10 +10,11 @@ mod movie;
 use crate::context::{RenderContext, UpdateContext};
 use crate::debug_ui::avm1::Avm1ObjectWindow;
 use crate::debug_ui::avm2::Avm2ObjectWindow;
+use crate::debug_ui::avm2_class::Avm2ClassWindow;
 use crate::debug_ui::display_object::{DisplayObjectSearchWindow, DisplayObjectWindow};
 use crate::debug_ui::domain::DomainListWindow;
 use crate::debug_ui::handle::{
-    AVM1ObjectHandle, AVM2ObjectHandle, DisplayObjectHandle, DomainHandle,
+    AVM1ObjectHandle, AVM2ObjectHandle, ClassHandle, DisplayObjectHandle, DomainHandle,
 };
 use crate::debug_ui::movie::{MovieListWindow, MovieWindow};
 use crate::display_object::TDisplayObject;
@@ -31,6 +33,7 @@ pub struct DebugUi {
     movies: PtrWeakKeyHashMap<Weak<SwfMovie>, MovieWindow>,
     avm1_objects: HashMap<AVM1ObjectHandle, Avm1ObjectWindow>,
     avm2_objects: HashMap<AVM2ObjectHandle, Avm2ObjectWindow>,
+    avm2_classes: HashMap<ClassHandle, Avm2ClassWindow>,
     domains: HashMap<DomainHandle, DomainListWindow>,
     queued_messages: Vec<Message>,
     items_to_save: Vec<ItemToSave>,
@@ -46,6 +49,7 @@ pub enum Message {
     TrackMovie(Arc<SwfMovie>),
     TrackAVM1Object(AVM1ObjectHandle),
     TrackAVM2Object(AVM2ObjectHandle),
+    TrackAVM2Class(ClassHandle),
     TrackStage,
     TrackTopLevelMovie,
     ShowKnownMovies,
@@ -77,6 +81,11 @@ impl DebugUi {
         self.avm2_objects.retain(|object, window| {
             let object = object.fetch(context.dynamic_root);
             window.show(egui_ctx, context, object, &mut messages)
+        });
+
+        self.avm2_classes.retain(|class, window| {
+            let class = class.fetch(context.dynamic_root);
+            window.show(egui_ctx, context, class, &mut messages)
         });
 
         self.movies
@@ -123,6 +132,9 @@ impl DebugUi {
                 }
                 Message::TrackAVM2Object(object) => {
                     self.avm2_objects.insert(object, Default::default());
+                }
+                Message::TrackAVM2Class(class) => {
+                    self.avm2_classes.insert(class, Default::default());
                 }
                 Message::SaveFile(file) => {
                     self.items_to_save.push(file);

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -4,6 +4,7 @@ use crate::avm2::{
     Activation, ArrayStorage, ClassObject, Error, Namespace, Object, TObject as _, Value,
 };
 use crate::context::UpdateContext;
+use crate::debug_ui::avm2_class::{class_name, show_avm2_class};
 use crate::debug_ui::display_object::open_display_object_button;
 use crate::debug_ui::handle::{AVM2ObjectHandle, DisplayObjectHandle};
 use crate::debug_ui::{ItemToSave, Message};
@@ -14,7 +15,6 @@ use gc_arena::Mutation;
 use std::borrow::Cow;
 
 use super::common::show_style_sheet;
-use super::movie::open_movie_button;
 
 #[derive(Debug, Eq, PartialEq, Hash, Default, Copy, Clone)]
 enum Panel {
@@ -85,7 +85,7 @@ impl Avm2ObjectWindow {
                     }
                     Panel::Class => {
                         if let Some(class) = object.as_class_object() {
-                            self.show_class(class, messages, &mut activation, ui)
+                            self.show_class(class, messages, activation.context, ui)
                         }
                     }
                     Panel::StyleSheet => {
@@ -109,11 +109,9 @@ impl Avm2ObjectWindow {
             .num_columns(2)
             .striped(true)
             .show(ui, |ui| {
-                if let Some(class) = object.instance_class().class_object() {
-                    ui.label("Instance Of");
-                    show_avm2_value(ui, activation.context, class.into(), messages);
-                    ui.end_row();
-                }
+                ui.label("Instance Of");
+                show_avm2_class(ui, activation.context, object.instance_class(), messages);
+                ui.end_row();
 
                 if let Some(object) = object.as_display_object() {
                     ui.label("Display Object");
@@ -241,7 +239,7 @@ impl Avm2ObjectWindow {
         &mut self,
         class: ClassObject<'gc>,
         messages: &mut Vec<Message>,
-        activation: &mut Activation<'_, 'gc>,
+        context: &mut UpdateContext<'gc>,
         ui: &mut Ui,
     ) {
         Grid::new(ui.id().with("class"))
@@ -249,45 +247,8 @@ impl Avm2ObjectWindow {
             .striped(true)
             .spacing([8.0, 8.0])
             .show(ui, |ui| {
-                let definition = class.inner_class_definition();
-                let name = definition.name();
-
-                ui.label("Namespace");
-                let namespace = name.namespace().as_uri(activation.strings());
-                ui.text_edit_singleline(&mut namespace.to_string().as_str());
-                ui.end_row();
-
-                ui.label("Name");
-                ui.text_edit_singleline(&mut name.local_name().to_string().as_str());
-                ui.end_row();
-
-                ui.label("Movie");
-                open_movie_button(ui, &class.translation_unit().movie(), messages);
-                ui.end_row();
-
-                ui.label("Super Chain");
-                ui.vertical(|ui| {
-                    let mut superclass = Some(class);
-                    while let Some(class) = superclass {
-                        show_avm2_value(ui, activation.context, class.into(), messages);
-                        superclass = class.superclass_object();
-                    }
-                });
-                ui.end_row();
-
-                ui.label("Interfaces");
-                ui.vertical(|ui| {
-                    for interface in class.inner_class_definition().all_interfaces() {
-                        ui.text_edit_singleline(
-                            &mut interface
-                                .name()
-                                .to_qualified_name_err_message(activation.gc())
-                                .to_string()
-                                .as_str(),
-                        );
-                    }
-                });
-                ui.end_row();
+                ui.label("Represents Class");
+                show_avm2_class(ui, context, class.inner_class_definition(), messages);
             });
     }
 
@@ -503,11 +464,7 @@ pub fn show_avm2_value<'gc>(
 
 fn object_name<'gc>(mc: &Mutation<'gc>, object: Object<'gc>) -> String {
     if let Some(class) = object.as_class_object() {
-        class
-            .inner_class_definition()
-            .name()
-            .to_qualified_name_err_message(mc)
-            .to_string()
+        class_name(mc, class.inner_class_definition())
     } else {
         let name = object.instance_class().name().local_name().to_string();
         format!("{} {:p}", name, object.as_ptr())

--- a/core/src/debug_ui/avm2_class.rs
+++ b/core/src/debug_ui/avm2_class.rs
@@ -78,6 +78,22 @@ impl Avm2ClassWindow {
                     open_movie_button(ui, &tu.movie(), messages);
                     ui.end_row();
                 }
+
+                ui.label("Sealed?");
+                ui.text_edit_singleline(&mut class.is_sealed().to_string().as_str());
+                ui.end_row();
+
+                ui.label("Final?");
+                ui.text_edit_singleline(&mut class.is_final().to_string().as_str());
+                ui.end_row();
+
+                ui.label("Interface?");
+                ui.text_edit_singleline(&mut class.is_interface().to_string().as_str());
+                ui.end_row();
+
+                ui.label("Generic?");
+                ui.text_edit_singleline(&mut class.is_generic().to_string().as_str());
+                ui.end_row();
             });
     }
 

--- a/core/src/debug_ui/avm2_class.rs
+++ b/core/src/debug_ui/avm2_class.rs
@@ -1,0 +1,145 @@
+use crate::avm2::Class;
+use crate::context::UpdateContext;
+use crate::debug_ui::Message;
+use crate::debug_ui::handle::ClassHandle;
+use crate::debug_ui::movie::open_movie_button;
+use egui::{Grid, Id, Ui, Window};
+use gc_arena::Mutation;
+
+#[derive(Debug, Eq, PartialEq, Hash, Default, Copy, Clone)]
+enum Panel {
+    #[default]
+    Class,
+    Superclasses,
+}
+
+#[derive(Debug, Default)]
+pub struct Avm2ClassWindow {
+    open_panel: Panel,
+}
+
+impl Avm2ClassWindow {
+    pub fn show<'gc>(
+        &mut self,
+        egui_ctx: &egui::Context,
+        context: &mut UpdateContext<'gc>,
+        class: Class<'gc>,
+        messages: &mut Vec<Message>,
+    ) -> bool {
+        let mut keep_open = true;
+        Window::new(class_name(context.gc(), class))
+            .id(Id::new(class.as_ptr()))
+            .open(&mut keep_open)
+            .scroll([true, true])
+            .show(egui_ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.selectable_value(&mut self.open_panel, Panel::Class, "Class Info");
+                    ui.selectable_value(
+                        &mut self.open_panel,
+                        Panel::Superclasses,
+                        "Superclasses and Interfaces",
+                    );
+                });
+                ui.separator();
+
+                match self.open_panel {
+                    Panel::Class => self.show_information(class, messages, context, ui),
+                    Panel::Superclasses => self.show_superclasses(class, messages, context, ui),
+                }
+            });
+        keep_open
+    }
+
+    fn show_information<'gc>(
+        &mut self,
+        class: Class<'gc>,
+        messages: &mut Vec<Message>,
+        context: &mut UpdateContext<'gc>,
+        ui: &mut Ui,
+    ) {
+        Grid::new(ui.id().with("class"))
+            .num_columns(2)
+            .striped(true)
+            .spacing([8.0, 8.0])
+            .show(ui, |ui| {
+                let name = class.name();
+
+                ui.label("Namespace");
+                let namespace = name.namespace().as_uri(&mut context.strings);
+                ui.text_edit_singleline(&mut namespace.to_string().as_str());
+                ui.end_row();
+
+                ui.label("Name");
+                ui.text_edit_singleline(&mut name.local_name().to_string().as_str());
+                ui.end_row();
+
+                if let Some(tu) = class.translation_unit() {
+                    ui.label("Movie");
+                    open_movie_button(ui, &tu.movie(), messages);
+                    ui.end_row();
+                }
+            });
+    }
+
+    fn show_superclasses<'gc>(
+        &mut self,
+        class: Class<'gc>,
+        messages: &mut Vec<Message>,
+        context: &mut UpdateContext<'gc>,
+        ui: &mut Ui,
+    ) {
+        Grid::new(ui.id().with("class"))
+            .num_columns(2)
+            .striped(true)
+            .spacing([8.0, 8.0])
+            .show(ui, |ui| {
+                ui.label("Super Chain");
+                ui.vertical(|ui| {
+                    let mut superclass = Some(class);
+                    while let Some(class) = superclass {
+                        show_avm2_class(ui, context, class, messages);
+                        superclass = class.super_class();
+                    }
+                });
+                ui.end_row();
+
+                ui.label("Interfaces");
+                ui.vertical(|ui| {
+                    for interface in class.all_interfaces() {
+                        show_avm2_class(ui, context, *interface, messages);
+                    }
+                });
+                ui.end_row();
+            });
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ClassWidget(ClassHandle, String);
+
+impl ClassWidget {
+    fn new<'gc>(context: &mut UpdateContext<'gc>, class: Class<'gc>) -> Self {
+        let name = class_name(context.gc(), class);
+
+        ClassWidget(ClassHandle::new(context, class), name)
+    }
+
+    fn show(&self, ui: &mut Ui, messages: &mut Vec<Message>) {
+        if ui.button(&self.1).clicked() {
+            messages.push(Message::TrackAVM2Class(self.0.clone()));
+        }
+    }
+}
+
+pub fn show_avm2_class<'gc>(
+    ui: &mut Ui,
+    context: &mut UpdateContext<'gc>,
+    class: Class<'gc>,
+    messages: &mut Vec<Message>,
+) {
+    ClassWidget::new(context, class).show(ui, messages)
+}
+
+pub fn class_name<'gc>(mc: &Mutation<'gc>, class: Class<'gc>) -> String {
+    class.name().to_qualified_name_err_message(mc).to_string()
+}

--- a/core/src/debug_ui/domain.rs
+++ b/core/src/debug_ui/domain.rs
@@ -58,28 +58,6 @@ impl DomainListWindow {
                     open_domain_button(ui, context, messages, domain);
                 })
                 .body(|ui| {
-                    let class_props = domain.classes();
-                    let mut classes: Vec<_> = class_props.iter().collect();
-                    classes.sort_by_key(|(name, _, _)| *name);
-
-                    for (class_index, (_, _, class)) in classes.iter().enumerate() {
-                        let name = class_name(context.gc(), **class);
-                        if !name.to_string().to_ascii_lowercase().contains(search) {
-                            continue;
-                        }
-
-                        ui.push_id(format!("class_obj_{class_index}"), |ui| {
-                            let button = ui.button(name);
-                            if button.clicked() {
-                                messages.push(Message::TrackAVM2Class(ClassHandle::new(
-                                    context, **class,
-                                )));
-                            }
-                        });
-                    }
-
-                    drop(class_props);
-
                     for (child_index, child_domain) in
                         domain.children(context.gc()).into_iter().enumerate()
                     {
@@ -92,6 +70,26 @@ impl DomainListWindow {
                                 search,
                                 depth + 1,
                             );
+                        });
+                    }
+
+                    let class_props = domain.classes();
+                    let mut classes: Vec<_> = class_props.iter().collect();
+                    classes.sort_by_key(|(name, _, _)| *name);
+
+                    for (class_index, (_, _, class)) in classes.iter().enumerate() {
+                        let name = class_name(context.gc(), **class);
+                        if !name.to_string().to_ascii_lowercase().contains(search) {
+                            continue;
+                        }
+
+                        ui.push_id(format!("class_{class_index}"), |ui| {
+                            let button = ui.button(format!("Class {name}"));
+                            if button.clicked() {
+                                messages.push(Message::TrackAVM2Class(ClassHandle::new(
+                                    context, **class,
+                                )));
+                            }
                         });
                     }
                 });

--- a/core/src/debug_ui/domain.rs
+++ b/core/src/debug_ui/domain.rs
@@ -1,11 +1,10 @@
-use egui::{CollapsingHeader, TextEdit, Ui, Window, collapsing_header::CollapsingState};
+use crate::avm2::Domain;
+use crate::context::UpdateContext;
+use crate::debug_ui::Message;
+use crate::debug_ui::avm2_class::class_name;
+use crate::debug_ui::handle::{ClassHandle, DomainHandle};
 
-use crate::{avm2::Domain, context::UpdateContext};
-
-use super::{
-    Message,
-    handle::{AVM2ObjectHandle, DomainHandle},
-};
+use egui::{TextEdit, Ui, Window, collapsing_header::CollapsingState};
 
 #[derive(Debug, Default)]
 pub struct DomainListWindow {
@@ -64,35 +63,18 @@ impl DomainListWindow {
                     classes.sort_by_key(|(name, _, _)| *name);
 
                     for (class_index, (_, _, class)) in classes.iter().enumerate() {
-                        let class_name = class.name().to_qualified_name(context.gc());
-                        if !class_name.to_string().to_ascii_lowercase().contains(search) {
+                        let name = class_name(context.gc(), **class);
+                        if !name.to_string().to_ascii_lowercase().contains(search) {
                             continue;
                         }
 
-                        let class_id =
-                            format!("class_{}_{}_{:p}", depth, class_index, class.as_ptr());
-
-                        ui.push_id(class_id, |ui| {
-                            CollapsingHeader::new(format!("Class {class_name}")).show(ui, |ui| {
-                                for (obj_index, class_obj) in
-                                    class.class_objects().iter().enumerate()
-                                {
-                                    ui.push_id(
-                                        format!("class_obj_{}_{}", class_index, obj_index),
-                                        |ui| {
-                                            let button = ui.button(format!("{class_obj:?}"));
-                                            if button.clicked() {
-                                                messages.push(Message::TrackAVM2Object(
-                                                    AVM2ObjectHandle::new(
-                                                        context,
-                                                        (*class_obj).into(),
-                                                    ),
-                                                ));
-                                            }
-                                        },
-                                    );
-                                }
-                            });
+                        ui.push_id(format!("class_obj_{class_index}"), |ui| {
+                            let button = ui.button(name);
+                            if button.clicked() {
+                                messages.push(Message::TrackAVM2Class(ClassHandle::new(
+                                    context, **class,
+                                )));
+                            }
                         });
                     }
 

--- a/core/src/debug_ui/handle.rs
+++ b/core/src/debug_ui/handle.rs
@@ -189,3 +189,48 @@ impl Hash for DomainHandle {
 }
 
 impl Eq for DomainHandle {}
+
+// AVM2 Class
+
+#[derive(Clone)]
+pub struct ClassHandle {
+    root: DynamicRoot<Rootable![crate::avm2::Class<'_>]>,
+    ptr: *const (),
+}
+
+impl ClassHandle {
+    pub fn new<'gc>(context: &mut UpdateContext<'gc>, class: crate::avm2::Class<'gc>) -> Self {
+        Self {
+            // TODO(moulins): it'd be nice to avoid the double indirection here...
+            root: context
+                .dynamic_root
+                .stash(context.gc(), Gc::new(context.gc(), class)),
+            ptr: class.as_ptr(),
+        }
+    }
+
+    pub fn fetch<'gc>(&self, dynamic_root_set: DynamicRootSet<'gc>) -> crate::avm2::Class<'gc> {
+        *dynamic_root_set.fetch(&self.root)
+    }
+}
+
+impl Debug for ClassHandle {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ClassHandle").field(&self.ptr).finish()
+    }
+}
+
+impl PartialEq<ClassHandle> for ClassHandle {
+    #[inline(always)]
+    fn eq(&self, other: &ClassHandle) -> bool {
+        std::ptr::eq(self.ptr, other.ptr)
+    }
+}
+
+impl Hash for ClassHandle {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.ptr.hash(state);
+    }
+}
+
+impl Eq for ClassHandle {}


### PR DESCRIPTION
## Description

Various improvements to how Classes are displayed in the AVM2 debug UI.
- Add a window for displaying `Class`es themselves (previously, class information was displayed in a section for `ClassObject`s)
- Show `Class` modifiers (sealed, generic, etc)
- Improve how the list of `Class`es appears for each `Domain`

<img width="1495" height="854" alt="image" src="https://github.com/user-attachments/assets/410589da-7806-49a2-96d6-607ab7fd4249" />

Duplicate classes showing in the playerglobal domain's class list is an existing issue.

## Testing

This is a set of changes to the debug UI, which has no test coverage.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
