### PR TITLE
render: Implement bitmap region rendering for wgpu

### DIFF
--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -676,6 +676,7 @@ mod wrapper {
                 context.transform_stack.transform(),
                 smoothing,
                 pixel_snapping,
+                inner_bitmap_data.full_region(),
             );
         }
 
@@ -865,6 +866,10 @@ impl<'gc> BitmapRawData<'gc> {
     }
     pub fn height(&self) -> u32 {
         self.height
+    }
+
+    pub fn full_region(&self) -> PixelRegion {
+        PixelRegion::for_whole_size(self.width(), self.height())
     }
 
     pub fn is_point_in_bounds(&self, x: i32, y: i32) -> bool {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -61,7 +61,7 @@ pub use loader_display::LoaderDisplay;
 pub use morph_shape::MorphShape;
 pub use movie_clip::{MovieClip, MovieClipHandle, MovieClipWeak, Scene};
 use ruffle_render::backend::{BitmapCacheEntry, RenderBackend};
-use ruffle_render::bitmap::{BitmapHandle, BitmapInfo, PixelSnapping};
+use ruffle_render::bitmap::{BitmapInfo, PixelSnapping};
 use ruffle_render::blend::ExtendedBlendMode;
 use ruffle_render::commands::{CommandHandler, CommandList, RenderBlendMode};
 use ruffle_render::filters::Filter;
@@ -190,8 +190,8 @@ impl BitmapCache {
         self.bitmap = None;
     }
 
-    fn handle(&self) -> Option<BitmapHandle> {
-        self.bitmap.as_ref().map(|b| b.handle.clone())
+    fn bitmap(&self) -> Option<BitmapInfo> {
+        self.bitmap.clone()
     }
 }
 
@@ -936,7 +936,7 @@ impl BoundsMode {
 }
 
 struct DrawCacheInfo {
-    handle: BitmapHandle,
+    bitmap: BitmapInfo,
     dirty: bool,
     base_transform: Transform,
     bounds: Rectangle<Twips>,
@@ -1015,8 +1015,8 @@ pub fn render_base<'gc>(
                         draw_offset,
                         swf_version,
                     );
-                    cache_info = cache.handle().map(|handle| DrawCacheInfo {
-                        handle,
+                    cache_info = cache.bitmap().map(|bitmap| DrawCacheInfo {
+                        bitmap,
                         dirty: true,
                         base_transform,
                         bounds,
@@ -1024,8 +1024,8 @@ pub fn render_base<'gc>(
                         filters,
                     });
                 } else {
-                    cache_info = cache.handle().map(|handle| DrawCacheInfo {
-                        handle,
+                    cache_info = cache.bitmap().map(|bitmap| DrawCacheInfo {
+                        bitmap,
                         dirty: false,
                         base_transform,
                         bounds,
@@ -1085,7 +1085,7 @@ pub fn render_base<'gc>(
             };
             this.render_self(&mut offscreen_context);
             offscreen_context.cache_draws.push(BitmapCacheEntry {
-                handle: cache_info.handle.clone(),
+                handle: cache_info.bitmap.handle.clone(),
                 commands: offscreen_context.commands,
                 clear: this.opaque_background().unwrap_or_default(),
                 filters: cache_info.filters,
@@ -1098,7 +1098,7 @@ pub fn render_base<'gc>(
             context,
             |context| {
                 context.commands.render_bitmap(
-                    cache_info.handle,
+                    cache_info.bitmap.handle,
                     Transform {
                         matrix: Matrix {
                             tx: context.transform_stack.transform().matrix.tx + offset_x,

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1097,6 +1097,7 @@ pub fn render_base<'gc>(
             this,
             context,
             |context| {
+                let region = cache_info.bitmap.full_region();
                 context.commands.render_bitmap(
                     cache_info.bitmap.handle,
                     Transform {
@@ -1110,6 +1111,7 @@ pub fn render_base<'gc>(
                     },
                     true,
                     PixelSnapping::Always, // cacheAsBitmap forces pixel snapping
+                    region,
                 )
             },
             &options,

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -554,11 +554,13 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
                 bounds.height().to_pixels() as f32 / bitmap.height as f32,
             );
 
+            let region = bitmap.full_region();
             context.commands.render_bitmap(
                 bitmap.handle,
                 transform,
                 smoothing,
                 PixelSnapping::Never,
+                region,
             );
         } else if codec != Some(VideoCodec::None) {
             tracing::warn!("Video has no decoded frame to render.");

--- a/core/src/font/glyph.rs
+++ b/core/src/font/glyph.rs
@@ -278,11 +278,13 @@ impl Glyph {
                     ..Default::default()
                 });
 
+                let region = info.full_region();
                 context.commands.render_bitmap(
                     info.handle,
                     context.transform_stack.transform(),
                     true,
                     ruffle_render::bitmap::PixelSnapping::Auto,
+                    region,
                 );
 
                 context.transform_stack.pop();

--- a/core/src/font/glyph.rs
+++ b/core/src/font/glyph.rs
@@ -3,7 +3,7 @@ use crate::drawing::Drawing;
 use crate::prelude::*;
 use ruffle_render::backend::null::NullBitmapSource;
 use ruffle_render::backend::{RenderBackend, ShapeHandle};
-use ruffle_render::bitmap::{Bitmap, BitmapHandle};
+use ruffle_render::bitmap::{Bitmap, BitmapInfo};
 use ruffle_render::error::Error;
 use ruffle_render::transform::Transform;
 
@@ -43,7 +43,7 @@ impl SwfGlyphOrShape {
 pub enum GlyphRenderData {
     Shape(ShapeHandle),
     Bitmap {
-        handle: BitmapHandle,
+        info: BitmapInfo,
         tx: Twips,
         ty: Twips,
     },
@@ -54,9 +54,9 @@ impl GlyphRenderData {
         Self::Shape(shape_handle)
     }
 
-    pub fn from_bitmap(bitmap_handle: BitmapHandle, tx: Twips, ty: Twips) -> Self {
+    pub fn from_bitmap(bitmap_info: BitmapInfo, tx: Twips, ty: Twips) -> Self {
         Self::Bitmap {
-            handle: bitmap_handle,
+            info: bitmap_info,
             tx,
             ty,
         }
@@ -103,7 +103,7 @@ impl GlyphShape {
                 .register_or_replace(renderer)
                 .map(GlyphRenderData::from_shape),
             GlyphShape::Bitmap(bitmap) => bitmap
-                .get_handle_or_register(renderer)
+                .get_bitmap_info_or_register(renderer)
                 .as_ref()
                 .inspect_err(|err| {
                     tracing::error!(
@@ -112,7 +112,7 @@ impl GlyphShape {
                 })
                 .ok()
                 .cloned()
-                .map(|handle| GlyphRenderData::from_bitmap(handle, bitmap.tx, bitmap.ty)),
+                .map(|info| GlyphRenderData::from_bitmap(info, bitmap.tx, bitmap.ty)),
             GlyphShape::None => None,
         }
     }
@@ -121,7 +121,7 @@ impl GlyphShape {
 /// A Bitmap that can be registered to a RenderBackend.
 struct GlyphBitmap<'a> {
     bitmap: Cell<Option<Bitmap<'a>>>,
-    handle: OnceCell<Result<BitmapHandle, Error>>,
+    handle: OnceCell<Result<BitmapInfo, Error>>,
 
     /// Translation in x to be applied before rendering the glyph.
     tx: Twips,
@@ -148,16 +148,23 @@ impl<'a> GlyphBitmap<'a> {
         }
     }
 
-    pub fn get_handle_or_register(
+    pub fn get_bitmap_info_or_register(
         &self,
         renderer: &mut dyn RenderBackend,
-    ) -> &Result<BitmapHandle, Error> {
+    ) -> &Result<BitmapInfo, Error> {
         self.handle.get_or_init(|| {
-            renderer.register_bitmap(
-                self.bitmap
-                    .take()
-                    .expect("Bitmap should be available before registering"),
-            )
+            let bitmap = self
+                .bitmap
+                .take()
+                .expect("Bitmap should be available before registering");
+            let width = bitmap.width();
+            let height = bitmap.height();
+            let handle = renderer.register_bitmap(bitmap)?;
+            Ok(BitmapInfo {
+                handle,
+                width,
+                height,
+            })
         })
     }
 }
@@ -265,14 +272,14 @@ impl Glyph {
                     .commands
                     .render_shape(shape_handle, context.transform_stack.transform());
             }
-            GlyphRenderData::Bitmap { handle, tx, ty } => {
+            GlyphRenderData::Bitmap { info, tx, ty } => {
                 context.transform_stack.push(&Transform {
                     matrix: Matrix::translate(tx, ty),
                     ..Default::default()
                 });
 
                 context.commands.render_bitmap(
-                    handle,
+                    info.handle,
                     context.transform_stack.transform(),
                     true,
                     ruffle_render::bitmap::PixelSnapping::Auto,

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -602,6 +602,7 @@ impl CommandHandler for WebCanvasRenderBackend {
         transform: Transform,
         smoothing: bool,
         _pixel_snapping: PixelSnapping,
+        _region: PixelRegion,
     ) {
         if self.mask_state == MaskState::ClearMask {
             return;

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -602,7 +602,7 @@ impl CommandHandler for WebCanvasRenderBackend {
         transform: Transform,
         smoothing: bool,
         _pixel_snapping: PixelSnapping,
-        _region: PixelRegion,
+        region: PixelRegion,
     ) {
         if self.mask_state == MaskState::ClearMask {
             return;
@@ -618,7 +618,17 @@ impl CommandHandler for WebCanvasRenderBackend {
         if bitmap_canvas.width() > 0 && bitmap_canvas.height() > 0 {
             let _ = self
                 .context
-                .draw_image_with_html_canvas_element(bitmap_canvas, 0.0, 0.0);
+                .draw_image_with_html_canvas_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
+                    bitmap_canvas,
+                    region.x_min as f64,
+                    region.y_min as f64,
+                    region.width() as f64,
+                    region.height() as f64,
+                    0.0,
+                    0.0,
+                    region.width() as f64,
+                    region.height() as f64,
+                );
         }
 
         self.clear_color_filter();

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -32,6 +32,12 @@ pub struct BitmapInfo {
     pub height: u32,
 }
 
+impl BitmapInfo {
+    pub fn full_region(&self) -> PixelRegion {
+        PixelRegion::for_whole_size(self.width, self.height)
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub struct BitmapSize {
     pub width: u32,

--- a/render/src/commands.rs
+++ b/render/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::backend::ShapeHandle;
-use crate::bitmap::{BitmapHandle, PixelSnapping};
+use crate::bitmap::{BitmapHandle, PixelRegion, PixelSnapping};
 use crate::matrix::Matrix;
 use crate::pixel_bender::PixelBenderShaderHandle;
 use crate::transform::Transform;
@@ -12,6 +12,7 @@ pub trait CommandHandler {
         transform: Transform,
         smoothing: bool,
         pixel_snapping: PixelSnapping,
+        region: PixelRegion,
     );
     fn render_stage3d(&mut self, bitmap: BitmapHandle, transform: Transform);
     fn render_shape(&mut self, shape: ShapeHandle, transform: Transform);
@@ -66,7 +67,8 @@ impl CommandList {
                     transform,
                     smoothing,
                     pixel_snapping,
-                } => handler.render_bitmap(bitmap, transform, smoothing, pixel_snapping),
+                    region,
+                } => handler.render_bitmap(bitmap, transform, smoothing, pixel_snapping, region),
                 Command::RenderShape { shape, transform } => handler.render_shape(shape, transform),
                 Command::RenderStage3D { bitmap, transform } => {
                     handler.render_stage3d(bitmap, transform)
@@ -100,6 +102,7 @@ impl CommandHandler for CommandList {
         transform: Transform,
         smoothing: bool,
         pixel_snapping: PixelSnapping,
+        region: PixelRegion,
     ) {
         if self.maskers_in_progress <= 1 {
             self.commands.push(Command::RenderBitmap {
@@ -107,6 +110,7 @@ impl CommandHandler for CommandList {
                 transform,
                 smoothing,
                 pixel_snapping,
+                region,
             });
         }
     }
@@ -204,6 +208,7 @@ pub enum Command {
         transform: Transform,
         smoothing: bool,
         pixel_snapping: PixelSnapping,
+        region: PixelRegion,
     },
     RenderStage3D {
         bitmap: BitmapHandle,

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1268,23 +1268,32 @@ impl CommandHandler for WebGlRenderBackend {
         transform: Transform,
         smoothing: bool,
         pixel_snapping: PixelSnapping,
-        _region: PixelRegion,
+        region: PixelRegion,
     ) {
         self.set_stencil_state();
         let entry = as_registry_data(&bitmap);
         // Adjust the quad draw to use the target bitmap.
         let quad = &self.bitmap_quad_draws;
         let draw = &quad[0];
-        let bitmap_matrix = if let DrawType::Bitmap(BitmapDraw { matrix, .. }) = &draw.draw_type {
-            matrix
-        } else {
-            unreachable!()
+
+        let bitmap_matrix = {
+            let width = entry.width as f32;
+            let height = entry.height as f32;
+            &[
+                [region.width() as f32 / width, 0.0, 0.0],
+                [0.0, region.height() as f32 / height, 0.0],
+                [
+                    region.x_min as f32 / width,
+                    region.y_min as f32 / height,
+                    1.0,
+                ],
+            ]
         };
 
-        // Scale the quad to the bitmap's dimensions.
         let mut matrix = transform.matrix;
         pixel_snapping.apply(&mut matrix);
-        matrix *= Matrix::scale(entry.width as f32, entry.height as f32);
+        // Scale the quad to the region's dimensions.
+        matrix *= Matrix::scale(region.width() as f32, region.height() as f32);
 
         let world_matrix = [
             [matrix.a, matrix.b, 0.0, 0.0],

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1268,6 +1268,7 @@ impl CommandHandler for WebGlRenderBackend {
         transform: Transform,
         smoothing: bool,
         pixel_snapping: PixelSnapping,
+        _region: PixelRegion,
     ) {
         self.set_stencil_state();
         let entry = as_registry_data(&bitmap);

--- a/render/wgpu/src/dynamic_transforms.rs
+++ b/render/wgpu/src/dynamic_transforms.rs
@@ -1,11 +1,12 @@
-use crate::Transforms;
 use crate::descriptors::Descriptors;
+use crate::{PosUvVertex, Transforms};
 use std::mem;
 
 const ESTIMATED_OBJECTS_PER_CHUNK: u64 = 200;
 
 pub struct DynamicTransforms {
     pub buffer: wgpu::Buffer,
+    pub vertex_buffer: wgpu::Buffer,
     pub bind_group: wgpu::BindGroup,
 }
 
@@ -17,6 +18,13 @@ impl DynamicTransforms {
                 .min(descriptors.limits.max_uniform_buffer_binding_size)
                 .min(descriptors.limits.max_buffer_size),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let vertex_buffer = descriptors.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: (mem::size_of::<PosUvVertex>() as u64 * ESTIMATED_OBJECTS_PER_CHUNK)
+                .min(descriptors.limits.max_buffer_size),
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
         let bind_group = descriptors
@@ -33,6 +41,10 @@ impl DynamicTransforms {
                     }),
                 }],
             });
-        Self { buffer, bind_group }
+        Self {
+            buffer,
+            bind_group,
+            vertex_buffer,
+        }
     }
 }

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -98,6 +98,12 @@ struct PosUvVertex {
 }
 
 impl PosUvVertex {
+    pub fn new(x: f32, y: f32, u: f32, v: f32, t: f32) -> Self {
+        let position = [x, y];
+        let uv = [u, v, t];
+        Self { position, uv }
+    }
+
     pub fn from_tessellator(vertex: TessVertex, texture_matrix: &[[f32; 3]; 3]) -> Self {
         let position = [vertex.x, vertex.y];
         let uv = Self::transform_uv(texture_matrix, vertex.x, vertex.y);

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -150,8 +150,14 @@ impl Surface {
                     chunk,
                     needs_stencil,
                     transforms,
+                    vertices,
                 } => {
                     transforms.copy_to(staging_belt, draw_encoder, &dynamic_transforms.buffer);
+                    vertices.copy_to(
+                        staging_belt,
+                        draw_encoder,
+                        &dynamic_transforms.vertex_buffer,
+                    );
                     let mut render_pass = draw_encoder.scoped_render_pass(
                         format!(
                             "Chunked draw calls {}",

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -8,7 +8,7 @@ use crate::dynamic_transforms::DynamicTransforms;
 use crate::mesh::{DrawType, Mesh, as_mesh};
 use crate::surface::Surface;
 use crate::surface::target::CommandTarget;
-use crate::{Descriptors, MaskState, Pipelines, Transforms, as_texture};
+use crate::{Descriptors, MaskState, Pipelines, PosUvVertex, Transforms, as_texture};
 use ruffle_render::backend::ShapeHandle;
 use ruffle_render::bitmap::{BitmapHandle, PixelRegion, PixelSnapping};
 use ruffle_render::commands::{CommandHandler, CommandList, RenderBlendMode};
@@ -75,6 +75,7 @@ impl<'encoder> CommandRenderer<'encoder> {
             DrawCommand::RenderBitmap {
                 bitmap,
                 transform_buffer,
+                vertex_offset,
                 smoothing,
                 blend_mode,
                 render_stage3d,
@@ -85,6 +86,7 @@ impl<'encoder> CommandRenderer<'encoder> {
                 *smoothing,
                 *blend_mode,
                 *render_stage3d,
+                *vertex_offset,
             ),
             DrawCommand::RenderTexture {
                 _texture,
@@ -201,6 +203,7 @@ impl<'encoder> CommandRenderer<'encoder> {
         render_pass.draw_indexed(0..num_indices, 0, 0..1);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn render_bitmap(
         &self,
         render_pass: &mut wgpu::RenderPass<'encoder>,
@@ -209,6 +212,7 @@ impl<'encoder> CommandRenderer<'encoder> {
         smoothing: bool,
         blend_mode: TrivialBlend,
         render_stage3d: bool,
+        vertex_offset: Option<wgpu::BufferAddress>,
     ) {
         let texture = as_texture(bitmap);
 
@@ -224,9 +228,15 @@ impl<'encoder> CommandRenderer<'encoder> {
         self.prep_bitmap(render_pass, &bind.bind_group, blend_mode, render_stage3d);
         render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
 
+        let vertex_slice = if let Some(vertex_offset) = vertex_offset {
+            self.dynamic_transforms.vertex_buffer.slice(vertex_offset..)
+        } else {
+            self.descriptors.quad.vertices_pos_uv.slice(..)
+        };
+
         self.draw(
             render_pass,
-            self.descriptors.quad.vertices_pos_uv.slice(..),
+            vertex_slice,
             self.descriptors.quad.indices.slice(..),
             6,
         );
@@ -405,6 +415,7 @@ pub enum Chunk {
         chunk: Vec<DrawCommand>,
         needs_stencil: bool,
         transforms: BufferBuilder,
+        vertices: BufferBuilder,
     },
     Blend {
         texture: PoolOrArcTexture,
@@ -424,6 +435,7 @@ pub enum DrawCommand {
     RenderBitmap {
         bitmap: BitmapHandle,
         transform_buffer: wgpu::DynamicOffset,
+        vertex_offset: Option<wgpu::BufferAddress>,
         smoothing: bool,
         blend_mode: TrivialBlend,
         render_stage3d: bool,
@@ -531,6 +543,7 @@ struct WgpuCommandHandler<'encoder, 'global: 'encoder> {
     result: Vec<Chunk>,
     current: Vec<DrawCommand>,
     transforms: BufferBuilder,
+    vertices: BufferBuilder,
     needs_stencil: bool,
     num_masks: i32,
 }
@@ -550,6 +563,7 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
         texture_pool: &'encoder mut TexturePool,
     ) -> Self {
         let transforms = Self::new_transforms(descriptors, dynamic_transforms);
+        let vertices = Self::new_vertices(descriptors, dynamic_transforms);
 
         // DirectX does support drawing lines, but it's very inconsistent.
         // With MSAA, lines have 1.4px thickness, which makes them too thick.
@@ -572,6 +586,7 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
             result: vec![],
             current: vec![],
             transforms,
+            vertices,
             needs_stencil: false,
             num_masks: 0,
         }
@@ -586,6 +601,15 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
         transforms
     }
 
+    fn new_vertices(
+        descriptors: &'encoder Descriptors,
+        dynamic_transforms: &'encoder DynamicTransforms,
+    ) -> BufferBuilder {
+        let mut vertices = BufferBuilder::new_for_vertices(&descriptors.limits);
+        vertices.set_buffer_limit(dynamic_transforms.vertex_buffer.size());
+        vertices
+    }
+
     /// Replaces every blend with a RenderBitmap, with the subcommands rendered out to a temporary texture
     /// Every complex blend will be its own item, but every other draw will be chunked together
     fn chunk_blends(&mut self, commands: CommandList) -> Vec<Chunk> {
@@ -598,12 +622,17 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
             &mut self.transforms,
             Self::new_transforms(self.descriptors, self.dynamic_transforms),
         );
+        let vertices = mem::replace(
+            &mut self.vertices,
+            Self::new_vertices(self.descriptors, self.dynamic_transforms),
+        );
 
         if !current.is_empty() {
             result.push(Chunk::Draw {
                 chunk: current,
                 needs_stencil,
                 transforms,
+                vertices,
             });
         }
 
@@ -615,6 +644,18 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
         matrix: Matrix,
         color_transform: ColorTransform,
         command_builder: impl FnOnce(wgpu::DynamicOffset) -> DrawCommand,
+    ) {
+        self.add_to_current_with_vertices(matrix, color_transform, None, |transform_buffer, _| {
+            command_builder(transform_buffer)
+        })
+    }
+
+    fn add_to_current_with_vertices(
+        &mut self,
+        matrix: Matrix,
+        color_transform: ColorTransform,
+        vertices: Option<&[PosUvVertex]>,
+        command_builder: impl FnOnce(wgpu::DynamicOffset, Option<wgpu::BufferAddress>) -> DrawCommand,
     ) {
         let transform = Transforms {
             world_matrix: [
@@ -631,9 +672,13 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
             mult_color: color_transform.mult_rgba_normalized(),
             add_color: color_transform.add_rgba_normalized(),
         };
-        if let Ok(transform_range) = self.transforms.add(&[transform]) {
+        if let (Ok(transform_range), Ok(vertices_range)) = (
+            self.transforms.add(&[transform]),
+            vertices.map(|v| self.vertices.add(v)).transpose(),
+        ) {
             self.current.push(command_builder(
                 transform_range.start as wgpu::DynamicOffset,
+                vertices_range.map(|v| v.start),
             ));
         } else {
             self.result.push(Chunk::Draw {
@@ -641,17 +686,25 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
                 needs_stencil: self.needs_stencil,
                 transforms: mem::replace(
                     &mut self.transforms,
-                    BufferBuilder::new_for_uniform(&self.descriptors.limits),
+                    Self::new_transforms(self.descriptors, self.dynamic_transforms),
+                ),
+                vertices: mem::replace(
+                    &mut self.vertices,
+                    Self::new_vertices(self.descriptors, self.dynamic_transforms),
                 ),
             });
-            self.transforms
-                .set_buffer_limit(self.dynamic_transforms.buffer.size());
             let transform_range = self
                 .transforms
                 .add(&[transform])
                 .expect("Buffer must be able to fit a new thing, it was just emptied");
+            let vertices_range = vertices.map(|v| {
+                self.vertices
+                    .add(v)
+                    .expect("Buffer must be able to fit a new thing, it was just emptied")
+            });
             self.current.push(command_builder(
                 transform_range.start as wgpu::DynamicOffset,
+                vertices_range.map(|v| v.start),
             ));
         }
     }
@@ -743,12 +796,14 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
                         needs_stencil: self.needs_stencil,
                         transforms: mem::replace(
                             &mut self.transforms,
-                            BufferBuilder::new_for_uniform(&self.descriptors.limits),
+                            Self::new_transforms(self.descriptors, self.dynamic_transforms),
+                        ),
+                        vertices: mem::replace(
+                            &mut self.vertices,
+                            Self::new_vertices(self.descriptors, self.dynamic_transforms),
                         ),
                     });
                 }
-                self.transforms
-                    .set_buffer_limit(self.dynamic_transforms.buffer.size());
                 let chunk_blend_mode = match blend_type {
                     BlendType::Complex(complex) => ChunkBlendMode::Complex(complex),
                     BlendType::Shader(shader) => ChunkBlendMode::Shader(shader),
@@ -770,27 +825,44 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
         transform: Transform,
         smoothing: bool,
         pixel_snapping: PixelSnapping,
-        _region: PixelRegion,
+        region: PixelRegion,
     ) {
+        let texture = as_texture(&bitmap);
+
         let mut matrix = transform.matrix;
-        {
-            let texture = as_texture(&bitmap);
-            pixel_snapping.apply(&mut matrix);
-            matrix *= Matrix::scale(
-                texture.texture.width() as f32,
-                texture.texture.height() as f32,
+        pixel_snapping.apply(&mut matrix);
+        matrix *= Matrix::scale(region.width() as f32, region.height() as f32);
+
+        let vertices: &[PosUvVertex] = {
+            let (u0, u1, v0, v1) = (
+                region.x_min as f32 / texture.texture.width() as f32,
+                region.x_max as f32 / texture.texture.width() as f32,
+                region.y_min as f32 / texture.texture.height() as f32,
+                region.y_max as f32 / texture.texture.height() as f32,
             );
-        }
-        self.add_to_current(matrix, transform.color_transform, |transform_buffer| {
-            DrawCommand::RenderBitmap {
+            &[
+                PosUvVertex::new(0.0, 0.0, u0, v0, 1.0),
+                PosUvVertex::new(1.0, 0.0, u1, v0, 1.0),
+                PosUvVertex::new(1.0, 1.0, u1, v1, 1.0),
+                PosUvVertex::new(0.0, 1.0, u0, v1, 1.0),
+            ]
+        };
+
+        self.add_to_current_with_vertices(
+            matrix,
+            transform.color_transform,
+            Some(vertices),
+            |transform_buffer, vertex_offset| DrawCommand::RenderBitmap {
                 bitmap,
                 transform_buffer,
+                vertex_offset,
                 smoothing,
                 blend_mode: TrivialBlend::Normal,
                 render_stage3d: false,
-            }
-        });
+            },
+        );
     }
+
     fn render_stage3d(&mut self, bitmap: BitmapHandle, transform: Transform) {
         let mut matrix = transform.matrix;
         {
@@ -804,6 +876,7 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
             DrawCommand::RenderBitmap {
                 bitmap,
                 transform_buffer,
+                vertex_offset: None,
                 smoothing: false,
                 blend_mode: TrivialBlend::Normal,
                 render_stage3d: true,

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -10,7 +10,7 @@ use crate::surface::Surface;
 use crate::surface::target::CommandTarget;
 use crate::{Descriptors, MaskState, Pipelines, Transforms, as_texture};
 use ruffle_render::backend::ShapeHandle;
-use ruffle_render::bitmap::{BitmapHandle, PixelSnapping};
+use ruffle_render::bitmap::{BitmapHandle, PixelRegion, PixelSnapping};
 use ruffle_render::commands::{CommandHandler, CommandList, RenderBlendMode};
 use ruffle_render::lines::{emulate_line, emulate_line_rect};
 use ruffle_render::matrix::Matrix;
@@ -770,6 +770,7 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
         transform: Transform,
         smoothing: bool,
         pixel_snapping: PixelSnapping,
+        _region: PixelRegion,
     ) {
         let mut matrix = transform.matrix;
         {


### PR DESCRIPTION
## Description

This is needed for rendering bitmap glyphs from a font atlas. This PR adds a `region` parameter to `render_bitmap()` which allows rendering only a part of it.

## Testing

It's quite difficult to test it as-is, I've tested it in my font atlas branch on desktop. This code will be covered by tests in future PRs (via freetype font rendering).

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
