### PR TITLE
avm2: Use restargs instead of passing arguments as an array in Date methods

### DIFF
--- a/core/src/avm2/globals/Date.as
+++ b/core/src/avm2/globals/Date.as
@@ -1,4 +1,6 @@
 package {
+    // TODO: This class should be `[Ruffle(CustomConstructor)]`, like `RegExp`-
+    // see `RegExp.as` for more information
     [Ruffle(InstanceAllocator)]
     [Ruffle(CallHandler)]
     public dynamic class Date {
@@ -230,9 +232,9 @@ package {
             seconds:* = undefined,
             ms:* = undefined
         ) {
-            this.init(arguments);
+            this.init.apply(this, arguments);
         }
-        private native function init(args:Array);
+        private native function init(...rest);
 
         public static native function parse(date:*):Number;
 

--- a/core/src/avm2/globals/Date.as
+++ b/core/src/avm2/globals/Date.as
@@ -122,59 +122,59 @@ package {
         }
         prototype.setFullYear = function(year:* = undefined, month:* = undefined, day:* = undefined):Number {
             var d:Date = this;
-            return d._setFullYear(arguments);
+            return d._setFullYear.apply(d, arguments);
         }
         prototype.setMonth = function(month:* = undefined, day:* = undefined):Number {
             var d:Date = this;
-            return d._setMonth(arguments);
+            return d._setMonth.apply(d, arguments);
         }
         prototype.setDate = function(day:* = undefined):Number {
             var d:Date = this;
-            return d._setDate(day);
+            return d._setDate.apply(d, arguments);
         }
         prototype.setHours = function(hour:* = undefined, min:* = undefined, sec:* = undefined, ms:* = undefined):Number {
             var d:Date = this;
-            return d._setHours(arguments);
+            return d._setHours.apply(d, arguments);
         }
         prototype.setMinutes = function(min:* = undefined, sec:* = undefined, ms:* = undefined):Number {
             var d:Date = this;
-            return d._setMinutes(arguments);
+            return d._setMinutes.apply(d, arguments);
         }
         prototype.setSeconds = function(sec:* = undefined, ms:* = undefined):Number {
             var d:Date = this;
-            return d._setSeconds(arguments);
+            return d._setSeconds.apply(d, arguments);
         }
         prototype.setMilliseconds = function(ms:* = undefined):Number {
             var d:Date = this;
-            return d._setMilliseconds(arguments);
+            return d._setMilliseconds.apply(d, arguments);
         }
         prototype.setUTCFullYear = function(year:* = undefined, month:* = undefined, day:* = undefined):Number {
             var d:Date = this;
-            return d._setUTCFullYear(arguments);
+            return d._setUTCFullYear.apply(d, arguments);
         }
         prototype.setUTCMonth = function(month:* = undefined, day:* = undefined):Number {
             var d:Date = this;
-            return d._setUTCMonth(arguments);
+            return d._setUTCMonth.apply(d, arguments);
         }
         prototype.setUTCDate = function(day:* = undefined):Number {
             var d:Date = this;
-            return d._setUTCDate(arguments);
+            return d._setUTCDate.apply(d, arguments);
         }
         prototype.setUTCHours = function(hour:* = undefined, min:* = undefined, sec:* = undefined, ms:* = undefined):Number {
             var d:Date = this;
-            return d._setUTCHours(arguments);
+            return d._setUTCHours.apply(d, arguments);
         }
         prototype.setUTCMinutes = function(min:* = undefined, sec:* = undefined, ms:* = undefined):Number {
             var d:Date = this;
-            return d._setUTCMinutes(arguments);
+            return d._setUTCMinutes.apply(d, arguments);
         }
         prototype.setUTCSeconds = function(sec:* = undefined, ms:* = undefined):Number {
             var d:Date = this;
-            return d._setUTCSeconds(arguments);
+            return d._setUTCSeconds.apply(d, arguments);
         }
         prototype.setUTCMilliseconds = function(ms:* = undefined):Number {
             var d:Date = this;
-            return d._setUTCMilliseconds(arguments);
+            return d._setUTCMilliseconds.apply(d, arguments);
         }
 
         prototype.setPropertyIsEnumerable("valueOf", false);
@@ -281,87 +281,87 @@ package {
         private native function _setTime(time:Number):Number;
 
         AS3 native function getFullYear():Number;
-        private native function _setFullYear(args:Array):Number;
+        private native function _setFullYear(...rest):Number;
         AS3 function setFullYear(year:* = undefined, month:* = undefined, day:* = undefined):Number {
-            return _setFullYear(arguments);
+            return this._setFullYear.apply(this, arguments);
         }
 
         AS3 native function getMonth():Number;
-        private native function _setMonth(args:Array):Number;
+        private native function _setMonth(...rest):Number;
         AS3 function setMonth(month:* = undefined, day:* = undefined):Number {
-            return _setMonth(arguments);
+            return this._setMonth.apply(this, arguments);
         }
 
         AS3 native function getDate():Number;
-        private native function _setDate(args:Array):Number;
+        private native function _setDate(...rest):Number;
         AS3 function setDate(day:* = undefined):Number {
-            return _setDate(arguments);
+            return this._setDate.apply(this, arguments);
         }
 
         AS3 native function getHours():Number;
-        private native function _setHours(args:Array):Number;
+        private native function _setHours(...rest):Number;
         AS3 function setHours(hour:* = undefined, min:* = undefined, sec:* = undefined, ms:* = undefined):Number {
-            return _setHours(arguments);
+            return this._setHours.apply(this, arguments);
         }
 
         AS3 native function getMinutes():Number;
-        private native function _setMinutes(args:Array):Number;
+        private native function _setMinutes(...rest):Number;
         AS3 function setMinutes(min:* = undefined, sec:* = undefined, ms:* = undefined):Number {
-            return _setMinutes(arguments);
+            return this._setMinutes.apply(this, arguments);
         }
 
         AS3 native function getSeconds():Number;
-        private native function _setSeconds(args:Array):Number;
+        private native function _setSeconds(...rest):Number;
         AS3 function setSeconds(sec:* = undefined, ms:* = undefined):Number {
-            return _setSeconds(arguments);
+            return this._setSeconds.apply(this, arguments);
         }
 
         AS3 native function getMilliseconds():Number;
-        private native function _setMilliseconds(args:Array):Number;
+        private native function _setMilliseconds(...rest):Number;
         AS3 function setMilliseconds(ms:* = undefined):Number {
-            return _setMilliseconds(arguments);
+            return this._setMilliseconds.apply(this, arguments);
         }
 
         AS3 native function getUTCFullYear():Number;
-        private native function _setUTCFullYear(args:Array):Number;
+        private native function _setUTCFullYear(...rest):Number;
         AS3 function setUTCFullYear(year:* = undefined, month:* = undefined, day:* = undefined):Number {
-            return _setUTCFullYear(arguments);
+            return this._setUTCFullYear.apply(this, arguments);
         }
 
         AS3 native function getUTCMonth():Number;
-        private native function _setUTCMonth(args:Array):Number;
+        private native function _setUTCMonth(...rest):Number;
         AS3 function setUTCMonth(month:* = undefined, day:* = undefined):Number {
-            return _setUTCMonth(arguments);
+            return this._setUTCMonth.apply(this, arguments);
         }
 
         AS3 native function getUTCDate():Number;
-        private native function _setUTCDate(args:Array):Number;
+        private native function _setUTCDate(...rest):Number;
         AS3 function setUTCDate(day:* = undefined):Number {
-            return _setUTCDate(arguments);
+            return this._setUTCDate.apply(this, arguments);
         }
 
         AS3 native function getUTCHours():Number;
-        private native function _setUTCHours(args:Array):Number;
+        private native function _setUTCHours(...rest):Number;
         AS3 function setUTCHours(hour:* = undefined, min:* = undefined, sec:* = undefined, ms:* = undefined):Number {
-            return _setUTCHours(arguments);
+            return this._setUTCHours.apply(this, arguments);
         }
 
         AS3 native function getUTCMinutes():Number;
-        private native function _setUTCMinutes(args:Array):Number;
+        private native function _setUTCMinutes(...rest):Number;
         AS3 function setUTCMinutes(min:* = undefined, sec:* = undefined, ms:* = undefined):Number {
-            return _setUTCMinutes(arguments);
+            return this._setUTCMinutes.apply(this, arguments);
         }
 
         AS3 native function getUTCSeconds():Number;
-        private native function _setUTCSeconds(args:Array):Number;
+        private native function _setUTCSeconds(...rest):Number;
         AS3 function setUTCSeconds(sec:* = undefined, ms:* = undefined):Number {
-            return _setUTCSeconds(arguments);
+            return this._setUTCSeconds.apply(this, arguments);
         }
 
         AS3 native function getUTCMilliseconds():Number;
-        private native function _setUTCMilliseconds(args:Array):Number;
+        private native function _setUTCMilliseconds(...rest):Number;
         AS3 function setUTCMilliseconds(ms:* = undefined):Number {
-            return _setUTCMilliseconds(arguments);
+            return this._setUTCMilliseconds.apply(this, arguments);
         }
 
 

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -182,15 +182,6 @@ impl<'builder, 'activation_a, 'gc, T: TimeZone> DateAdjustment<'builder, 'activa
     }
 }
 
-fn get_arguments_array<'gc>(args: &[Value<'gc>]) -> Vec<Value<'gc>> {
-    let object = args.try_get_object(0).expect("Expected an Object");
-    let array_storage = object.as_array_storage().unwrap();
-    array_storage
-        .iter()
-        .map(|v| v.unwrap()) // Arguments should be array with no holes
-        .collect()
-}
-
 pub fn init_custom_prototype<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
@@ -215,11 +206,10 @@ pub fn init<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let arguments = get_arguments_array(args);
 
-    let timestamp = arguments.get(0).unwrap_or(&Value::Undefined);
-    if timestamp != &Value::Undefined {
-        if arguments.len() > 1 {
+    let timestamp = args.get_optional(0).unwrap_or(Value::Undefined);
+    if timestamp != Value::Undefined {
+        if args.len() > 1 {
             let timezone = get_timezone();
 
             // We need a starting value to adjust from.
@@ -232,18 +222,18 @@ pub fn init<'gc>(
             ));
 
             DateAdjustment::new(activation, &timezone)
-                .year(arguments.get(0).copied())?
-                .month(arguments.get(1).copied())?
-                .day(arguments.get(2).copied())?
-                .hour(arguments.get(3).copied())?
-                .minute(arguments.get(4).copied())?
-                .second(arguments.get(5).copied())?
-                .millisecond(arguments.get(6).copied())?
+                .year(args.get_optional(0))?
+                .month(args.get_optional(1))?
+                .day(args.get_optional(2))?
+                .hour(args.get_optional(3))?
+                .minute(args.get_optional(4))?
+                .second(args.get_optional(5))?
+                .millisecond(args.get_optional(6))?
                 .map_year(|year| if year < 100.0 { year + 1900.0 } else { year })
                 .apply(this);
         } else {
             let timestamp = if let Value::String(date_str) = timestamp {
-                parse_full_date(activation, *date_str).unwrap_or(f64::NAN)
+                parse_full_date(activation, date_str).unwrap_or(f64::NAN)
             } else {
                 timestamp.coerce_to_number(activation)?
             };

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -51,7 +51,7 @@ impl<'builder, 'activation_a, 'gc, T: TimeZone> DateAdjustment<'builder, 'activa
         self
     }
 
-    fn year(&mut self, value: Option<&Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
+    fn year(&mut self, value: Option<Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
         self.year = match value {
             Some(value) => Some(Some(value.coerce_to_number(self.activation)?)),
             None => None,
@@ -59,7 +59,7 @@ impl<'builder, 'activation_a, 'gc, T: TimeZone> DateAdjustment<'builder, 'activa
         Ok(self)
     }
 
-    fn month(&mut self, value: Option<&Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
+    fn month(&mut self, value: Option<Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
         self.month = match value {
             Some(value) => Some(Some(value.coerce_to_number(self.activation)?)),
             None => None,
@@ -67,7 +67,7 @@ impl<'builder, 'activation_a, 'gc, T: TimeZone> DateAdjustment<'builder, 'activa
         Ok(self)
     }
 
-    fn day(&mut self, value: Option<&Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
+    fn day(&mut self, value: Option<Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
         self.day = match value {
             Some(value) => Some(Some(value.coerce_to_number(self.activation)?)),
             None => None,
@@ -75,7 +75,7 @@ impl<'builder, 'activation_a, 'gc, T: TimeZone> DateAdjustment<'builder, 'activa
         Ok(self)
     }
 
-    fn hour(&mut self, value: Option<&Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
+    fn hour(&mut self, value: Option<Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
         self.hour = match value {
             Some(value) => Some(Some(value.coerce_to_number(self.activation)?)),
             None => None,
@@ -83,7 +83,7 @@ impl<'builder, 'activation_a, 'gc, T: TimeZone> DateAdjustment<'builder, 'activa
         Ok(self)
     }
 
-    fn minute(&mut self, value: Option<&Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
+    fn minute(&mut self, value: Option<Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
         self.minute = match value {
             Some(value) => Some(Some(value.coerce_to_number(self.activation)?)),
             None => None,
@@ -91,7 +91,7 @@ impl<'builder, 'activation_a, 'gc, T: TimeZone> DateAdjustment<'builder, 'activa
         Ok(self)
     }
 
-    fn second(&mut self, value: Option<&Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
+    fn second(&mut self, value: Option<Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
         self.second = match value {
             Some(value) => Some(Some(value.coerce_to_number(self.activation)?)),
             None => None,
@@ -99,7 +99,7 @@ impl<'builder, 'activation_a, 'gc, T: TimeZone> DateAdjustment<'builder, 'activa
         Ok(self)
     }
 
-    fn millisecond(&mut self, value: Option<&Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
+    fn millisecond(&mut self, value: Option<Value<'gc>>) -> Result<&mut Self, Error<'gc>> {
         self.millisecond = match value {
             Some(value) => Some(Some(value.coerce_to_number(self.activation)?)),
             None => None,
@@ -232,13 +232,13 @@ pub fn init<'gc>(
             ));
 
             DateAdjustment::new(activation, &timezone)
-                .year(arguments.get(0))?
-                .month(arguments.get(1))?
-                .day(arguments.get(2))?
-                .hour(arguments.get(3))?
-                .minute(arguments.get(4))?
-                .second(arguments.get(5))?
-                .millisecond(arguments.get(6))?
+                .year(arguments.get(0).copied())?
+                .month(arguments.get(1).copied())?
+                .day(arguments.get(2).copied())?
+                .hour(arguments.get(3).copied())?
+                .minute(arguments.get(4).copied())?
+                .second(arguments.get(5).copied())?
+                .millisecond(arguments.get(6).copied())?
                 .map_year(|year| if year < 100.0 { year + 1900.0 } else { year })
                 .apply(this);
         } else {
@@ -338,10 +338,9 @@ pub fn _set_milliseconds<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &get_timezone())
-        .millisecond(args.get(0))?
+        .millisecond(args.get_optional(0))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -375,11 +374,10 @@ pub fn _set_seconds<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &get_timezone())
-        .second(args.get(0))?
-        .millisecond(args.get(1))?
+        .second(args.get_optional(0))?
+        .millisecond(args.get_optional(1))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -413,12 +411,11 @@ pub fn _set_minutes<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &get_timezone())
-        .minute(args.get(0))?
-        .second(args.get(1))?
-        .millisecond(args.get(2))?
+        .minute(args.get_optional(0))?
+        .second(args.get_optional(1))?
+        .millisecond(args.get_optional(2))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -452,13 +449,12 @@ pub fn _set_hours<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &get_timezone())
-        .hour(args.get(0))?
-        .minute(args.get(1))?
-        .second(args.get(2))?
-        .millisecond(args.get(3))?
+        .hour(args.get_optional(0))?
+        .minute(args.get_optional(1))?
+        .second(args.get_optional(2))?
+        .millisecond(args.get_optional(3))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -492,10 +488,9 @@ pub fn _set_date<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &get_timezone())
-        .day(args.get(0))?
+        .day(args.get_optional(0))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -529,11 +524,10 @@ pub fn _set_month<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &get_timezone())
-        .month(args.get(0))?
-        .day(args.get(1))?
+        .month(args.get_optional(0))?
+        .day(args.get_optional(1))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -567,7 +561,6 @@ pub fn _set_full_year<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timezone = get_timezone();
     if this.date_time().is_none() {
@@ -580,9 +573,9 @@ pub fn _set_full_year<'gc>(
         ));
     }
     let timestamp = DateAdjustment::new(activation, &timezone)
-        .year(args.get(0))?
-        .month(args.get(1))?
-        .day(args.get(2))?
+        .year(args.get_optional(0))?
+        .month(args.get_optional(1))?
+        .day(args.get_optional(2))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -633,10 +626,9 @@ pub fn _set_utc_milliseconds<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &Utc)
-        .millisecond(args.get(0))?
+        .millisecond(args.get_optional(0))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -667,11 +659,10 @@ pub fn _set_utc_seconds<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &Utc)
-        .second(args.get(0))?
-        .millisecond(args.get(1))?
+        .second(args.get_optional(0))?
+        .millisecond(args.get_optional(1))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -702,12 +693,11 @@ pub fn _set_utc_minutes<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &Utc)
-        .minute(args.get(0))?
-        .second(args.get(1))?
-        .millisecond(args.get(2))?
+        .minute(args.get_optional(0))?
+        .second(args.get_optional(1))?
+        .millisecond(args.get_optional(2))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -738,13 +728,12 @@ pub fn _set_utc_hours<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &Utc)
-        .hour(args.get(0))?
-        .minute(args.get(1))?
-        .second(args.get(2))?
-        .millisecond(args.get(3))?
+        .hour(args.get_optional(0))?
+        .minute(args.get_optional(1))?
+        .second(args.get_optional(2))?
+        .millisecond(args.get_optional(3))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -775,10 +764,9 @@ pub fn _set_utc_date<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &Utc)
-        .day(args.get(0))?
+        .day(args.get_optional(0))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -809,11 +797,10 @@ pub fn _set_utc_month<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     let timestamp = DateAdjustment::new(activation, &Utc)
-        .month(args.get(0))?
-        .day(args.get(1))?
+        .month(args.get_optional(0))?
+        .day(args.get_optional(1))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -844,7 +831,6 @@ pub fn _set_utc_full_year<'gc>(
     let this = this.as_object().unwrap();
 
     let this = this.as_date_object().unwrap();
-    let args = get_arguments_array(args);
 
     if this.date_time().is_none() {
         this.set_date_time(Some(
@@ -854,9 +840,9 @@ pub fn _set_utc_full_year<'gc>(
         ));
     }
     let timestamp = DateAdjustment::new(activation, &Utc)
-        .year(args.get(0))?
-        .month(args.get(1))?
-        .day(args.get(2))?
+        .year(args.get_optional(0))?
+        .month(args.get_optional(1))?
+        .day(args.get_optional(2))?
         .apply(this);
     Ok(timestamp.into())
 }
@@ -905,14 +891,22 @@ pub fn utc<'gc>(
     _this: Value<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    let year = args.get_value(0);
+    let month = args.get_value(1);
+    let day = args.get_value(2);
+    let hour = args.get_value(3);
+    let minute = args.get_value(4);
+    let second = args.get_value(5);
+    let millisecond = args.get_value(6);
+
     let date = DateAdjustment::new(activation, &Utc)
-        .year(args.get(0))?
-        .month(args.get(1))?
-        .day(args.get(2))?
-        .hour(args.get(3))?
-        .minute(args.get(4))?
-        .second(args.get(5))?
-        .millisecond(args.get(6))?
+        .year(Some(year))?
+        .month(Some(month))?
+        .day(Some(day))?
+        .hour(Some(hour))?
+        .minute(Some(minute))?
+        .second(Some(second))?
+        .millisecond(Some(millisecond))?
         .map_year(|year| if year < 100.0 { year + 1900.0 } else { year })
         .calculate(
             Utc.with_ymd_and_hms(0, 1, 1, 0, 0, 0)


### PR DESCRIPTION
## Description

Instead of creating an `arguments` array and using it to pass arguments to native methods, we can just pass the arguments as restargs directly. This ~~should be slightly more efficient.~~ is slightly shorter and allows us to remove the `get_arguments_array` method.

I've also switched `globals::date::utc` over to use `ParametersExt`.

## Testing

No Actionscript-observable changes.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
