### PR TITLE
debug_ui: Add a font inspector window

### DIFF
--- a/core/src/debug_ui.rs
+++ b/core/src/debug_ui.rs
@@ -4,6 +4,7 @@ mod avm2_class;
 mod common;
 mod display_object;
 mod domain;
+mod font;
 mod handle;
 mod movie;
 
@@ -13,8 +14,9 @@ use crate::debug_ui::avm2::Avm2ObjectWindow;
 use crate::debug_ui::avm2_class::Avm2ClassWindow;
 use crate::debug_ui::display_object::{DisplayObjectSearchWindow, DisplayObjectWindow};
 use crate::debug_ui::domain::DomainListWindow;
+use crate::debug_ui::font::FontWindow;
 use crate::debug_ui::handle::{
-    AVM1ObjectHandle, AVM2ObjectHandle, ClassHandle, DisplayObjectHandle, DomainHandle,
+    AVM1ObjectHandle, AVM2ObjectHandle, ClassHandle, DisplayObjectHandle, DomainHandle, FontHandle,
 };
 use crate::debug_ui::movie::{MovieListWindow, MovieWindow};
 use crate::display_object::TDisplayObject;
@@ -35,6 +37,7 @@ pub struct DebugUi {
     avm2_objects: HashMap<AVM2ObjectHandle, Avm2ObjectWindow>,
     avm2_classes: HashMap<ClassHandle, Avm2ClassWindow>,
     domains: HashMap<DomainHandle, DomainListWindow>,
+    fonts: HashMap<FontHandle, FontWindow>,
     queued_messages: Vec<Message>,
     items_to_save: Vec<ItemToSave>,
     movie_list: Option<MovieListWindow>,
@@ -50,6 +53,7 @@ pub enum Message {
     TrackAVM1Object(AVM1ObjectHandle),
     TrackAVM2Object(AVM2ObjectHandle),
     TrackAVM2Class(ClassHandle),
+    TrackFont(FontHandle),
     TrackStage,
     TrackTopLevelMovie,
     ShowKnownMovies,
@@ -90,6 +94,11 @@ impl DebugUi {
 
         self.movies
             .retain(|movie, window| window.show(egui_ctx, context, movie, &mut messages));
+
+        self.fonts.retain(|font, window| {
+            let font = font.fetch(context.dynamic_root);
+            window.show(egui_ctx, font)
+        });
 
         if let Some(mut movie_list) = self.movie_list.take()
             && movie_list.show(egui_ctx, context, &mut messages)
@@ -135,6 +144,9 @@ impl DebugUi {
                 }
                 Message::TrackAVM2Class(class) => {
                     self.avm2_classes.insert(class, Default::default());
+                }
+                Message::TrackFont(font) => {
+                    self.fonts.insert(font, Default::default());
                 }
                 Message::SaveFile(file) => {
                     self.items_to_save.push(file);

--- a/core/src/debug_ui.rs
+++ b/core/src/debug_ui.rs
@@ -97,7 +97,7 @@ impl DebugUi {
 
         self.fonts.retain(|font, window| {
             let font = font.fetch(context.dynamic_root);
-            window.show(egui_ctx, font)
+            window.show(egui_ctx, font, &mut messages)
         });
 
         if let Some(mut movie_list) = self.movie_list.take()

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -7,7 +7,9 @@ use crate::avm2::object::TObject as _;
 use crate::bitmap::bitmap_data::DirtyState;
 use crate::context::UpdateContext;
 use crate::debug_ui::Message;
-use crate::debug_ui::handle::{AVM1ObjectHandle, AVM2ObjectHandle, DisplayObjectHandle};
+use crate::debug_ui::handle::{
+    AVM1ObjectHandle, AVM2ObjectHandle, DisplayObjectHandle, FontHandle,
+};
 use crate::debug_ui::movie::open_movie_button;
 use crate::display_object::{
     AutoSizeMode, Avm2Button, Bitmap, BoundsMode, ButtonState, DisplayObject, EditText,
@@ -15,7 +17,7 @@ use crate::display_object::{
     TDisplayObjectContainer, TInteractiveObject,
 };
 use crate::focus_tracker::Highlight;
-use crate::font::{FontDescriptor, FontLike};
+use crate::font::{Font, FontDescriptor, FontLike};
 use crate::html::{LayoutBox, LayoutContent, LayoutLine, TextFormat};
 use egui::collapsing_header::CollapsingState;
 use egui::{
@@ -664,7 +666,7 @@ impl DisplayObjectWindow {
                     });
 
                 for line in layout.lines() {
-                    self.show_edit_text_layout_line(ui, &text, line);
+                    self.show_edit_text_layout_line(ui, context, &text, line, messages);
                 }
             });
 
@@ -692,8 +694,10 @@ impl DisplayObjectWindow {
     fn show_edit_text_layout_line<'gc>(
         &mut self,
         ui: &mut Ui,
+        context: &mut UpdateContext<'gc>,
         text: &WStr,
         line: &LayoutLine<'gc>,
+        messages: &mut Vec<Message>,
     ) {
         let line_index = line.index();
         let line_text = serde_json::to_string(
@@ -733,10 +737,10 @@ impl DisplayObjectWindow {
                         ui.end_row();
                     });
 
-                self.show_edit_text_layout_characters(ui, text, line);
+                self.show_edit_text_layout_characters(ui, context, text, line, messages);
 
                 for (index, lbox) in line.boxes_iter().enumerate() {
-                    self.show_edit_text_layout_box(ui, text, index, lbox);
+                    self.show_edit_text_layout_box(ui, context, text, index, lbox, messages);
                 }
             });
     }
@@ -744,8 +748,10 @@ impl DisplayObjectWindow {
     fn show_edit_text_layout_characters<'gc>(
         &mut self,
         ui: &mut Ui,
+        context: &mut UpdateContext<'gc>,
         text: &WStr,
         line: &LayoutLine<'gc>,
+        messages: &mut Vec<Message>,
     ) {
         CollapsingHeader::new("Characters")
             .id_salt(ui.id().with("chars"))
@@ -775,9 +781,7 @@ impl DisplayObjectWindow {
                                     );
                                     ui.label(format!("{ch}"));
                                     if let Some(resolution) = font_set.resolve_glyph(ch) {
-                                        ui.label(format_font_descriptor(
-                                            resolution.font.descriptor(),
-                                        ));
+                                        show_font(ui, context, messages, resolution.font);
                                     } else {
                                         ui.weak("None");
                                     }
@@ -795,9 +799,11 @@ impl DisplayObjectWindow {
     fn show_edit_text_layout_box<'gc>(
         &mut self,
         ui: &mut Ui,
+        context: &mut UpdateContext<'gc>,
         text: &WStr,
         index: usize,
         lbox: &LayoutBox<'gc>,
+        messages: &mut Vec<Message>,
     ) {
         let box_type = match lbox.content() {
             LayoutContent::Text { .. } => "Text box",
@@ -832,12 +838,12 @@ impl DisplayObjectWindow {
 
                         if let Some((_, _, font_set, _, _)) = lbox.as_renderable_text(text) {
                             ui.label("Main Font");
-                            ui.label(format_font_descriptor(font_set.main_font().descriptor()));
+                            show_font(ui, context, messages, font_set.main_font());
                             ui.end_row();
 
                             for (i, fallback_font) in font_set.fallback_fonts().iter().enumerate() {
                                 ui.label(format!("Fallback Font {i}"));
-                                ui.label(format_font_descriptor(fallback_font.descriptor()));
+                                show_font(ui, context, messages, *fallback_font);
                                 ui.end_row();
                             }
 
@@ -1856,6 +1862,20 @@ pub fn open_display_object_button<'gc>(
         messages.push(Message::TrackDisplayObject(DisplayObjectHandle::new(
             context, object,
         )));
+    }
+}
+
+fn show_font<'gc>(
+    ui: &mut Ui,
+    context: &mut UpdateContext<'gc>,
+    messages: &mut Vec<Message>,
+    font: Font<'gc>,
+) {
+    if ui
+        .button(format_font_descriptor(font.descriptor()))
+        .clicked()
+    {
+        messages.push(Message::TrackFont(FontHandle::new(context, font)));
     }
 }
 

--- a/core/src/debug_ui/font.rs
+++ b/core/src/debug_ui/font.rs
@@ -1,5 +1,9 @@
-use crate::font::{Font, FontLike};
+use crate::debug_ui::{ItemToSave, Message};
+use crate::font::{Font, FontFace, FontLike, FontRenderer, Glyph, GlyphSource};
 use egui::{CollapsingHeader, Grid, TextEdit, Ui, Window};
+use fnv::FnvHashMap;
+use std::cell::RefCell;
+use swf::Twips;
 
 #[derive(Debug, Default)]
 pub struct FontWindow {
@@ -7,7 +11,12 @@ pub struct FontWindow {
 }
 
 impl FontWindow {
-    pub fn show<'gc>(&mut self, egui_ctx: &egui::Context, font: Font<'gc>) -> bool {
+    pub fn show<'gc>(
+        &mut self,
+        egui_ctx: &egui::Context,
+        font: Font<'gc>,
+        messages: &mut Vec<Message>,
+    ) -> bool {
         let mut keep_open = true;
 
         Window::new(format!("Font {:p}", font.as_ptr()))
@@ -17,6 +26,7 @@ impl FontWindow {
                 self.show_font_info(ui, font);
                 self.show_font_metrics(ui, font);
                 self.show_glyph_info(ui, font);
+                self.show_glyph_source(ui, font, messages);
             });
 
         keep_open
@@ -133,6 +143,121 @@ impl FontWindow {
                             ui.end_row();
                         }
                     });
+            });
+    }
+
+    fn show_glyph_source(&self, ui: &mut Ui, font: Font<'_>, messages: &mut Vec<Message>) {
+        let source = font.glyph_source();
+        let kind = match source {
+            GlyphSource::Memory { .. } => "Memory (embedded shapes)",
+            GlyphSource::FontFace { .. } => "Font Face (TTF)",
+            GlyphSource::ExternalRenderer { .. } => "External Renderer",
+            GlyphSource::Empty => "None",
+        };
+
+        CollapsingHeader::new(format!("Glyph Source: {kind}"))
+            .id_salt(ui.id().with("glyph-source"))
+            .show(ui, |ui| match source {
+                GlyphSource::Memory {
+                    glyphs,
+                    kerning_pairs,
+                    ..
+                } => self.show_glyph_source_memory(ui, glyphs, kerning_pairs),
+                GlyphSource::FontFace { face, .. } => {
+                    self.show_glyph_source_font_face(ui, font, face, messages)
+                }
+                GlyphSource::ExternalRenderer {
+                    glyph_cache,
+                    kerning_cache,
+                    font_renderer,
+                } => self.show_glyph_source_external_renderer(
+                    ui,
+                    glyph_cache,
+                    kerning_cache,
+                    font_renderer.as_ref(),
+                ),
+                GlyphSource::Empty => {
+                    ui.weak("This font has no glyphs.");
+                }
+            });
+    }
+
+    fn show_glyph_source_memory(
+        &self,
+        ui: &mut Ui,
+        glyphs: &[Glyph],
+        kerning_pairs: &FnvHashMap<(u16, u16), Twips>,
+    ) {
+        Grid::new(ui.id().with("glyph-source-table"))
+            .num_columns(2)
+            .striped(true)
+            .show(ui, |ui| {
+                ui.label("Glyph Count");
+                ui.label(format!("{}", glyphs.len()));
+                ui.end_row();
+
+                ui.label("Kerning Pairs");
+                ui.label(format!("{}", kerning_pairs.len()));
+                ui.end_row();
+            });
+    }
+
+    fn show_glyph_source_font_face(
+        &self,
+        ui: &mut Ui,
+        font: Font<'_>,
+        face: &FontFace,
+        messages: &mut Vec<Message>,
+    ) {
+        Grid::new(ui.id().with("glyph-source-table"))
+            .num_columns(2)
+            .striped(true)
+            .show(ui, |ui| {
+                ui.label("Face Index");
+                ui.label(format!("{}", face.font_index()));
+                ui.end_row();
+            });
+
+        if ui.button("Save Font").clicked() {
+            messages.push(Message::SaveFile(ItemToSave {
+                suggested_name: format!("{}.ttf", font.descriptor().name()),
+                data: face.data().to_vec(),
+            }));
+        }
+    }
+
+    fn show_glyph_source_external_renderer(
+        &self,
+        ui: &mut Ui,
+        glyph_cache: &RefCell<FnvHashMap<u16, Option<Glyph>>>,
+        kerning_cache: &RefCell<FnvHashMap<(u16, u16), Twips>>,
+        font_renderer: &dyn FontRenderer,
+    ) {
+        Grid::new(ui.id().with("glyph-source-table"))
+            .num_columns(2)
+            .striped(true)
+            .show(ui, |ui| {
+                ui.label("Renderer");
+                ui.label(format!("{font_renderer:?}"));
+                ui.end_row();
+
+                ui.label("Glyph Cache Size");
+                ui.horizontal(|ui| {
+                    ui.label(format!("{}", glyph_cache.borrow().len()));
+                    if ui.button("Clear").clicked() {
+                        glyph_cache.borrow_mut().clear();
+                    }
+                });
+                ui.end_row();
+
+                ui.label("Kerning Cache Size");
+                ui.horizontal(|ui| {
+                    ui.label(format!("{}", kerning_cache.borrow().len()));
+                    if ui.button("Clear").clicked() {
+                        kerning_cache.borrow_mut().clear();
+                    }
+                });
+                ui.end_row();
             });
     }
 }

--- a/core/src/debug_ui/font.rs
+++ b/core/src/debug_ui/font.rs
@@ -1,0 +1,87 @@
+use crate::font::{Font, FontLike};
+use egui::{CollapsingHeader, Grid, Ui, Window};
+
+#[derive(Debug, Default)]
+pub struct FontWindow {}
+
+impl FontWindow {
+    pub fn show<'gc>(&mut self, egui_ctx: &egui::Context, font: Font<'gc>) -> bool {
+        let mut keep_open = true;
+
+        Window::new(format!("Font {:p}", font.as_ptr()))
+            .open(&mut keep_open)
+            .scroll([true, true])
+            .show(egui_ctx, |ui| {
+                self.show_font_info(ui, font);
+                self.show_font_metrics(ui, font);
+            });
+
+        keep_open
+    }
+
+    fn show_font_info(&self, ui: &mut Ui, font: Font<'_>) {
+        Grid::new(ui.id().with("font-info"))
+            .num_columns(2)
+            .striped(true)
+            .show(ui, |ui| {
+                let desc = font.descriptor();
+
+                ui.label("Name");
+                ui.label(desc.name());
+                ui.end_row();
+
+                ui.label("Font Type");
+                ui.label(format!("{:?}", font.font_type()));
+                ui.end_row();
+
+                ui.label("Bold");
+                ui.label(if desc.bold() { "Yes" } else { "No" });
+                ui.end_row();
+
+                ui.label("Italic");
+                ui.label(if desc.italic() { "Yes" } else { "No" });
+                ui.end_row();
+
+                ui.label("Has Layout");
+                ui.label(if font.has_layout() { "Yes" } else { "No" });
+                ui.end_row();
+
+                ui.label("Has Glyphs");
+                ui.label(if font.has_glyphs() { "Yes" } else { "No" });
+                ui.end_row();
+
+                ui.label("Has Kerning Info");
+                ui.label(if font.has_kerning_info() { "Yes" } else { "No" });
+                ui.end_row();
+            });
+    }
+
+    fn show_font_metrics(&self, ui: &mut Ui, font: Font<'_>) {
+        CollapsingHeader::new("Font Metrics")
+            .id_salt(ui.id().with("metrics"))
+            .show(ui, |ui| {
+                let metrics = font.metrics();
+
+                Grid::new(ui.id().with("font-metrics"))
+                    .num_columns(2)
+                    .striped(true)
+                    .show(ui, |ui| {
+                        ui.label("Scale");
+                        ui.label(format!("{:.2}", metrics.scale));
+                        ui.end_row();
+
+                        ui.label("Ascent");
+                        ui.label(format!("{}", metrics.ascent));
+                        ui.end_row();
+
+                        ui.label("Descent");
+                        ui.label(format!("{}", metrics.descent));
+                        ui.end_row();
+
+                        ui.label("Leading");
+                        ui.label(format!("{}", metrics.leading));
+                        ui.end_row();
+                    });
+            });
+    }
+}

--- a/core/src/debug_ui/font.rs
+++ b/core/src/debug_ui/font.rs
@@ -1,8 +1,10 @@
 use crate::font::{Font, FontLike};
-use egui::{CollapsingHeader, Grid, Ui, Window};
+use egui::{CollapsingHeader, Grid, TextEdit, Ui, Window};
 
 #[derive(Debug, Default)]
-pub struct FontWindow {}
+pub struct FontWindow {
+    glyph_info_text: String,
+}
 
 impl FontWindow {
     pub fn show<'gc>(&mut self, egui_ctx: &egui::Context, font: Font<'gc>) -> bool {
@@ -14,6 +16,7 @@ impl FontWindow {
             .show(egui_ctx, |ui| {
                 self.show_font_info(ui, font);
                 self.show_font_metrics(ui, font);
+                self.show_glyph_info(ui, font);
             });
 
         keep_open
@@ -81,6 +84,54 @@ impl FontWindow {
                         ui.label("Leading");
                         ui.label(format!("{}", metrics.leading));
                         ui.end_row();
+                    });
+            });
+    }
+
+    fn show_glyph_info(&mut self, ui: &mut Ui, font: Font<'_>) {
+        CollapsingHeader::new("Glyph Info")
+            .id_salt(ui.id().with("glyph-info"))
+            .show(ui, |ui| {
+                ui.add(
+                    TextEdit::singleline(&mut self.glyph_info_text)
+                        .hint_text("Type characters to inspect..."),
+                );
+
+                let chars: Vec<char> = self.glyph_info_text.chars().collect();
+                if chars.is_empty() {
+                    return;
+                }
+
+                Grid::new(ui.id().with("glyph-info-table"))
+                    .num_columns(4)
+                    .striped(true)
+                    .show(ui, |ui| {
+                        ui.label("Char");
+                        ui.label("Has Glyph");
+                        ui.label("Advance");
+                        ui.label("Kerning to Next");
+                        ui.end_row();
+
+                        for (i, &ch) in chars.iter().enumerate() {
+                            ui.label(format!("{ch}"));
+
+                            let resolution = font.resolve_glyph(ch);
+                            ui.label(if resolution.is_some() { "Yes" } else { "No" });
+
+                            if let Some(resolution) = &resolution {
+                                ui.label(format!("{}", resolution.glyph.advance()));
+                            } else {
+                                ui.weak("-");
+                            }
+
+                            if let Some(&next) = chars.get(i + 1) {
+                                ui.label(format!("{}", font.get_kerning_offset(ch, next)));
+                            } else {
+                                ui.weak("-");
+                            }
+
+                            ui.end_row();
+                        }
                     });
             });
     }

--- a/core/src/debug_ui/handle.rs
+++ b/core/src/debug_ui/handle.rs
@@ -234,3 +234,47 @@ impl Hash for ClassHandle {
 }
 
 impl Eq for ClassHandle {}
+
+// Font
+
+#[derive(Clone)]
+pub struct FontHandle {
+    root: DynamicRoot<Rootable![crate::font::Font<'_>]>,
+    ptr: *const (),
+}
+
+impl FontHandle {
+    pub fn new<'gc>(context: &mut UpdateContext<'gc>, font: crate::font::Font<'gc>) -> Self {
+        Self {
+            root: context
+                .dynamic_root
+                .stash(context.gc(), Gc::new(context.gc(), font)),
+            ptr: font.as_ptr(),
+        }
+    }
+
+    pub fn fetch<'gc>(&self, dynamic_root_set: DynamicRootSet<'gc>) -> crate::font::Font<'gc> {
+        *dynamic_root_set.fetch(&self.root)
+    }
+}
+
+impl Debug for FontHandle {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FontHandle").field(&self.ptr).finish()
+    }
+}
+
+impl PartialEq<FontHandle> for FontHandle {
+    #[inline(always)]
+    fn eq(&self, other: &FontHandle) -> bool {
+        std::ptr::eq(self.ptr, other.ptr)
+    }
+}
+
+impl Hash for FontHandle {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.ptr.hash(state);
+    }
+}
+
+impl Eq for FontHandle {}

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -508,6 +508,10 @@ impl<'gc> Font<'gc> {
         ))
     }
 
+    pub fn as_ptr(self) -> *const () {
+        Gc::as_ptr(self.0).cast()
+    }
+
     /// Returns whether this font contains glyph shapes.
     /// If not, this font should be rendered as a device font.
     pub fn has_glyphs(self) -> bool {

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -112,7 +112,7 @@ impl DefaultFont {
 }
 
 #[derive(Debug)]
-enum GlyphSource {
+pub(crate) enum GlyphSource {
     Memory {
         /// The list of glyphs defined in the font.
         /// Used directly by `DefineText` tags.
@@ -510,6 +510,11 @@ impl<'gc> Font<'gc> {
 
     pub fn as_ptr(self) -> *const () {
         Gc::as_ptr(self.0).cast()
+    }
+
+    #[cfg(feature = "egui")]
+    pub(crate) fn glyph_source(&self) -> &GlyphSource {
+        &self.0.glyphs
     }
 
     /// Returns whether this font contains glyph shapes.

--- a/core/src/font/font_face.rs
+++ b/core/src/font/font_face.rs
@@ -135,6 +135,14 @@ impl FontFace {
         })
     }
 
+    pub fn font_index(&self) -> u32 {
+        self.font_index
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
     pub fn metrics(&self) -> FontMetrics {
         FontMetrics {
             scale: self.scale,


### PR DESCRIPTION
## Description

Clicking a font descriptor in an EditText's layout inspector now opens
a window showing basic info about that font (name, style, etc.).

<img height="300" alt="image" src="https://github.com/user-attachments/assets/e5afb100-d64a-42d8-8f11-4d3503d05101" />


## Testing

Tested manually

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
