### PR TITLE
chore: Drop clippy::float_cmp lint attributes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ cargo clippy --all --tests
 Specific warnings and clippy lints can be allowed when appropriate using attributes, such as:
 
 ```rs
-#[allow(clippy::float_cmp)]
+#[expect(clippy::trivially_copy_pass_by_ref)]
 ```
 
 ## Test Guidelines

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1124,7 +1124,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    #[expect(clippy::float_cmp)]
     fn action_equals(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 equality
         // If both of the values to compare coerce to `NaN`, the result will always be false.

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -1034,7 +1034,6 @@ mod test {
     }
 
     #[test]
-    #[expect(clippy::float_cmp)]
     fn to_number_swf7() {
         with_avm(7, |activation, _this| -> Result<(), Error> {
             let t = Value::Bool(true);
@@ -1056,7 +1055,6 @@ mod test {
     }
 
     #[test]
-    #[expect(clippy::float_cmp)]
     fn to_number_swf6() {
         with_avm(6, |activation, _this| -> Result<(), Error> {
             let t = Value::Bool(true);

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -1630,7 +1630,6 @@ impl<'gc> Value<'gc> {
 
     /// Determine if this value is a number representable as a u32 without loss
     /// of precision.
-    #[expect(clippy::float_cmp)]
     pub fn is_u32(&self) -> bool {
         match self {
             Value::Number(n) => *n == (*n as u32 as f64),
@@ -1641,7 +1640,6 @@ impl<'gc> Value<'gc> {
 
     /// Determine if this value is a number representable as an i32 without
     /// loss of precision.
-    #[expect(clippy::float_cmp)]
     pub fn is_i32(&self) -> bool {
         match self {
             Value::Number(n) => *n == (*n as i32 as f64),

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2330,7 +2330,6 @@ impl Player {
             let ret = f(&mut update_context);
 
             // If we changed the framerate, let the audio handler now.
-            #[expect(clippy::float_cmp)]
             if *update_context.frame_rate != prev_frame_rate {
                 update_context
                     .audio


### PR DESCRIPTION
## Description

clippy::float_cmp became pedantic, so it's not triggering for Ruffle
anymore, this patch removes attributes referencing it.

## Testing
N/A
## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
