### PR TITLE
avm2: In Sound constructor, call Sound.load from Actionscript

### DIFF
--- a/core/src/avm2/globals/flash/media/Sound.as
+++ b/core/src/avm2/globals/flash/media/Sound.as
@@ -6,10 +6,14 @@ package flash.media {
     [Ruffle(InstanceAllocator)]
     public class Sound extends EventDispatcher {
         public function Sound(stream:URLRequest = null, context:SoundLoaderContext = null) {
-            this.init(stream, context)
+            this.init();
+
+            if (stream != null) {
+                this.load(stream, context);
+            }
         }
 
-        private native function init(stream:URLRequest, context:SoundLoaderContext);
+        private native function init();
 
         public native function get bytesLoaded():uint;
         public native function get bytesTotal():int;
@@ -22,7 +26,6 @@ package flash.media {
         public native function extract(target:ByteArray, length:Number, startPosition:Number = -1):Number;
         public native function close():void;
 
-        [Ruffle(NativeCallable)]
         public native function load(stream:URLRequest, context:SoundLoaderContext = null):void;
 
         [API("674")]

--- a/core/src/avm2/globals/flash/media/sound.rs
+++ b/core/src/avm2/globals/flash/media/sound.rs
@@ -4,7 +4,6 @@ use crate::avm2::Avm2;
 use crate::avm2::Error;
 use crate::avm2::activation::Activation;
 use crate::avm2::error::{make_error_2037, make_error_2084};
-use crate::avm2::globals::methods::flash_media_sound as sound_methods;
 use crate::avm2::globals::slots::flash_net_url_request as url_request_slots;
 use crate::avm2::object::{
     EventObject, QueuedPlay, SoundChannelObject, SoundLoadingState, TObject as _,
@@ -23,7 +22,7 @@ pub use crate::avm2::object::sound_allocator;
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Value<'gc>,
-    args: &[Value<'gc>],
+    _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(sound_object) = this.as_object().and_then(|o| o.as_sound_object()) {
         let class_def = this.instance_class(activation);
@@ -49,10 +48,6 @@ pub fn init<'gc>(
                 );
             }
         }
-    }
-
-    if args.try_get_object(0).is_some() {
-        this.call_method(sound_methods::LOAD, args, activation)?;
     }
 
     Ok(Value::Undefined)


### PR DESCRIPTION
## Description

Instead of calling it from Rust, we can just call it from Actionscript.

## Testing

This change isn't observable

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
