### PR TITLE
ci: Remove nightly lints

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -59,7 +59,7 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     name: Test Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}
+    continue-on-error: ${{ matrix.rust_version != 'stable' }}
     strategy:
       fail-fast: false
       matrix:
@@ -130,11 +130,12 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     name: Lints with Rust ${{ matrix.rust_version }}
     runs-on: ubuntu-24.04
-    continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}
+    continue-on-error: ${{ matrix.rust_version != 'stable' }}
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [stable, beta, nightly]
+        # nightly lints are too unstable for us
+        rust_version: [stable, beta]
 
     steps:
       - uses: actions/checkout@v7
@@ -154,12 +155,10 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Check clippy (with tests)
-        # Don't fail the build for clippy on nightly, since we get a lot of false-positives
-        run: cargo clippy --all --all-features --tests ${{ (matrix.rust_version != 'nightly' && '-- -D warnings') || '' }}
+        run: cargo clippy --all --all-features --tests -- -D warnings
 
       - name: Check clippy (without tests)
-        # Don't fail the build for clippy on nightly, since we get a lot of false-positives
-        run: cargo clippy --all --all-features ${{ (matrix.rust_version != 'nightly' && '-- -D warnings') || '' }}
+        run: cargo clippy --all --all-features -- -D warnings
 
       - name: Check documentation
         run: cargo doc --no-deps --all-features
@@ -170,7 +169,7 @@ jobs:
         run: |
           cd fuzz/
           cargo fmt --all -- --check
-          cargo clippy --all ${{ (matrix.rust_version != 'nightly' && '-- -D warnings') || '' }}
+          cargo clippy --all -- -D warnings
 
   coverage:
     needs: changes
@@ -340,7 +339,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        rust_version: [stable, beta, nightly]
+        rust_version: [stable, beta]
 
     steps:
       - name: No-op


### PR DESCRIPTION


## Description

Nightly lints are super unstable, they change daily and often have false positives. Having them enabled causes all our PRs to become red all the time, and we can't differentiate between PR not compiling and nightly reporting new stuff or being broken.

## Testing

Not tested

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
