### PR TITLE
desktop: Gate FreeType behind a feature

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -60,7 +60,6 @@ fontconfig = { version = "0.11.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = "0.12.1"
-ruffle_frontend_utils = { path = "../frontend-utils", features = ["freetype"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_System_Console", "Win32_Storage_FileSystem"] }
@@ -81,7 +80,7 @@ InternalName = "ruffle_desktop"
 OriginalFilename = "ruffle.exe"
 
 [features]
-default = ["software_video", "external_video", "lzma", "fontconfig"]
+default = ["software_video", "external_video", "lzma", "fontconfig", "freetype"]
 jpegxr = ["ruffle_core/jpegxr"]
 
 # core features
@@ -92,6 +91,7 @@ external_video = ["ruffle_video_external"]
 tracy = ["tracing-tracy", "ruffle_render_wgpu/profile-with-tracy"]
 fontconfig = ["dep:fontconfig"]
 fontconfig-dlopen = ["fontconfig", "fontconfig/dlopen"]
+freetype = ["ruffle_frontend_utils/freetype"]
 
 # wgpu features
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -439,7 +439,7 @@ fn load_font_from_file(
     device_font_renderer: DeviceFontRenderer,
 ) -> Result<FontDefinition<'static>> {
     match device_font_renderer {
-        #[cfg(target_os = "linux")]
+        #[cfg(all(target_os = "linux", feature = "freetype"))]
         DeviceFontRenderer::Freetype => {
             use ruffle_frontend_utils::backends::ui::FreetypeFontRenderer;
 

--- a/frontend-utils/Cargo.toml
+++ b/frontend-utils/Cargo.toml
@@ -52,6 +52,8 @@ reqwest = { workspace = true, features = [
 tokio = { workspace = true, features = ["net", "macros"], optional = true }
 cpal = { workspace = true, optional = true }
 bytemuck = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
 freetype-rs = { version = "0.38.0", optional = true }
 
 [dev-dependencies]

--- a/frontend-utils/src/backends/ui.rs
+++ b/frontend-utils/src/backends/ui.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "freetype")]
+#[cfg(all(target_os = "linux", feature = "freetype"))]
 mod freetype_font_renderer;
 
-#[cfg(feature = "freetype")]
+#[cfg(all(target_os = "linux", feature = "freetype"))]
 pub use freetype_font_renderer::FreetypeFontRenderer;


### PR DESCRIPTION
## Description

FreeType remains a Linux-specific dependency but now is put behind the freetype feature, so that Ruffle can be built without it on Linux.

## Testing

Checked it compiles without freetype.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
