### PR TITLE
wgpu: Pass UV(T) to shaders, rather than always calculating via a uniform

### DIFF
--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -13,11 +13,9 @@ struct VertexOutput {
 override late_saturate: bool = false;
 
 @vertex
-fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let matrix_ = textureTransforms.texture_matrix;
-    let uv = (mat3x3<f32>(matrix_[0].xyz, matrix_[1].xyz, matrix_[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
+fn main_vertex(in: common__VertexInputUv) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
-    return VertexOutput(pos, uv);
+    return VertexOutput(pos, in.uv.xy / in.uv.z);
 }
 
 @fragment

--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -7,9 +7,8 @@ struct VertexOutput {
 };
 
 @group(1) @binding(0) var<uniform> transforms: common__Transforms;
-@group(2) @binding(0) var<uniform> textureTransforms: common__TextureTransforms;
-@group(2) @binding(1) var texture: texture_2d<f32>;
-@group(2) @binding(2) var texture_sampler: sampler;
+@group(2) @binding(0) var texture: texture_2d<f32>;
+@group(2) @binding(1) var texture_sampler: sampler;
 override late_saturate: bool = false;
 
 @vertex

--- a/render/wgpu/shaders/common.wgsl
+++ b/render/wgpu/shaders/common.wgsl
@@ -33,6 +33,11 @@ struct common__VertexInput {
     @location(0) position: vec2<f32>,
 };
 
+struct common__VertexInputUv {
+    @location(0) position: vec2<f32>,
+    @location(1) uv: vec3<f32>,
+};
+
 /// Common uniform layout shared by all shaders.
 @group(0) @binding(0) var<uniform> common__globals: common__Globals;
 

--- a/render/wgpu/shaders/common.wgsl
+++ b/render/wgpu/shaders/common.wgsl
@@ -20,13 +20,6 @@ struct common__Transforms {
     add_color: vec4<f32>,
 };
 
-/// Uniforms used by texture draws (bitmaps and gradients).
-struct common__TextureTransforms {
-    /// The transform matrix of the gradient or texture.
-    /// Transforms from object space to UV space.
-    texture_matrix: mat4x4<f32>,
-};
-
 /// The vertex format shared among most shaders.
 struct common__VertexInput {
     /// The position of the vertex in object space.

--- a/render/wgpu/shaders/copy.wgsl
+++ b/render/wgpu/shaders/copy.wgsl
@@ -8,9 +8,8 @@ struct VertexOutput {
 };
 
 @group(1) @binding(0) var<uniform> transforms: common__Transforms;
-@group(2) @binding(0) var<uniform> textureTransforms: common__TextureTransforms;
-@group(2) @binding(1) var texture: texture_2d<f32>;
-@group(2) @binding(2) var texture_sampler: sampler;
+@group(2) @binding(0) var texture: texture_2d<f32>;
+@group(2) @binding(1) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInputUv) -> VertexOutput {

--- a/render/wgpu/shaders/copy.wgsl
+++ b/render/wgpu/shaders/copy.wgsl
@@ -13,11 +13,9 @@ struct VertexOutput {
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
-fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let matrix_ = textureTransforms.texture_matrix;
-    let uv = (mat3x3<f32>(matrix_[0].xyz, matrix_[1].xyz, matrix_[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
+fn main_vertex(in: common__VertexInputUv) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
-    return VertexOutput(pos, uv);
+    return VertexOutput(pos, in.uv.xy / in.uv.z);
 }
 
 @fragment

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -19,17 +19,10 @@ struct Gradient {
 @group(2) @binding(2) var texture: texture_2d<f32>;
 @group(2) @binding(3) var texture_sampler: sampler;
 
-struct GradientVertexInput {
-    /// The position of the vertex in object space.
-    @location(0) position: vec2<f32>,
-};
-
 @vertex
-fn main_vertex(in: GradientVertexInput) -> VertexOutput {
-    let matrix_ = textureTransforms.texture_matrix;
-    let uv = (mat3x3<f32>(matrix_[0].xyz, matrix_[1].xyz, matrix_[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
+fn main_vertex(in: common__VertexInputUv) -> VertexOutput {
     let pos = common__globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
-    return VertexOutput(pos, uv);
+    return VertexOutput(pos, in.uv.xy / in.uv.z);
 }
 
 fn find_t(uv: vec2<f32>) -> f32 {

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -6,7 +6,6 @@ struct VertexOutput {
 };
 
 @group(1) @binding(0) var<uniform> transforms: common__Transforms;
-@group(2) @binding(0) var<uniform> textureTransforms: common__TextureTransforms;
 
 struct Gradient {
     focal_point: f32,
@@ -15,9 +14,9 @@ struct Gradient {
     repeat: i32,
 };
 
-@group(2) @binding(1) var<uniform> gradient: Gradient;
-@group(2) @binding(2) var texture: texture_2d<f32>;
-@group(2) @binding(3) var texture_sampler: sampler;
+@group(2) @binding(0) var<uniform> gradient: Gradient;
+@group(2) @binding(1) var texture: texture_2d<f32>;
+@group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInputUv) -> VertexOutput {

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -723,8 +723,10 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
 
         let handle = BitmapHandle(Arc::new(Texture {
             texture,
-            bind_linear: Default::default(),
-            bind_nearest: Default::default(),
+            repeating_linear: Default::default(),
+            repeating_nearest: Default::default(),
+            clamped_linear: Default::default(),
+            clamped_nearest: Default::default(),
             copy_count: Cell::new(0),
         }));
 
@@ -999,8 +1001,10 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                     });
                 BitmapHandle(Arc::new(Texture {
                     texture,
-                    bind_linear: Default::default(),
-                    bind_nearest: Default::default(),
+                    repeating_linear: Default::default(),
+                    repeating_nearest: Default::default(),
+                    clamped_linear: Default::default(),
+                    clamped_nearest: Default::default(),
                     copy_count: Cell::new(0),
                 }))
             }
@@ -1157,8 +1161,10 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
             });
         Ok(BitmapHandle(Arc::new(Texture {
             texture,
-            bind_linear: Default::default(),
-            bind_nearest: Default::default(),
+            repeating_linear: Default::default(),
+            repeating_nearest: Default::default(),
+            clamped_linear: Default::default(),
+            clamped_nearest: Default::default(),
             copy_count: Cell::new(0),
         })))
     }

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -324,7 +324,6 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                 draw,
                 shape_id,
                 draw_id,
-                &mut uniform_buffer,
                 &mut vertex_buffer,
                 &mut index_buffer,
             ) {

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -111,8 +111,10 @@ impl WgpuContext3D {
             });
 
             BitmapHandle(Arc::new(Texture {
-                bind_linear: Default::default(),
-                bind_nearest: Default::default(),
+                repeating_linear: Default::default(),
+                repeating_nearest: Default::default(),
+                clamped_linear: Default::default(),
+                clamped_nearest: Default::default(),
                 texture: dummy_texture,
                 copy_count: Cell::new(0),
             }))
@@ -645,14 +647,18 @@ impl Context3D for WgpuContext3D {
                     // this is our resolve texture.
                     self.back_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
                         texture: back_buffer_resolve_texture.unwrap(),
-                        bind_linear: Default::default(),
-                        bind_nearest: Default::default(),
+                        repeating_linear: Default::default(),
+                        repeating_nearest: Default::default(),
+                        clamped_linear: Default::default(),
+                        clamped_nearest: Default::default(),
                         copy_count: Cell::new(0),
                     }));
                     self.front_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
                         texture: front_buffer_resolve_texture.unwrap(),
-                        bind_linear: Default::default(),
-                        bind_nearest: Default::default(),
+                        repeating_linear: Default::default(),
+                        repeating_nearest: Default::default(),
+                        clamped_linear: Default::default(),
+                        clamped_nearest: Default::default(),
                         copy_count: Cell::new(0),
                     }));
                 } else {
@@ -661,14 +667,18 @@ impl Context3D for WgpuContext3D {
 
                     self.back_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
                         texture: back_buffer_texture,
-                        bind_linear: Default::default(),
-                        bind_nearest: Default::default(),
+                        repeating_linear: Default::default(),
+                        repeating_nearest: Default::default(),
+                        clamped_linear: Default::default(),
+                        clamped_nearest: Default::default(),
                         copy_count: Cell::new(0),
                     }));
                     self.front_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
                         texture: front_buffer_texture,
-                        bind_linear: Default::default(),
-                        bind_nearest: Default::default(),
+                        repeating_linear: Default::default(),
+                        repeating_nearest: Default::default(),
+                        clamped_linear: Default::default(),
+                        clamped_nearest: Default::default(),
                         copy_count: Cell::new(0),
                     }));
                     self.current_texture_resolve_view = None;

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -1,6 +1,6 @@
 use crate::filters::{FilterVertex, Filters};
 use crate::layouts::BindLayouts;
-use crate::pipelines::VERTEX_BUFFERS_DESCRIPTION_POS;
+use crate::pipelines::VERTEX_BUFFERS_DESCRIPTION_POS_UV;
 use crate::shaders::Shaders;
 use crate::{
     BitmapSamplers, Pipelines, PosColorVertex, PosUvVertex, PosVertex, TextureTransforms,
@@ -96,7 +96,7 @@ impl Descriptors {
                         vertex: wgpu::VertexState {
                             module: &self.shaders.copy_shader,
                             entry_point: Some("main_vertex"),
-                            buffers: &VERTEX_BUFFERS_DESCRIPTION_POS,
+                            buffers: &VERTEX_BUFFERS_DESCRIPTION_POS_UV,
                             compilation_options: Default::default(),
                         },
                         fragment: Some(wgpu::FragmentState {

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -3,7 +3,7 @@ use crate::layouts::BindLayouts;
 use crate::pipelines::VERTEX_BUFFERS_DESCRIPTION_POS;
 use crate::shaders::Shaders;
 use crate::{
-    BitmapSamplers, Pipelines, PosColorVertex, PosVertex, TextureTransforms,
+    BitmapSamplers, Pipelines, PosColorVertex, PosUvVertex, PosVertex, TextureTransforms,
     create_buffer_with_data,
 };
 use fnv::FnvHashMap;
@@ -155,6 +155,7 @@ impl Descriptors {
 
 pub struct Quad {
     pub vertices_pos: wgpu::Buffer,
+    pub vertices_pos_uv: wgpu::Buffer,
     pub vertices_pos_color: wgpu::Buffer,
     pub filter_vertices: wgpu::Buffer,
     pub indices: wgpu::Buffer,
@@ -177,6 +178,24 @@ impl Quad {
             },
             PosVertex {
                 position: [0.0, 1.0],
+            },
+        ];
+        let vertices_pos_uv = [
+            PosUvVertex {
+                position: [0.0, 0.0],
+                uv: [0.0, 0.0, 1.0],
+            },
+            PosUvVertex {
+                position: [1.0, 0.0],
+                uv: [1.0, 0.0, 1.0],
+            },
+            PosUvVertex {
+                position: [1.0, 1.0],
+                uv: [1.0, 1.0, 1.0],
+            },
+            PosUvVertex {
+                position: [0.0, 1.0],
+                uv: [0.0, 1.0, 1.0],
             },
         ];
         let vertices_pos_color = [
@@ -224,6 +243,13 @@ impl Quad {
             bytemuck::cast_slice(&vertices_pos),
             wgpu::BufferUsages::VERTEX,
             create_debug_label!("Quad vbo (pos)"),
+        );
+
+        let vbo_pos_uv = create_buffer_with_data(
+            device,
+            bytemuck::cast_slice(&vertices_pos_uv),
+            wgpu::BufferUsages::VERTEX,
+            create_debug_label!("Quad vbo (pos & uv)"),
         );
 
         let vbo_pos_color = create_buffer_with_data(
@@ -275,6 +301,7 @@ impl Quad {
 
         Self {
             vertices_pos: vbo_pos,
+            vertices_pos_uv: vbo_pos_uv,
             vertices_pos_color: vbo_pos_color,
             filter_vertices: vbo_filter,
             indices: ibo,

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -3,8 +3,7 @@ use crate::layouts::BindLayouts;
 use crate::pipelines::VERTEX_BUFFERS_DESCRIPTION_POS_UV;
 use crate::shaders::Shaders;
 use crate::{
-    BitmapSamplers, Pipelines, PosColorVertex, PosUvVertex, PosVertex, TextureTransforms,
-    create_buffer_with_data,
+    BitmapSamplers, Pipelines, PosColorVertex, PosUvVertex, PosVertex, create_buffer_with_data,
 };
 use fnv::FnvHashMap;
 use std::fmt::Debug;
@@ -161,7 +160,6 @@ pub struct Quad {
     pub indices: wgpu::Buffer,
     pub indices_line: wgpu::Buffer,
     pub indices_line_rect: wgpu::Buffer,
-    pub texture_transforms: wgpu::Buffer,
 }
 
 impl Quad {
@@ -285,20 +283,6 @@ impl Quad {
             create_debug_label!("Line rect ibo"),
         );
 
-        let tex_transforms = create_buffer_with_data(
-            device,
-            bytemuck::cast_slice(&[TextureTransforms {
-                u_matrix: [
-                    [1.0, 0.0, 0.0, 0.0],
-                    [0.0, 1.0, 0.0, 0.0],
-                    [0.0, 0.0, 1.0, 0.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ],
-            }]),
-            wgpu::BufferUsages::UNIFORM,
-            create_debug_label!("Quad tex transforms"),
-        );
-
         Self {
             vertices_pos: vbo_pos,
             vertices_pos_uv: vbo_pos_uv,
@@ -307,7 +291,6 @@ impl Quad {
             indices: ibo,
             indices_line: ibo_line,
             indices_line_rect: ibo_line_rect,
-            texture_transforms: tex_transforms,
         }
     }
 }

--- a/render/wgpu/src/layouts.rs
+++ b/render/wgpu/src/layouts.rs
@@ -1,5 +1,5 @@
 use crate::globals::GlobalsUniform;
-use crate::{GradientUniforms, TextureTransforms, Transforms};
+use crate::{GradientUniforms, Transforms};
 
 #[derive(Debug)]
 pub struct BindLayouts {
@@ -52,18 +52,6 @@ impl BindLayouts {
             entries: &[
                 wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: wgpu::BufferSize::new(
-                            std::mem::size_of::<TextureTransforms>() as u64,
-                        ),
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         multisampled: false,
@@ -73,7 +61,7 @@ impl BindLayouts {
                     count: None,
                 },
                 wgpu::BindGroupLayoutEntry {
-                    binding: 2,
+                    binding: 1,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
@@ -120,18 +108,6 @@ impl BindLayouts {
             entries: &[
                 wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: wgpu::BufferSize::new(
-                            std::mem::size_of::<TextureTransforms>() as u64,
-                        ),
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
@@ -143,7 +119,7 @@ impl BindLayouts {
                     count: None,
                 },
                 wgpu::BindGroupLayoutEntry {
-                    binding: 2,
+                    binding: 1,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         multisampled: false,
@@ -153,7 +129,7 @@ impl BindLayouts {
                     count: None,
                 },
                 wgpu::BindGroupLayoutEntry {
-                    binding: 3,
+                    binding: 2,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -264,29 +264,34 @@ impl QueueSyncHandle {
 #[derive(Debug)]
 pub struct Texture {
     pub(crate) texture: wgpu::Texture,
-    bind_linear: OnceCell<BitmapBinds>,
-    bind_nearest: OnceCell<BitmapBinds>,
+    repeating_linear: OnceCell<BitmapBinds>,
+    repeating_nearest: OnceCell<BitmapBinds>,
+    clamped_linear: OnceCell<BitmapBinds>,
+    clamped_nearest: OnceCell<BitmapBinds>,
     copy_count: Cell<u8>,
 }
 
 impl Texture {
     pub fn bind_group(
         &self,
+        repeating: bool,
         smoothed: bool,
         device: &wgpu::Device,
         layout: &wgpu::BindGroupLayout,
         handle: BitmapHandle,
         samplers: &BitmapSamplers,
     ) -> &BitmapBinds {
-        let bind = match smoothed {
-            true => &self.bind_linear,
-            false => &self.bind_nearest,
+        let bind = match (repeating, smoothed) {
+            (true, true) => &self.repeating_linear,
+            (true, false) => &self.repeating_nearest,
+            (false, true) => &self.clamped_linear,
+            (false, false) => &self.clamped_nearest,
         };
         bind.get_or_init(|| {
             BitmapBinds::new(
                 device,
                 layout,
-                samplers.get_sampler(false, smoothed),
+                samplers.get_sampler(repeating, smoothed),
                 self.texture.create_view(&Default::default()),
                 create_debug_label!("Bitmap {:?} bind group (smoothed: {})", handle.0, smoothed),
             )

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -4,7 +4,6 @@
 use crate::backend::ActiveFrame;
 use crate::bitmaps::BitmapSamplers;
 use crate::buffer_pool::{BufferPool, PoolEntry};
-use crate::descriptors::Quad;
 use crate::mesh::BitmapBinds;
 use crate::pipelines::Pipelines;
 use crate::target::{RenderTarget, SwapChainTarget};
@@ -75,12 +74,6 @@ pub struct Transforms {
     world_matrix: [[f32; 4]; 4],
     mult_color: [f32; 4],
     add_color: [f32; 4],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Pod, Zeroable)]
-struct TextureTransforms {
-    u_matrix: [[f32; 4]; 4],
 }
 
 #[repr(C)]
@@ -282,7 +275,6 @@ impl Texture {
         smoothed: bool,
         device: &wgpu::Device,
         layout: &wgpu::BindGroupLayout,
-        quad: &Quad,
         handle: BitmapHandle,
         samplers: &BitmapSamplers,
     ) -> &BitmapBinds {
@@ -295,8 +287,6 @@ impl Texture {
                 device,
                 layout,
                 samplers.get_sampler(false, smoothed),
-                &quad.texture_transforms,
-                0 as wgpu::BufferAddress,
                 self.texture.create_view(&Default::default()),
                 create_debug_label!("Bitmap {:?} bind group (smoothed: {})", handle.0, smoothed),
             )

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -99,6 +99,29 @@ impl From<TessVertex> for PosVertex {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct PosUvVertex {
+    position: [f32; 2],
+    uv: [f32; 3],
+}
+
+impl PosUvVertex {
+    pub fn from_tessellator(vertex: TessVertex, texture_matrix: &[[f32; 3]; 3]) -> Self {
+        let position = [vertex.x, vertex.y];
+        let uv = Self::transform_uv(texture_matrix, vertex.x, vertex.y);
+        Self { position, uv }
+    }
+
+    fn transform_uv(matrix: &[[f32; 3]; 3], x: f32, y: f32) -> [f32; 3] {
+        [
+            matrix[0][0] * x + matrix[1][0] * y + matrix[2][0],
+            matrix[0][1] * x + matrix[1][1] * y + matrix[2][1],
+            1.0,
+        ]
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
 struct PosColorVertex {
     position: [f32; 2],
     color: [f32; 4],

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -1,8 +1,7 @@
 use crate::backend::WgpuRenderBackend;
 use crate::target::RenderTarget;
 use crate::{
-    Descriptors, GradientUniforms, PosColorVertex, PosUvVertex, PosVertex, TextureTransforms,
-    as_texture,
+    Descriptors, GradientUniforms, PosColorVertex, PosUvVertex, TextureTransforms, as_texture,
 };
 use std::any::Any;
 use std::ops::Range;
@@ -90,8 +89,12 @@ impl PendingDraw {
                     .add(&vertices)
                     .expect("Mesh vertex buffer was too large!")
             }
-            TessDrawType::Gradient { .. } => {
-                let vertices: Vec<_> = draw.vertices.into_iter().map(PosVertex::from).collect();
+            TessDrawType::Gradient { matrix, .. } => {
+                let vertices: Vec<_> = draw
+                    .vertices
+                    .into_iter()
+                    .map(|v| PosUvVertex::from_tessellator(v, matrix))
+                    .collect();
                 vertex_buffer
                     .add(&vertices)
                     .expect("Mesh vertex buffer was too large!")

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use wgpu::util::DeviceExt;
 
 use crate::buffer_builder::BufferBuilder;
-use ruffle_render::backend::{RenderBackend, ShapeHandle, ShapeHandleImpl};
+use ruffle_render::backend::{ShapeHandle, ShapeHandleImpl};
 use ruffle_render::bitmap::BitmapSource;
 use ruffle_render::tessellator::{Bitmap, Draw as LyonDraw, DrawType as TessDrawType, Gradient};
 use swf::{CharacterId, GradientInterpolation};
@@ -118,9 +118,7 @@ impl PendingDraw {
                 matrix: _,
                 gradient,
             } => PendingDrawType::gradient(gradient, shape_id, draw_id),
-            TessDrawType::Bitmap(bitmap) => {
-                PendingDrawType::bitmap(bitmap, shape_id, draw_id, source, backend)?
-            }
+            TessDrawType::Bitmap(bitmap) => PendingDrawType::bitmap(bitmap, source, backend)?,
         };
         Some(PendingDraw {
             draw_type,
@@ -140,10 +138,7 @@ pub enum PendingDrawType {
         bind_group_label: Option<String>,
     },
     Bitmap {
-        texture_view: wgpu::TextureView,
-        is_repeating: bool,
-        is_smoothed: bool,
-        bind_group_label: Option<String>,
+        binds: BitmapBinds,
     },
 }
 
@@ -174,24 +169,24 @@ impl PendingDrawType {
         }
     }
 
-    pub fn bitmap(
+    pub fn bitmap<T: RenderTarget>(
         bitmap: Bitmap,
-        shape_id: CharacterId,
-        draw_id: usize,
         source: &dyn BitmapSource,
-        backend: &mut dyn RenderBackend,
+        backend: &mut WgpuRenderBackend<T>,
     ) -> Option<Self> {
         let handle = source.bitmap_handle(bitmap.bitmap_id, backend)?;
         let texture = as_texture(&handle);
-        let texture_view = texture.texture.create_view(&Default::default());
-        let bind_group_label =
-            create_debug_label!("Shape {} (bitmap) draw {} bindgroup", shape_id, draw_id);
+        let binds = texture.bind_group(
+            bitmap.is_repeating,
+            bitmap.is_smoothed,
+            &backend.descriptors.device,
+            &backend.descriptors.bind_layouts.bitmap,
+            handle.clone(),
+            &backend.descriptors.bitmap_samplers,
+        );
 
         Some(PendingDrawType::Bitmap {
-            texture_view,
-            is_repeating: bitmap.is_repeating,
-            is_smoothed: bitmap.is_smoothed,
-            bind_group_label,
+            binds: binds.clone(),
         })
     }
 
@@ -238,24 +233,7 @@ impl PendingDrawType {
                     });
                 DrawType::Gradient { bind_group }
             }
-            PendingDrawType::Bitmap {
-                texture_view,
-                is_repeating,
-                is_smoothed,
-                bind_group_label,
-            } => {
-                let binds = BitmapBinds::new(
-                    &descriptors.device,
-                    &descriptors.bind_layouts.bitmap,
-                    descriptors
-                        .bitmap_samplers
-                        .get_sampler(is_repeating, is_smoothed),
-                    texture_view,
-                    bind_group_label,
-                );
-
-                DrawType::Bitmap { binds }
-            }
+            PendingDrawType::Bitmap { binds } => DrawType::Bitmap { binds },
         }
     }
 }
@@ -373,7 +351,7 @@ impl CommonGradient {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BitmapBinds {
     pub bind_group: wgpu::BindGroup,
 }

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -1,7 +1,8 @@
 use crate::backend::WgpuRenderBackend;
 use crate::target::RenderTarget;
 use crate::{
-    Descriptors, GradientUniforms, PosColorVertex, PosVertex, TextureTransforms, as_texture,
+    Descriptors, GradientUniforms, PosColorVertex, PosUvVertex, PosVertex, TextureTransforms,
+    as_texture,
 };
 use std::any::Any;
 use std::ops::Range;
@@ -78,20 +79,33 @@ impl PendingDraw {
         vertex_buffer: &mut BufferBuilder,
         index_buffer: &mut BufferBuilder,
     ) -> Option<Self> {
-        let vertices = if matches!(draw.draw_type, TessDrawType::Color) {
-            let vertices: Vec<_> = draw
-                .vertices
-                .into_iter()
-                .map(PosColorVertex::from)
-                .collect();
-            vertex_buffer
-                .add(&vertices)
-                .expect("Mesh vertex buffer was too large!")
-        } else {
-            let vertices: Vec<_> = draw.vertices.into_iter().map(PosVertex::from).collect();
-            vertex_buffer
-                .add(&vertices)
-                .expect("Mesh vertex buffer was too large!")
+        let vertices = match &draw.draw_type {
+            TessDrawType::Color => {
+                let vertices: Vec<_> = draw
+                    .vertices
+                    .into_iter()
+                    .map(PosColorVertex::from)
+                    .collect();
+                vertex_buffer
+                    .add(&vertices)
+                    .expect("Mesh vertex buffer was too large!")
+            }
+            TessDrawType::Gradient { .. } => {
+                let vertices: Vec<_> = draw.vertices.into_iter().map(PosVertex::from).collect();
+                vertex_buffer
+                    .add(&vertices)
+                    .expect("Mesh vertex buffer was too large!")
+            }
+            TessDrawType::Bitmap(bitmap) => {
+                let vertices: Vec<_> = draw
+                    .vertices
+                    .into_iter()
+                    .map(|v| PosUvVertex::from_tessellator(v, &bitmap.matrix))
+                    .collect();
+                vertex_buffer
+                    .add(&vertices)
+                    .expect("Mesh vertex buffer was too large!")
+            }
         };
 
         let indices = index_buffer

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -1,8 +1,6 @@
 use crate::backend::WgpuRenderBackend;
 use crate::target::RenderTarget;
-use crate::{
-    Descriptors, GradientUniforms, PosColorVertex, PosUvVertex, TextureTransforms, as_texture,
-};
+use crate::{Descriptors, GradientUniforms, PosColorVertex, PosUvVertex, as_texture};
 use std::any::Any;
 use std::ops::Range;
 use wgpu::util::DeviceExt;
@@ -67,14 +65,12 @@ pub struct Draw {
 }
 
 impl PendingDraw {
-    #[expect(clippy::too_many_arguments)]
     pub fn new<T: RenderTarget>(
         backend: &mut WgpuRenderBackend<T>,
         source: &dyn BitmapSource,
         draw: LyonDraw,
         shape_id: CharacterId,
         draw_id: usize,
-        uniform_buffer: &mut BufferBuilder,
         vertex_buffer: &mut BufferBuilder,
         index_buffer: &mut BufferBuilder,
     ) -> Option<Self> {
@@ -118,11 +114,12 @@ impl PendingDraw {
         let index_count = draw.indices.len() as u32;
         let draw_type = match draw.draw_type {
             TessDrawType::Color => PendingDrawType::color(),
-            TessDrawType::Gradient { matrix, gradient } => {
-                PendingDrawType::gradient(gradient, matrix, shape_id, draw_id, uniform_buffer)
-            }
+            TessDrawType::Gradient {
+                matrix: _,
+                gradient,
+            } => PendingDrawType::gradient(gradient, shape_id, draw_id),
             TessDrawType::Bitmap(bitmap) => {
-                PendingDrawType::bitmap(bitmap, shape_id, draw_id, source, backend, uniform_buffer)?
+                PendingDrawType::bitmap(bitmap, shape_id, draw_id, source, backend)?
             }
         };
         Some(PendingDraw {
@@ -139,12 +136,10 @@ impl PendingDraw {
 pub enum PendingDrawType {
     Color,
     Gradient {
-        texture_transforms_index: wgpu::BufferAddress,
         gradient_index: usize,
         bind_group_label: Option<String>,
     },
     Bitmap {
-        texture_transforms_index: wgpu::BufferAddress,
         texture_view: wgpu::TextureView,
         is_repeating: bool,
         is_smoothed: bool,
@@ -170,19 +165,10 @@ impl PendingDrawType {
         PendingDrawType::Color
     }
 
-    pub fn gradient(
-        gradient_index: usize,
-        matrix: [[f32; 3]; 3],
-        shape_id: CharacterId,
-        draw_id: usize,
-        uniform_buffers: &mut BufferBuilder,
-    ) -> Self {
-        let tex_transforms_index = create_texture_transforms(&matrix, uniform_buffers);
-
+    pub fn gradient(gradient_index: usize, shape_id: CharacterId, draw_id: usize) -> Self {
         let bind_group_label =
             create_debug_label!("Shape {} (gradient) draw {} bindgroup", shape_id, draw_id);
         PendingDrawType::Gradient {
-            texture_transforms_index: tex_transforms_index,
             gradient_index,
             bind_group_label,
         }
@@ -194,17 +180,14 @@ impl PendingDrawType {
         draw_id: usize,
         source: &dyn BitmapSource,
         backend: &mut dyn RenderBackend,
-        uniform_buffers: &mut BufferBuilder,
     ) -> Option<Self> {
         let handle = source.bitmap_handle(bitmap.bitmap_id, backend)?;
         let texture = as_texture(&handle);
         let texture_view = texture.texture.create_view(&Default::default());
-        let texture_transforms_index = create_texture_transforms(&bitmap.matrix, uniform_buffers);
         let bind_group_label =
             create_debug_label!("Shape {} (bitmap) draw {} bindgroup", shape_id, draw_id);
 
         Some(PendingDrawType::Bitmap {
-            texture_transforms_index,
             texture_view,
             is_repeating: bitmap.is_repeating,
             is_smoothed: bitmap.is_smoothed,
@@ -221,7 +204,6 @@ impl PendingDrawType {
         match self {
             PendingDrawType::Color => DrawType::Color,
             PendingDrawType::Gradient {
-                texture_transforms_index,
                 gradient_index,
                 bind_group_label,
             } => {
@@ -235,16 +217,6 @@ impl PendingDrawType {
                                 binding: 0,
                                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
                                     buffer: uniform_buffer,
-                                    offset: texture_transforms_index,
-                                    size: wgpu::BufferSize::new(
-                                        std::mem::size_of::<TextureTransforms>() as u64,
-                                    ),
-                                }),
-                            },
-                            wgpu::BindGroupEntry {
-                                binding: 1,
-                                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                                    buffer: uniform_buffer,
                                     offset: common.buffer_offset,
                                     size: wgpu::BufferSize::new(
                                         std::mem::size_of::<GradientUniforms>() as u64,
@@ -252,11 +224,11 @@ impl PendingDrawType {
                                 }),
                             },
                             wgpu::BindGroupEntry {
-                                binding: 2,
+                                binding: 1,
                                 resource: wgpu::BindingResource::TextureView(&common.texture_view),
                             },
                             wgpu::BindGroupEntry {
-                                binding: 3,
+                                binding: 2,
                                 resource: wgpu::BindingResource::Sampler(
                                     descriptors.bitmap_samplers.get_sampler(false, true),
                                 ),
@@ -267,7 +239,6 @@ impl PendingDrawType {
                 DrawType::Gradient { bind_group }
             }
             PendingDrawType::Bitmap {
-                texture_transforms_index,
                 texture_view,
                 is_repeating,
                 is_smoothed,
@@ -279,8 +250,6 @@ impl PendingDrawType {
                     descriptors
                         .bitmap_samplers
                         .get_sampler(is_repeating, is_smoothed),
-                    uniform_buffer,
-                    texture_transforms_index,
                     texture_view,
                     bind_group_label,
                 );
@@ -414,50 +383,23 @@ impl BitmapBinds {
         device: &wgpu::Device,
         layout: &wgpu::BindGroupLayout,
         sampler: &wgpu::Sampler,
-        uniform_buffer: &wgpu::Buffer,
-        texture_transforms: wgpu::BufferAddress,
         texture_view: wgpu::TextureView,
         label: Option<String>,
     ) -> Self {
-        let bind_group =
-            device.create_bind_group(&wgpu::BindGroupDescriptor {
-                layout,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                            buffer: uniform_buffer,
-                            offset: texture_transforms,
-                            size: wgpu::BufferSize::new(
-                                std::mem::size_of::<TextureTransforms>() as u64
-                            ),
-                        }),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::TextureView(&texture_view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: wgpu::BindingResource::Sampler(sampler),
-                    },
-                ],
-                label: label.as_deref(),
-            });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&texture_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(sampler),
+                },
+            ],
+            label: label.as_deref(),
+        });
         Self { bind_group }
     }
-}
-
-fn create_texture_transforms(
-    matrix: &[[f32; 3]; 3],
-    buffer: &mut BufferBuilder,
-) -> wgpu::BufferAddress {
-    let mut texture_transform = [[0.0; 4]; 4];
-    texture_transform[0][..3].copy_from_slice(&matrix[0]);
-    texture_transform[1][..3].copy_from_slice(&matrix[1]);
-    texture_transform[2][..3].copy_from_slice(&matrix[2]);
-    buffer
-        .add(&[texture_transform])
-        .expect("Mesh uniform buffer was too large!")
-        .start
 }

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -1,7 +1,7 @@
 use crate::blend::{ComplexBlend, TrivialBlend};
 use crate::layouts::BindLayouts;
 use crate::shaders::Shaders;
-use crate::{MaskState, PosColorVertex, PosVertex};
+use crate::{MaskState, PosColorVertex, PosUvVertex, PosVertex};
 use enum_map::{EnumMap, enum_map};
 use wgpu::{BlendState, PrimitiveTopology, vertex_attr_array};
 
@@ -11,6 +11,16 @@ pub const VERTEX_BUFFERS_DESCRIPTION_POS: [Option<wgpu::VertexBufferLayout>; 1] 
         step_mode: wgpu::VertexStepMode::Vertex,
         attributes: &vertex_attr_array![
             0 => Float32x2,
+        ],
+    })];
+
+pub const VERTEX_BUFFERS_DESCRIPTION_POS_UV: [Option<wgpu::VertexBufferLayout>; 1] =
+    [Some(wgpu::VertexBufferLayout {
+        array_stride: std::mem::size_of::<PosUvVertex>() as u64,
+        step_mode: wgpu::VertexStepMode::Vertex,
+        attributes: &vertex_attr_array![
+            0 => Float32x2,
+            1 => Float32x3,
         ],
     })];
 
@@ -161,7 +171,7 @@ impl Pipelines {
                 format,
                 &shaders.bitmap_shader,
                 msaa_sample_count,
-                &VERTEX_BUFFERS_DESCRIPTION_POS,
+                &VERTEX_BUFFERS_DESCRIPTION_POS_UV,
                 &bitmap_blend_bindings,
                 blend.blend_state(),
                 0,
@@ -189,7 +199,7 @@ impl Pipelines {
                 blend: Some(BlendState::REPLACE),
                 write_mask: wgpu::ColorWrites::COLOR,
             })],
-            &VERTEX_BUFFERS_DESCRIPTION_POS,
+            &VERTEX_BUFFERS_DESCRIPTION_POS_UV,
             msaa_sample_count,
             &[("late_saturate", 1.0)],
             PrimitiveTopology::TriangleList,
@@ -217,7 +227,7 @@ impl Pipelines {
                 blend: Some(BlendState::REPLACE),
                 write_mask: wgpu::ColorWrites::COLOR,
             })],
-            &VERTEX_BUFFERS_DESCRIPTION_POS,
+            &VERTEX_BUFFERS_DESCRIPTION_POS_UV,
             msaa_sample_count,
             &[],
             PrimitiveTopology::TriangleList,

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -130,7 +130,7 @@ impl Pipelines {
             format,
             &shaders.gradient_shader,
             msaa_sample_count,
-            &VERTEX_BUFFERS_DESCRIPTION_POS,
+            &VERTEX_BUFFERS_DESCRIPTION_POS_UV,
             &gradient_bindings,
             BlendState::PREMULTIPLIED_ALPHA_BLENDING,
             0,

--- a/render/wgpu/src/pixel_bender.rs
+++ b/render/wgpu/src/pixel_bender.rs
@@ -483,8 +483,10 @@ pub(super) fn run_pixelbender_shader_impl(
 
                         BitmapHandle(Arc::new(Texture {
                             texture: fresh_texture,
-                            bind_linear: Default::default(),
-                            bind_nearest: Default::default(),
+                            repeating_linear: Default::default(),
+                            repeating_nearest: Default::default(),
+                            clamped_linear: Default::default(),
+                            clamped_nearest: Default::default(),
                             copy_count: Cell::new(0),
                         }))
                     });

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -281,19 +281,12 @@ impl Surface {
                                         entries: &[
                                             wgpu::BindGroupEntry {
                                                 binding: 0,
-                                                resource: descriptors
-                                                    .quad
-                                                    .texture_transforms
-                                                    .as_entire_binding(),
-                                            },
-                                            wgpu::BindGroupEntry {
-                                                binding: 1,
                                                 resource: wgpu::BindingResource::TextureView(
                                                     child_texture.view(),
                                                 ),
                                             },
                                             wgpu::BindGroupEntry {
-                                                binding: 2,
+                                                binding: 1,
                                                 resource: wgpu::BindingResource::Sampler(
                                                     descriptors
                                                         .bitmap_samplers

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -209,7 +209,6 @@ impl<'encoder> CommandRenderer<'encoder> {
             smoothing,
             &descriptors.device,
             &descriptors.bind_layouts.bitmap,
-            &descriptors.quad,
             bitmap.clone(),
             &descriptors.bitmap_samplers,
         );

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -218,7 +218,7 @@ impl<'encoder> CommandRenderer<'encoder> {
 
         self.draw(
             render_pass,
-            self.descriptors.quad.vertices_pos.slice(..),
+            self.descriptors.quad.vertices_pos_uv.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
         );
@@ -237,7 +237,7 @@ impl<'encoder> CommandRenderer<'encoder> {
 
         self.draw(
             render_pass,
-            self.descriptors.quad.vertices_pos.slice(..),
+            self.descriptors.quad.vertices_pos_uv.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
         );

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -206,6 +206,7 @@ impl<'encoder> CommandRenderer<'encoder> {
 
         let descriptors = self.descriptors;
         let bind = texture.bind_group(
+            false,
             smoothing,
             &descriptors.device,
             &descriptors.bind_layouts.bitmap,

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -214,14 +214,10 @@ pub fn run_copy_pipeline(
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: descriptors.quad.texture_transforms.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
                     resource: wgpu::BindingResource::TextureView(input),
                 },
                 wgpu::BindGroupEntry {
-                    binding: 2,
+                    binding: 1,
                     resource: wgpu::BindingResource::Sampler(
                         descriptors.bitmap_samplers.get_sampler(false, false),
                     ),

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -256,7 +256,7 @@ pub fn run_copy_pipeline(
     render_pass.set_bind_group(1, whole_frame_bind_group, &[0]);
     render_pass.set_bind_group(2, &copy_bind_group, &[]);
 
-    render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos.slice(..));
+    render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos_uv.slice(..));
     render_pass.set_index_buffer(
         descriptors.quad.indices.slice(..),
         wgpu::IndexFormat::Uint32,

--- a/render/wgpu/uniforms.md
+++ b/render/wgpu/uniforms.md
@@ -35,9 +35,8 @@ These should be set for the current mesh being rendered.
 ## Group 2: Texture transforms
 | Index | Type       | Description                          | Availability |
 |:-----:|------------|:-------------------------------------|--------------|
-|   0   | uniform    | Transformation matrix of the texture | Vertex       |
-|   1   | texture_2d | Texture to be drawn                  | Fragment     |
-|   2   | sampler    | Sampler used for the texture         | Fragment     |
+|   0   | texture_2d | Texture to be drawn                  | Fragment     |
+|   1   | sampler    | Sampler used for the texture         | Fragment     |
 
 # Gradient
 ## Group 2: Texture transforms
@@ -46,5 +45,4 @@ Storage buffers are more efficient and waste less memory, but are not as widely 
 
 | Index | Type               | Description                           | Availability |
 |:-----:|--------------------|:--------------------------------------|--------------|
-|   0   | uniform            | Transformation matrix of the gradient | Vertex       |
-|   1   | uniform or storage | Gradient information, colors etc      | Fragment     |
+|   0   | uniform or storage | Gradient information, colors etc      | Fragment     |


### PR DESCRIPTION
## Description

This should have much less overhead and save on some resource usage, but it also unlocks being able to draw from arbitrary regions of a texture (for the atlas work).

This may simplify #24254 a bunch?

## Testing

All existing tests pass, and I've ran my usual swfs to verify they look good. I'd appreciate some extra testing though.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
