### PR TITLE
avm2: Add a method to ParametersExt to allow slicing it

### DIFF
--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -681,7 +681,11 @@ pub fn splice<'gc>(
         .coerce_to_i32(activation)?
         .max(0);
 
-    let args_slice = if args.len() > 2 { &args[2..] } else { &[] };
+    let args_slice = if args.len() > 2 {
+        args.get_slice_from(2..)
+    } else {
+        &[]
+    };
 
     // FIXME Flash does not iterate over those elements like we do, it's too
     //   inefficient. Flash probably iterates through set properties only.

--- a/core/src/avm2/globals/flash/net/local_connection.rs
+++ b/core/src/avm2/globals/flash/net/local_connection.rs
@@ -50,7 +50,7 @@ pub fn send<'gc>(
     }
 
     let mut amf_arguments = Vec::with_capacity(args.len() - 2);
-    for arg in &args[2..] {
+    for arg in args.get_slice_from(2..) {
         let value = serialize_value(activation, *arg, AMFVersion::AMF0, &mut Default::default());
         amf_arguments.push(value);
     }

--- a/core/src/avm2/globals/flash/net/net_connection.rs
+++ b/core/src/avm2/globals/flash/net/net_connection.rs
@@ -281,7 +281,7 @@ pub fn call<'gc>(
     let mut arguments = Vec::new();
 
     let mut object_table = FnvHashMap::default();
-    for arg in &args[2..] {
+    for arg in args.get_slice_from(2..) {
         let value = serialize_value(activation, *arg, AMFVersion::AMF0, &mut object_table);
         arguments.push(Rc::new(value));
     }

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -34,7 +34,7 @@ pub fn set_interval<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let closure = args.try_get_function(0);
     let interval = args.get_f64(1);
-    let params = &args[2..];
+    let params = args.get_slice_from(2..);
 
     let callback = crate::timer::TimerCallback::Avm2Callback {
         closure,
@@ -67,7 +67,7 @@ pub fn set_timeout<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let closure = args.try_get_function(0);
     let interval = args.get_f64(1);
-    let params = &args[2..];
+    let params = args.get_slice_from(2..);
 
     let callback = crate::timer::TimerCallback::Avm2Callback {
         closure,

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -71,12 +71,8 @@ pub fn call<'gc>(
 
     let this = args.get_value(0);
 
-    if args.len() > 1 {
-        let passed_args = &args[1..];
-        Ok(func.call(activation, this, FunctionArgs::from_slice(passed_args))?)
-    } else {
-        Ok(func.call(activation, this, FunctionArgs::empty())?)
-    }
+    let passed_args = args.get_slice_from(1..);
+    func.call(activation, this, FunctionArgs::from_slice(passed_args))
 }
 
 /// Implements `Function.prototype.apply`

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -701,7 +701,7 @@ pub fn splice<'gc>(
     // Make sure vector is not borrowed while coercing which can have side-effects.
 
     let mut coerced_args = Vec::new();
-    for value in args[2..].iter() {
+    for value in args.get_slice_from(2..).iter() {
         coerced_args.push(value.coerce_to_type(activation, value_type_for_coercion)?);
     }
 

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -596,7 +596,11 @@ pub fn namespace_internal_impl<'gc>(
     let mut children = list.children_mut(activation.gc());
 
     let has_prefix = args.get_bool(0);
-    let args = if has_prefix { &args[1..] } else { &[] };
+    let args: &[Value<'gc>] = if has_prefix {
+        &[args.get_value(1)]
+    } else {
+        &[]
+    };
 
     match &mut children[..] {
         [child] => Value::from(child.get_or_create_xml(activation)).call_method(

--- a/core/src/avm2/parameters.rs
+++ b/core/src/avm2/parameters.rs
@@ -4,6 +4,7 @@ use crate::avm2::{Activation, Error, Value};
 use crate::string::AvmString;
 
 use ruffle_macros::istr;
+use std::ops::RangeFrom;
 
 /// Extensions over parameters that are passed into AS-defined, Rust-implemented methods.
 ///
@@ -34,6 +35,10 @@ pub trait ParametersExt<'gc> {
 
     /// Gets the value at the given index, if it exists.
     fn get_optional(&self, index: usize) -> Option<Value<'gc>>;
+
+    /// Get a slice of these values using a `RangeFrom`. This method will panic
+    /// if the range is out of bounds.
+    fn get_slice_from(&self, range: RangeFrom<usize>) -> Self;
 
     /// Gets the value at the given index as an Object. It is expected that the
     /// value is either Object or Null.
@@ -156,5 +161,10 @@ impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
     #[inline]
     fn get_optional(&self, index: usize) -> Option<Value<'gc>> {
         self.get(index).copied()
+    }
+
+    #[inline]
+    fn get_slice_from(&self, range: RangeFrom<usize>) -> Self {
+        &self[range]
     }
 }


### PR DESCRIPTION
## Description

Add `ParametersExt::get_slice_from`, which allows for slicing implementers of `ParametersExt` with a `RangeFrom`.

## Testing

No functional changes.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
