### PR TITLE
tests: Improve the default log filter

### DIFF
--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -38,15 +38,20 @@ struct RuffleTestOpts {
 }
 
 fn main() {
+    let default_log_filter = default_log_filter();
+
     let _ = env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("info,wgpu_core=warn,wgpu_hal=warn"),
+        env_logger::Env::default().default_filter_or(&default_log_filter),
     )
     .format_timestamp(None)
     .is_test(true)
     .try_init();
 
     let subscriber = tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_log_filter)),
+        )
         .finish();
     // Ignore error if it's already been set
     let _ = tracing::subscriber::set_global_default(subscriber);
@@ -114,6 +119,17 @@ fn main() {
     env.flush_gpu_with_timeout(std::time::Duration::from_secs(15));
 
     conclusion.exit()
+}
+
+/// The default filter used when `RUST_LOG` isn't set.
+fn default_log_filter() -> String {
+    // Silence non-errors.
+    let mut filter = "error".to_owned();
+
+    // We don't have access to device fonts in tests, so font errors are expected.
+    filter.push_str(",ruffle_core::html::layout=off");
+
+    filter
 }
 
 fn load_test_dir<'a>(test_dir: &'a VfsPath, name: &'a str) -> impl Iterator<Item = Test> + 'a {


### PR DESCRIPTION
## Description

Silence all non-error logs, and silence errors resulting from font lookup, as we don't have access to device fonts in tests.

These font error logs cause thousands of lines of logs traced when running tests.

## Testing

Check logs when running SWF tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
