### PR TITLE
avm2: Don't allocate a buffer for arguments when calling non-variadic native methods

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1088,16 +1088,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         num_args: u32,
         push_return_value: bool,
     ) -> Result<(), Error<'gc>> {
-        let mut args_buf = [Value::Undefined; 2];
-        let args = &mut args_buf[..num_args as usize];
-        for arg in args.iter_mut().rev() {
-            *arg = self.pop_stack();
-        }
+        let args = self.get_args(num_args);
 
         let receiver = self.pop_stack().null_check(self, None)?;
 
-        let value = method(self, receiver, FunctionArgs::from_slice(args))
-            .expect("FastCall methods should not return Err");
+        let value = method(self, receiver, args).expect("FastCall methods should not return Err");
 
         if push_return_value {
             self.push_stack(value);

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -30,7 +30,6 @@ use crate::tag_utils::SwfMovie;
 use gc_arena::Gc;
 use ruffle_macros::istr;
 use std::cell::Cell;
-use std::cmp::{Ordering, min};
 use std::sync::Arc;
 use swf::avm2::types::MethodFlags as AbcMethodFlags;
 
@@ -202,71 +201,73 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
     }
 
-    /// Statically resolve all of the parameters for a native method.
+    /// Constrain all non-variadic user-provided arguments to a function call
+    /// to the types and count declared in the signature, then place them on
+    /// this Activation's stack frame.
     ///
-    /// This function makes no attempt to enforce a given method's parameter
-    /// count limits or to package variadic arguments.
-    ///
-    /// The returned list of parameters will be coerced to the stated types in
-    /// the signature, with missing parameters filled in with defaults.
-    pub fn resolve_parameters(
+    /// This method will:
+    ///  - Ensure that there aren't too many arguments
+    ///  - Ensure that all arguments are of the correct type
+    ///  - Ensure that all required parameters have been provided
+    ///  - Subtitute default parameters for parameters that are missing
+    fn coerce_and_setup_arguments(
         &mut self,
         method: Method<'gc>,
-        user_arguments: FunctionArgs<'_, 'gc>,
         signature: &[ResolvedParamConfig<'gc>],
-    ) -> Result<Vec<Value<'gc>>, Error<'gc>> {
-        let mut arguments_list = Vec::new();
-        for (arg, param_config) in user_arguments.iter().zip(signature.iter()) {
+        user_arguments: FunctionArgs<'_, 'gc>,
+    ) -> Result<(), Error<'gc>> {
+        if user_arguments.len() > signature.len() && !method.is_variadic() && !method.is_unchecked()
+        {
+            return Err(make_error_1063(self, method, user_arguments.len()));
+        }
+
+        // Statically verify all non-variadic, provided parameters.
+        for (i, param_config) in signature.iter().enumerate().take(user_arguments.len()) {
+            let arg = user_arguments.get_at(i);
+
             let coerced_arg = if let Some(param_class) = param_config.param_type {
                 arg.coerce_to_type(self, param_class)?
             } else {
                 arg
             };
 
-            arguments_list.push(coerced_arg);
+            self.push_stack(coerced_arg);
         }
 
-        match user_arguments.len().cmp(&signature.len()) {
-            Ordering::Greater => {
-                let user_arguments = &user_arguments.to_slice();
-                // Variadic parameters exist, just push them into the list
-                arguments_list.extend_from_slice(&user_arguments[signature.len()..])
-            }
-            Ordering::Less => {
-                // Apply remaining default parameters
-                for param_config in signature[user_arguments.len()..].iter() {
-                    let arg = if let Some(default_value) = &param_config.default_value {
-                        *default_value
-                    } else {
-                        return Err(make_error_1063(self, method, user_arguments.len()));
-                    };
+        // Now add missing arguments
+        if user_arguments.len() < signature.len() {
+            // Apply remaining default parameters
+            for param_config in signature[user_arguments.len()..].iter() {
+                let arg = if let Some(default_value) = &param_config.default_value {
+                    *default_value
+                } else if method.is_unchecked() {
+                    Value::Undefined
+                } else {
+                    return Err(make_error_1063(self, method, user_arguments.len()));
+                };
 
-                    let coerced_arg = if let Some(param_class) = param_config.param_type {
-                        arg.coerce_to_type(self, param_class)?
-                    } else {
-                        arg
-                    };
+                let coerced_arg = if let Some(param_class) = param_config.param_type {
+                    arg.coerce_to_type(self, param_class)?
+                } else {
+                    arg
+                };
 
-                    arguments_list.push(coerced_arg);
-                }
+                self.push_stack(coerced_arg);
             }
-            _ => {}
         }
 
-        Ok(arguments_list)
+        Ok(())
     }
 
-    /// Create an `arguments` or `rest` object for a given method. This function
-    /// expects the rest of the arguments to already be on the AVM stack.
-    #[inline(never)]
-    fn create_varargs_object(
+    /// Collects all arguments passed to this `Activation` into a `Vec`. This
+    /// function expects the rest of the arguments to already be on the AVM
+    /// stack.
+    pub fn collect_all_arguments(
         &mut self,
-        method: Method<'gc>,
         signature: &[ResolvedParamConfig<'gc>],
         user_arguments: FunctionArgs<'_, 'gc>,
-        callee: Option<FunctionObject<'gc>>,
-    ) -> ArrayObject<'gc> {
-        let mut all_arguments = Vec::new();
+    ) -> Vec<Value<'gc>> {
+        let mut all_arguments = Vec::with_capacity(user_arguments.len());
 
         // Unfortunately we need to allocate now: we need to put all the
         // arguments we just processed into a Vec, so `arguments` or `rest`
@@ -284,6 +285,21 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             let arg = user_arguments.get_at(i);
             all_arguments.push(arg);
         }
+
+        all_arguments
+    }
+
+    /// Create an `arguments` or `rest` object for a given method. This function
+    /// expects the rest of the arguments to already be on the AVM stack.
+    #[inline(never)]
+    fn create_varargs_object(
+        &mut self,
+        method: Method<'gc>,
+        signature: &[ResolvedParamConfig<'gc>],
+        user_arguments: FunctionArgs<'_, 'gc>,
+        callee: Option<FunctionObject<'gc>>,
+    ) -> ArrayObject<'gc> {
+        let all_arguments = self.collect_all_arguments(signature, user_arguments);
 
         let args_array = if method.method().flags.contains(AbcMethodFlags::NEED_REST) {
             if let Some(rest_args) = all_arguments.get(signature.len()..) {
@@ -341,7 +357,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .expect("Cannot execute non-native method without body");
 
         let num_locals = body.num_locals as usize;
-        let has_rest_or_args = method.is_variadic();
 
         if let Some(bound_class) = method.bound_class() {
             assert!(this.is_of_type(bound_class));
@@ -364,51 +379,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let signature = method.resolved_param_config();
 
-        if user_arguments.len() > signature.len() && !has_rest_or_args && !method.is_unchecked() {
-            return Err(make_error_1063(self, method, user_arguments.len()));
-        }
-
-        // Create locals
+        // Set up the local registers with the receiver and arguments
         self.push_stack(this);
+        self.coerce_and_setup_arguments(method, signature, user_arguments)?;
 
-        // Statically verify all non-variadic, provided parameters.
-        let static_arg_count = min(user_arguments.len(), signature.len());
-        for (i, param_config) in signature.iter().enumerate().take(static_arg_count) {
-            let arg = user_arguments.get_at(i);
-
-            let coerced_arg = if let Some(param_class) = param_config.param_type {
-                arg.coerce_to_type(self, param_class)?
-            } else {
-                arg
-            };
-
-            self.push_stack(coerced_arg);
-        }
-
-        // Now add missing arguments
-        if user_arguments.len() < signature.len() {
-            // Apply remaining default parameters
-            for param_config in signature[user_arguments.len()..].iter() {
-                let arg = if let Some(default_value) = &param_config.default_value {
-                    *default_value
-                } else if method.is_unchecked() {
-                    Value::Undefined
-                } else {
-                    return Err(make_error_1063(self, method, user_arguments.len()));
-                };
-
-                let coerced_arg = if let Some(param_class) = param_config.param_type {
-                    arg.coerce_to_type(self, param_class)?
-                } else {
-                    arg
-                };
-
-                self.push_stack(coerced_arg);
-            }
-        }
-
-        // Finally, handle variadic arguments
-        if has_rest_or_args {
+        // Handle variadic arguments
+        if method.is_variadic() {
             let args_object = self.create_varargs_object(method, signature, user_arguments, callee);
 
             self.push_stack(args_object);
@@ -433,26 +409,33 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     /// activation as the method or script that called them. You must use this
     /// function to construct a new activation for the builtin so that it can
     /// properly supercall.
-    pub fn from_builtin(
-        context: &'a mut UpdateContext<'gc>,
-        bound_superclass_object: Option<ClassObject<'gc>>,
+    #[expect(clippy::too_many_arguments)]
+    pub fn init_from_builtin(
+        &mut self,
+        method: Method<'gc>,
         outer: ScopeChain<'gc>,
+        user_arguments: FunctionArgs<'_, 'gc>,
+        stack_frame: StackFrame<'a, 'gc>,
+        bound_superclass_object: Option<ClassObject<'gc>>,
         caller_domain: Option<Domain<'gc>>,
         caller_movie: Option<Arc<SwfMovie>>,
         caller_dxns: Option<AvmString<'gc>>,
-    ) -> Self {
-        Self {
-            num_locals: 0,
-            outer,
-            caller_domain,
-            caller_movie,
-            bound_superclass_object,
-            stack: StackFrame::empty(),
-            scope_depth: context.avm2.scope_stack.len(),
-            is_interpreter: false,
-            default_xml_namespace: caller_dxns,
-            context,
-        }
+    ) -> Result<(), Error<'gc>> {
+        self.outer = outer;
+        self.caller_domain = caller_domain;
+        self.caller_movie = caller_movie;
+        self.bound_superclass_object = bound_superclass_object;
+        self.stack = stack_frame;
+        self.scope_depth = self.context.avm2.scope_stack.len();
+        self.default_xml_namespace = caller_dxns;
+
+        method.resolve_info(self)?;
+
+        let signature = method.resolved_param_config();
+
+        self.coerce_and_setup_arguments(method, signature, user_arguments)?;
+
+        Ok(())
     }
 
     /// Call the superclass's instance initializer.

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -1,6 +1,6 @@
 use crate::avm2::Multiname;
 use crate::avm2::activation::Activation;
-use crate::avm2::error::{Error, make_error_1001, make_error_1063};
+use crate::avm2::error::{Error, make_error_1001};
 use crate::avm2::method::{Method, MethodKind, ParamConfig};
 use crate::avm2::object::{ClassObject, FunctionObject};
 use crate::avm2::scope::ScopeChain;
@@ -236,7 +236,7 @@ pub fn exec<'gc>(
     scope: ScopeChain<'gc>,
     receiver: Value<'gc>,
     bound_superclass: Option<ClassObject<'gc>>,
-    arguments: FunctionArgs<'_, 'gc>,
+    user_arguments: FunctionArgs<'_, 'gc>,
     activation: &mut Activation<'_, 'gc>,
     callee: Option<FunctionObject<'gc>>,
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -246,28 +246,51 @@ pub fn exec<'gc>(
 
     let ret = match method.method_kind() {
         MethodKind::Native { native_method, .. } => {
+            let declared_arg_count = method.signature().len();
+
+            // We must initialize the stack frame here so the lifetime works out
+            let stack = activation.context.avm2.stack;
+            let stack_frame = stack.get_frame(declared_arg_count);
+
             let caller_domain = activation.caller_domain();
             let caller_movie = activation.caller_movie();
-            let mut activation = Activation::from_builtin(
-                activation.context,
-                bound_superclass,
+            let mut activation = Activation::from_nothing(activation.context);
+            if let Err(e) = activation.init_from_builtin(
+                method,
                 scope,
+                user_arguments,
+                stack_frame,
+                bound_superclass,
                 caller_domain,
                 caller_movie,
                 caller_dxns,
-            );
-
-            method.resolve_info(&mut activation)?;
-
-            let signature = method.resolved_param_config();
-
-            // Check for too many arguments
-            if arguments.len() > signature.len() && !method.is_variadic() && !method.is_unchecked()
-            {
-                return Err(make_error_1063(&mut activation, method, arguments.len()));
+            ) {
+                // If an error is thrown during verification or argument coercion,
+                // we still need to call cleanup to dispose of the stack frame
+                activation.cleanup();
+                return Err(e);
             }
 
-            let arguments = activation.resolve_parameters(method, arguments, signature)?;
+            // Retrieve the arguments from the Activation's stack frame.
+            let args_vec: Vec<_>;
+            let args = if method.is_variadic() {
+                let signature = method.resolved_param_config();
+
+                // We need to allocate a buffer, then put the coerced args into
+                // it, then put the rest of the variadic args into it. We can't
+                // just put them all on the AVM stack because ActionScript can
+                // use `Function.apply` to call a method with a massive number
+                // of arguments, which would overflow the AVM stack.
+                args_vec = activation.collect_all_arguments(signature, user_arguments);
+
+                FunctionArgs::from_slice(&args_vec)
+            } else {
+                // Non-variadic methods have exactly the number of declared
+                // arguments as arguments, so we can just take a slice into the
+                // Activation's stack frame.
+
+                activation.get_args(declared_arg_count as u32)
+            };
 
             #[cfg(feature = "tracy_avm")]
             let _span = {
@@ -282,9 +305,11 @@ pub fn exec<'gc>(
 
             activation.context.avm2.push_call(mc, method);
 
-            let arguments = FunctionArgs::from_slice(&arguments);
+            let result = native_method(&mut activation, receiver, args);
 
-            native_method(&mut activation, receiver, arguments)
+            activation.cleanup();
+
+            result
         }
         MethodKind::Bytecode { .. } => {
             if method.body().is_none() {
@@ -293,7 +318,7 @@ pub fn exec<'gc>(
 
             // We must initialize the stack frame here so the lifetime works out
             let stack = activation.context.avm2.stack;
-            let stack_frame = stack.get_stack_frame(method);
+            let stack_frame = stack.get_frame_for_method(method);
 
             // This used to be a one step called Activation::from_method,
             // but avoiding moving an Activation around helps perf
@@ -302,7 +327,7 @@ pub fn exec<'gc>(
                 method,
                 scope,
                 receiver,
-                arguments,
+                user_arguments,
                 stack_frame,
                 bound_superclass,
                 callee,

--- a/core/src/avm2/globals/README.md
+++ b/core/src/avm2/globals/README.md
@@ -81,8 +81,7 @@ As an optimization, native methods defined in playerglobals can be annotated wit
 the following conditions must all be met before declaring a method `FastCall`:
 
 - the method is declared as `static`, or the class the method is declared in is `final`;
-- the method has zero, one, or two arguments;
-- the method does not use default values for any of these arguments;
+- the method does not use default values for any of its arguments;
 - the method does not use `...rest` arguments;
 - the Rust function that defines the method does not throw exceptions (does not ever return `Err`);
 - and the method's Rust function does not access any fields on the provided `activation` except for the `activation.context` field.

--- a/core/src/avm2/stack.rs
+++ b/core/src/avm2/stack.rs
@@ -43,17 +43,22 @@ impl<'gc> Stack<'gc> {
         ))
     }
 
-    /// Returns a slice of stack data for the specified method, starting at the
-    /// current stack pointer. Stack frames obtained from this method must be
-    /// properly disposed of by using the `dispose_stack_frame` method.
-    pub fn get_stack_frame(&self, method: Method<'gc>) -> StackFrame<'_, 'gc> {
-        // First calculate the frame size
+    /// Returns a slice of stack data for the specified method
+    pub fn get_frame_for_method(&self, method: Method<'gc>) -> StackFrame<'_, 'gc> {
+        // Calculate the frame size
         let body = method
             .body()
             .expect("Cannot execute non-native method without body");
         let frame_size = body.max_stack as usize + body.num_locals as usize;
 
-        // Then actually create the stack frame
+        self.get_frame(frame_size)
+    }
+
+    /// Returns a slice of stack data with the specified size, starting at the
+    /// current stack pointer. Stack frames obtained from this method must be
+    /// properly disposed of by using the `dispose_stack_frame` method.
+    pub fn get_frame(&self, frame_size: usize) -> StackFrame<'_, 'gc> {
+        // Create the stack frame
         let stack_data = &self.0.stack;
         let stack_pointer = &self.0.stack_pointer;
 


### PR DESCRIPTION
## Description

Don't allocate a buffer for arguments when calling non-variadic native methods. We still allocate a buffer for variadic native methods.

This reduces the overhead of calling a native method by about 20%.

The downside of this approach is that we are now required to acquire a stack frame for each native method call. As native method calls are virtually all leaf calls, I doubt this will have much of an impact in real SWFs.

## Testing

This is a performance improvement

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
