### PR TITLE
desktop: Remove the wgpu-report-to-tracy-plot feature

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -3,7 +3,7 @@ use crate::gui::{GuiController, MENU_HEIGHT};
 use crate::player::{LaunchOptions, PlayerController};
 use crate::preferences::GlobalPreferences;
 use crate::util::{
-    get_screen_size, gilrs_button_to_gamepad_button, plot_stats_in_tracy,
+    get_screen_size, gilrs_button_to_gamepad_button, mark_tracy_frame,
     winit_input_to_ruffle_key_descriptor, winit_to_ruffle_text_control,
 };
 use anyhow::Error;
@@ -54,7 +54,7 @@ impl MainWindow {
                 }
 
                 self.gui.render(player);
-                plot_stats_in_tracy(&self.gui.descriptors().wgpu_instance);
+                mark_tracy_frame();
             }
 
             // Important that we return here, or we'll get a feedback loop with egui

--- a/desktop/src/util.rs
+++ b/desktop/src/util.rs
@@ -394,26 +394,13 @@ pub fn parse_url(path: &Path) -> Result<Url, Error> {
 }
 
 #[cfg(not(feature = "tracy"))]
-pub fn plot_stats_in_tracy(_instance: &wgpu::Instance) {}
+pub fn mark_tracy_frame() {}
 
 #[cfg(feature = "tracy")]
-pub fn plot_stats_in_tracy(instance: &wgpu::Instance) {
+pub fn mark_tracy_frame() {
     use tracing_tracy::client::*;
-    const BIND_GROUPS: PlotName = plot_name!("Bind Groups");
-    const BUFFERS: PlotName = plot_name!("Buffers");
-    const TEXTURES: PlotName = plot_name!("Textures");
-    const TEXTURE_VIEWS: PlotName = plot_name!("Texture Views");
 
     let tracy = Client::running().expect("tracy client must be running");
-    let report = instance
-        .generate_report()
-        .expect("reports should be available on desktop");
-
-    tracy.plot(BIND_GROUPS, report.hub.bind_groups.num_allocated as f64);
-    tracy.plot(BUFFERS, report.hub.buffers.num_allocated as f64);
-    tracy.plot(TEXTURES, report.hub.textures.num_allocated as f64);
-    tracy.plot(TEXTURE_VIEWS, report.hub.texture_views.num_allocated as f64);
-
     tracy.frame_mark();
 }
 


### PR DESCRIPTION
I don't think we've used this more than a handful of times, but the wgpu report mechanism is being removed soon so I figure let's just remove it now and save ourselves trouble later.

## Description

We still want to keep the tracy frame mark, so I renamed the method and made it do just that.

## Testing

It compiles with and without the flag, and tracy seems fine.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
