### PR TITLE
fix(desktop): Prefer CJK-capable system fonts for default device fonts on Windows

### DIFF
--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -358,33 +358,42 @@ impl ActivePlayer {
                 Box::new(on_metadata),
             );
 
-            player_lock.set_default_font(
-                DefaultFont::Serif,
-                vec![
-                    "Times New Roman".into(),
-                    "Tinos".into(),
-                    "Liberation Serif".into(),
-                    "DejaVu Serif".into(),
-                ],
-            );
-            player_lock.set_default_font(
-                DefaultFont::Sans,
-                vec![
-                    "Arial".into(),
-                    "Arimo".into(),
-                    "Liberation Sans".into(),
-                    "DejaVu Sans".into(),
-                ],
-            );
-            player_lock.set_default_font(
-                DefaultFont::Typewriter,
-                vec![
-                    "Courier New".into(),
-                    "Cousine".into(),
-                    "Liberation Mono".into(),
-                    "DejaVu Sans Mono".into(),
-                ],
-            );
+            // On Windows, put CJK-capable system fonts first so that text rendered
+            // with the `_sans`/`_serif`/`_typewriter` device font aliases can
+            // display CJK glyphs. This mirrors native Flash Player behavior on
+            // a Chinese Windows installation (SimSun / Microsoft YaHei), and is
+            // a no-op on other platforms. The core resolves a default font to
+            // the *first* name found in the system, so appending CJK fonts at
+            // the end would have no effect.
+            let mut serif = vec![
+                "Times New Roman".into(),
+                "Tinos".into(),
+                "Liberation Serif".into(),
+                "DejaVu Serif".into(),
+            ];
+            #[cfg(target_os = "windows")]
+            serif.insert(0, "SimSun".into());
+            player_lock.set_default_font(DefaultFont::Serif, serif);
+
+            let mut sans = vec![
+                "Arial".into(),
+                "Arimo".into(),
+                "Liberation Sans".into(),
+                "DejaVu Sans".into(),
+            ];
+            #[cfg(target_os = "windows")]
+            sans.insert(0, "Microsoft YaHei".into());
+            player_lock.set_default_font(DefaultFont::Sans, sans);
+
+            let mut typewriter = vec![
+                "Courier New".into(),
+                "Cousine".into(),
+                "Liberation Mono".into(),
+                "DejaVu Sans Mono".into(),
+            ];
+            #[cfg(target_os = "windows")]
+            typewriter.insert(0, "NSimSun".into());
+            player_lock.set_default_font(DefaultFont::Typewriter, typewriter);
             player_lock.set_default_font(
                 DefaultFont::JapaneseGothic,
                 vec![


### PR DESCRIPTION
## Problem

On Windows, the default device font lists for `_sans`/`_serif`/`_typewriter` only contain Latin-only fonts (Arial, Times New Roman, Courier New...). The Japanese defaults have dedicated Windows entries (MS UI Gothic etc.), but there is no CJK-capable Windows font in the Serif/Sans/Typewriter lists.

Since the core resolves a default font to **the first name found on the system** (see the `TODO: Return multiple fonts when it's needed` in `library.rs`), appending fonts at the end has no effect — on a stock Windows machine the resolved font is plain Arial/Times, which has no CJK glyphs. The result: **any CJK text rendered through a device-font alias is completely blank** (no tofu, just nothing).

This affects real-world content — a 2012 Chinese MMO page-game client (SWF v10, AS3) renders its quest log, chat, and most UI labels blank on desktop Ruffle for Windows.

The egui-side warning confirms the situation:
```
WARN ruffle_desktop::gui::controller: Failed to register [Name("Noto Sans CJK"), ...] as Proportional: no unicode fonts found!
```
(That particular warning is about the egui UI font, but it illustrates that none of the pan-CJK families exist on Windows by default.)

## Fix

On Windows, insert the built-in CJK fonts at the **front** of the Serif/Sans/Typewriter default lists:

- Serif → `SimSun` (matches native Flash Player on a Chinese Windows install)
- Sans → `Microsoft YaHei`
- Typewriter → `NSimSun` (its monospace companion)

These fonts ship with every Windows installation and include Latin glyphs, so Western text keeps rendering (in the CJK font's Latin style, exactly as native Flash Player does on a zh-CN system). No change on other platforms (`cfg(target_os = "windows")`).

## Verification

Patched desktop build renders the quest log / chat / UI labels of the above-mentioned Chinese MMO client correctly (was blank before). CI build of this patch: https://github.com/wgt19861219/ruffle/actions/runs/32547594350