### PR TITLE
desktop: Profile wgpu into Tracy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5126,6 +5126,7 @@ dependencies = [
  "tracing",
  "web-sys",
  "wgpu",
+ "wgpu-profiler",
 ]
 
 [[package]]
@@ -7202,6 +7203,18 @@ checksum = "d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081"
 dependencies = [
  "naga",
  "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-profiler"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15a635a2a2ec0b9787589f17dbbffaa7960e779bcf0348a67f73c3e7665f9eb"
+dependencies = [
+ "parking_lot",
+ "thiserror 2.0.18",
+ "tracy-client",
+ "wgpu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,8 @@ tracing = "0.1.43"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 naga = { version = "30.0.1", features = ["wgsl-out"] }
 wgpu = "30.0.1"
-egui = "0.36.1"
+wgpu-profiler = "0.28.0"
+ egui = "0.36.1"
 egui_extras = { version = "0.36.1", default-features = false }
 egui-wgpu = "0.36.1"
 egui-winit = "0.36.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -69,7 +69,7 @@ unicode-segmentation = "1.13.3"
 id3 = "1.17.0"
 either = "1.16.0"
 chardetng = "0.1.17"
-tracy-client = { version = "0.18.2", optional = true, default-features = false }
+tracy-client = { version = "0.18.4", optional = true, default-features = false }
 itertools = "0.14.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -1,3 +1,5 @@
+use super::dialogs::export_bundle_dialog::ExportBundleDialogConfiguration;
+use super::{DialogDescriptor, FilePicker};
 use crate::backends::DesktopUiBackend;
 use crate::custom_event::RuffleEvent;
 use crate::gui::movie::{MovieView, MovieViewRenderer};
@@ -27,9 +29,6 @@ use winit::event::WindowEvent;
 use winit::event_loop::EventLoopProxy;
 use winit::keyboard::{Key, NamedKey};
 use winit::window::{ImePurpose as WinitImePurpose, Theme, Window};
-
-use super::dialogs::export_bundle_dialog::ExportBundleDialogConfiguration;
-use super::{DialogDescriptor, FilePicker};
 
 /// Integration layer connecting wgpu+winit to egui.
 pub struct GuiController {
@@ -480,6 +479,12 @@ impl GuiController {
             self.egui_renderer.free_texture(id);
         }
 
+        if let Some(player) = player.as_deref_mut() {
+            let renderer =
+                <dyn Any>::downcast_mut::<WgpuRenderBackend<MovieView>>(player.renderer_mut())
+                    .expect("Renderer must be correct type");
+            renderer.profiler_mut().resolve_queries(&mut encoder);
+        }
         command_buffers.push(encoder.finish());
         self.descriptors.queue.submit(command_buffers);
         self.window.pre_present_notify();
@@ -488,6 +493,19 @@ impl GuiController {
         tracing_tracy::client::frame_mark();
         #[cfg(feature = "tracy_images")]
         self.tracy_frame_captures.finish_frame();
+        if let Some(player) = player.as_deref_mut() {
+            let renderer =
+                <dyn Any>::downcast_mut::<WgpuRenderBackend<MovieView>>(player.renderer_mut())
+                    .expect("Renderer must be correct type");
+            renderer
+                .profiler_mut()
+                .end_frame()
+                .expect("Frame should end successfully");
+            let timestamp_period = renderer.descriptors().queue.get_timestamp_period();
+            renderer
+                .profiler_mut()
+                .process_finished_frame(timestamp_period);
+        }
     }
 
     pub fn show_context_menu(

--- a/render/src/filters.rs
+++ b/render/src/filters.rs
@@ -58,6 +58,21 @@ impl Clone for Box<dyn ShaderObject> {
 }
 
 impl Filter {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Filter::BevelFilter(_) => "Bevel",
+            Filter::BlurFilter(_) => "Blur",
+            Filter::ColorMatrixFilter(_) => "Color Matrix",
+            Filter::ConvolutionFilter(_) => "Convolution",
+            Filter::DisplacementMapFilter(_) => "Displacement Map",
+            Filter::DropShadowFilter(_) => "Drop Shadow",
+            Filter::GlowFilter(_) => "Glow",
+            Filter::GradientBevelFilter(_) => "Gradient Bevel",
+            Filter::GradientGlowFilter(_) => "Gradient Glow",
+            Filter::ShaderFilter(_) => "Shader",
+        }
+    }
+
     pub fn scale(&mut self, x: f32, y: f32) {
         match self {
             Filter::BevelFilter(filter) => filter.scale(x, y),

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -27,6 +27,7 @@ lru = "0.18.2"
 naga = { workspace = true }
 indexmap = { workspace = true }
 smallvec = { workspace = true }
+wgpu-profiler = { workspace = true }
 
 # desktop
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
@@ -40,7 +41,7 @@ features = ["HtmlCanvasElement"]
 [features]
 render_debug_labels = []
 webgl = ["wgpu/webgl"]
-profile-with-tracy = ["profiling", "profiling/profile-with-tracy"]
+profile-with-tracy = ["profiling", "profiling/profile-with-tracy", "wgpu-profiler/tracy"]
 tracy_images = ["profile-with-tracy"]
 
 [package.metadata.cargo-machete]

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -37,6 +37,7 @@ use std::sync::Arc;
 use swf::Color;
 use tracing::instrument;
 use wgpu::SubmissionIndex;
+use wgpu_profiler::{GpuProfiler, GpuProfilerSettings};
 
 /// Creates a wgpu instance with Ruffle's required configuration.
 ///
@@ -81,6 +82,7 @@ pub struct WgpuRenderBackend<T: RenderTarget> {
     pub(crate) offscreen_buffer_pool: Arc<BufferPool<wgpu::Buffer, BufferDimensions>>,
     dynamic_transforms: DynamicTransforms,
     active_frame: ActiveFrame,
+    profiler: GpuProfiler,
 }
 
 impl WgpuRenderBackend<SwapChainTarget> {
@@ -250,6 +252,21 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
         let transforms = DynamicTransforms::new(&descriptors);
         let active_frame = ActiveFrame::new(&descriptors);
 
+        let profiler_settings = GpuProfilerSettings {
+            enable_timer_queries: cfg!(feature = "profile-with-tracy"),
+            enable_debug_groups: cfg!(feature = "render_debug_labels"),
+            ..Default::default()
+        };
+        #[cfg(feature = "profile-with-tracy")]
+        let profiler = GpuProfiler::new_with_tracy_client(
+            profiler_settings,
+            descriptors.backend,
+            &descriptors.device,
+            &descriptors.queue,
+        )?;
+        #[cfg(not(feature = "profile-with-tracy"))]
+        let profiler = GpuProfiler::new(&descriptors.device, profiler_settings)?;
+
         Ok(Self {
             descriptors,
             target,
@@ -262,7 +279,16 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
             offscreen_buffer_pool: Arc::new(offscreen_buffer_pool),
             dynamic_transforms: transforms,
             active_frame,
+            profiler,
         })
+    }
+
+    pub fn profiler(&self) -> &GpuProfiler {
+        &self.profiler
+    }
+
+    pub fn profiler_mut(&mut self) -> &mut GpuProfiler {
+        &mut self.profiler
     }
 
     fn register_shape_internal(
@@ -1187,7 +1213,8 @@ async fn request_device(
 
     let optional_features = wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
         | wgpu::Features::TEXTURE_COMPRESSION_BC
-        | wgpu::Features::FLOAT32_FILTERABLE;
+        | wgpu::Features::FLOAT32_FILTERABLE
+        | GpuProfiler::ALL_WGPU_TIMER_FEATURES;
 
     features |= optional_features & adapter.features();
 

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -590,11 +590,16 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                     entry.commands,
                     &mut self.active_frame.staging_belt,
                     &self.dynamic_transforms,
-                    &mut self.active_frame.command_encoder,
+                    &mut self
+                        .profiler
+                        .scope("Draw to CAB", &mut self.active_frame.command_encoder),
                     LayerRef::None,
                     &mut self.offscreen_texture_pool,
                 );
             } else {
+                let mut scope = self
+                    .profiler
+                    .scope("Filters", &mut self.active_frame.command_encoder);
                 // We're relying on there being no impotent filters here,
                 // so that we can safely start by using the actual CAB texture.
                 // It's guaranteed that at least one filter would have used it and moved the target to something else,
@@ -614,14 +619,14 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                     entry.commands,
                     &mut self.active_frame.staging_belt,
                     &self.dynamic_transforms,
-                    &mut self.active_frame.command_encoder,
+                    &mut scope.scope("Draw to CAB"),
                     LayerRef::None,
                     &mut self.offscreen_texture_pool,
                 );
                 for filter in entry.filters {
                     target = self.descriptors.filters.apply(
                         &self.descriptors,
-                        &mut self.active_frame.command_encoder,
+                        &mut scope.scope(filter.name()),
                         &mut self.offscreen_texture_pool,
                         &mut self.active_frame.staging_belt,
                         FilterSource::for_entire_texture(target.color_texture()),
@@ -636,7 +641,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                     target.whole_frame_bind_group(&self.descriptors),
                     target.globals(),
                     target.color_texture().sample_count(),
-                    &mut self.active_frame.command_encoder,
+                    &mut scope.scope("Copy filtered to CAB"),
                 );
             }
             // Periodically flush GPU work to prevent OOM when many cache entries
@@ -656,7 +661,9 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
             &self.descriptors,
             &mut self.active_frame.staging_belt,
             &self.dynamic_transforms,
-            &mut self.active_frame.command_encoder,
+            &mut self
+                .profiler
+                .scope("Frame commands", &mut self.active_frame.command_encoder),
             &self.meshes,
             commands,
             LayerRef::None,
@@ -818,7 +825,9 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
             &self.descriptors,
             &mut self.active_frame.staging_belt,
             &self.dynamic_transforms,
-            &mut self.active_frame.command_encoder,
+            &mut self
+                .profiler
+                .scope("Offscreen commands", &mut self.active_frame.command_encoder),
             &self.meshes,
             commands,
             LayerRef::Current,

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -1185,17 +1185,11 @@ async fn request_device(
 
     let mut features = Default::default();
 
-    let try_features = [
-        wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
-        wgpu::Features::TEXTURE_COMPRESSION_BC,
-        wgpu::Features::FLOAT32_FILTERABLE,
-    ];
+    let optional_features = wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
+        | wgpu::Features::TEXTURE_COMPRESSION_BC
+        | wgpu::Features::FLOAT32_FILTERABLE;
 
-    for feature in try_features {
-        if adapter.features().contains(feature) {
-            features |= feature;
-        }
-    }
+    features |= optional_features & adapter.features();
 
     adapter
         .request_device(&wgpu::DeviceDescriptor {

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -23,6 +23,7 @@ use std::cell::{Cell, OnceCell};
 use std::sync::Arc;
 use swf::GradientSpread;
 pub use wgpu;
+pub use wgpu_profiler;
 
 type Error = Box<dyn std::error::Error>;
 

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -10,6 +10,7 @@ use crate::filters::FilterSource;
 use crate::mesh::Mesh;
 use crate::pixel_bender::{ShaderMode, run_pixelbender_shader_impl};
 use crate::surface::commands::{Chunk, CommandRenderer, chunk_blends};
+use crate::utils::run_copy_pipeline;
 use crate::utils::supported_sample_count;
 use crate::{Descriptors, MaskState, Pipelines, Transforms};
 use ruffle_render::commands::{CommandList, RenderBlendMode};
@@ -19,8 +20,7 @@ use std::sync::Arc;
 use swf::BlendMode;
 use target::CommandTarget;
 use tracing::instrument;
-
-use crate::utils::run_copy_pipeline;
+use wgpu_profiler::Scope;
 
 pub use crate::surface::commands::LayerRef;
 
@@ -69,13 +69,13 @@ impl Surface {
         frame_view: &wgpu::TextureView,
         render_target_mode: RenderTargetMode,
         descriptors: &'global Descriptors,
-        staging_belt: &'encoder mut wgpu::util::StagingBelt,
+        staging_belt: &'global mut wgpu::util::StagingBelt,
         dynamic_transforms: &'global DynamicTransforms,
-        draw_encoder: &'encoder mut wgpu::CommandEncoder,
+        draw_encoder: &'encoder mut Scope<'global, wgpu::CommandEncoder>,
         meshes: &'global Vec<Mesh>,
         commands: CommandList,
-        layer: LayerRef,
-        texture_pool: &mut TexturePool,
+        layer: LayerRef<'encoder>,
+        texture_pool: &'global mut TexturePool,
     ) {
         let target = self.draw_commands(
             render_target_mode,
@@ -106,14 +106,14 @@ impl Surface {
     pub fn draw_commands<'encoder, 'global: 'encoder>(
         &self,
         render_target_mode: RenderTargetMode,
-        descriptors: &'global Descriptors,
-        meshes: &'global Vec<Mesh>,
+        descriptors: &'encoder Descriptors,
+        meshes: &'encoder Vec<Mesh>,
         commands: CommandList,
-        staging_belt: &'global mut wgpu::util::StagingBelt,
-        dynamic_transforms: &'global DynamicTransforms,
-        draw_encoder: &'encoder mut wgpu::CommandEncoder,
+        staging_belt: &'encoder mut wgpu::util::StagingBelt,
+        dynamic_transforms: &'encoder DynamicTransforms,
+        draw_encoder: &'encoder mut Scope<'global, wgpu::CommandEncoder>,
         nearest_layer: LayerRef<'encoder>,
-        texture_pool: &mut TexturePool,
+        texture_pool: &'encoder mut TexturePool,
     ) -> CommandTarget {
         let target = CommandTarget::new(
             descriptors,

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -64,14 +64,14 @@ impl Surface {
 
     #[expect(clippy::too_many_arguments)]
     #[instrument(level = "debug", skip_all)]
-    pub fn draw_commands_and_copy_to<'frame, 'global: 'frame>(
+    pub fn draw_commands_and_copy_to<'encoder, 'global: 'encoder>(
         &self,
         frame_view: &wgpu::TextureView,
         render_target_mode: RenderTargetMode,
         descriptors: &'global Descriptors,
-        staging_belt: &'frame mut wgpu::util::StagingBelt,
+        staging_belt: &'encoder mut wgpu::util::StagingBelt,
         dynamic_transforms: &'global DynamicTransforms,
-        draw_encoder: &'frame mut wgpu::CommandEncoder,
+        draw_encoder: &'encoder mut wgpu::CommandEncoder,
         meshes: &'global Vec<Mesh>,
         commands: CommandList,
         layer: LayerRef,
@@ -103,7 +103,7 @@ impl Surface {
 
     #[expect(clippy::too_many_arguments)]
     #[instrument(level = "debug", skip_all)]
-    pub fn draw_commands<'frame, 'global: 'frame>(
+    pub fn draw_commands<'encoder, 'global: 'encoder>(
         &self,
         render_target_mode: RenderTargetMode,
         descriptors: &'global Descriptors,
@@ -111,8 +111,8 @@ impl Surface {
         commands: CommandList,
         staging_belt: &'global mut wgpu::util::StagingBelt,
         dynamic_transforms: &'global DynamicTransforms,
-        draw_encoder: &'frame mut wgpu::CommandEncoder,
-        nearest_layer: LayerRef<'frame>,
+        draw_encoder: &'encoder mut wgpu::CommandEncoder,
+        nearest_layer: LayerRef<'encoder>,
         texture_pool: &mut TexturePool,
     ) -> CommandTarget {
         let target = CommandTarget::new(
@@ -172,14 +172,13 @@ impl Surface {
                         &self.pipelines,
                         descriptors,
                         dynamic_transforms,
-                        render_pass,
                         num_masks,
                         mask_state,
                         needs_stencil,
                     );
 
                     for command in &chunk {
-                        renderer.execute(command);
+                        renderer.execute(&mut render_pass, command);
                     }
 
                     num_masks = renderer.num_masks();
@@ -324,16 +323,20 @@ impl Surface {
                                     ..Default::default()
                                 });
                             render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
-                            let mut renderer = CommandRenderer::new(
+                            let renderer = CommandRenderer::new(
                                 &self.pipelines,
                                 descriptors,
                                 dynamic_transforms,
-                                render_pass,
                                 num_masks,
                                 mask_state,
                                 needs_stencil,
                             );
-                            renderer.render_texture(transform_offset, &bind_group, blend_mode);
+                            renderer.render_texture(
+                                &mut render_pass,
+                                transform_offset,
+                                &bind_group,
+                                blend_mode,
+                            );
                         }
                         BlendType::Complex(blend_mode) => {
                             let parent_blend_buffer = parent_blend_buffer

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -148,17 +148,16 @@ impl Surface {
                     transforms,
                 } => {
                     transforms.copy_to(staging_belt, draw_encoder, &dynamic_transforms.buffer);
-                    let mut render_pass =
-                        draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                            label: create_debug_label!(
-                                "Chunked draw calls {}",
-                                if needs_stencil {
-                                    "(with stencil)"
-                                } else {
-                                    "(Stencilless)"
-                                }
-                            )
-                            .as_deref(),
+                    let mut render_pass = draw_encoder.scoped_render_pass(
+                        format!(
+                            "Chunked draw calls {}",
+                            if needs_stencil {
+                                "(with stencil)"
+                            } else {
+                                "(Stencilless)"
+                            }
+                        ),
+                        wgpu::RenderPassDescriptor {
                             color_attachments: &[target.color_attachments()],
                             depth_stencil_attachment: if needs_stencil {
                                 target.stencil_attachment(descriptors, texture_pool)
@@ -166,7 +165,8 @@ impl Surface {
                                 None
                             },
                             ..Default::default()
-                        });
+                        },
+                    );
                     render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
                     let mut renderer = CommandRenderer::new(
                         &self.pipelines,
@@ -178,7 +178,7 @@ impl Surface {
                     );
 
                     for command in &chunk {
-                        renderer.execute(&mut render_pass, command);
+                        renderer.execute(&mut render_pass.scope(command.name()), command);
                     }
 
                     num_masks = renderer.num_masks();
@@ -303,17 +303,16 @@ impl Surface {
                                         ],
                                         label: None,
                                     });
-                            let mut render_pass =
-                                draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                    label: create_debug_label!(
-                                        "Apply trivial blend {blend_mode:?} {}",
-                                        if needs_stencil {
-                                            "(with stencil)"
-                                        } else {
-                                            "(Stencilless)"
-                                        }
-                                    )
-                                    .as_deref(),
+                            let mut render_pass = draw_encoder.scoped_render_pass(
+                                format!(
+                                    "Apply trivial blend {blend_mode:?} {}",
+                                    if needs_stencil {
+                                        "(with stencil)"
+                                    } else {
+                                        "(Stencilless)"
+                                    }
+                                ),
+                                wgpu::RenderPassDescriptor {
                                     color_attachments: &[target.color_attachments()],
                                     depth_stencil_attachment: if needs_stencil {
                                         target.stencil_attachment(descriptors, texture_pool)
@@ -321,7 +320,8 @@ impl Surface {
                                         None
                                     },
                                     ..Default::default()
-                                });
+                                },
+                            );
                             render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
                             let renderer = CommandRenderer::new(
                                 &self.pipelines,

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -20,22 +20,21 @@ use wgpu::Backend;
 
 use super::target::PoolOrArcTexture;
 
-pub struct CommandRenderer<'pass, 'frame: 'pass, 'global: 'frame> {
-    pipelines: &'frame Pipelines,
-    descriptors: &'global Descriptors,
+pub struct CommandRenderer<'encoder> {
+    pipelines: &'encoder Pipelines,
+    descriptors: &'encoder Descriptors,
     num_masks: u32,
     mask_state: MaskState,
-    render_pass: wgpu::RenderPass<'pass>,
     needs_stencil: bool,
-    dynamic_transforms: &'global DynamicTransforms,
+    dynamic_transforms: &'encoder DynamicTransforms,
 }
 
-impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'global> {
+impl<'encoder> CommandRenderer<'encoder> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        pipelines: &'frame Pipelines,
-        descriptors: &'global Descriptors,
-        dynamic_transforms: &'global DynamicTransforms,
-        render_pass: wgpu::RenderPass<'pass>,
+        pipelines: &'encoder Pipelines,
+        descriptors: &'encoder Descriptors,
+        dynamic_transforms: &'encoder DynamicTransforms,
         num_masks: u32,
         mask_state: MaskState,
         needs_stencil: bool,
@@ -44,25 +43,28 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
             pipelines,
             num_masks,
             mask_state,
-            render_pass,
             descriptors,
             needs_stencil,
             dynamic_transforms,
         }
     }
 
-    pub fn execute(&mut self, command: &'frame DrawCommand) {
+    pub fn execute(
+        &mut self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
+        command: &'encoder DrawCommand,
+    ) {
         if self.needs_stencil {
             match self.mask_state {
                 MaskState::NoMask => {}
                 MaskState::DrawMaskStencil => {
-                    self.render_pass.set_stencil_reference(self.num_masks - 1);
+                    render_pass.set_stencil_reference(self.num_masks - 1);
                 }
                 MaskState::DrawMaskedContent => {
-                    self.render_pass.set_stencil_reference(self.num_masks);
+                    render_pass.set_stencil_reference(self.num_masks);
                 }
                 MaskState::ClearMaskStencil => {
-                    self.render_pass.set_stencil_reference(self.num_masks);
+                    render_pass.set_stencil_reference(self.num_masks);
                 }
             }
         }
@@ -75,6 +77,7 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
                 blend_mode,
                 render_stage3d,
             } => self.render_bitmap(
+                render_pass,
                 bitmap,
                 *transform_buffer,
                 *smoothing,
@@ -84,122 +87,123 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
             DrawCommand::RenderShape {
                 shape,
                 transform_buffer,
-            } => self.render_shape(shape, *transform_buffer),
-            DrawCommand::DrawRect { transform_buffer } => self.draw_rect(*transform_buffer),
+            } => self.render_shape(render_pass, shape, *transform_buffer),
+            DrawCommand::DrawRect { transform_buffer } => {
+                self.draw_rect(render_pass, *transform_buffer)
+            }
             DrawCommand::DrawLine { transform_buffer } => {
-                self.draw_lines::<false>(*transform_buffer)
+                self.draw_lines::<false>(render_pass, *transform_buffer)
             }
             DrawCommand::DrawLineRect { transform_buffer } => {
-                self.draw_lines::<true>(*transform_buffer)
+                self.draw_lines::<true>(render_pass, *transform_buffer)
             }
-            DrawCommand::PushMask => self.push_mask(),
-            DrawCommand::ActivateMask => self.activate_mask(),
-            DrawCommand::DeactivateMask => self.deactivate_mask(),
-            DrawCommand::PopMask => self.pop_mask(),
+            DrawCommand::PushMask => self.push_mask(render_pass),
+            DrawCommand::ActivateMask => self.activate_mask(render_pass),
+            DrawCommand::DeactivateMask => self.deactivate_mask(render_pass),
+            DrawCommand::PopMask => self.pop_mask(render_pass),
             DrawCommand::RenderAlphaMask {
                 maskee,
                 mask,
                 binds,
                 transform_buffer,
-            } => self.render_alpha_mask(maskee, mask, binds, *transform_buffer),
+            } => self.render_alpha_mask(render_pass, maskee, mask, binds, *transform_buffer),
         }
     }
 
-    pub fn prep_color(&mut self) {
+    pub fn prep_color(&self, render_pass: &mut wgpu::RenderPass<'encoder>) {
         if self.needs_stencil {
-            self.render_pass
-                .set_pipeline(self.pipelines.color.pipeline_for(self.mask_state));
+            render_pass.set_pipeline(self.pipelines.color.pipeline_for(self.mask_state));
         } else {
-            self.render_pass
-                .set_pipeline(self.pipelines.color.stencilless_pipeline());
+            render_pass.set_pipeline(self.pipelines.color.stencilless_pipeline());
         }
     }
 
-    pub fn prep_lines(&mut self) {
+    pub fn prep_lines(&self, render_pass: &mut wgpu::RenderPass<'encoder>) {
         if self.needs_stencil {
-            self.render_pass
-                .set_pipeline(self.pipelines.lines.pipeline_for(self.mask_state));
+            render_pass.set_pipeline(self.pipelines.lines.pipeline_for(self.mask_state));
         } else {
-            self.render_pass
-                .set_pipeline(self.pipelines.lines.stencilless_pipeline());
+            render_pass.set_pipeline(self.pipelines.lines.stencilless_pipeline());
         }
     }
 
-    pub fn prep_gradient(&mut self, bind_group: &'pass wgpu::BindGroup) {
+    pub fn prep_gradient(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
+        bind_group: &'encoder wgpu::BindGroup,
+    ) {
         if self.needs_stencil {
-            self.render_pass
-                .set_pipeline(self.pipelines.gradients.pipeline_for(self.mask_state));
+            render_pass.set_pipeline(self.pipelines.gradients.pipeline_for(self.mask_state));
         } else {
-            self.render_pass
-                .set_pipeline(self.pipelines.gradients.stencilless_pipeline());
+            render_pass.set_pipeline(self.pipelines.gradients.stencilless_pipeline());
         }
 
-        self.render_pass.set_bind_group(2, bind_group, &[]);
+        render_pass.set_bind_group(2, bind_group, &[]);
     }
 
     pub fn prep_bitmap(
-        &mut self,
-        bind_group: &'pass wgpu::BindGroup,
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
+        bind_group: &'encoder wgpu::BindGroup,
         blend_mode: TrivialBlend,
         render_stage3d: bool,
     ) {
         match (self.needs_stencil, render_stage3d) {
             (true, true) => {
-                self.render_pass
-                    .set_pipeline(&self.pipelines.bitmap_opaque_dummy_stencil);
+                render_pass.set_pipeline(&self.pipelines.bitmap_opaque_dummy_stencil);
             }
             (true, false) => {
-                self.render_pass
+                render_pass
                     .set_pipeline(self.pipelines.bitmap[blend_mode].pipeline_for(self.mask_state));
             }
             (false, true) => {
-                self.render_pass.set_pipeline(&self.pipelines.bitmap_opaque);
+                render_pass.set_pipeline(&self.pipelines.bitmap_opaque);
             }
             (false, false) => {
-                self.render_pass
-                    .set_pipeline(self.pipelines.bitmap[blend_mode].stencilless_pipeline());
+                render_pass.set_pipeline(self.pipelines.bitmap[blend_mode].stencilless_pipeline());
             }
         }
 
-        self.render_pass.set_bind_group(2, bind_group, &[]);
+        render_pass.set_bind_group(2, bind_group, &[]);
     }
 
-    pub fn prep_alpha_mask(&mut self, bind_group: &'pass wgpu::BindGroup) {
+    pub fn prep_alpha_mask(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
+        bind_group: &'encoder wgpu::BindGroup,
+    ) {
         if self.needs_stencil {
-            self.render_pass
-                .set_pipeline(self.pipelines.alpha_mask.pipeline_for(self.mask_state));
+            render_pass.set_pipeline(self.pipelines.alpha_mask.pipeline_for(self.mask_state));
         } else {
-            self.render_pass
-                .set_pipeline(self.pipelines.alpha_mask.stencilless_pipeline());
+            render_pass.set_pipeline(self.pipelines.alpha_mask.stencilless_pipeline());
         }
 
-        self.render_pass.set_bind_group(2, bind_group, &[]);
+        render_pass.set_bind_group(2, bind_group, &[]);
     }
 
     pub fn draw(
-        &mut self,
-        vertices: wgpu::BufferSlice<'pass>,
-        indices: wgpu::BufferSlice<'pass>,
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
+        vertices: wgpu::BufferSlice<'encoder>,
+        indices: wgpu::BufferSlice<'encoder>,
         num_indices: u32,
     ) {
-        self.render_pass.set_vertex_buffer(0, vertices);
-        self.render_pass
-            .set_index_buffer(indices, wgpu::IndexFormat::Uint32);
+        render_pass.set_vertex_buffer(0, vertices);
+        render_pass.set_index_buffer(indices, wgpu::IndexFormat::Uint32);
 
-        self.render_pass.draw_indexed(0..num_indices, 0, 0..1);
+        render_pass.draw_indexed(0..num_indices, 0, 0..1);
     }
 
     pub fn render_bitmap(
-        &mut self,
-        bitmap: &'frame BitmapHandle,
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
+        bitmap: &'encoder BitmapHandle,
         transform_buffer: wgpu::DynamicOffset,
         smoothing: bool,
         blend_mode: TrivialBlend,
         render_stage3d: bool,
     ) {
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass
-                .push_debug_group(&format!("render_bitmap {:?}", bitmap.0));
+            render_pass.push_debug_group(&format!("render_bitmap {:?}", bitmap.0));
         }
         let texture = as_texture(bitmap);
 
@@ -212,57 +216,53 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
             bitmap.clone(),
             &descriptors.bitmap_samplers,
         );
-        self.prep_bitmap(&bind.bind_group, blend_mode, render_stage3d);
-        self.render_pass.set_bind_group(
-            1,
-            &self.dynamic_transforms.bind_group,
-            &[transform_buffer],
-        );
+        self.prep_bitmap(render_pass, &bind.bind_group, blend_mode, render_stage3d);
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
 
         self.draw(
+            render_pass,
             self.descriptors.quad.vertices_pos.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
         );
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.pop_debug_group();
+            render_pass.pop_debug_group();
         }
     }
 
     pub fn render_texture(
-        &mut self,
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
         transform_buffer: wgpu::DynamicOffset,
-        bind_group: &'frame wgpu::BindGroup,
+        bind_group: &'encoder wgpu::BindGroup,
         blend_mode: TrivialBlend,
     ) {
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.push_debug_group("render_texture");
+            render_pass.push_debug_group("render_texture");
         }
-        self.prep_bitmap(bind_group, blend_mode, false);
+        self.prep_bitmap(render_pass, bind_group, blend_mode, false);
 
-        self.render_pass.set_bind_group(
-            1,
-            &self.dynamic_transforms.bind_group,
-            &[transform_buffer],
-        );
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
 
         self.draw(
+            render_pass,
             self.descriptors.quad.vertices_pos.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
         );
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.pop_debug_group();
+            render_pass.pop_debug_group();
         }
     }
 
     pub fn render_shape(
-        &mut self,
-        shape: &'frame ShapeHandle,
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
+        shape: &'encoder ShapeHandle,
         transform_buffer: wgpu::DynamicOffset,
     ) {
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.push_debug_group("render_shape");
+            render_pass.push_debug_group("render_shape");
         }
 
         let mesh = as_mesh(shape);
@@ -281,97 +281,94 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
 
             match &draw.draw_type {
                 DrawType::Color => {
-                    self.prep_color();
+                    self.prep_color(render_pass);
                 }
                 DrawType::Gradient { bind_group, .. } => {
-                    self.prep_gradient(bind_group);
+                    self.prep_gradient(render_pass, bind_group);
                 }
                 DrawType::Bitmap { binds, .. } => {
-                    self.prep_bitmap(&binds.bind_group, TrivialBlend::Normal, false);
+                    self.prep_bitmap(render_pass, &binds.bind_group, TrivialBlend::Normal, false);
                 }
             }
-            self.render_pass.set_bind_group(
-                1,
-                &self.dynamic_transforms.bind_group,
-                &[transform_buffer],
-            );
+            render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
 
             self.draw(
+                render_pass,
                 mesh.vertex_buffer.slice(draw.vertices.clone()),
                 mesh.index_buffer.slice(draw.indices.clone()),
                 num_indices,
             );
         }
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.pop_debug_group();
+            render_pass.pop_debug_group();
         }
     }
 
     pub fn render_alpha_mask(
-        &mut self,
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
         _maskee: &PoolOrArcTexture,
         _mask: &PoolOrArcTexture,
-        bind_group: &'frame wgpu::BindGroup,
+        bind_group: &'encoder wgpu::BindGroup,
         transform_buffer: wgpu::DynamicOffset,
     ) {
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.push_debug_group("render_alpha_mask");
+            render_pass.push_debug_group("render_alpha_mask");
         }
 
-        self.prep_alpha_mask(bind_group);
+        self.prep_alpha_mask(render_pass, bind_group);
 
-        self.render_pass.set_bind_group(
-            1,
-            &self.dynamic_transforms.bind_group,
-            &[transform_buffer],
-        );
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
 
         self.draw(
+            render_pass,
             self.descriptors.quad.vertices_pos.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
         );
 
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.pop_debug_group();
+            render_pass.pop_debug_group();
         }
     }
 
-    pub fn draw_rect(&mut self, transform_buffer: wgpu::DynamicOffset) {
+    pub fn draw_rect(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
+        transform_buffer: wgpu::DynamicOffset,
+    ) {
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.push_debug_group("draw_rect");
+            render_pass.push_debug_group("draw_rect");
         }
-        self.prep_color();
+        self.prep_color(render_pass);
 
-        self.render_pass.set_bind_group(
-            1,
-            &self.dynamic_transforms.bind_group,
-            &[transform_buffer],
-        );
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
 
         self.draw(
+            render_pass,
             self.descriptors.quad.vertices_pos_color.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
         );
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.pop_debug_group();
+            render_pass.pop_debug_group();
         }
     }
 
-    pub fn draw_lines<const RECT: bool>(&mut self, transform_buffer: wgpu::DynamicOffset) {
+    pub fn draw_lines<const RECT: bool>(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'encoder>,
+        transform_buffer: wgpu::DynamicOffset,
+    ) {
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.push_debug_group("draw_lines");
+            render_pass.push_debug_group("draw_lines");
         }
-        self.prep_lines();
+        self.prep_lines(render_pass);
 
-        self.render_pass.set_bind_group(
-            1,
-            &self.dynamic_transforms.bind_group,
-            &[transform_buffer],
-        );
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
 
         self.draw(
+            render_pass,
             self.descriptors.quad.vertices_pos_color.slice(..),
             if RECT {
                 self.descriptors.quad.indices_line_rect.slice(..)
@@ -381,35 +378,35 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
             if RECT { 5 } else { 2 },
         );
         if cfg!(feature = "render_debug_labels") {
-            self.render_pass.pop_debug_group();
+            render_pass.pop_debug_group();
         }
     }
 
-    pub fn push_mask(&mut self) {
+    pub fn push_mask(&mut self, render_pass: &mut wgpu::RenderPass<'encoder>) {
         debug_assert!(
             self.mask_state == MaskState::NoMask || self.mask_state == MaskState::DrawMaskedContent
         );
         self.num_masks += 1;
         self.mask_state = MaskState::DrawMaskStencil;
-        self.render_pass.set_stencil_reference(self.num_masks - 1);
+        render_pass.set_stencil_reference(self.num_masks - 1);
     }
 
-    pub fn activate_mask(&mut self) {
+    pub fn activate_mask(&mut self, render_pass: &mut wgpu::RenderPass<'encoder>) {
         debug_assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskStencil);
         self.mask_state = MaskState::DrawMaskedContent;
-        self.render_pass.set_stencil_reference(self.num_masks);
+        render_pass.set_stencil_reference(self.num_masks);
     }
 
-    pub fn deactivate_mask(&mut self) {
+    pub fn deactivate_mask(&mut self, render_pass: &mut wgpu::RenderPass<'encoder>) {
         debug_assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskedContent);
         self.mask_state = MaskState::ClearMaskStencil;
-        self.render_pass.set_stencil_reference(self.num_masks);
+        render_pass.set_stencil_reference(self.num_masks);
     }
 
-    pub fn pop_mask(&mut self) {
+    pub fn pop_mask(&mut self, render_pass: &mut wgpu::RenderPass<'encoder>) {
         debug_assert!(self.num_masks > 0 && self.mask_state == MaskState::ClearMaskStencil);
         self.num_masks -= 1;
-        self.render_pass.set_stencil_reference(self.num_masks);
+        render_pass.set_stencil_reference(self.num_masks);
         if self.num_masks == 0 {
             self.mask_state = MaskState::NoMask;
         } else {
@@ -509,16 +506,16 @@ pub fn chunk_blends<'a>(
     .chunk_blends(commands)
 }
 
-struct WgpuCommandHandler<'a> {
-    descriptors: &'a Descriptors,
+struct WgpuCommandHandler<'encoder, 'global: 'encoder> {
+    descriptors: &'global Descriptors,
     quality: StageQuality,
     width: u32,
     height: u32,
-    meshes: &'a Vec<Mesh>,
-    staging_belt: &'a mut wgpu::util::StagingBelt,
-    dynamic_transforms: &'a DynamicTransforms,
-    draw_encoder: &'a mut wgpu::CommandEncoder,
-    texture_pool: &'a mut TexturePool,
+    meshes: &'global Vec<Mesh>,
+    staging_belt: &'global mut wgpu::util::StagingBelt,
+    dynamic_transforms: &'global DynamicTransforms,
+    draw_encoder: &'encoder mut wgpu::CommandEncoder,
+    texture_pool: &'global mut TexturePool,
     emulate_lines: bool,
 
     result: Vec<Chunk>,
@@ -528,18 +525,18 @@ struct WgpuCommandHandler<'a> {
     num_masks: i32,
 }
 
-impl<'a> WgpuCommandHandler<'a> {
+impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
     #[expect(clippy::too_many_arguments)]
     fn new(
-        descriptors: &'a Descriptors,
-        staging_belt: &'a mut wgpu::util::StagingBelt,
-        dynamic_transforms: &'a DynamicTransforms,
-        draw_encoder: &'a mut wgpu::CommandEncoder,
-        meshes: &'a Vec<Mesh>,
+        descriptors: &'global Descriptors,
+        staging_belt: &'global mut wgpu::util::StagingBelt,
+        dynamic_transforms: &'global DynamicTransforms,
+        draw_encoder: &'encoder mut wgpu::CommandEncoder,
+        meshes: &'global Vec<Mesh>,
         quality: StageQuality,
         width: u32,
         height: u32,
-        texture_pool: &'a mut TexturePool,
+        texture_pool: &'global mut TexturePool,
     ) -> Self {
         let transforms = Self::new_transforms(descriptors, dynamic_transforms);
 
@@ -569,8 +566,8 @@ impl<'a> WgpuCommandHandler<'a> {
     }
 
     fn new_transforms(
-        descriptors: &'a Descriptors,
-        dynamic_transforms: &'a DynamicTransforms,
+        descriptors: &'global Descriptors,
+        dynamic_transforms: &'global DynamicTransforms,
     ) -> BufferBuilder {
         let mut transforms = BufferBuilder::new_for_uniform(&descriptors.limits);
         transforms.set_buffer_limit(dynamic_transforms.buffer.size());
@@ -648,7 +645,7 @@ impl<'a> WgpuCommandHandler<'a> {
     }
 }
 
-impl CommandHandler for WgpuCommandHandler<'_> {
+impl CommandHandler for WgpuCommandHandler<'_, '_> {
     fn blend(&mut self, commands: CommandList, blend_mode: RenderBlendMode) {
         // A Layer only changes rendering when one of its children blends with
         // the layer's contents. Avoid allocating a full-frame intermediate

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -202,9 +202,6 @@ impl<'encoder> CommandRenderer<'encoder> {
         blend_mode: TrivialBlend,
         render_stage3d: bool,
     ) {
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.push_debug_group(&format!("render_bitmap {:?}", bitmap.0));
-        }
         let texture = as_texture(bitmap);
 
         let descriptors = self.descriptors;
@@ -225,9 +222,6 @@ impl<'encoder> CommandRenderer<'encoder> {
             self.descriptors.quad.indices.slice(..),
             6,
         );
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.pop_debug_group();
-        }
     }
 
     pub fn render_texture(
@@ -237,9 +231,6 @@ impl<'encoder> CommandRenderer<'encoder> {
         bind_group: &'encoder wgpu::BindGroup,
         blend_mode: TrivialBlend,
     ) {
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.push_debug_group("render_texture");
-        }
         self.prep_bitmap(render_pass, bind_group, blend_mode, false);
 
         render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
@@ -250,9 +241,6 @@ impl<'encoder> CommandRenderer<'encoder> {
             self.descriptors.quad.indices.slice(..),
             6,
         );
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.pop_debug_group();
-        }
     }
 
     pub fn render_shape(
@@ -261,10 +249,6 @@ impl<'encoder> CommandRenderer<'encoder> {
         shape: &'encoder ShapeHandle,
         transform_buffer: wgpu::DynamicOffset,
     ) {
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.push_debug_group("render_shape");
-        }
-
         let mesh = as_mesh(shape);
         for draw in &mesh.draws {
             let num_indices = if self.mask_state != MaskState::DrawMaskStencil
@@ -298,9 +282,6 @@ impl<'encoder> CommandRenderer<'encoder> {
                 mesh.index_buffer.slice(draw.indices.clone()),
                 num_indices,
             );
-        }
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.pop_debug_group();
         }
     }
 
@@ -337,9 +318,6 @@ impl<'encoder> CommandRenderer<'encoder> {
         render_pass: &mut wgpu::RenderPass<'encoder>,
         transform_buffer: wgpu::DynamicOffset,
     ) {
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.push_debug_group("draw_rect");
-        }
         self.prep_color(render_pass);
 
         render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
@@ -350,9 +328,6 @@ impl<'encoder> CommandRenderer<'encoder> {
             self.descriptors.quad.indices.slice(..),
             6,
         );
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.pop_debug_group();
-        }
     }
 
     pub fn draw_lines<const RECT: bool>(
@@ -360,9 +335,6 @@ impl<'encoder> CommandRenderer<'encoder> {
         render_pass: &mut wgpu::RenderPass<'encoder>,
         transform_buffer: wgpu::DynamicOffset,
     ) {
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.push_debug_group("draw_lines");
-        }
         self.prep_lines(render_pass);
 
         render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
@@ -377,9 +349,6 @@ impl<'encoder> CommandRenderer<'encoder> {
             },
             if RECT { 5 } else { 2 },
         );
-        if cfg!(feature = "render_debug_labels") {
-            render_pass.pop_debug_group();
-        }
     }
 
     pub fn push_mask(&mut self, render_pass: &mut wgpu::RenderPass<'encoder>) {
@@ -468,6 +437,23 @@ pub enum DrawCommand {
     ActivateMask,
     DeactivateMask,
     PopMask,
+}
+
+impl DrawCommand {
+    pub fn name(&self) -> &'static str {
+        match self {
+            DrawCommand::RenderBitmap { .. } => "render bitmap",
+            DrawCommand::RenderShape { .. } => "render shape",
+            DrawCommand::DrawRect { .. } => "draw rect",
+            DrawCommand::DrawLine { .. } => "draw line",
+            DrawCommand::DrawLineRect { .. } => "draw line rect",
+            DrawCommand::PushMask => "push mask",
+            DrawCommand::ActivateMask => "activate mask",
+            DrawCommand::DeactivateMask => "deactivate mask",
+            DrawCommand::PopMask => "pop mask",
+            DrawCommand::RenderAlphaMask { .. } => "render alpha mask",
+        }
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -1,3 +1,4 @@
+use super::target::PoolOrArcTexture;
 use crate::backend::RenderTargetMode;
 use crate::blend::TrivialBlend;
 use crate::buffer_builder::BufferBuilder;
@@ -17,8 +18,7 @@ use ruffle_render::transform::Transform;
 use std::mem;
 use swf::{BlendMode, Color, ColorTransform, Twips};
 use wgpu::Backend;
-
-use super::target::PoolOrArcTexture;
+use wgpu_profiler::Scope;
 
 pub struct CommandRenderer<'encoder> {
     pipelines: &'encoder Pipelines,
@@ -480,17 +480,17 @@ pub enum LayerRef<'a> {
 /// Splits the command list at blend boundaries while leaving blend subcommands lazy.
 /// Every blend will be its own item, but adjacent ordinary draws are chunked together.
 #[expect(clippy::too_many_arguments)]
-pub fn chunk_blends<'a>(
+pub fn chunk_blends<'encoder, 'global: 'encoder>(
     commands: CommandList,
-    descriptors: &'a Descriptors,
-    staging_belt: &'a mut wgpu::util::StagingBelt,
-    dynamic_transforms: &'a DynamicTransforms,
-    draw_encoder: &mut wgpu::CommandEncoder,
-    meshes: &'a Vec<Mesh>,
+    descriptors: &'encoder Descriptors,
+    staging_belt: &'encoder mut wgpu::util::StagingBelt,
+    dynamic_transforms: &'encoder DynamicTransforms,
+    draw_encoder: &'encoder mut Scope<'global, wgpu::CommandEncoder>,
+    meshes: &'encoder Vec<Mesh>,
     quality: StageQuality,
     width: u32,
     height: u32,
-    texture_pool: &mut TexturePool,
+    texture_pool: &'encoder mut TexturePool,
 ) -> Vec<Chunk> {
     WgpuCommandHandler::new(
         descriptors,
@@ -507,15 +507,15 @@ pub fn chunk_blends<'a>(
 }
 
 struct WgpuCommandHandler<'encoder, 'global: 'encoder> {
-    descriptors: &'global Descriptors,
+    descriptors: &'encoder Descriptors,
     quality: StageQuality,
     width: u32,
     height: u32,
-    meshes: &'global Vec<Mesh>,
-    staging_belt: &'global mut wgpu::util::StagingBelt,
-    dynamic_transforms: &'global DynamicTransforms,
-    draw_encoder: &'encoder mut wgpu::CommandEncoder,
-    texture_pool: &'global mut TexturePool,
+    meshes: &'encoder Vec<Mesh>,
+    staging_belt: &'encoder mut wgpu::util::StagingBelt,
+    dynamic_transforms: &'encoder DynamicTransforms,
+    draw_encoder: &'encoder mut Scope<'global, wgpu::CommandEncoder>,
+    texture_pool: &'encoder mut TexturePool,
     emulate_lines: bool,
 
     result: Vec<Chunk>,
@@ -528,15 +528,15 @@ struct WgpuCommandHandler<'encoder, 'global: 'encoder> {
 impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
     #[expect(clippy::too_many_arguments)]
     fn new(
-        descriptors: &'global Descriptors,
-        staging_belt: &'global mut wgpu::util::StagingBelt,
-        dynamic_transforms: &'global DynamicTransforms,
-        draw_encoder: &'encoder mut wgpu::CommandEncoder,
-        meshes: &'global Vec<Mesh>,
+        descriptors: &'encoder Descriptors,
+        staging_belt: &'encoder mut wgpu::util::StagingBelt,
+        dynamic_transforms: &'encoder DynamicTransforms,
+        draw_encoder: &'encoder mut Scope<'global, wgpu::CommandEncoder>,
+        meshes: &'encoder Vec<Mesh>,
         quality: StageQuality,
         width: u32,
         height: u32,
-        texture_pool: &'global mut TexturePool,
+        texture_pool: &'encoder mut TexturePool,
     ) -> Self {
         let transforms = Self::new_transforms(descriptors, dynamic_transforms);
 
@@ -566,8 +566,8 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
     }
 
     fn new_transforms(
-        descriptors: &'global Descriptors,
-        dynamic_transforms: &'global DynamicTransforms,
+        descriptors: &'encoder Descriptors,
+        dynamic_transforms: &'encoder DynamicTransforms,
     ) -> BufferBuilder {
         let mut transforms = BufferBuilder::new_for_uniform(&descriptors.limits);
         transforms.set_buffer_limit(dynamic_transforms.buffer.size());


### PR DESCRIPTION
## Description

Reviving ancient branches that I never finished hurray

This adds gpu profiling to Tracy, via wgpu_profiler. Very useful in profiling the gpu work.

This is how it looks for one frame of Heartcore:
<img width="2606" height="1075" alt="image" src="https://github.com/user-attachments/assets/d10fe3da-4836-4ab3-a678-715525c4b807" />

The very top bar in red here is GPU profiling, and the big vertical line on the left is where it issued that rendering command on the CPU.

Without tracy enabled, most of the library is a noop - with the exception of debug labels which it handles instead of us manually inserting them (but that's still feature gated like before).

## Testing

Manually test it with Tracy (0.13.1, the rust crate isn't updated for 0.14 yet) and load up any game - ideally a graphically demanding one! 

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
