### PR TITLE
avm2: Don't make a `SwfMovie` for playerglobals

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -535,7 +535,7 @@ impl<'gc> Avm2<'gc> {
         }
 
         let num_scripts = abc.scripts.len();
-        let tunit = TranslationUnit::from_abc(abc, domain, name, movie, activation.gc());
+        let tunit = TranslationUnit::from_abc(abc, domain, name, Some(movie), activation.gc());
         tunit.load_classes(&mut activation)?;
         for i in 0..num_scripts {
             tunit.load_script(i as u32, &mut activation)?;
@@ -548,12 +548,7 @@ impl<'gc> Avm2<'gc> {
     }
 
     /// Load the playerglobal ABC file.
-    pub fn load_builtin_abc(
-        context: &mut UpdateContext<'gc>,
-        data: &[u8],
-        domain: Domain<'gc>,
-        movie: Arc<SwfMovie>,
-    ) {
+    pub fn load_builtin_abc(context: &mut UpdateContext<'gc>, data: &[u8], domain: Domain<'gc>) {
         let mut reader = Reader::new(data);
         let abc = match reader.read() {
             Ok(abc) => abc,
@@ -565,7 +560,7 @@ impl<'gc> Avm2<'gc> {
         // domain using `activation.domain()`
         activation.set_outer(ScopeChain::new(domain));
 
-        let tunit = TranslationUnit::from_abc(abc, domain, None, movie, activation.gc());
+        let tunit = TranslationUnit::from_abc(abc, domain, None, None, activation.gc());
 
         globals::init_early_classes(&mut activation, tunit).expect("Early classes should load");
 

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -350,7 +350,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.num_locals = num_locals;
         self.outer = outer;
         self.caller_domain = Some(outer.domain());
-        self.caller_movie = Some(method.owner_movie());
+        self.caller_movie = method.translation_unit().movie().cloned();
         self.bound_superclass_object = bound_superclass_object;
         self.stack = stack_frame;
         self.scope_depth = self.context.avm2.scope_stack.len();

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -322,7 +322,7 @@ pub fn exec<'gc>(
                 let span = option.expect("tracy_client should be running").span_alloc(
                     None,
                     &name.to_utf8_lossy(),
-                    method.owner_movie().url(),
+                    method.translation_unit().debug_name(),
                     line!(),
                     0,
                 );

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -8,9 +8,7 @@ use crate::avm2::script::TranslationUnit;
 use crate::avm2::{Avm2, Error, Multiname, Namespace, QName};
 use crate::context::UpdateContext;
 use crate::string::WStr;
-use crate::tag_utils::{self, ControlFlow, SwfMovie, SwfSlice, SwfStream};
 use gc_arena::Collect;
-use std::sync::Arc;
 use swf::TagCode;
 
 mod __ruffle__;
@@ -824,34 +822,35 @@ pub fn init_native_system_classes(activation: &mut Activation<'_, '_>) {
 /// Loads classes from our custom 'playerglobal' (which are written in ActionScript)
 /// into the environment. See 'core/src/avm2/globals/README.md' for more information
 pub fn load_playerglobal<'gc>(context: &mut UpdateContext<'gc>, domain: Domain<'gc>) {
+    use crate::tag_utils::{ControlFlow, Error, decode_tags};
+    use std::borrow::Cow;
+    use swf::error::Error as SwfError;
+
+    fn extract_abc(data: &[u8]) -> Result<&[u8], Error> {
+        const ERR: SwfError = SwfError::InvalidData(Cow::Borrowed("expected a single DoAbc2 tag"));
+        let (_, mut reader) = swf::read::parse_swf_header(data)?;
+
+        let mut do_abc = None;
+        decode_tags(&mut reader, |reader, code| match code {
+            TagCode::DoAbc2 if do_abc.is_none() => {
+                do_abc = Some(reader.read_do_abc_2()?);
+                Ok(ControlFlow::Continue)
+            }
+            TagCode::End => Ok(ControlFlow::Exit),
+            _ => Err(ERR.into()),
+        })?;
+
+        Ok(do_abc.ok_or(ERR)?.data)
+    }
+
     context.avm2.native_method_table = native::NATIVE_METHOD_TABLE;
     context.avm2.native_instance_allocator_table = native::NATIVE_INSTANCE_ALLOCATOR_TABLE;
     context.avm2.native_call_handler_table = native::NATIVE_CALL_HANDLER_TABLE;
     context.avm2.native_custom_constructor_table = native::NATIVE_CUSTOM_CONSTRUCTOR_TABLE;
     context.avm2.native_fast_call_list = native::NATIVE_FAST_CALL_LIST;
 
-    let movie = Arc::new(
-        SwfMovie::from_data(PLAYERGLOBAL, "file:///".into(), None, None)
-            .expect("playerglobal_avm2.swf should be valid"),
-    );
-
-    let slice = SwfSlice::from(movie);
-
-    let mut reader = slice.read_from(0);
-
-    let tag_callback = |reader: &mut SwfStream<'_>, tag_code| {
-        if tag_code == TagCode::DoAbc2 {
-            let do_abc = reader
-                .read_do_abc_2()
-                .expect("playerglobal_avm2.swf should be valid");
-            Avm2::load_builtin_abc(context, do_abc.data, domain);
-        } else if tag_code != TagCode::End {
-            panic!("playerglobal should only contain `DoAbc2` tag - found tag {tag_code:?}")
-        }
-        Ok(ControlFlow::Continue)
-    };
-
-    let _ = tag_utils::decode_tags(&mut reader, tag_callback);
+    let abc = extract_abc(PLAYERGLOBAL).expect("playerglobal_avm2.swf should be valid");
+    Avm2::load_builtin_abc(context, abc, domain);
 
     // Domain memory must be initialized after playerglobals is loaded because it relies on ByteArray.
     domain.init_default_domain_memory(context);

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -835,7 +835,7 @@ pub fn load_playerglobal<'gc>(context: &mut UpdateContext<'gc>, domain: Domain<'
             .expect("playerglobal_avm2.swf should be valid"),
     );
 
-    let slice = SwfSlice::from(movie.clone());
+    let slice = SwfSlice::from(movie);
 
     let mut reader = slice.read_from(0);
 
@@ -844,7 +844,7 @@ pub fn load_playerglobal<'gc>(context: &mut UpdateContext<'gc>, domain: Domain<'
             let do_abc = reader
                 .read_do_abc_2()
                 .expect("playerglobal_avm2.swf should be valid");
-            Avm2::load_builtin_abc(context, do_abc.data, domain, movie.clone());
+            Avm2::load_builtin_abc(context, do_abc.data, domain);
         } else if tag_code != TagCode::End {
             panic!("playerglobal should only contain `DoAbc2` tag - found tag {tag_code:?}")
         }

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -11,13 +11,11 @@ use crate::avm2::script::TranslationUnit;
 use crate::avm2::value::{Value, abc_default_value};
 use crate::avm2::verify::VerifiedMethodInfo;
 use crate::string::AvmString;
-use crate::tag_utils::SwfMovie;
 use gc_arena::barrier::{Write, unlock};
 use gc_arena::lock::OnceLock;
 use gc_arena::{Collect, Gc};
 use std::borrow::Cow;
 use std::rc::Rc;
-use std::sync::Arc;
 use swf::avm2::types::{
     AbcFile, Index, Method as AbcMethod, MethodBody as AbcMethodBody,
     MethodFlags as AbcMethodFlags, MethodParam as AbcMethodParam,
@@ -254,11 +252,6 @@ impl<'gc> Method<'gc> {
     /// Get a reference to the ABC method entry this refers to.
     pub fn method(&self) -> &AbcMethod {
         &self.0.abc.methods[self.0.abc_method as usize]
-    }
-
-    /// Get a reference to the SwfMovie this method came from.
-    pub fn owner_movie(self) -> Arc<SwfMovie> {
-        self.0.txunit.movie()
     }
 
     /// Get a reference to the ABC method body entry this refers to.

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -79,7 +79,8 @@ struct TranslationUnitData<'gc> {
     multinames: Box<[OnceLock<Gc<'gc, Multiname<'gc>>>]>,
 
     /// The movie that this TranslationUnit was loaded from.
-    movie: Arc<SwfMovie>,
+    /// If `None`, this is the embedded `playerglobal_avm2.swf`.
+    movie: Option<Arc<SwfMovie>>,
 }
 
 impl<'gc> TranslationUnit<'gc> {
@@ -89,7 +90,7 @@ impl<'gc> TranslationUnit<'gc> {
         abc: AbcFile,
         domain: Domain<'gc>,
         name: Option<AvmString<'gc>>,
-        movie: Arc<SwfMovie>,
+        movie: Option<Arc<SwfMovie>>,
         mc: &Mutation<'gc>,
     ) -> Self {
         use std::iter::repeat_n;
@@ -154,8 +155,12 @@ impl<'gc> TranslationUnit<'gc> {
         Rc::ptr_eq(&self.0.abc, &other.0.abc)
     }
 
-    pub fn movie(self) -> Arc<SwfMovie> {
-        self.0.movie.clone()
+    pub fn movie(self) -> Option<&'gc Arc<SwfMovie>> {
+        Gc::as_ref(self.0).movie.as_ref()
+    }
+
+    pub fn debug_name(self) -> &'gc str {
+        self.movie().map_or("playerglobal_avm2", |m| m.url())
     }
 
     pub fn api_version(self, avm2: &Avm2<'gc>) -> ApiVersion {

--- a/core/src/debug_ui/avm2_class.rs
+++ b/core/src/debug_ui/avm2_class.rs
@@ -73,9 +73,9 @@ impl Avm2ClassWindow {
                 ui.text_edit_singleline(&mut name.local_name().to_string().as_str());
                 ui.end_row();
 
-                if let Some(tu) = class.translation_unit() {
+                if let Some(movie) = class.translation_unit().and_then(|tu| tu.movie()) {
                     ui.label("Movie");
-                    open_movie_button(ui, &tu.movie(), messages);
+                    open_movie_button(ui, movie, messages);
                     ui.end_row();
                 }
 

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -13,7 +13,7 @@ use std::io::{self, Read};
 /// Maximum buffer capacity for reading the SWF.
 ///
 /// Prevents large allocations in case the SWF has a malformed length.
-const MAX_DATA_CAPACITY: u32 = 128 * 1024 * 1024; // 128 MiB
+const MAX_DATA_CAPACITY: usize = 128 * 1024 * 1024; // 128 MiB
 
 /// Parse a decompressed SWF.
 ///
@@ -53,6 +53,23 @@ pub fn extract_swz(input: &[u8]) -> Result<Vec<u8>> {
     Err(Error::invalid_data("Invalid ASN1 blob"))
 }
 
+/// Parses an SWF header from a byte slice; returns the parsed header
+/// along with a `Reader` to the rest of the SWF.
+///
+/// Returns an `Error` if the header is invalid, or if the SWF is compressed.
+pub fn parse_swf_header(mut input: &[u8]) -> Result<(Header, Reader<'_>)> {
+    let (mut header, uncompressed_len) = read_start_of_header(&mut input)?;
+
+    if header.compression != Compression::None {
+        return Err(Error::unsupported(
+            "called `parse_swf_header` on a compressed SWF",
+        ));
+    }
+
+    let reader = read_rest_of_header(input, &mut header, uncompressed_len)?;
+    Ok((header, reader))
+}
+
 /// Parses an SWF header and returns a `Reader` that can be used
 /// to read the SWF tags inside the SWF file.
 ///
@@ -70,24 +87,8 @@ pub fn extract_swz(input: &[u8]) -> Result<Vec<u8>> {
 /// println!("FPS: {}", swf_stream.header.frame_rate());
 /// ```
 pub fn decompress_swf<'a, R: Read + 'a>(mut input: R) -> Result<SwfBuf> {
-    // Read SWF header.
-    let compression = read_compression_type(&mut input)?;
-
-    let mut raw_header = [0u8; 5];
-    input.read_exact(&mut raw_header)?;
-
-    let version = raw_header[0];
-    let uncompressed_len = u32::from_le_bytes(*raw_header.split_last_chunk::<4>().unwrap().1);
-
-    // Check whether the SWF version is 0.
-    // Note that the behavior should actually vary, depending on the player version:
-    // - Flash Player 9 and later bail out (the behavior we implement).
-    // - Flash Player 8 loops through all the frames, without running any AS code.
-    // - Flash Player 7 and older don't fail and use the player version instead: a
-    // function like `getSWFVersion()` in AVM1 will then return the player version.
-    if version == 0 {
-        return Err(Error::invalid_data("Invalid SWF version"));
-    }
+    let (mut header, uncompressed_len) = read_start_of_header(&mut input)?;
+    let version = header.version;
 
     // Uncompressed length includes the 4-byte header and 4-byte uncompressed length itself,
     // subtract it here.
@@ -96,25 +97,25 @@ pub fn decompress_swf<'a, R: Read + 'a>(mut input: R) -> Result<SwfBuf> {
         .ok_or_else(|| Error::invalid_data("Malformed SWF length"))?;
 
     // Now the SWF switches to a compressed stream.
-    let decompress_stream: Box<dyn Read> = match compression {
-        Compression::None => Box::new(input),
+    let decompress_stream: &mut dyn Read = match header.compression {
+        Compression::None => &mut input,
         Compression::Zlib => {
             if version < 6 {
                 log::warn!("zlib compressed SWF is version {version} but minimum version is 6");
             }
-            make_zlib_reader(input)?
+            &mut make_zlib_reader(input)?
         }
         Compression::Lzma => {
             if version < 13 {
                 log::warn!("LZMA compressed SWF is version {version} but minimum version is 13");
             }
-            make_lzma_reader(input, body_len)?
+            &mut make_lzma_reader(input, body_len)?
         }
     };
 
     // Flash Player allocates a fixed buffer based on the header length and
     // never accesses data beyond it. Match that behavior by capping reads here.
-    let mut data = Vec::with_capacity(body_len.min(MAX_DATA_CAPACITY) as usize);
+    let mut data = Vec::with_capacity(body_len.min(MAX_DATA_CAPACITY));
     if let Err(e) = decompress_stream
         .take(body_len as u64)
         .read_to_end(&mut data)
@@ -122,33 +123,13 @@ pub fn decompress_swf<'a, R: Read + 'a>(mut input: R) -> Result<SwfBuf> {
         log::error!("Error decompressing SWF: {e}");
     }
 
-    // Some SWF streams may not be compressed correctly,
-    // (e.g. incorrect data length in the stream), so decompressing
-    // may throw an error even though the data otherwise comes
-    // through the stream.
-    // We'll still try to parse what we get if the full decompression fails.
-    // (+ 8 for header size)
-    if data.len() as u64 + 8 != uncompressed_len as u64 {
-        log::warn!("SWF length doesn't match header, may be corrupt");
-    }
-
-    let mut reader = Reader::new(&data, version);
-    let stage_size = reader.read_rectangle()?;
-    let frame_rate = reader.read_fixed8()?;
-    let num_frames = reader.read_u16()?;
-    let header = Header {
-        compression,
-        version,
-        stage_size,
-        frame_rate,
-        num_frames,
-    };
-    let offset = reader.as_slice().as_ptr() as usize - data.as_ptr() as usize;
+    let reader = read_rest_of_header(&data, &mut header, uncompressed_len)?;
+    let offset = reader.as_slice().as_ptr().addr() - data.as_ptr().addr();
     // Remove the header.
     // As an alternative we could return the entire original buffer with header length,
     // but that's a nontrivial API change, probably not worth the effort.
     data.drain(..offset);
-    let mut reader = Reader::new(&data, version);
+    let mut reader = Reader::new(&data, header.version);
 
     // Parse the first two tags, searching for the FileAttributes and SetBackgroundColor tags.
     // This metadata is useful, so we want to return it along with the header.
@@ -185,15 +166,69 @@ pub fn decompress_swf<'a, R: Read + 'a>(mut input: R) -> Result<SwfBuf> {
     })
 }
 
+fn read_start_of_header(mut input: &mut impl Read) -> Result<(Header, usize)> {
+    // Read SWF header.
+    let compression = read_compression_type(&mut input)?;
+
+    let mut raw_header = [0u8; 5];
+    input.read_exact(&mut raw_header)?;
+
+    let version = raw_header[0];
+    let uncompressed_len = u32::from_le_bytes(*raw_header.split_last_chunk::<4>().unwrap().1);
+
+    // Check whether the SWF version is 0.
+    // Note that the behavior should actually vary, depending on the player version:
+    // - Flash Player 9 and later bail out (the behavior we implement).
+    // - Flash Player 8 loops through all the frames, without running any AS code.
+    // - Flash Player 7 and older don't fail and use the player version instead: a
+    // function like `getSWFVersion()` in AVM1 will then return the player version.
+    if version == 0 {
+        return Err(Error::invalid_data("Invalid SWF version"));
+    }
+
+    let header = Header {
+        compression,
+        version,
+        // Dummy values, will be filled later.
+        stage_size: Default::default(),
+        frame_rate: Default::default(),
+        num_frames: Default::default(),
+    };
+
+    Ok((header, uncompressed_len as usize))
+}
+
+fn read_rest_of_header<'a>(
+    data: &'a [u8],
+    header: &mut Header,
+    uncompressed_len: usize,
+) -> Result<Reader<'a>> {
+    // Some SWF streams may not be compressed correctly,
+    // (e.g. incorrect data length in the stream), so decompressing
+    // may throw an error even though the data otherwise comes
+    // through the stream.
+    // We'll still try to parse what we get if the full decompression fails.
+    // (+ 8 for header size)
+    if data.len().checked_add(8) != Some(uncompressed_len) {
+        log::warn!("SWF length doesn't match header, may be corrupt");
+    }
+
+    let mut reader = Reader::new(data, header.version);
+    header.stage_size = reader.read_rectangle()?;
+    header.frame_rate = reader.read_fixed8()?;
+    header.num_frames = reader.read_u16()?;
+    Ok(reader)
+}
+
 #[cfg(feature = "flate2")]
-fn make_zlib_reader<'a, R: Read + 'a>(input: R) -> Result<Box<dyn Read + 'a>> {
+fn make_zlib_reader<'a, R: Read + 'a>(input: R) -> Result<impl Read + 'a> {
     use flate2::read::ZlibDecoder;
-    Ok(Box::new(ZlibDecoder::new(input)))
+    Ok(ZlibDecoder::new(input))
 }
 
 #[cfg(not(feature = "flate2"))]
-fn make_zlib_reader<'a, R: Read + 'a>(_input: R) -> Result<Box<dyn Read + 'a>> {
-    Err(Error::unsupported(
+fn make_zlib_reader<'a, R: Read + 'a>(_input: R) -> Result<impl Read + 'a> {
+    Err::<R, _>(Error::unsupported(
         "Support for Zlib compressed SWFs is not enabled.",
     ))
 }
@@ -201,8 +236,8 @@ fn make_zlib_reader<'a, R: Read + 'a>(_input: R) -> Result<Box<dyn Read + 'a>> {
 #[cfg(feature = "lzma")]
 fn make_lzma_reader<'a, R: Read + 'a>(
     mut input: R,
-    unpacked_size: u32,
-) -> Result<Box<dyn Read + 'a>> {
+    unpacked_size: usize,
+) -> Result<impl Read + 'a> {
     use lzma_rs::{
         decompress::{Options, UnpackedSize},
         lzma_decompress_with_options,
@@ -226,7 +261,7 @@ fn make_lzma_reader<'a, R: Read + 'a>(
     input.read_exact(&mut [0; 4])?;
 
     // TODO: Switch to lzma-rs streaming API when stable.
-    let mut output = Vec::with_capacity(unpacked_size.min(MAX_DATA_CAPACITY) as usize);
+    let mut output = Vec::with_capacity(unpacked_size.min(MAX_DATA_CAPACITY));
     lzma_decompress_with_options(
         &mut io::BufReader::new(input),
         &mut output,
@@ -244,11 +279,8 @@ fn make_lzma_reader<'a, R: Read + 'a>(
 }
 
 #[cfg(not(feature = "lzma"))]
-fn make_lzma_reader<'a, R: Read + 'a>(
-    _input: R,
-    _unpacked_size: u32,
-) -> Result<Box<dyn Read + 'a>> {
-    Err(Error::unsupported(
+fn make_lzma_reader<'a, R: Read + 'a>(_input: R, _unpacked_size: usize) -> Result<impl Read + 'a> {
+    Err::<R, _>(Error::unsupported(
         "Support for LZMA compressed SWFs is not enabled.",
     ))
 }


### PR DESCRIPTION
## Description

Makes `TranslationUnit`'s `movie` field optional, and sets it to `None` for the AVM2 playerglobals. This avoids the need to construct a dummy movie, and saves a few allocations on startup.

This is only a *very marginal* RAM gain (after all the playerglobals is <300KB), but IMHO the new code isn't too complex so... :shrug:

## Testing

No functional changes.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
