### PR TITLE
chore: Appease clippy

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -548,6 +548,9 @@ pub fn init_early_classes<'gc>(
 const PLAYERGLOBAL: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/playerglobal_avm2.swf"));
 
 mod native {
+    // Some native methods have names starting with '_'.
+    #![allow(clippy::used_underscore_items)]
+
     include!(concat!(env!("OUT_DIR"), "/native_table.rs"));
 }
 

--- a/core/src/tessellation_cache.rs
+++ b/core/src/tessellation_cache.rs
@@ -40,8 +40,8 @@ impl TessellationCache {
         let mut best_index = None;
         let mut best_deviation = f32::INFINITY;
 
-        for index in 0..self.len {
-            if let Some((cached_scale, _)) = &self.entries[index] {
+        for (index, entry) in self.entries[..self.len].iter().enumerate() {
+            if let Some((cached_scale, _)) = entry {
                 let ratio = f32::abs(target_scale / cached_scale);
 
                 // Check if the cached scale is within the retessellation threshold of the target scale.


### PR DESCRIPTION
We use `allow` instead of `expect` in `avm2::globals::native`, as the lint only triggers on nightly.

## Testing

Nope.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
