### PR TITLE
avm2: Use f64 sign methods in f64_to_string

### DIFF
--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -16,7 +16,7 @@ use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use crate::string::{AvmAtom, AvmString, WStr};
 use gc_arena::Collect;
 use num_bigint::BigInt;
-use num_traits::{Signed, ToPrimitive, Zero};
+use num_traits::{ToPrimitive, Zero};
 use ruffle_macros::istr;
 use std::mem::size_of;
 use swf::avm2::types::DefaultValue as AbcDefaultValue;
@@ -465,7 +465,7 @@ fn f64_to_string<'gc>(n: f64, activation: &mut Activation<'_, 'gc>) -> AvmString
     if !n.is_finite() {
         return if n.is_nan() {
             istr!("NaN")
-        } else if n.is_positive() {
+        } else if n.is_sign_positive() {
             istr!("Infinity")
         } else {
             istr!("-Infinity")
@@ -480,7 +480,11 @@ fn f64_to_string<'gc>(n: f64, activation: &mut Activation<'_, 'gc>) -> AvmString
 }
 
 fn f64_to_string_finite_nonzero(n: f64) -> String {
-    let (sign, n) = if n.is_negative() { ("-", -n) } else { ("", n) };
+    let (sign, n) = if n.is_sign_negative() {
+        ("-", -n)
+    } else {
+        ("", n)
+    };
 
     if n >= 0.000001 && n < 1e+21 {
         // No exponent.


### PR DESCRIPTION
## Description

Use f64 sign methods instead of num_traits::Signed in f64_to_string. This prevents the name clash with f64's deprecated methods in older Rust and simplifies logic.

## Testing

Tests existing.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
