### PR TITLE
Fix AVM1 rewind placement replacement

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1785,7 +1785,7 @@ impl<'gc> MovieClip<'gc> {
         }
 
         // Run the list of goto commands to actually create and update the display objects.
-        let run_goto_command = |clip: MovieClip<'gc>,
+        let run_goto_command = |mut clip: MovieClip<'gc>,
                                 context: &mut UpdateContext<'gc>,
                                 params: &GotoPlaceObject<'_>| {
             use swf::PlaceObjectAction;
@@ -1819,6 +1819,21 @@ impl<'gc> MovieClip<'gc> {
                 // If the ID is 0, we are modifying a previous child. Otherwise, we're replacing it.
                 // If it's a rewind, we removed any dead children above, so we always
                 // modify the previous child.
+                //
+                // A `Place` can still replace an object when the destination
+                // frame uses a different character at the same depth. Reusing
+                // the old child here leaves the previous scene visible after
+                // a label-based rewind.
+                (PlaceObjectAction::Place(id), Some(prev_child), true)
+                    if prev_child.id() != id =>
+                {
+                    clip.remove_child(context, prev_child);
+                    if let Some(child) =
+                        clip.instantiate_child(context, id, params.depth(), &params.place_object)
+                    {
+                        child.set_place_frame(params.frame);
+                    }
+                }
                 (_, Some(prev_child), true) | (PlaceObjectAction::Modify, Some(prev_child), _) => {
                     prev_child.apply_place_object(context, &params.place_object);
                 }


### PR DESCRIPTION
## Description

Fixes an AVM1 timeline bug during rewind-style gotoAndPlay transitions. If a PlaceObject tag revisits an occupied depth but requests a different character, Ruffle previously applied the tag to the old MovieClip. MovieClips do not replace their character through that update path, leaving the stale clip on stage.

The fix removes the mismatched child and instantiates the requested character. Matching children retain the existing update path.

This was reproduced in a legacy DragonFable room timeline: the stale clip prevented the destination scene from loading. No game assets or launcher-specific code are included.

## Testing

- Ran cargo check --package ruffle_core.
- Manually reproduced the transition in DragonFable before and after the change. Calamity and Blood and Roses now proceed through their affected transitions.
- No automated regression test has been added yet. The current reproduction uses externally hosted game content; I am happy to add a minimal test if a maintainer can point me to the preferred AVM1 timeline-test pattern.

## Checklist

- [ ] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have made or updated tests where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.