### PR TITLE
desktop: Implement font atlases and use them for FreeType

### DIFF
--- a/core/src/debug_ui/font.rs
+++ b/core/src/debug_ui/font.rs
@@ -1,13 +1,19 @@
 use crate::debug_ui::{ItemToSave, Message};
-use crate::font::{Font, FontFace, FontLike, FontRenderer, Glyph, GlyphSource};
+use crate::font::{
+    Font, FontAtlas, FontAtlases, FontFace, FontLike, FontRenderer, Glyph, GlyphSource,
+};
 use egui::{CollapsingHeader, Grid, TextEdit, Ui, Window};
 use fnv::FnvHashMap;
 use std::cell::RefCell;
 use swf::Twips;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct FontWindow {
     glyph_info_text: String,
+
+    /// Cached egui preview textures for atlas pages shown by this window,
+    /// keyed by atlas name and page index.
+    atlas_page_textures: RefCell<FnvHashMap<(String, usize), egui::TextureHandle>>,
 }
 
 impl FontWindow {
@@ -258,6 +264,62 @@ impl FontWindow {
                     }
                 });
                 ui.end_row();
+            });
+
+        if let Some(atlases) = font_renderer.atlases() {
+            self.show_glyph_atlases(ui, atlases);
+        }
+    }
+
+    fn show_glyph_atlases(&self, ui: &mut Ui, atlases: &FontAtlases) {
+        self.show_glyph_atlas(ui, &atlases.rgba(), "RGBA");
+    }
+
+    fn show_glyph_atlas(&self, ui: &mut Ui, atlas: &FontAtlas, name: &str) {
+        CollapsingHeader::new(format!("Glyph Atlas ({name})"))
+            .id_salt(ui.id().with(format!("atlas-{name}")))
+            .show(ui, |ui| {
+                ui.label(format!("Atlas: {:p}", atlas.as_ptr()));
+
+                let pages = atlas.pages();
+                let refresh = ui.button("Refresh").clicked();
+
+                if pages.is_empty() {
+                    ui.weak("(no pages allocated yet)");
+                }
+
+                for (i, page) in pages.iter().enumerate() {
+                    let key = (name.to_string(), i);
+
+                    if refresh {
+                        self.atlas_page_textures.borrow_mut().remove(&key);
+                    }
+
+                    CollapsingHeader::new(format!("Page {i}"))
+                        .id_salt(ui.id().with("page").with(i))
+                        .show(ui, |ui| {
+                            let texture = self
+                                .atlas_page_textures
+                                .borrow_mut()
+                                .entry(key)
+                                .or_insert_with(|| {
+                                    let bitmap = page.to_rgba();
+                                    let image = egui::ColorImage::from_rgba_premultiplied(
+                                        [bitmap.width() as usize, bitmap.height() as usize],
+                                        bitmap.data(),
+                                    );
+                                    ui.ctx().load_texture(
+                                        format!("font-atlas-{name}-page-{i}"),
+                                        image,
+                                        Default::default(),
+                                    )
+                                })
+                                .clone();
+                            let size = texture.size_vec2();
+                            ui.label(format!("{}x{}", size.x as u32, size.y as u32));
+                            ui.image((texture.id(), size));
+                        });
+                }
             });
     }
 }

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -1,3 +1,4 @@
+mod atlas;
 mod font_descriptor;
 mod font_face;
 mod font_like;
@@ -6,6 +7,7 @@ mod font_set;
 mod glyph;
 mod text_render_settings;
 
+pub use atlas::{FontAtlas, FontAtlasGlyph, FontAtlases};
 pub use font_descriptor::FontDescriptor;
 pub use font_face::{FontFace, FontFileData};
 pub use font_like::{EvalParameters, FontLike, GlyphResolution};

--- a/core/src/font/atlas.rs
+++ b/core/src/font/atlas.rs
@@ -1,0 +1,557 @@
+use ruffle_render::backend::RenderBackend;
+use ruffle_render::bitmap::atlas::{BitmapAtlas, BitmapAtlasRegion};
+use ruffle_render::bitmap::{Bitmap, BitmapFormat, BitmapHandle, BitmapSize, PixelRegion};
+use std::cell::RefCell;
+use std::rc::Rc;
+use swf::Twips;
+
+struct FontAtlasData {
+    size: BitmapSize,
+    format: BitmapFormat,
+
+    /// All atlas pages created so far, in the order they were created. A fresh
+    /// page is only added once none of the existing ones fit.
+    pages: Vec<BitmapAtlas>,
+}
+
+/// Font atlas takes care of allocating bitmaps and managing glyphs on them.
+///
+/// It supports unbounded, variable-size glyphs spread across atlas pages with
+/// an option to deallocate them when they are not used.
+#[derive(Clone)]
+pub struct FontAtlas(Rc<RefCell<FontAtlasData>>);
+
+impl FontAtlas {
+    pub fn new(size: BitmapSize, format: BitmapFormat) -> Self {
+        Self(Rc::new(RefCell::new(FontAtlasData {
+            size,
+            format,
+            pages: Vec::new(),
+        })))
+    }
+
+    /// A pointer uniquely identifying this atlas instance, for debug/inspection
+    /// purposes.
+    pub fn as_ptr(&self) -> *const () {
+        Rc::as_ptr(&self.0) as *const ()
+    }
+
+    /// Allocates space for `bitmap` in the atlas and copies it in, starting a
+    /// fresh atlas page if none of the existing ones have room left.
+    pub fn new_glyph(&self, bitmap: Bitmap<'_>, tx: Twips, ty: Twips) -> FontAtlasGlyph {
+        let mut data = self.0.borrow_mut();
+
+        let atlas_region = match data.pages.iter().find_map(|page| allocate(page, &bitmap)) {
+            Some(atlas_region) => atlas_region,
+            None => {
+                // None of the existing pages have room; start a fresh one, sized to
+                // guarantee it fits `bitmap` (plus its margin) even if it's larger
+                // than the configured size.
+                let width = data.size.width.max(bitmap.width() + GLYPH_MARGIN * 2);
+                let height = data.size.height.max(bitmap.height() + GLYPH_MARGIN * 2);
+                let new_page = BitmapAtlas::new(width, height, data.format);
+                let atlas_region = allocate(&new_page, &bitmap)
+                    .expect("a fresh page sized to fit `bitmap` should fit `bitmap`");
+                data.pages.push(new_page);
+                atlas_region
+            }
+        };
+
+        let region = trim_margin(&atlas_region);
+
+        FontAtlasGlyph(Rc::new(FontAtlasGlyphData {
+            atlas_region,
+            region,
+            tx,
+            ty,
+        }))
+    }
+
+    /// All atlas pages, for debug/inspection purposes.
+    pub fn pages(&self) -> Vec<BitmapAtlas> {
+        self.0.borrow().pages.clone()
+    }
+}
+
+impl std::fmt::Debug for FontAtlas {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FontAtlas")
+            .field("pages", &self.0.borrow().pages)
+            .finish()
+    }
+}
+
+/// Empty space reserved around each glyph's pixels in the atlas, so that
+/// texture filtering at the glyph's edge can't sample an unrelated
+/// neighboring glyph packed right next to it.
+const GLYPH_MARGIN: u32 = 1;
+
+fn allocate(atlas: &BitmapAtlas, bitmap: &Bitmap<'_>) -> Option<BitmapAtlasRegion> {
+    let padded_width = bitmap.width() + GLYPH_MARGIN * 2;
+    let padded_height = bitmap.height() + GLYPH_MARGIN * 2;
+
+    let region = atlas.allocate(padded_width, padded_height, true)?;
+    region.set_region(bitmap, GLYPH_MARGIN, GLYPH_MARGIN);
+    Some(region)
+}
+
+/// The glyph's own pixels within its atlas allocation, excluding the margin
+/// reserved around them.
+fn trim_margin(atlas_region: &BitmapAtlasRegion) -> PixelRegion {
+    let region = atlas_region.region();
+    PixelRegion {
+        x_min: region.x_min + GLYPH_MARGIN,
+        y_min: region.y_min + GLYPH_MARGIN,
+        x_max: region.x_max - GLYPH_MARGIN,
+        y_max: region.y_max - GLYPH_MARGIN,
+    }
+}
+
+struct FontAtlasGlyphData {
+    atlas_region: BitmapAtlasRegion,
+
+    /// The glyph's own pixels within the atlas, excluding the margin
+    /// reserved around them. Held in an `Rc` so it can be handed out as a
+    /// `Weak` alongside render commands: once this glyph is dropped, that
+    /// `Weak` can no longer be upgraded, even if the atlas later reuses the
+    /// same coordinates for an unrelated glyph. Backends use this to know
+    /// when a resource they cached keyed on the rectangle (e.g. a bind
+    /// group) has gone stale.
+    region: PixelRegion,
+
+    tx: Twips,
+    ty: Twips,
+}
+
+#[derive(Clone)]
+pub struct FontAtlasGlyph(Rc<FontAtlasGlyphData>);
+
+impl FontAtlasGlyph {
+    pub fn tx(&self) -> Twips {
+        self.0.tx
+    }
+
+    pub fn ty(&self) -> Twips {
+        self.0.ty
+    }
+
+    pub fn atlas_handle(&self, renderer: &mut dyn RenderBackend) -> Option<BitmapHandle> {
+        self.0.atlas_region.atlas().handle(renderer)
+    }
+
+    /// The glyph's own pixels within the atlas, excluding the margin reserved
+    /// around them.
+    pub fn atlas_region(&self) -> PixelRegion {
+        self.0.region
+    }
+}
+
+impl std::fmt::Debug for FontAtlasGlyph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FontAtlasGlyph")
+            .field("atlas", self.0.atlas_region.atlas())
+            .field("atlas_region", &self.atlas_region())
+            .field("tx", &self.0.tx)
+            .field("ty", &self.0.ty)
+            .finish()
+    }
+}
+
+/// The page size used for atlases created through [`FontAtlases`].
+const SHARED_ATLAS_PAGE_SIZE: BitmapSize = BitmapSize {
+    width: 1024,
+    height: 1024,
+};
+
+/// A small, shared, global set of font atlases.
+///
+/// There's one atlas per pixel format rather than per font, since different
+/// fonts producing glyphs of the same format can happily share pages. Each
+/// atlas starts out empty, so eagerly creating all of them costs nothing
+/// until a glyph actually gets placed in one.
+#[derive(Debug, Clone)]
+pub struct FontAtlases {
+    rgba: FontAtlas,
+    // TODO Add grayscale atlas?
+}
+
+impl FontAtlases {
+    pub fn new() -> Self {
+        Self {
+            rgba: FontAtlas::new(SHARED_ATLAS_PAGE_SIZE, BitmapFormat::Rgba),
+        }
+    }
+
+    /// The shared atlas for RGBA glyphs.
+    pub fn rgba(&self) -> FontAtlas {
+        self.rgba.clone()
+    }
+}
+
+impl Default for FontAtlases {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ruffle_render::backend::ViewportDimensions;
+    use ruffle_render::backend::null::NullRenderer;
+
+    fn null_renderer() -> NullRenderer {
+        NullRenderer::new(ViewportDimensions {
+            width: 100,
+            height: 80,
+            scale_factor: 1.0,
+        })
+    }
+
+    fn font_atlas(width: u32, height: u32) -> FontAtlas {
+        FontAtlas::new(BitmapSize { width, height }, BitmapFormat::Rgba)
+    }
+
+    fn solid_bitmap(width: u32, height: u32, format: BitmapFormat, fill: u8) -> Bitmap<'static> {
+        let len = format.length_for_size(width as usize, height as usize);
+        Bitmap::new(width, height, format, vec![fill; len])
+    }
+
+    /// Adds a glyph of solid `fill` at the origin, the shape most of these
+    /// tests care about.
+    fn add_glyph(atlas: &FontAtlas, width: u32, height: u32, fill: u8) -> FontAtlasGlyph {
+        atlas.new_glyph(
+            solid_bitmap(width, height, BitmapFormat::Rgba, fill),
+            Twips::ZERO,
+            Twips::ZERO,
+        )
+    }
+
+    /// Expands one value per pixel into RGBA data. All test glyphs are solid
+    /// fills, so a whole page can be written out one value per pixel.
+    fn expand_pixels(pixels: &[u8]) -> Vec<u8> {
+        pixels.iter().flat_map(|&value| [value; 4]).collect()
+    }
+
+    /// Index of the page holding `glyph`, identified by its texture handle.
+    fn page_index_of(atlas: &FontAtlas, glyph: &FontAtlasGlyph) -> usize {
+        let mut renderer = null_renderer();
+        let handle = glyph
+            .atlas_handle(&mut renderer)
+            .expect("glyph's page should register");
+        atlas
+            .pages()
+            .iter()
+            .position(|page| page.handle(&mut renderer).as_ref() == Some(&handle))
+            .expect("glyph should live on one of the atlas's pages")
+    }
+
+    #[test]
+    fn new_atlas_has_no_pages() {
+        let atlas = font_atlas(8, 8);
+        assert!(atlas.pages().is_empty());
+    }
+
+    #[test]
+    fn first_glyph_creates_a_page() {
+        let atlas = FontAtlas::new(
+            BitmapSize {
+                width: 16,
+                height: 8,
+            },
+            BitmapFormat::Rgb,
+        );
+        let _glyph = atlas.new_glyph(
+            solid_bitmap(2, 2, BitmapFormat::Rgb, 0x33),
+            Twips::ZERO,
+            Twips::ZERO,
+        );
+
+        let pages = atlas.pages();
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].format(), BitmapFormat::Rgb);
+
+        let page = pages[0].to_rgba();
+        assert_eq!(page.width(), 16);
+        assert_eq!(page.height(), 8);
+    }
+
+    #[test]
+    fn glyph_region_matches_the_bitmap_size() {
+        let atlas = font_atlas(64, 64);
+        let glyph = add_glyph(&atlas, 5, 3, 0xAB);
+
+        let region = glyph.atlas_region();
+        assert_eq!(region.width(), 5);
+        assert_eq!(region.height(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "Can't copy a region between bitmaps of different formats")]
+    fn bad_bitmap_format() {
+        let atlas = font_atlas(8, 8);
+
+        // The atlas is RGBA, so a glyph in another format can't be copied in.
+        atlas.new_glyph(
+            solid_bitmap(2, 2, BitmapFormat::Rgb, 0xAB),
+            Twips::ZERO,
+            Twips::ZERO,
+        );
+    }
+
+    #[test]
+    fn glyph_placement() {
+        let atlas = font_atlas(10, 5);
+        let first = add_glyph(&atlas, 3, 3, 0x11);
+        let second = add_glyph(&atlas, 3, 3, 0x22);
+
+        assert_eq!(atlas.pages().len(), 1, "both glyphs should share one page");
+        assert_eq!(
+            first.atlas_region(),
+            PixelRegion {
+                x_min: 1,
+                y_min: 1,
+                x_max: 4,
+                y_max: 4,
+            }
+        );
+        assert_eq!(
+            second.atlas_region(),
+            PixelRegion {
+                x_min: 6,
+                y_min: 1,
+                x_max: 9,
+                y_max: 4,
+            }
+        );
+
+        // The whole page: both glyphs intact, with blank margin between them
+        // and along the page edges, so neither glyph bleeds into the other's
+        // filtering neighborhood.
+        let page = atlas.pages()[0].to_rgba();
+        #[rustfmt::skip]
+        let expected = expand_pixels(&[
+            0x00, 0x00, 0x00, 0x00, 0x00,   0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x11, 0x11, 0x11, 0x00,   0x00, 0x22, 0x22, 0x22, 0x00,
+            0x00, 0x11, 0x11, 0x11, 0x00,   0x00, 0x22, 0x22, 0x22, 0x00,
+            0x00, 0x11, 0x11, 0x11, 0x00,   0x00, 0x22, 0x22, 0x22, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00,   0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(page.data(), expected);
+    }
+
+    #[test]
+    fn margins_are_cleared() {
+        let atlas = font_atlas(6, 4);
+
+        // Fills the whole page, leaving its pixels behind when dropped.
+        let first = add_glyph(&atlas, 4, 2, 0x11);
+        assert_eq!(
+            first.atlas_region(),
+            PixelRegion {
+                x_min: 1,
+                y_min: 1,
+                x_max: 5,
+                y_max: 3,
+            }
+        );
+        drop(first);
+
+        #[rustfmt::skip]
+        let expected = expand_pixels(&[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x11, 0x11, 0x11, 0x11, 0x00,
+            0x00, 0x11, 0x11, 0x11, 0x11, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(atlas.pages()[0].to_rgba().data(), expected);
+
+        // Reuses the left part of the space the first glyph occupied, so its
+        // margin falls on pixels the first glyph had written.
+        let second = add_glyph(&atlas, 2, 2, 0x22);
+        assert_eq!(
+            second.atlas_region(),
+            PixelRegion {
+                x_min: 1,
+                y_min: 1,
+                x_max: 3,
+                y_max: 3,
+            }
+        );
+
+        // The margin around the second glyph is blank despite the first
+        // glyph's pixels having been there. Only the reused space is cleared
+        // though; the rest of the page keeps the leftovers.
+        #[rustfmt::skip]
+        let expected = expand_pixels(&[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x22, 0x22, 0x00, 0x11, 0x00,
+            0x00, 0x22, 0x22, 0x00, 0x11, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(atlas.pages()[0].to_rgba().data(), expected);
+    }
+
+    #[test]
+    fn new_page_created_when_no_space() {
+        let atlas = font_atlas(8, 8);
+
+        let first = add_glyph(&atlas, 5, 5, 0x11);
+        assert_eq!(atlas.pages().len(), 1);
+
+        let second = add_glyph(&atlas, 1, 1, 0x22);
+        assert_eq!(atlas.pages().len(), 2);
+        assert_eq!(page_index_of(&atlas, &first), 0);
+        assert_eq!(page_index_of(&atlas, &second), 1);
+    }
+
+    #[test]
+    fn glyphs_go_to_the_earliest_page() {
+        let atlas = font_atlas(16, 16);
+        let first = add_glyph(&atlas, 4, 4, 0x11);
+
+        // Too large for the first page, so it gets a page of its own.
+        let oversized = add_glyph(&atlas, 14, 14, 0x22);
+        assert_eq!(atlas.pages().len(), 2);
+
+        // The first page still has plenty of room, so this goes back to it
+        // rather than onto the most recently created page.
+        let third = add_glyph(&atlas, 2, 2, 0x33);
+
+        assert_eq!(page_index_of(&atlas, &first), 0);
+        assert_eq!(page_index_of(&atlas, &oversized), 1);
+        assert_eq!(page_index_of(&atlas, &third), 0);
+        assert_eq!(atlas.pages().len(), 2, "no third page should be needed");
+    }
+
+    #[test]
+    fn glyph_larger_than_page() {
+        let atlas = font_atlas(4, 4);
+        let first_big = add_glyph(&atlas, 3, 3, 0x11);
+        let second = add_glyph(&atlas, 1, 1, 0x22);
+        let third_big = add_glyph(&atlas, 3, 3, 0x33);
+
+        assert_eq!(atlas.pages().len(), 3);
+
+        assert_eq!(page_index_of(&atlas, &first_big), 0);
+        assert_eq!(page_index_of(&atlas, &second), 1);
+        assert_eq!(page_index_of(&atlas, &third_big), 2);
+
+        let page0 = atlas.pages()[0].to_rgba();
+        let page1 = atlas.pages()[1].to_rgba();
+        let page2 = atlas.pages()[2].to_rgba();
+        assert_eq!(page0.width(), 5);
+        assert_eq!(page0.height(), 5);
+        assert_eq!(page1.width(), 4);
+        assert_eq!(page1.height(), 4);
+        assert_eq!(page2.width(), 5);
+        assert_eq!(page2.height(), 5);
+
+        #[rustfmt::skip]
+        let expected0 = expand_pixels(&[
+            0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x11, 0x11, 0x11, 0x00,
+            0x00, 0x11, 0x11, 0x11, 0x00,
+            0x00, 0x11, 0x11, 0x11, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(page0.data(), expected0);
+
+        #[rustfmt::skip]
+        let expected1 = expand_pixels(&[
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x22, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(page1.data(), expected1);
+
+        #[rustfmt::skip]
+        let expected2 = expand_pixels(&[
+            0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x33, 0x33, 0x33, 0x00,
+            0x00, 0x33, 0x33, 0x33, 0x00,
+            0x00, 0x33, 0x33, 0x33, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(page2.data(), expected2);
+    }
+
+    #[test]
+    fn zero_sized_glyph() {
+        let atlas = font_atlas(8, 8);
+        let glyph = atlas.new_glyph(Bitmap::empty(BitmapFormat::Rgba), Twips::ZERO, Twips::ZERO);
+
+        assert!(glyph.atlas_region().is_empty());
+        assert_eq!(atlas.pages().len(), 1);
+    }
+
+    #[test]
+    fn dropping_a_glyph_frees_its_space_for_reuse() {
+        let atlas = font_atlas(4, 4);
+        let glyph = add_glyph(&atlas, 2, 2, 0x11);
+        let region = glyph.atlas_region();
+
+        drop(glyph);
+
+        let reused = add_glyph(&atlas, 2, 2, 0x22);
+        assert_eq!(
+            atlas.pages().len(),
+            1,
+            "the freed space should be reused instead of starting a new page"
+        );
+        assert_eq!(reused.atlas_region(), region);
+
+        // Reusing the space overwrites the dropped glyph's pixels entirely,
+        // leaving no trace of it anywhere on the page.
+        #[rustfmt::skip]
+        let expected = expand_pixels(&[
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x22, 0x22, 0x00,
+            0x00, 0x22, 0x22, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(atlas.pages()[0].to_rgba().data(), expected);
+    }
+
+    #[test]
+    fn glyph_translation() {
+        let atlas = font_atlas(8, 8);
+        let glyph = atlas.new_glyph(
+            solid_bitmap(2, 2, BitmapFormat::Rgba, 0xAB),
+            Twips::from_pixels(1.5),
+            Twips::new(-40),
+        );
+
+        assert_eq!(glyph.tx(), Twips::from_pixels(1.5));
+        assert_eq!(glyph.ty(), Twips::new(-40));
+    }
+
+    #[test]
+    fn cloned_atlas_shares_pages_with_the_original() {
+        let atlas = font_atlas(4, 4);
+        let clone = atlas.clone();
+
+        let glyph = add_glyph(&clone, 2, 2, 0xAB);
+
+        // The glyph added through the clone is visible on the original's page.
+        assert_eq!(atlas.pages().len(), 1);
+        assert_eq!(
+            glyph.atlas_region(),
+            PixelRegion {
+                x_min: 1,
+                y_min: 1,
+                x_max: 3,
+                y_max: 3,
+            }
+        );
+        #[rustfmt::skip]
+        let expected = expand_pixels(&[
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0xAB, 0xAB, 0x00,
+            0x00, 0xAB, 0xAB, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(atlas.pages()[0].to_rgba().data(), expected);
+    }
+}

--- a/core/src/font/font_renderer.rs
+++ b/core/src/font/font_renderer.rs
@@ -1,6 +1,6 @@
 use swf::Twips;
 
-use crate::font::{FontMetrics, Glyph};
+use crate::font::{FontAtlases, FontMetrics, Glyph};
 
 pub trait FontRenderer: std::fmt::Debug {
     fn scale(&self) -> f32;
@@ -12,4 +12,8 @@ pub trait FontRenderer: std::fmt::Debug {
     fn render_glyph(&self, character: char) -> Option<Glyph>;
 
     fn calculate_kerning(&self, left: char, right: char) -> Twips;
+
+    fn atlases(&self) -> Option<&FontAtlases> {
+        None
+    }
 }

--- a/core/src/font/glyph.rs
+++ b/core/src/font/glyph.rs
@@ -1,5 +1,6 @@
 use crate::context::RenderContext;
 use crate::drawing::Drawing;
+use crate::font::FontAtlasGlyph;
 use crate::prelude::*;
 use ruffle_render::backend::null::NullBitmapSource;
 use ruffle_render::backend::{RenderBackend, ShapeHandle};
@@ -47,6 +48,7 @@ pub enum GlyphRenderData {
         tx: Twips,
         ty: Twips,
     },
+    AtlasGlyph(FontAtlasGlyph),
 }
 
 impl GlyphRenderData {
@@ -61,6 +63,10 @@ impl GlyphRenderData {
             ty,
         }
     }
+
+    pub fn from_atlas(atlas_glyph: FontAtlasGlyph) -> Self {
+        Self::AtlasGlyph(atlas_glyph)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -68,6 +74,7 @@ enum GlyphShape {
     Swf(Box<RefCell<SwfGlyphOrShape>>),
     Drawing(Box<Drawing>),
     Bitmap(Rc<GlyphBitmap<'static>>),
+    AtlasGlyph(FontAtlasGlyph),
     None,
 }
 
@@ -82,6 +89,10 @@ impl GlyphShape {
             }
             GlyphShape::Drawing(drawing) => drawing.hit_test(point, local_matrix),
             GlyphShape::Bitmap(_) => {
+                // TODO Implement this.
+                true
+            }
+            GlyphShape::AtlasGlyph(_) => {
                 // TODO Implement this.
                 true
             }
@@ -113,6 +124,10 @@ impl GlyphShape {
                 .ok()
                 .cloned()
                 .map(|info| GlyphRenderData::from_bitmap(info, bitmap.tx, bitmap.ty)),
+            GlyphShape::AtlasGlyph(atlas_glyph) => atlas_glyph
+                .atlas_handle(renderer)
+                .as_ref()
+                .map(|_| GlyphRenderData::from_atlas(atlas_glyph.clone())),
             GlyphShape::None => None,
         }
     }
@@ -226,6 +241,14 @@ impl Glyph {
         }
     }
 
+    pub fn from_atlas(character: char, atlas_glyph: FontAtlasGlyph, advance: Twips) -> Self {
+        Self {
+            shape: GlyphShape::AtlasGlyph(atlas_glyph),
+            advance,
+            character,
+        }
+    }
+
     pub fn glyph_render_data(&self, renderer: &mut dyn RenderBackend) -> Option<GlyphRenderData> {
         self.shape.register(renderer)
     }
@@ -251,6 +274,7 @@ impl Glyph {
             GlyphShape::Swf(_) => true,
             GlyphShape::Drawing(_) => true,
             GlyphShape::Bitmap(_) => false,
+            GlyphShape::AtlasGlyph(_) => false,
             GlyphShape::None => false,
         }
     }
@@ -285,6 +309,27 @@ impl Glyph {
                     true,
                     ruffle_render::bitmap::PixelSnapping::Auto,
                     region,
+                );
+
+                context.transform_stack.pop();
+            }
+            GlyphRenderData::AtlasGlyph(atlas_glyph) => {
+                let handle = atlas_glyph.atlas_handle(context.renderer);
+                let Some(handle) = handle else {
+                    return;
+                };
+
+                context.transform_stack.push(&Transform {
+                    matrix: Matrix::translate(atlas_glyph.tx(), atlas_glyph.ty()),
+                    ..Default::default()
+                });
+
+                context.commands.render_bitmap(
+                    handle,
+                    context.transform_stack.transform(),
+                    true,
+                    ruffle_render::bitmap::PixelSnapping::Auto,
+                    atlas_glyph.atlas_region(),
                 );
 
                 context.transform_stack.pop();

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -15,7 +15,7 @@ use ruffle_core::backend::ui::{
     FullscreenError, LanguageIdentifier, MouseCursor, MultiDialogResultFuture,
     MultiFileDialogResult, UiBackend,
 };
-use ruffle_core::font::{FontFileData, FontQuery};
+use ruffle_core::font::{FontAtlases, FontFileData, FontQuery};
 use std::fs::File;
 use std::path::Path;
 use std::rc::Rc;
@@ -162,6 +162,10 @@ pub struct DesktopUiBackend {
     // It's non-trivial to invalidate all fonts and change the renderer, so
     // do not allow changing it in runtime.
     device_font_renderer: DeviceFontRenderer,
+
+    // Shared atlas pages that every device font loaded by this backend packs
+    // its glyphs into, instead of each font getting its own.
+    font_atlases: FontAtlases,
 }
 
 impl DesktopUiBackend {
@@ -187,6 +191,7 @@ impl DesktopUiBackend {
                 .device_font_renderer()
                 .unwrap_or(DeviceFontRenderer::Embedded),
             preferences,
+            font_atlases: FontAtlases::new(),
         })
     }
 
@@ -342,7 +347,12 @@ impl UiBackend for DesktopUiBackend {
                 face.post_script_name
             );
 
-            match load_fontdb_font(name.to_string(), face, self.device_font_renderer) {
+            match load_fontdb_font(
+                name.to_string(),
+                face,
+                self.device_font_renderer,
+                &self.font_atlases,
+            ) {
                 Ok(font_definition) => register(font_definition),
                 Err(error) => tracing::error!("Error loading font from fontdb: {error}"),
             }
@@ -357,7 +367,7 @@ impl UiBackend for DesktopUiBackend {
     ) -> Vec<FontQuery> {
         cfg_select! {
             all(unix, feature = "fontconfig") => {
-                fontconfig::sort_device_fonts(query, register, self.device_font_renderer)
+                fontconfig::sort_device_fonts(query, register, self.device_font_renderer, &self.font_atlases)
                     .inspect_err(|err| tracing::error!("Cannot sort device fonts: {err}"))
                     .unwrap_or_default()
             }
@@ -437,6 +447,7 @@ fn load_font_from_file(
     is_bold: bool,
     is_italic: bool,
     device_font_renderer: DeviceFontRenderer,
+    #[allow(unused_variables)] atlases: &FontAtlases,
 ) -> Result<FontDefinition<'static>> {
     match device_font_renderer {
         #[cfg(all(target_os = "linux", feature = "freetype"))]
@@ -447,7 +458,7 @@ fn load_font_from_file(
                 name,
                 is_bold,
                 is_italic,
-                font_renderer: Box::new(FreetypeFontRenderer::new(path, index)?),
+                font_renderer: Box::new(FreetypeFontRenderer::new(path, index, atlases)?),
             })
         }
         _ => {
@@ -479,6 +490,7 @@ fn load_fontdb_font(
     name: String,
     face: &FaceInfo,
     device_font_renderer: DeviceFontRenderer,
+    atlases: &FontAtlases,
 ) -> Result<FontDefinition<'static>> {
     let is_bold = face.weight > fontdb::Weight::NORMAL;
     let is_italic = face.style != fontdb::Style::Normal;
@@ -491,6 +503,7 @@ fn load_fontdb_font(
             is_bold,
             is_italic,
             device_font_renderer,
+            atlases,
         ),
 
         fontdb::Source::Binary(bin) | fontdb::Source::SharedFile(_, bin) => {
@@ -509,7 +522,7 @@ fn load_fontdb_font(
 mod fontconfig {
     use crate::backends::ui::{DeviceFontRenderer, load_font_from_file};
     use ruffle_core::backend::ui::FontDefinition;
-    use ruffle_core::font::FontQuery;
+    use ruffle_core::font::{FontAtlases, FontQuery};
     use std::path::Path;
 
     #[derive(Debug, thiserror::Error)]
@@ -524,6 +537,7 @@ mod fontconfig {
         query: &FontQuery,
         register: &mut dyn FnMut(FontDefinition),
         device_font_renderer: DeviceFontRenderer,
+        atlases: &FontAtlases,
     ) -> Result<Vec<FontQuery>, FontconfigError> {
         use fontconfig::{FontFormat, Pattern};
         use std::sync::LazyLock;
@@ -597,6 +611,7 @@ mod fontconfig {
                 is_bold,
                 is_italic,
                 device_font_renderer,
+                atlases,
             ) {
                 Ok(definition) => register(definition),
                 Err(err) => {

--- a/frontend-utils/src/backends/ui/freetype_font_renderer.rs
+++ b/frontend-utils/src/backends/ui/freetype_font_renderer.rs
@@ -148,6 +148,10 @@ impl FontRenderer for FreetypeFontRenderer {
             .map_err(|err| tracing::error!("Failed to calculate kerning: {err:?}"))
             .unwrap_or(Twips::ZERO)
     }
+
+    fn atlases(&self) -> Option<&FontAtlases> {
+        Some(&self.atlases)
+    }
 }
 
 /// Converts a FreeType 26.6 fixed-point value (1/64th of a pixel) to Twips

--- a/frontend-utils/src/backends/ui/freetype_font_renderer.rs
+++ b/frontend-utils/src/backends/ui/freetype_font_renderer.rs
@@ -1,6 +1,7 @@
 use freetype::bitmap::PixelMode;
 use freetype::face::KerningMode;
 use freetype::face::LoadFlag;
+use ruffle_core::font::FontAtlases;
 use std::ffi::OsStr;
 use thiserror::Error;
 
@@ -23,6 +24,7 @@ pub enum Error {
 #[derive(Debug)]
 pub struct FreetypeFontRenderer {
     face: freetype::Face,
+    atlases: FontAtlases,
 }
 
 impl FreetypeFontRenderer {
@@ -32,14 +34,17 @@ impl FreetypeFontRenderer {
     /// Divide each pixel into 20 (use twips precision). It affects metrics.
     const SCALE: f64 = 20.0;
 
-    pub fn new<P>(path: P, face_index: u32) -> Result<Self, Error>
+    pub fn new<P>(path: P, face_index: u32, atlases: &FontAtlases) -> Result<Self, Error>
     where
         P: AsRef<OsStr>,
     {
         let ft = freetype::Library::init()?;
         let face = ft.new_face(path, face_index as isize)?;
         face.set_char_size((Self::SIZE_PX * 64.0) as isize, 0, 0, 0)?;
-        Ok(Self { face })
+        Ok(Self {
+            face,
+            atlases: atlases.clone(),
+        })
     }
 
     fn size_metrics(&self) -> freetype::ffi::FT_Size_Metrics {
@@ -87,8 +92,9 @@ impl FreetypeFontRenderer {
             BitmapFormat::Rgba,
             convert_bitmap(&bitmap)?,
         );
+        let atlas_glyph = self.atlases.rgba().new_glyph(bitmap, tx, ty);
 
-        Ok(Glyph::from_bitmap(character, bitmap, advance, tx, ty))
+        Ok(Glyph::from_atlas(character, atlas_glyph, advance))
     }
 
     fn calculate_kerning_internal(&self, left: char, right: char) -> Result<Twips, Error> {

--- a/tests/framework/src/backends/ui.rs
+++ b/tests/framework/src/backends/ui.rs
@@ -7,6 +7,8 @@ use ruffle_core::backend::ui::{
     FullscreenError, LanguageIdentifier, MouseCursor, MultiDialogResultFuture,
     MultiFileDialogResult, US_ENGLISH, UiBackend,
 };
+#[cfg(feature = "freetype")]
+use ruffle_core::font::FontAtlases;
 use ruffle_core::font::{FontFileData, FontQuery};
 use serde::Deserialize;
 use url::Url;
@@ -82,6 +84,8 @@ pub struct TestUiBackend {
     fonts: HashMap<FontQuery, Font>,
     font_sorts: HashMap<FontQuery, Vec<FontQuery>>,
     device_font_renderer: FontRendererKind,
+    #[cfg(feature = "freetype")]
+    font_atlases: FontAtlases,
     clipboard: String,
 }
 
@@ -95,6 +99,8 @@ impl TestUiBackend {
             fonts,
             font_sorts,
             device_font_renderer,
+            #[cfg(feature = "freetype")]
+            font_atlases: FontAtlases::new(),
             clipboard: "".to_string(),
         }
     }
@@ -153,9 +159,10 @@ impl UiBackend for TestUiBackend {
             }
             #[cfg(feature = "freetype")]
             FontRendererKind::Freetype => {
-                let font_renderer = freetype_renderer(font).unwrap_or_else(|e| {
-                    panic!("Couldn't create FreeType renderer for {}: {e}", font.family)
-                });
+                let font_renderer =
+                    freetype_renderer(font, &self.font_atlases).unwrap_or_else(|e| {
+                        panic!("Couldn't create FreeType renderer for {}: {e}", font.family)
+                    });
                 register(FontDefinition::ExternalRenderer {
                     name: font.family.to_owned(),
                     is_bold: font.bold,
@@ -246,10 +253,11 @@ impl UiBackend for TestUiBackend {
 #[cfg(feature = "freetype")]
 fn freetype_renderer(
     font: &Font,
+    atlases: &FontAtlases,
 ) -> anyhow::Result<ruffle_frontend_utils::backends::ui::FreetypeFontRenderer> {
     use std::io::Write;
 
     let mut file = tempfile::NamedTempFile::new()?;
     file.write_all(&font.bytes)?;
-    Ok(ruffle_frontend_utils::backends::ui::FreetypeFontRenderer::new(file.path(), 0)?)
+    Ok(ruffle_frontend_utils::backends::ui::FreetypeFontRenderer::new(file.path(), 0, atlases)?)
 }

--- a/tests/tests/swfs/visual/fonts/leading_device_font/test.toml
+++ b/tests/tests/swfs/visual/fonts/leading_device_font/test.toml
@@ -26,4 +26,4 @@ device_font_renderer = "freetype"
 
 [subtests.freetype.image_comparisons.output]
 # TODO This could probably be fixed by implementing scaling properly.
-tolerance = 195
+tolerance = 215


### PR DESCRIPTION
## Description

Font atlases allow easy management of bitmap fonts. One font atlas can contain multiple glyphs and can grow on demand.

This prevents allocating separate textures for new glyphs instead allocating them on the atlas.

It's implemented for FreeType font renderer for now only, with Canvas font renderer getting support in near future.

<img height="300" alt="image" src="https://github.com/user-attachments/assets/47f48cb2-6145-4ff5-89da-693ed42e2284" />

## Testing

There are FreeType tests that verify this behavior. Additionally, unit tests for the font atlas are included.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
