### PR TITLE
avm2: Optimize calls to call handlers to use CallNative

### DIFF
--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -2352,27 +2352,42 @@ fn optimize_call_property<'gc>(
                     if let Some(slot_class) = resolved_value_class
                         && let Some(called_class) = slot_class.i_class()
                     {
-                        // Calling a c_class will perform a simple coercion to the class
-                        let result = if called_class.call_handler().is_none() {
-                            Some((
-                                Op::CoerceSwapPop {
-                                    class: called_class,
-                                },
-                                called_class,
-                            ))
-                        } else if called_class == types.int {
-                            Some((Op::CoerceISwapPop, types.int))
-                        } else if called_class == types.uint {
-                            Some((Op::CoerceUSwapPop, types.uint))
-                        } else if called_class == types.number {
-                            Some((Op::CoerceDSwapPop, types.number))
-                        } else {
-                            None
-                        };
+                        let (new_op, return_type) =
+                            if let Some(call_handler) = called_class.call_handler() {
+                                // For `int(x)`, `uint(x)` and `Number(x)`, we emit
+                                // custom ops, as they can be very hot. For other
+                                // call handlers, we fall back to directly calling
+                                // the native method.
+                                if called_class == types.int {
+                                    (Op::CoerceISwapPop, Some(types.int))
+                                } else if called_class == types.uint {
+                                    (Op::CoerceUSwapPop, Some(types.uint))
+                                } else if called_class == types.number {
+                                    (Op::CoerceDSwapPop, Some(types.number))
+                                } else {
+                                    // We aren't sure what value the call handler
+                                    // will produce, but we do know exactly which
+                                    // native method is going to be called, so we
+                                    // can emit a `CallNative`.
 
-                        if let Some((new_op, return_type)) = result {
-                            return Ok(Some((new_op, Some(return_type))));
-                        }
+                                    let call_native_op = Op::CallNative {
+                                        method: call_handler,
+                                        num_args: 1,
+                                        push_return_value: true,
+                                    };
+                                    (call_native_op, None)
+                                }
+                            } else {
+                                // Calling a c_class will perform a simple coercion
+                                // to the class
+
+                                let coerce_op = Op::CoerceSwapPop {
+                                    class: called_class,
+                                };
+                                (coerce_op, Some(called_class))
+                            };
+
+                        return Ok(Some((new_op, return_type)));
                     }
                 }
             }


### PR DESCRIPTION
## Description

If we know that a `CallProperty` op is going to invoke a call handler, we can optimize the op to a `CallNative` to directly invoke the call handler rather than going through a full property resolution and `Value::call`.

This massively speeds up stuff like `String(x)` or `Boolean(x)` where the compiler decided to use a `findpropstrict` + `callproperty` rather than a `coerce_s`/`coerce_b`, though I've never seen any cases where such code is hot.

## Testing

We don't have test coverage for AVM2 optimizations.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
