### PR TITLE
tests: Add FreeType variants to more tests

### DIFF
--- a/tests/tests/swfs/avm2/edittext_device_transform_layout/output.freetype.ruffle.txt
+++ b/tests/tests/swfs/avm2/edittext_device_transform_layout/output.freetype.ruffle.txt
@@ -1,0 +1,288 @@
+Word wrap, device=false, scaleX=1, scaleY=1
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Word wrap, device=false, scaleX=2, scaleY=1
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Word wrap, device=false, scaleX=1, scaleY=2
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Word wrap, device=false, scaleX=2, scaleY=2
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Word wrap, device=true, scaleX=1, scaleY=1
+  0: (x=2, y=2, w=8, h=10.1)
+  1: (x=10, y=2, w=8, h=10.1)
+  2: (x=18, y=2, w=8, h=10.1)
+  3: (x=26, y=2, w=8, h=10.1)
+  4: (x=34, y=2, w=8, h=10.1)
+  5: (x=42, y=2, w=8, h=10.1)
+  6: (x=50, y=2, w=8, h=10.1)
+  7: (x=2, y=12.1, w=8, h=10.1)
+Word wrap, device=true, scaleX=2, scaleY=1
+  0: (x=2, y=2, w=4, h=10.1)
+  1: (x=6, y=2, w=4, h=10.1)
+  2: (x=10, y=2, w=4, h=10.1)
+  3: (x=14, y=2, w=4, h=10.1)
+  4: (x=18, y=2, w=4, h=10.1)
+  5: (x=22, y=2, w=4, h=10.1)
+  6: (x=26, y=2, w=4, h=10.1)
+  7: (x=30, y=2, w=4, h=10.1)
+Word wrap, device=true, scaleX=1, scaleY=2
+  0: (x=2, y=2, w=16, h=10.1)
+  1: (x=18, y=2, w=16, h=10.1)
+  2: (x=34, y=2, w=16, h=10.1)
+  3: (x=2, y=12.1, w=16, h=10.1)
+  4: (x=18, y=12.1, w=16, h=10.1)
+  5: (x=34, y=12.1, w=16, h=10.1)
+  6: (x=2, y=22.2, w=16, h=10.1)
+  7: (x=18, y=22.2, w=16, h=10.1)
+Word wrap, device=true, scaleX=2, scaleY=2
+  0: (x=2, y=2, w=8, h=10.1)
+  1: (x=10, y=2, w=8, h=10.1)
+  2: (x=18, y=2, w=8, h=10.1)
+  3: (x=26, y=2, w=8, h=10.1)
+  4: (x=34, y=2, w=8, h=10.1)
+  5: (x=42, y=2, w=8, h=10.1)
+  6: (x=50, y=2, w=8, h=10.1)
+  7: (x=2, y=12.1, w=8, h=10.1)
+Text align, align=center, device=false, scaleX=1, scaleY=1
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=center, device=false, scaleX=2, scaleY=1
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=center, device=false, scaleX=1, scaleY=2
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=center, device=false, scaleX=2, scaleY=2
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=center, device=true, scaleX=1, scaleY=1
+  0: (x=22, y=2, w=8, h=10.1)
+  1: (x=30, y=2, w=8, h=10.1)
+Text align, align=center, device=true, scaleX=2, scaleY=1
+  0: (x=12, y=2, w=4, h=10.1)
+  1: (x=16, y=2, w=4, h=10.1)
+Text align, align=center, device=true, scaleX=1, scaleY=2
+  0: (x=42, y=2, w=16, h=10.1)
+  1: (x=58, y=2, w=16, h=10.1)
+Text align, align=center, device=true, scaleX=2, scaleY=2
+  0: (x=22, y=2, w=8, h=10.1)
+  1: (x=30, y=2, w=8, h=10.1)
+Text align, align=right, device=false, scaleX=1, scaleY=1
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Text align, align=right, device=false, scaleX=2, scaleY=1
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Text align, align=right, device=false, scaleX=1, scaleY=2
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Text align, align=right, device=false, scaleX=2, scaleY=2
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Text align, align=right, device=true, scaleX=1, scaleY=1
+  0: (x=42, y=2, w=8, h=10.1)
+  1: (x=50, y=2, w=8, h=10.1)
+Text align, align=right, device=true, scaleX=2, scaleY=1
+  0: (x=22, y=2, w=4, h=10.1)
+  1: (x=26, y=2, w=4, h=10.1)
+Text align, align=right, device=true, scaleX=1, scaleY=2
+  0: (x=82, y=2, w=16, h=10.1)
+  1: (x=98, y=2, w=16, h=10.1)
+Text align, align=right, device=true, scaleX=2, scaleY=2
+  0: (x=42, y=2, w=8, h=10.1)
+  1: (x=50, y=2, w=8, h=10.1)
+Auto size, autoSize=left, device=false, scaleX=1, scaleY=1
+  x: 0
+  y: 0
+  width: 20
+  height: 14
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=left, device=false, scaleX=2, scaleY=1
+  x: 0
+  y: 0
+  width: 40
+  height: 14
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=left, device=false, scaleX=1, scaleY=2
+  x: 0
+  y: 0
+  width: 20
+  height: 28
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=left, device=false, scaleX=2, scaleY=2
+  x: 0
+  y: 0
+  width: 40
+  height: 28
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=left, device=true, scaleX=1, scaleY=1
+  x: 0
+  y: 0
+  width: 20
+  height: 14.1
+  0: (x=2, y=2, w=8, h=10.1)
+  1: (x=10, y=2, w=8, h=10.1)
+Auto size, autoSize=left, device=true, scaleX=2, scaleY=1
+  x: 0
+  y: 0
+  width: 24
+  height: 14.1
+  0: (x=2, y=2, w=4, h=10.1)
+  1: (x=6, y=2, w=4, h=10.1)
+Auto size, autoSize=left, device=true, scaleX=1, scaleY=2
+  x: 0
+  y: 0
+  width: 36
+  height: 28.2
+  0: (x=2, y=2, w=16, h=10.1)
+  1: (x=18, y=2, w=16, h=10.1)
+Auto size, autoSize=left, device=true, scaleX=2, scaleY=2
+  x: 0
+  y: 0
+  width: 40
+  height: 28.2
+  0: (x=2, y=2, w=8, h=10.1)
+  1: (x=10, y=2, w=8, h=10.1)
+Auto size, autoSize=center, device=false, scaleX=1, scaleY=1
+  x: 20
+  y: 0
+  width: 20
+  height: 14
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=center, device=false, scaleX=2, scaleY=1
+  x: 40
+  y: 0
+  width: 40
+  height: 14
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=center, device=false, scaleX=1, scaleY=2
+  x: 20
+  y: 0
+  width: 20
+  height: 28
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=center, device=false, scaleX=2, scaleY=2
+  x: 40
+  y: 0
+  width: 40
+  height: 28
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=center, device=true, scaleX=1, scaleY=1
+  x: 20
+  y: 0
+  width: 20
+  height: 14.1
+  0: (x=22, y=2, w=8, h=10.1)
+  1: (x=30, y=2, w=8, h=10.1)
+Auto size, autoSize=center, device=true, scaleX=2, scaleY=1
+  x: 48
+  y: 0
+  width: 24
+  height: 14.1
+  0: (x=26, y=2, w=4, h=10.1)
+  1: (x=30, y=2, w=4, h=10.1)
+Auto size, autoSize=center, device=true, scaleX=1, scaleY=2
+  x: 12
+  y: 0
+  width: 36
+  height: 28.2
+  0: (x=14, y=2, w=16, h=10.1)
+  1: (x=30, y=2, w=16, h=10.1)
+Auto size, autoSize=center, device=true, scaleX=2, scaleY=2
+  x: 40
+  y: 0
+  width: 40
+  height: 28.2
+  0: (x=22, y=2, w=8, h=10.1)
+  1: (x=30, y=2, w=8, h=10.1)
+Auto size, autoSize=right, device=false, scaleX=1, scaleY=1
+  x: 40
+  y: 0
+  width: 20
+  height: 14
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Auto size, autoSize=right, device=false, scaleX=2, scaleY=1
+  x: 80
+  y: 0
+  width: 40
+  height: 14
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Auto size, autoSize=right, device=false, scaleX=1, scaleY=2
+  x: 40
+  y: 0
+  width: 20
+  height: 28
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Auto size, autoSize=right, device=false, scaleX=2, scaleY=2
+  x: 80
+  y: 0
+  width: 40
+  height: 28
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Auto size, autoSize=right, device=true, scaleX=1, scaleY=1
+  x: 40
+  y: 0
+  width: 20
+  height: 14.1
+  0: (x=42, y=2, w=8, h=10.1)
+  1: (x=50, y=2, w=8, h=10.1)
+Auto size, autoSize=right, device=true, scaleX=2, scaleY=1
+  x: 96
+  y: 0
+  width: 24
+  height: 14.1
+  0: (x=50, y=2, w=4, h=10.1)
+  1: (x=54, y=2, w=4, h=10.1)
+Auto size, autoSize=right, device=true, scaleX=1, scaleY=2
+  x: 24
+  y: 0
+  width: 36
+  height: 28.2
+  0: (x=26, y=2, w=16, h=10.1)
+  1: (x=42, y=2, w=16, h=10.1)
+Auto size, autoSize=right, device=true, scaleX=2, scaleY=2
+  x: 80
+  y: 0
+  width: 40
+  height: 28.2
+  0: (x=42, y=2, w=8, h=10.1)
+  1: (x=50, y=2, w=8, h=10.1)

--- a/tests/tests/swfs/avm2/edittext_device_transform_layout/output.freetype.txt
+++ b/tests/tests/swfs/avm2/edittext_device_transform_layout/output.freetype.txt
@@ -1,0 +1,288 @@
+Word wrap, device=false, scaleX=1, scaleY=1
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Word wrap, device=false, scaleX=2, scaleY=1
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Word wrap, device=false, scaleX=1, scaleY=2
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Word wrap, device=false, scaleX=2, scaleY=2
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Word wrap, device=true, scaleX=1, scaleY=1
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Word wrap, device=true, scaleX=2, scaleY=1
+  0: (x=2, y=2, w=4, h=10)
+  1: (x=6, y=2, w=4, h=10)
+  2: (x=10, y=2, w=4, h=10)
+  3: (x=14, y=2, w=4, h=10)
+  4: (x=18, y=2, w=4, h=10)
+  5: (x=22, y=2, w=4, h=10)
+  6: (x=26, y=2, w=4, h=10)
+  7: (x=30, y=2, w=4, h=10)
+Word wrap, device=true, scaleX=1, scaleY=2
+  0: (x=2, y=2, w=16, h=10)
+  1: (x=18, y=2, w=16, h=10)
+  2: (x=34, y=2, w=16, h=10)
+  3: (x=2, y=12, w=16, h=10)
+  4: (x=18, y=12, w=16, h=10)
+  5: (x=34, y=12, w=16, h=10)
+  6: (x=2, y=22, w=16, h=10)
+  7: (x=18, y=22, w=16, h=10)
+Word wrap, device=true, scaleX=2, scaleY=2
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+  2: (x=18, y=2, w=8, h=10)
+  3: (x=26, y=2, w=8, h=10)
+  4: (x=34, y=2, w=8, h=10)
+  5: (x=42, y=2, w=8, h=10)
+  6: (x=50, y=2, w=8, h=10)
+  7: (x=2, y=12, w=8, h=10)
+Text align, align=center, device=false, scaleX=1, scaleY=1
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=center, device=false, scaleX=2, scaleY=1
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=center, device=false, scaleX=1, scaleY=2
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=center, device=false, scaleX=2, scaleY=2
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=center, device=true, scaleX=1, scaleY=1
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=center, device=true, scaleX=2, scaleY=1
+  0: (x=26, y=2, w=4, h=10)
+  1: (x=30, y=2, w=4, h=10)
+Text align, align=center, device=true, scaleX=1, scaleY=2
+  0: (x=14, y=2, w=16, h=10)
+  1: (x=30, y=2, w=16, h=10)
+Text align, align=center, device=true, scaleX=2, scaleY=2
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Text align, align=right, device=false, scaleX=1, scaleY=1
+  0: (x=41.95, y=2, w=8, h=10)
+  1: (x=49.95, y=2, w=8, h=10)
+Text align, align=right, device=false, scaleX=2, scaleY=1
+  0: (x=41.95, y=2, w=8, h=10)
+  1: (x=49.95, y=2, w=8, h=10)
+Text align, align=right, device=false, scaleX=1, scaleY=2
+  0: (x=41.95, y=2, w=8, h=10)
+  1: (x=49.95, y=2, w=8, h=10)
+Text align, align=right, device=false, scaleX=2, scaleY=2
+  0: (x=41.95, y=2, w=8, h=10)
+  1: (x=49.95, y=2, w=8, h=10)
+Text align, align=right, device=true, scaleX=1, scaleY=1
+  0: (x=41, y=2, w=8, h=10)
+  1: (x=49, y=2, w=8, h=10)
+Text align, align=right, device=true, scaleX=2, scaleY=1
+  0: (x=49.5, y=2, w=4, h=10)
+  1: (x=53.5, y=2, w=4, h=10)
+Text align, align=right, device=true, scaleX=1, scaleY=2
+  0: (x=25, y=2, w=16, h=10)
+  1: (x=41, y=2, w=16, h=10)
+Text align, align=right, device=true, scaleX=2, scaleY=2
+  0: (x=41.5, y=2, w=8, h=10)
+  1: (x=49.5, y=2, w=8, h=10)
+Auto size, autoSize=left, device=false, scaleX=1, scaleY=1
+  x: 0
+  y: 0
+  width: 20
+  height: 14
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=left, device=false, scaleX=2, scaleY=1
+  x: 0
+  y: 0
+  width: 40
+  height: 14
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=left, device=false, scaleX=1, scaleY=2
+  x: 0
+  y: 0
+  width: 20
+  height: 28
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=left, device=false, scaleX=2, scaleY=2
+  x: 0
+  y: 0
+  width: 40
+  height: 28
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=left, device=true, scaleX=1, scaleY=1
+  x: 0
+  y: 0
+  width: 20
+  height: 14
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=left, device=true, scaleX=2, scaleY=1
+  x: 0
+  y: 0
+  width: 24
+  height: 14
+  0: (x=2, y=2, w=4, h=10)
+  1: (x=6, y=2, w=4, h=10)
+Auto size, autoSize=left, device=true, scaleX=1, scaleY=2
+  x: 0
+  y: 0
+  width: 36
+  height: 28
+  0: (x=2, y=2, w=16, h=10)
+  1: (x=18, y=2, w=16, h=10)
+Auto size, autoSize=left, device=true, scaleX=2, scaleY=2
+  x: 0
+  y: 0
+  width: 40
+  height: 28
+  0: (x=2, y=2, w=8, h=10)
+  1: (x=10, y=2, w=8, h=10)
+Auto size, autoSize=center, device=false, scaleX=1, scaleY=1
+  x: 20
+  y: 0
+  width: 20
+  height: 14
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=center, device=false, scaleX=2, scaleY=1
+  x: 40
+  y: 0
+  width: 40
+  height: 14
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=center, device=false, scaleX=1, scaleY=2
+  x: 20
+  y: 0
+  width: 20
+  height: 28
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=center, device=false, scaleX=2, scaleY=2
+  x: 40
+  y: 0
+  width: 40
+  height: 28
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=center, device=true, scaleX=1, scaleY=1
+  x: 20
+  y: 0
+  width: 20
+  height: 14
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=center, device=true, scaleX=2, scaleY=1
+  x: 48
+  y: 0
+  width: 24
+  height: 14
+  0: (x=26, y=2, w=4, h=10)
+  1: (x=30, y=2, w=4, h=10)
+Auto size, autoSize=center, device=true, scaleX=1, scaleY=2
+  x: 12
+  y: 0
+  width: 36
+  height: 28
+  0: (x=14, y=2, w=16, h=10)
+  1: (x=30, y=2, w=16, h=10)
+Auto size, autoSize=center, device=true, scaleX=2, scaleY=2
+  x: 40
+  y: 0
+  width: 40
+  height: 28
+  0: (x=22, y=2, w=8, h=10)
+  1: (x=30, y=2, w=8, h=10)
+Auto size, autoSize=right, device=false, scaleX=1, scaleY=1
+  x: 40
+  y: 0
+  width: 20
+  height: 14
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Auto size, autoSize=right, device=false, scaleX=2, scaleY=1
+  x: 80
+  y: 0
+  width: 40
+  height: 14
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Auto size, autoSize=right, device=false, scaleX=1, scaleY=2
+  x: 40
+  y: 0
+  width: 20
+  height: 28
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Auto size, autoSize=right, device=false, scaleX=2, scaleY=2
+  x: 80
+  y: 0
+  width: 40
+  height: 28
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Auto size, autoSize=right, device=true, scaleX=1, scaleY=1
+  x: 40
+  y: 0
+  width: 20
+  height: 14
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)
+Auto size, autoSize=right, device=true, scaleX=2, scaleY=1
+  x: 96
+  y: 0
+  width: 24
+  height: 14
+  0: (x=50, y=2, w=4, h=10)
+  1: (x=54, y=2, w=4, h=10)
+Auto size, autoSize=right, device=true, scaleX=1, scaleY=2
+  x: 24
+  y: 0
+  width: 36
+  height: 28
+  0: (x=26, y=2, w=16, h=10)
+  1: (x=42, y=2, w=16, h=10)
+Auto size, autoSize=right, device=true, scaleX=2, scaleY=2
+  x: 80
+  y: 0
+  width: 40
+  height: 28
+  0: (x=42, y=2, w=8, h=10)
+  1: (x=50, y=2, w=8, h=10)

--- a/tests/tests/swfs/avm2/edittext_device_transform_layout/test.toml
+++ b/tests/tests/swfs/avm2/edittext_device_transform_layout/test.toml
@@ -6,3 +6,13 @@ family = "TestFont"
 path = "TestFont.ttf"
 bold = false
 italic = false
+
+[subtests.embedded.player_options]
+device_font_renderer = "embedded"
+
+[subtests.freetype]
+output_path = "output.freetype.txt"
+known_failure = true
+
+[subtests.freetype.player_options]
+device_font_renderer = "freetype"

--- a/tests/tests/swfs/fonts/device_font_glyph_fallback/test.toml
+++ b/tests/tests/swfs/fonts/device_font_glyph_fallback/test.toml
@@ -11,3 +11,9 @@ path = "TestFontB.ttf"
 [font_sorts.a]
 family = "TestFontA"
 sort = ["a", "b"]
+
+[subtests.embedded.player_options]
+device_font_renderer = "embedded"
+
+[subtests.freetype.player_options]
+device_font_renderer = "freetype"

--- a/tests/tests/swfs/fonts/device_font_kerning/test.toml
+++ b/tests/tests/swfs/fonts/device_font_kerning/test.toml
@@ -9,3 +9,9 @@ with_renderer = { optional = false, quality = "high" }
 [fonts.a]
 family = "TestFont"
 path = "TestFont.ttf"
+
+[subtests.embedded.player_options]
+device_font_renderer = "embedded"
+
+[subtests.freetype.player_options]
+device_font_renderer = "freetype"

--- a/tests/tests/swfs/visual/edittext/edittext_device_transform_metrics/output.freetype.ruffle.txt
+++ b/tests/tests/swfs/visual/edittext/edittext_device_transform_metrics/output.freetype.ruffle.txt
@@ -1,0 +1,40 @@
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+false = height=10,width=16,x=2,ascent=8,descent=2
+false = 120
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+false = height=10,width=16,x=2,ascent=8,descent=2
+false = 120
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+false = height=10,width=16,x=2,ascent=8,descent=2
+false = 120
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+false = height=10,width=16,x=2,ascent=8,descent=2
+false = 120
+false = 16
+true = (x=2, y=2, w=8, h=10.1),(x=10, y=2, w=8, h=10.1)
+true = 0,0,0,0,1,1,1,-1,-1,0,1,
+true = height=10,width=16,x=2,ascent=8,descent=2
+true = 121.2
+true = 16
+true = (x=2, y=2, w=4, h=10.1),(x=6, y=2, w=4, h=10.1)
+true = 0,0,0,0,1,1,1,-1,-1,0,1,
+true = height=10,width=8,x=2,ascent=8,descent=2
+true = 121.2
+true = 8
+true = (x=2, y=2, w=16, h=10.1),(x=18, y=2, w=16, h=10.1)
+true = 0,0,0,0,1,1,1,-1,-1,0,1,
+true = height=10,width=32,x=2,ascent=8,descent=2
+true = 121.2
+true = 32
+true = (x=2, y=2, w=8, h=10.1),(x=10, y=2, w=8, h=10.1)
+true = 0,0,0,0,1,1,1,-1,-1,0,1,
+true = height=10,width=16,x=2,ascent=8,descent=2
+true = 121.2
+true = 16

--- a/tests/tests/swfs/visual/edittext/edittext_device_transform_metrics/output.freetype.txt
+++ b/tests/tests/swfs/visual/edittext/edittext_device_transform_metrics/output.freetype.txt
@@ -1,0 +1,40 @@
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+false = height=10,width=16,x=2,ascent=8,descent=2
+false = 120
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+false = height=10,width=16,x=2,ascent=8,descent=2
+false = 120
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+false = height=10,width=16,x=2,ascent=8,descent=2
+false = 120
+false = 16
+false = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+false = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+false = height=10,width=16,x=2,ascent=8,descent=2
+false = 120
+false = 16
+true = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+true = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+true = height=10,width=16,x=102,ascent=8,descent=2
+true = 120
+true = 16
+true = (x=2, y=2, w=4, h=10),(x=6, y=2, w=4, h=10)
+true = 0,0,0,1,-1,-1,-1,-1,-1,-1,-1,
+true = height=5,width=8,x=52,ascent=4,descent=1
+true = 60
+true = 8
+true = (x=2, y=2, w=16, h=10),(x=18, y=2, w=16, h=10)
+true = 0,0,0,0,0,0,0,-1,-1,-1,-1,
+true = height=20,width=32,x=102,ascent=16,descent=4
+true = 240
+true = 32
+true = (x=2, y=2, w=8, h=10),(x=10, y=2, w=8, h=10)
+true = 0,0,0,0,1,1,1,-1,-1,-1,-1,
+true = height=10,width=16,x=52,ascent=8,descent=2
+true = 120
+true = 16

--- a/tests/tests/swfs/visual/edittext/edittext_device_transform_metrics/test.toml
+++ b/tests/tests/swfs/visual/edittext/edittext_device_transform_metrics/test.toml
@@ -6,3 +6,15 @@ family = "TestFont"
 path = "TestFont.ttf"
 bold = false
 italic = false
+
+[subtests.embedded.player_options]
+device_font_renderer = "embedded"
+
+[subtests.freetype]
+output_path = "output.freetype.txt"
+
+# TODO It currently fails because glyph scaling is not implemented properly.
+known_failure = true
+
+[subtests.freetype.player_options]
+device_font_renderer = "freetype"

--- a/tests/tests/swfs/visual/fonts/leading_device_font/test.toml
+++ b/tests/tests/swfs/visual/fonts/leading_device_font/test.toml
@@ -17,3 +17,13 @@ family = "TestFontGap100"
 path = "TestFontGap100.ttf"
 bold = false
 italic = false
+
+[subtests.embedded.player_options]
+device_font_renderer = "embedded"
+
+[subtests.freetype.player_options]
+device_font_renderer = "freetype"
+
+[subtests.freetype.image_comparisons.output]
+# TODO This could probably be fixed by implementing scaling properly.
+tolerance = 195


### PR DESCRIPTION
## Description

Adds FreeType variants to more tests. This improves test coverage for bitmap fonts.

## Testing

Yes.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
