### PR TITLE
Use `assert` shorthands

### DIFF
--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -688,21 +688,51 @@ fn avm2_to_gradient_filter<'gc>(
     activation: &mut Activation<'_, 'gc>,
     object: Object<'gc>,
 ) -> Result<GradientFilter, Error<'gc>> {
-    #[expect(clippy::assertions_on_constants)]
-    {
-        assert!(gradient_bevel_filter_slots::_ANGLE == gradient_glow_filter_slots::_ANGLE);
-        assert!(gradient_bevel_filter_slots::_BLUR_X == gradient_glow_filter_slots::_BLUR_X);
-        assert!(gradient_bevel_filter_slots::_BLUR_Y == gradient_glow_filter_slots::_BLUR_Y);
-        assert!(gradient_bevel_filter_slots::_DISTANCE == gradient_glow_filter_slots::_DISTANCE);
-        assert!(gradient_bevel_filter_slots::_KNOCKOUT == gradient_glow_filter_slots::_KNOCKOUT);
-        assert!(gradient_bevel_filter_slots::_QUALITY == gradient_glow_filter_slots::_QUALITY);
-        assert!(gradient_bevel_filter_slots::_STRENGTH == gradient_glow_filter_slots::_STRENGTH);
-        assert!(gradient_bevel_filter_slots::_TYPE == gradient_glow_filter_slots::_TYPE);
+    assert_eq!(
+        gradient_bevel_filter_slots::_ANGLE,
+        gradient_glow_filter_slots::_ANGLE
+    );
+    assert_eq!(
+        gradient_bevel_filter_slots::_BLUR_X,
+        gradient_glow_filter_slots::_BLUR_X
+    );
+    assert_eq!(
+        gradient_bevel_filter_slots::_BLUR_Y,
+        gradient_glow_filter_slots::_BLUR_Y
+    );
+    assert_eq!(
+        gradient_bevel_filter_slots::_DISTANCE,
+        gradient_glow_filter_slots::_DISTANCE
+    );
+    assert_eq!(
+        gradient_bevel_filter_slots::_KNOCKOUT,
+        gradient_glow_filter_slots::_KNOCKOUT
+    );
+    assert_eq!(
+        gradient_bevel_filter_slots::_QUALITY,
+        gradient_glow_filter_slots::_QUALITY
+    );
+    assert_eq!(
+        gradient_bevel_filter_slots::_STRENGTH,
+        gradient_glow_filter_slots::_STRENGTH
+    );
+    assert_eq!(
+        gradient_bevel_filter_slots::_TYPE,
+        gradient_glow_filter_slots::_TYPE
+    );
 
-        assert!(gradient_bevel_filter_slots::_COLORS == gradient_glow_filter_slots::_COLORS);
-        assert!(gradient_bevel_filter_slots::_ALPHAS == gradient_glow_filter_slots::_ALPHAS);
-        assert!(gradient_bevel_filter_slots::_RATIOS == gradient_glow_filter_slots::_RATIOS);
-    }
+    assert_eq!(
+        gradient_bevel_filter_slots::_COLORS,
+        gradient_glow_filter_slots::_COLORS
+    );
+    assert_eq!(
+        gradient_bevel_filter_slots::_ALPHAS,
+        gradient_glow_filter_slots::_ALPHAS
+    );
+    assert_eq!(
+        gradient_bevel_filter_slots::_RATIOS,
+        gradient_glow_filter_slots::_RATIOS
+    );
 
     let angle = object
         .get_slot(gradient_bevel_filter_slots::_ANGLE)

--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -524,7 +524,7 @@ impl<'gc> AbstractState<'gc> {
         let mut changed = false;
 
         // Merge locals
-        assert!(self.locals.len() == other.locals.len());
+        assert_eq!(self.locals.len(), other.locals.len());
 
         for i in 0..self.locals.len() {
             let our_local = self.locals.at(i);

--- a/core/src/avm2/stack.rs
+++ b/core/src/avm2/stack.rs
@@ -84,7 +84,7 @@ unsafe impl<'gc> Collect<'gc> for StackData<'gc> {
     // StackFrames from before a collection can't be accessed after the collection.
     fn trace<C: Trace<'gc>>(&self, _cc: &mut C) {
         // There should be no values on the value stack when collection is triggered
-        assert!(self.stack_pointer.get() == 0);
+        assert_eq!(self.stack_pointer.get(), 0);
     }
 }
 

--- a/core/src/html/line_wrapping.rs
+++ b/core/src/html/line_wrapping.rs
@@ -123,8 +123,8 @@ pub fn wrap_line<'gc, T: FontLike<'gc>>(
             if is_start_of_line {
                 //Failsafe: we get a word wider than the field, break anywhere.
 
-                assert!(i == 0);
-                assert!(word_start == 0);
+                assert_eq!(i, 0);
+                assert_eq!(word_start, 0);
 
                 let mut last_fitting_end = 0;
                 for (frag_end, _) in trimmed_word.char_indices() {

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -163,7 +163,7 @@ impl<'a> Bitmap<'a> {
     #[cold]
     fn resize_data(data: &mut Cow<'_, [u8]>, expected_len: usize) {
         let len = data.len();
-        assert!(len != expected_len);
+        assert_ne!(len, expected_len);
         tracing::warn!("Incorrect bitmap data size, expected {expected_len} bytes, got {len}");
 
         match (&mut *data, expected_len.checked_sub(len)) {

--- a/render/src/bitmap/atlas.rs
+++ b/render/src/bitmap/atlas.rs
@@ -382,8 +382,8 @@ mod test {
             .expect("allocation should succeed");
 
         let r = region.region();
-        assert!(r.width() == 4);
-        assert!(r.height() == 4);
+        assert_eq!(r.width(), 4);
+        assert_eq!(r.height(), 4);
         assert!(r.x_max <= 16);
         assert!(r.y_max <= 16);
     }

--- a/wstr/src/tests.rs
+++ b/wstr/src/tests.rs
@@ -75,10 +75,10 @@ fn cmp() {
     let a2 = wstr!('h''e''l''l''o');
     let b2 = wstr!('w''o''r''l''d');
 
-    assert!(a1 == a1); assert!(a2 == a1); assert!(b1 >  a1); assert!(b2 >  a1);
-    assert!(a1 == a2); assert!(a2 == a2); assert!(b1 >  a2); assert!(b2 >  a2);
-    assert!(a1 <  b1); assert!(a2 <  b1); assert!(b1 == b1); assert!(b2 == b1);
-    assert!(a1 <  b2); assert!(a2 <  b2); assert!(b1 == b2); assert!(b2 == b2);
+    assert_eq!(a1, a1); assert_eq!(a2, a1); assert!(b1 >  a1); assert!(b2 >  a1);
+    assert_eq!(a1, a2); assert_eq!(a2, a2); assert!(b1 >  a2); assert!(b2 >  a2);
+    assert!(a1 <  b1); assert!(a2 <  b1); assert_eq!(b1, b1); assert_eq!(b2, b1);
+    assert!(a1 <  b2); assert!(a2 <  b2); assert_eq!(b1, b2); assert_eq!(b2, b2);
 }
 
 #[test]
@@ -89,10 +89,10 @@ fn cmp_common_prefix() {
     let a2 = wstr!('h''e''l''l''o');
     let b2 = wstr!('h''e''l''l''o''!');
 
-    assert!(a1 == a1); assert!(a2 == a1); assert!(b1 >  a1); assert!(b2 >  a1);
-    assert!(a1 == a2); assert!(a2 == a2); assert!(b1 >  a2); assert!(b2 >  a2);
-    assert!(a1 <  b1); assert!(a2 <  b1); assert!(b1 == b1); assert!(b2 == b1);
-    assert!(a1 <  b2); assert!(a2 <  b2); assert!(b1 == b2); assert!(b2 == b2);
+    assert_eq!(a1, a1); assert_eq!(a2, a1); assert!(b1 >  a1); assert!(b2 >  a1);
+    assert_eq!(a1, a2); assert_eq!(a2, a2); assert!(b1 >  a2); assert!(b2 >  a2);
+    assert!(a1 <  b1); assert!(a2 <  b1); assert_eq!(b1, b1); assert_eq!(b2, b1);
+    assert!(a1 <  b2); assert!(a2 <  b2); assert_eq!(b1, b2); assert_eq!(b2, b2);
 }
 
 #[test]


### PR DESCRIPTION
## Description

Replaces `assert(a == b)` with `assert_eq(a, b)` and `assert(a != b)` with `assert_ne(a, b)`

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
