### PR TITLE
avm2: Support default superclass object for callstatic op

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1160,12 +1160,16 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let bound_class = method
             .bound_class()
             .expect("Verifier ensures callstatic methods are classbound");
+
         let receiver = receiver.coerce_to_type(self, bound_class)?;
 
-        // TODO: What scope should the function be executed with?
+        let superclass_object = method.default_superclass_object();
+
+        // TODO: Use the correct scope
         let scope = self.create_scopechain();
 
-        let function = FunctionObject::from_method(self.context, method, scope, None, None);
+        let function =
+            FunctionObject::from_method(self.context, method, scope, None, superclass_object);
         let value = function.call(self, receiver, args)?;
 
         self.push_stack(value);

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -7,6 +7,7 @@ use crate::avm2::error::{
     Error, Error1014Type, make_error_1014, make_error_1027, make_error_1079, make_error_1107,
 };
 use crate::avm2::function::FunctionArgs;
+use crate::avm2::object::ClassObject;
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::value::{Value, abc_default_value};
 use crate::avm2::verify::VerifiedMethodInfo;
@@ -392,6 +393,14 @@ impl<'gc> Method<'gc> {
             .bound_class()
     }
 
+    /// Get the superclass object used when this method is invoked using the
+    /// `callstatic` op.
+    pub fn default_superclass_object(self) -> Option<ClassObject<'gc>> {
+        self.method_association()
+            .expect("Association should be initialized")
+            .default_superclass_object()
+    }
+
     /// Returns true if this method should be run in "interpreter mode". This
     /// method will panic if the method has not been associated yet.
     pub fn is_interpreted(self) -> bool {
@@ -481,8 +490,7 @@ pub enum MethodKind<'gc> {
 /// whether the method should be run in interpreter mode. The association is
 /// used to ensure that, for example, a SWF cannot use `newfunction` to create
 /// a freestanding function for a method that is also class-bound, as this would
-/// break the verifier/optimizer. TODO: Add the default super-ClassObject and
-/// ScopeChain to this struct
+/// break the verifier/optimizer. TODO: Add the ScopeChain to this struct
 #[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct MethodAssociation<'gc> {
@@ -490,6 +498,17 @@ pub struct MethodAssociation<'gc> {
     /// The method may only be called with a receiver that is an instance of
     /// this class.
     bound_class: Option<Class<'gc>>,
+
+    /// The superclass of the first ClassObject that this method was used in.
+    /// One method can be used in multiple ClassObjects, as long as they are all
+    /// derived from the same Class. Using the `callstatic` op on such a method
+    /// will call the method using the superclass object of the first
+    /// ClassObject that this method was used in.
+    ///
+    /// NOTE: This field is specifically for supporting the `callstatic` op. All
+    /// other ways to call this method will use the "correct" superclass object,
+    /// rather than this "default" one.
+    default_superclass_object: Option<ClassObject<'gc>>,
 
     /// Whether this method should be run in "interpreter mode" (as opposed to
     /// "JIT mode"). Most methods run in "JIT mode", except for class
@@ -502,19 +521,30 @@ impl<'gc> MethodAssociation<'gc> {
     pub fn freestanding() -> Self {
         Self {
             bound_class: None,
+            // TODO seems like this should be `Object`?
+            default_superclass_object: None,
             is_interpreted: false,
         }
     }
 
-    pub fn classbound(bound_class: Class<'gc>, is_interpreted: bool) -> Self {
+    pub fn classbound(
+        bound_class: Class<'gc>,
+        default_superclass_object: Option<ClassObject<'gc>>,
+        is_interpreted: bool,
+    ) -> Self {
         Self {
             bound_class: Some(bound_class),
+            default_superclass_object,
             is_interpreted,
         }
     }
 
     pub fn bound_class(self) -> Option<Class<'gc>> {
         self.bound_class
+    }
+
+    pub fn default_superclass_object(self) -> Option<ClassObject<'gc>> {
+        self.default_superclass_object
     }
 
     pub fn is_interpreted(self) -> bool {

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -302,21 +302,39 @@ impl<'gc> ClassObject<'gc> {
             .c_class()
             .expect("ClassObject should have an i_class");
 
-        // Bind all the methods that are declared on the i_class and c_class
-        i_class.bind_methods(activation, MethodAssociation::classbound(i_class, false))?;
-        c_class.bind_methods(activation, MethodAssociation::classbound(c_class, false))?;
-
-        i_class
+        let instance_init = i_class
             .instance_init()
-            .expect("Cannot create ClassObject for Class without init")
-            .associate(activation, MethodAssociation::classbound(i_class, false))?;
+            .expect("Cannot create ClassObject for Class without init");
+
+        let class_init = c_class
+            .instance_init()
+            .expect("c_class always has initializer");
+
+        let class_class = activation.avm2().classes().class;
+        let superclass_object = self.superclass_object();
+
+        // Bind all the methods that are declared on the i_class and c_class
+        i_class.bind_methods(
+            activation,
+            MethodAssociation::classbound(i_class, superclass_object, false),
+        )?;
+        c_class.bind_methods(
+            activation,
+            MethodAssociation::classbound(c_class, Some(class_class), false),
+        )?;
+
+        // Bind the instance initializer
+        instance_init.associate(
+            activation,
+            MethodAssociation::classbound(i_class, superclass_object, false),
+        )?;
 
         // The class initializer (but not the instance initializer) is always
         // in "interpreter mode"
-        c_class
-            .instance_init()
-            .expect("c_class always has initializer")
-            .associate(activation, MethodAssociation::classbound(c_class, true))?;
+        class_init.associate(
+            activation,
+            MethodAssociation::classbound(c_class, Some(class_class), true),
+        )?;
 
         Ok(())
     }

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -627,14 +627,14 @@ impl<'gc> Script<'gc> {
         let global_obj_vtable = global_obj_vtable.expect("Global object vtable should be valid");
 
         // Script initializers are always run in "interpreter mode"
-        let script_init_assoc = MethodAssociation::classbound(global_class, true);
+        let script_init_assoc =
+            MethodAssociation::classbound(global_class, Some(object_class), true);
         init_method.associate(activation, script_init_assoc)?;
 
         // Associate all the methods on the script
-        global_class.bind_methods(
-            activation,
-            MethodAssociation::classbound(global_class, false),
-        )?;
+        let script_method_assoc =
+            MethodAssociation::classbound(global_class, Some(object_class), false);
+        global_class.bind_methods(activation, script_method_assoc)?;
 
         Ok(ScriptObject::custom_object(
             mc,

--- a/tests/tests/swfs/avm2/init_callee_cached/output.ruffle.txt
+++ b/tests/tests/swfs/avm2/init_callee_cached/output.ruffle.txt
@@ -1,0 +1,24 @@
+// Entered instance init
+this.count ++;
+// this.count is 1
+// arguments.callee is function Function() {}
+// this.savedCallee is null
+// arguments.callee == this.savedCallee? false
+this.count = arguments.callee;
+this.callInitAgain();
+// Entered instance init
+this.count ++;
+// this.count is 2
+// arguments.callee is function Function() {}
+// this.savedCallee is function Function() {}
+// arguments.callee == this.savedCallee? false
+this.count = arguments.callee;
+this.callInitAgain();
+// Entered instance init
+this.count ++;
+// this.count is 3
+// arguments.callee is function Function() {}
+// this.savedCallee is function Function() {}
+// arguments.callee == this.savedCallee? false
+this.count = arguments.callee;
+// this.count >= 3, stopping

--- a/tests/tests/swfs/avm2/init_callee_cached/test.toml
+++ b/tests/tests/swfs/avm2/init_callee_cached/test.toml
@@ -1,2 +1,2 @@
 num_frames = 1
-ignore = true # Currently panics in AVM2 code
+known_failure = true


### PR DESCRIPTION
## Description

When the `callstatic` op is used to call a method, the method is called with a superclass object that is the superclass of the first ClassObject the method was bound to. Previously, the method was being called with no superclass object.

This makes the `avm2/init_callee_cached` test no longer panic.

## Testing

`avm2/init_callee_cached` is no longer panicking.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
