### PR TITLE
desktop: Fix crashes resulting from handling egui texture deltas

### DIFF
--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -415,13 +415,15 @@ impl GuiController {
                     label: Some("egui encoder"),
                 });
 
-        for (id, image_delta) in &full_output.textures_delta.set {
-            self.egui_renderer.update_texture(
-                &self.descriptors.device,
-                &self.descriptors.queue,
-                *id,
-                &image_delta[0],
-            );
+        for (id, image_deltas) in full_output.textures_delta.set.drain() {
+            for image_delta in &image_deltas {
+                self.egui_renderer.update_texture(
+                    &self.descriptors.device,
+                    &self.descriptors.queue,
+                    id,
+                    image_delta,
+                );
+            }
         }
 
         let mut command_buffers = self.egui_renderer.update_buffers(
@@ -475,8 +477,8 @@ impl GuiController {
             }
         }
 
-        for id in &full_output.textures_delta.free {
-            self.egui_renderer.free_texture(id);
+        for id in full_output.textures_delta.free.drain() {
+            self.egui_renderer.free_texture(&id);
         }
 
         if let Some(player) = player.as_deref_mut() {

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -477,10 +477,6 @@ impl GuiController {
             }
         }
 
-        for id in full_output.textures_delta.free.drain() {
-            self.egui_renderer.free_texture(&id);
-        }
-
         if let Some(player) = player.as_deref_mut() {
             let renderer =
                 <dyn Any>::downcast_mut::<WgpuRenderBackend<MovieView>>(player.renderer_mut())
@@ -489,6 +485,14 @@ impl GuiController {
         }
         command_buffers.push(encoder.finish());
         self.descriptors.queue.submit(command_buffers);
+
+        // Free textures only after submitting the command buffer that may still
+        // reference them.  Destroying a texture before its usage is submitted
+        // causes a wgpu validation panic.
+        for id in full_output.textures_delta.free.drain() {
+            self.egui_renderer.free_texture(&id);
+        }
+
         self.window.pre_present_notify();
         self.descriptors.queue.present(surface_texture);
         #[cfg(feature = "tracy")]


### PR DESCRIPTION
## Description

Includes two patches fixing crashes resulting from handling egui texture deltas.

### (1) desktop: Drain freed and updated egui textures

This apparently was a long standing bug, but it started crashing Ruffle
after updating egui.  A Drop impl was added that asserts on
TexturesDelta being empty.

This patch drains those texture deltas, making sure we don't leave
handled deltas behind.

### (2) desktop: Fix crash during freeing egui textures

When an egui texture is still used and queued to be freed, wgpu crashed
because we freed the textures before submitting the command buffer.

This patch reverses the order and allows us to use a texture directly
in the debug UI window.

## Testing

(1) can crash Ruffle when running in debug mode on master. This started happening after the egui update.

(2) can crash Ruffle when deallocating textures in debug UI code. This cannot happen on master because debug UI doesn't own textures (but it will).

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
