### PR TITLE
avm1: Track activations in Tracy with `tracy_avm` feature

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -217,6 +217,9 @@ pub struct Activation<'a, 'gc: 'a> {
     /// This is often the name of a function (if known), or some static name to indicate where
     /// in the code it is (for example, a with{} block).
     pub id: ActivationIdentifier<'a>,
+
+    #[cfg(feature = "tracy_avm")]
+    _tracy_span: tracy_client::Span,
 }
 
 impl Drop for Activation<'_, '_> {
@@ -301,7 +304,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     ) -> Self {
         debug_assert!(swf_version > 0, "cannot execute code with SWF version 0");
         avm_debug!(context.avm1, "START {id}");
+        #[cfg(feature = "tracy_avm")]
+        let tracy_span = {
+            let span = tracy_client::Client::running()
+                .expect("tracy_client should be running")
+                .span_alloc(None, id.name, base_clip.movie().url(), 0, 0);
+            span.emit_color(0x49802c);
+            span
+        };
         Self {
+            #[cfg(feature = "tracy_avm")]
+            _tracy_span: tracy_span,
             context,
             id,
             swf_version,
@@ -323,7 +336,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     ) -> Activation<'b, 'gc> {
         let id = self.id.child(name);
         avm_debug!(self.context.avm1, "START {id}");
+        #[cfg(feature = "tracy_avm")]
+        let tracy_span = {
+            let span = tracy_client::Client::running()
+                .expect("tracy_client should be running")
+                .span_alloc(None, name, self.base_clip.movie().url(), 0, 0);
+            span.emit_color(0x49802c);
+            span
+        };
         Activation {
+            #[cfg(feature = "tracy_avm")]
+            _tracy_span: tracy_span,
             id,
             context: self.context,
             swf_version: self.swf_version,
@@ -354,7 +377,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let swf_version = base_clip.swf_version();
         debug_assert!(swf_version > 0, "cannot execute code with SWF version 0");
         let scope = context.avm1.global_scope(swf_version);
+        #[cfg(feature = "tracy_avm")]
+        let tracy_span = {
+            let span = tracy_client::Client::running()
+                .expect("tracy_client should be running")
+                .span_alloc(None, id.name, "rust", 0, 0);
+            span.emit_color(0x49802c);
+            span
+        };
         Self {
+            #[cfg(feature = "tracy_avm")]
+            _tracy_span: tracy_span,
             id,
             swf_version,
             scope,

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -342,7 +342,7 @@ impl<'gc> Avm1Function<'gc> {
         // The caller is the previous callee.
         let arguments_caller = activation.callee;
 
-        let name = if cfg!(feature = "avm_debug") {
+        let name = if cfg!(any(feature = "avm_debug", feature = "tracy_avm")) {
             Cow::Owned(self.debug_string_for_call(activation, name, args))
         } else {
             Cow::Borrowed("[Anonymous]")

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -650,10 +650,16 @@ impl<'gc> RenderContext<'_, 'gc> {
 #[collect(no_drop)]
 pub enum ActionType<'gc> {
     /// Normal frame or event actions.
-    Normal { bytecode: SwfSlice },
+    Normal {
+        bytecode: SwfSlice,
+        name: &'static str,
+    },
 
     /// AVM1 initialize clip event.
-    Initialize { bytecode: SwfSlice },
+    Initialize {
+        bytecode: SwfSlice,
+        name: &'static str,
+    },
 
     /// Construct a movie with a custom class or on(construct) events.
     Construct {
@@ -689,13 +695,15 @@ impl ActionType<'_> {
 impl fmt::Debug for ActionType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ActionType::Normal { bytecode } => f
+            ActionType::Normal { bytecode, name } => f
                 .debug_struct("ActionType::Normal")
                 .field("bytecode", bytecode)
+                .field("name", name)
                 .finish(),
-            ActionType::Initialize { bytecode } => f
+            ActionType::Initialize { bytecode, name } => f
                 .debug_struct("ActionType::Initialize")
                 .field("bytecode", bytecode)
+                .field("name", name)
                 .finish(),
             ActionType::Construct {
                 constructor,

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -612,6 +612,7 @@ impl<'gc> Avm1ButtonData<'gc> {
                         parent,
                         ActionType::Normal {
                             bytecode: action.action_data.clone(),
+                            name: "[Button event]",
                         },
                         false,
                     );

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2043,6 +2043,7 @@ impl<'gc> MovieClip<'gc> {
                         self.into(),
                         ActionType::Initialize {
                             bytecode: event_handler.action_data.clone(),
+                            name: "[MovieClip initialize]",
                         },
                         false,
                     );
@@ -2923,6 +2924,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
                         self.into(),
                         ActionType::Normal {
                             bytecode: event_handler.action_data.clone(),
+                            name: "[MovieClip event]",
                         },
                         event == ClipEvent::Unload,
                     );
@@ -4235,7 +4237,10 @@ impl<'gc, 'a> MovieClip<'gc> {
         if !slice.is_empty() {
             context.action_queue.queue_action(
                 self.into(),
-                ActionType::Normal { bytecode: slice },
+                ActionType::Normal {
+                    bytecode: slice,
+                    name: "[MovieClip action]",
+                },
                 false,
             );
         }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2162,8 +2162,9 @@ impl Player {
 
             match action.action_type {
                 // DoAction/clip event code.
-                ActionType::Normal { bytecode } | ActionType::Initialize { bytecode } => {
-                    Avm1::run_stack_frame_for_action(action.clip, "[Frame]", bytecode, context);
+                ActionType::Normal { bytecode, name }
+                | ActionType::Initialize { bytecode, name } => {
+                    Avm1::run_stack_frame_for_action(action.clip, name, bytecode, context);
                 }
                 // Change the prototype of a MovieClip and run constructor events.
                 ActionType::Construct {


### PR DESCRIPTION
## Description

This matches avm2 by effectively showing AVM1 executions (like functions, events, frame actions) in Tracy.

<img width="1257" height="686" alt="image" src="https://github.com/user-attachments/assets/c469742c-eefc-483b-ba57-aaa1cc300d6f" />

## Testing

Download Tracy (0.13.1) and try it out with the `tracy_avm` feature on an AVM1 heavy game.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
