### PR TITLE
debug_ui: Add "Preview" tab to Display Objects

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -1,6 +1,9 @@
+mod preview;
 mod search;
 
+use preview::RenderedPreview;
 use ruffle_render::blend::ExtendedBlendMode;
+use ruffle_render::quality::StageQuality;
 pub use search::DisplayObjectSearchWindow;
 
 use crate::avm2::object::TObject as _;
@@ -62,6 +65,17 @@ const ALL_BLEND_MODES: [ExtendedBlendMode; 15] = [
     ExtendedBlendMode::Shader,
 ];
 
+const ALL_STAGE_QUALITIES: [StageQuality; 8] = [
+    StageQuality::Low,
+    StageQuality::Medium,
+    StageQuality::High,
+    StageQuality::Best,
+    StageQuality::High8x8,
+    StageQuality::High8x8Linear,
+    StageQuality::High16x16,
+    StageQuality::High16x16Linear,
+];
+
 #[derive(Debug, Eq, PartialEq, Hash, Default, Copy, Clone)]
 pub enum Panel {
     #[default]
@@ -70,6 +84,7 @@ pub enum Panel {
     Children,
     Interactive,
     TypeSpecific,
+    Preview,
 }
 
 #[derive(Debug)]
@@ -86,6 +101,20 @@ pub struct DisplayObjectWindow {
 
     /// A buffer for editing EditText
     html_text: String,
+
+    /// A rendered preview of the display object, if one has been requested.
+    preview: Option<RenderedPreview>,
+
+    /// The scale factor to render the next preview at.
+    preview_scale: f32,
+
+    /// The quality to render the next preview at, or `None` to use the
+    /// stage's current quality.
+    preview_quality: Option<StageQuality>,
+
+    /// The largest width or height, in pixels, that the next preview's
+    /// texture may have, regardless of `preview_scale`.
+    preview_max_dimension: u32,
 }
 
 impl Default for DisplayObjectWindow {
@@ -105,6 +134,10 @@ impl Default for DisplayObjectWindow {
             track_current_frame: false,
             scroll_to_frame: None,
             html_text: Default::default(),
+            preview: None,
+            preview_scale: 1.0,
+            preview_quality: None,
+            preview_max_dimension: 4 * 1024,
         }
     }
 }
@@ -178,6 +211,7 @@ impl DisplayObjectWindow {
                             format!("Children ({})", ctr.num_children()),
                         );
                     }
+                    ui.selectable_value(&mut self.open_panel, Panel::Preview, "Preview");
                 });
                 ui.separator();
 
@@ -203,6 +237,7 @@ impl DisplayObjectWindow {
                             self.show_interactive(ui, context, int)
                         }
                     }
+                    Panel::Preview => self.show_preview(ui, context, object, messages),
                 }
             });
         keep_open
@@ -1475,6 +1510,105 @@ impl DisplayObjectWindow {
                         ui.label(format!("{filter:?}"));
                     }
                 });
+        }
+    }
+
+    fn show_preview<'gc>(
+        &mut self,
+        ui: &mut Ui,
+        context: &mut UpdateContext<'gc>,
+        object: DisplayObject<'gc>,
+        messages: &mut Vec<Message>,
+    ) {
+        Grid::new(ui.id().with("preview-settings"))
+            .num_columns(2)
+            .show(ui, |ui| {
+                ui.label("Scale");
+                ui.add(
+                    DragValue::new(&mut self.preview_scale)
+                        .speed(0.01)
+                        .range(0.01..=8.0)
+                        .suffix("x"),
+                );
+                ui.end_row();
+
+                ui.label("Quality");
+                ComboBox::from_id_salt(ui.id().with("preview-quality"))
+                    .selected_text(match self.preview_quality {
+                        Some(quality) => quality.to_string(),
+                        None => "Stage Quality".to_string(),
+                    })
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut self.preview_quality, None, "Stage");
+                        for quality in ALL_STAGE_QUALITIES {
+                            ui.selectable_value(
+                                &mut self.preview_quality,
+                                Some(quality),
+                                quality.to_string(),
+                            );
+                        }
+                    });
+                ui.end_row();
+
+                ui.label("Max Size");
+                ui.add(
+                    DragValue::new(&mut self.preview_max_dimension)
+                        .speed(16)
+                        .range(1..=16384)
+                        .suffix("px"),
+                );
+                ui.end_row();
+            });
+
+        match RenderedPreview::size_and_scale_for(
+            object,
+            self.preview_scale,
+            self.preview_max_dimension,
+        ) {
+            Some((width, height, _)) => {
+                ui.label(format!("Resulting size: {width} x {height} px"));
+            }
+            None => {
+                ui.weak("Resulting size: (object has no bounds)");
+            }
+        }
+
+        let mut clear = false;
+        ui.horizontal(|ui| {
+            if ui.button("Render").clicked() {
+                let quality = self
+                    .preview_quality
+                    .unwrap_or_else(|| context.stage.quality());
+                self.preview = RenderedPreview::render(
+                    context,
+                    object,
+                    ui.ctx(),
+                    self.preview_scale,
+                    quality,
+                    self.preview_max_dimension,
+                );
+            }
+            if let Some(preview) = &self.preview {
+                if ui.button("Save as PNG...").clicked() {
+                    preview.save_as_png(object, messages);
+                }
+                if ui.button("Clear").clicked() {
+                    clear = true;
+                }
+            }
+        });
+        if clear {
+            self.preview = None;
+        }
+
+        match &self.preview {
+            Some(preview) => {
+                let texture = preview.texture();
+                ui.image((texture.id(), texture.size_vec2()));
+            }
+            None => {
+                ui.weak("(not rendered - click \"Render\" to capture a snapshot)");
+            }
         }
     }
 

--- a/core/src/debug_ui/display_object/preview.rs
+++ b/core/src/debug_ui/display_object/preview.rs
@@ -1,0 +1,154 @@
+use crate::bitmap::bitmap_data::{BitmapData, IBitmapDrawable};
+use crate::bitmap::operations;
+use crate::context::UpdateContext;
+use crate::debug_ui::{ItemToSave, Message};
+use crate::display_object::{BoundsMode, DisplayObject, TDisplayObject};
+use ruffle_render::matrix::Matrix;
+use ruffle_render::quality::StageQuality;
+use ruffle_render::transform::Transform;
+use std::fmt::{Debug, Formatter};
+use swf::{BlendMode, Twips};
+
+/// A snapshot of a display object rendered on demand for the "Preview" panel.
+///
+/// The raw RGBA pixels are kept alongside the uploaded texture so the image
+/// can be exported (e.g. saved as a PNG) without needing to read the pixels
+/// back from the GPU-owned egui texture.
+pub struct RenderedPreview {
+    texture: egui::TextureHandle,
+    width: u32,
+    height: u32,
+    rgba_premultiplied: Vec<u8>,
+}
+
+impl Debug for RenderedPreview {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderedPreview")
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("rgba", &self.rgba_premultiplied.len())
+            .finish()
+    }
+}
+
+impl RenderedPreview {
+    pub fn texture(&self) -> &egui::TextureHandle {
+        &self.texture
+    }
+
+    /// Computes the effective scale (after clamping to `max_dimension`) and
+    /// resulting pixel dimensions a preview of `object` would have, without
+    /// actually rendering it.
+    ///
+    /// `max_dimension` caps the width and height of the resulting texture,
+    /// regardless of `scale`, as a safety net against accidentally
+    /// allocating an enormous texture.
+    pub fn size_and_scale_for(
+        object: DisplayObject,
+        scale: f32,
+        max_dimension: u32,
+    ) -> Option<(u32, u32, f64)> {
+        let bounds = object.bounds(BoundsMode::Engine);
+        if !bounds.is_valid() {
+            return None;
+        }
+
+        let width_px = bounds.width().to_pixels();
+        let height_px = bounds.height().to_pixels();
+        if width_px <= 0.0 || height_px <= 0.0 {
+            return None;
+        }
+
+        let scale = (scale as f64).min(max_dimension as f64 / width_px.max(height_px));
+        let out_width = ((width_px * scale).ceil() as u32).clamp(1, max_dimension);
+        let out_height = ((height_px * scale).ceil() as u32).clamp(1, max_dimension);
+
+        Some((out_width, out_height, scale))
+    }
+
+    /// Renders a `DisplayObject` (and its children) offscreen, in its own local
+    /// coordinate space, and uploads the result as an egui texture.
+    pub fn render<'gc>(
+        context: &mut UpdateContext<'gc>,
+        object: DisplayObject<'gc>,
+        egui_ctx: &egui::Context,
+        scale: f32,
+        quality: StageQuality,
+        max_dimension: u32,
+    ) -> Option<Self> {
+        let bounds = object.bounds(BoundsMode::Engine);
+        let (out_width, out_height, scale) =
+            Self::size_and_scale_for(object, scale, max_dimension)?;
+
+        let transform = Transform {
+            matrix: Matrix {
+                a: scale as f32,
+                b: 0.0,
+                c: 0.0,
+                d: scale as f32,
+                tx: Twips::from_pixels(-bounds.x_min.to_pixels() * scale),
+                ty: Twips::from_pixels(-bounds.y_min.to_pixels() * scale),
+            },
+            ..Default::default()
+        };
+
+        let target = BitmapData::new(context.gc(), out_width, out_height, true, 0);
+
+        operations::draw(
+            context,
+            target,
+            IBitmapDrawable::DisplayObject(object),
+            transform,
+            true,
+            BlendMode::Normal,
+            None,
+            quality,
+        )
+        .ok()?;
+
+        let data = target.sync(context.renderer);
+        let data = data.borrow();
+        let width = data.width();
+        let height = data.height();
+        let rgba_premultiplied = data.pixels_rgba().to_vec();
+        let image = egui::ColorImage::from_rgba_premultiplied(
+            [width as usize, height as usize],
+            &rgba_premultiplied,
+        );
+
+        let texture = egui_ctx.load_texture(
+            format!("do-preview-{:p}", object.as_ptr()),
+            image,
+            Default::default(),
+        );
+
+        Some(Self {
+            texture,
+            width,
+            height,
+            rgba_premultiplied,
+        })
+    }
+
+    /// Encodes this preview as a PNG and queues it to be saved via a native
+    /// file dialog.
+    pub fn save_as_png(&self, object: DisplayObject, messages: &mut Vec<Message>) {
+        let mut straight_rgba = self.rgba_premultiplied.clone();
+        ruffle_render::utils::unmultiply_alpha_rgba(&mut straight_rgba);
+
+        let mut data = Vec::new();
+        let mut encoder = png::Encoder::new(&mut data, self.width, self.height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        match encoder
+            .write_header()
+            .and_then(|mut w| w.write_image_data(&straight_rgba))
+        {
+            Ok(()) => messages.push(Message::SaveFile(ItemToSave {
+                suggested_name: format!("{:p}.png", object.as_ptr()),
+                data,
+            })),
+            Err(e) => tracing::error!("Couldn't create png: {e}"),
+        }
+    }
+}


### PR DESCRIPTION
## Description

The Preview tab allows rendering the Display Object into a bitmap using
BitmapData.draw(). This helps identifying objects in complex SWFs.

<img width="600" src="https://github.com/user-attachments/assets/785756ef-7c1f-433e-b6ed-c38cb7f1a907" />

<!--
Please explain the changes made within this PR and the context around them.
Why did you make this change; does it add a feature, or fix a bug? Be sure to
link to any content or issues that it affects!

Please also remember that each commit message should describe its own changes
too.
-->

## Testing

Tested manually.

<!-- How can we test this PR? -->

<!--
If possible, please follow our [test guidelines](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines)
to make a SWF test which should fail before this PR, and pass after it. This
helps us protect against breaking your changes in the future.

If applicable, add unit tests or web integration tests, but don't test SWF
behavior with unit tests. Describe what you added!

Note that in most cases, it's obligatory to add a SWF test for every
observable change you make!

If you need help with making tests, or do not believe this change is easily
automatically testable, please describe how we can verify the changes ourselves.
If there is real world content that we can test on, that helps a lot!
-->

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
