### PR TITLE
fix(avm2): Treat non-object elements and missing fields as undefined in Array.sortOn

### DIFF
--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -1240,15 +1240,20 @@ pub fn sort_on<'gc>(
         first_option,
         constrain(|activation, a, b| {
             for (field_name, options) in field_names.iter().zip(options.iter()) {
-                // note: these are incorrect: pretty sure
-                // if the object is null/undefined or does not have the field,
-                // it's treated as if the field's value was undefined.
-                // TODO: verify this and fix it
-                let a_object = a.null_check(activation, None)?;
-                let a_field = a_object.get_public_property(*field_name, activation)?;
+                // Flash Player treats elements that are null/undefined, non-objects
+                // (e.g. numbers or strings), or objects lacking the field as if
+                // the field's value was undefined, without throwing an error.
+                let a_field = if a.has_public_property(*field_name, activation) {
+                    a.get_public_property(*field_name, activation)?
+                } else {
+                    Value::Undefined
+                };
 
-                let b_object = b.null_check(activation, None)?;
-                let b_field = b_object.get_public_property(*field_name, activation)?;
+                let b_field = if b.has_public_property(*field_name, activation) {
+                    b.get_public_property(*field_name, activation)?
+                } else {
+                    Value::Undefined
+                };
 
                 let ord = if options.contains(SortOptions::NUMERIC) {
                     compare_numeric_slow(activation, a_field, b_field)?


### PR DESCRIPTION
## Problem

`Array.sortOn` on an array containing non-object elements (e.g. numbers) throws:

```
ReferenceError: Error #1069: Property <name> not found on Number and there is no default value.
	at Array/http://adobe.com/AS3/2006/builtin::sortOn()
	...
```

Flash Player does **not** throw here — it treats elements that are null/undefined, non-objects, or objects lacking the field as if the field's value was `undefined`, which is exactly what the pre-existing `TODO: verify this and fix it` comment in the code describes.

This breaks real-world content: I hit this with a 2012 Chinese MMO page-game client (SWF v10, pure AS3). The sortOn call happens inside a `socketData` event handler that processes server-pushed config tables; the ReferenceError aborts the whole message-dispatch chain and freezes the game after login. Reproduces on 0.5.0 stable and on the 2026-08-21 nightly.

## Fix

Check `has_public_property` before reading the field in the `sort_on` comparison closure; when the property does not exist (or the element is not an object), use `Value::Undefined` so the existing undefined-ordering rules in `sort_inner` apply — matching the native behavior noted in the old comment.

## Verification

- Patched desktop build runs the above game client through login into the world with animations and click-to-move interaction working (unpatched builds freeze).
- Fork CI run building this patch: https://github.com/wgt19861219/ruffle/actions/runs/32545106094
- The full upstream test suites (Test Rust / Test Web / Quick Fuzz) triggered by the push all pass with this change: https://github.com/wgt19861219/ruffle/actions