### PR TITLE
chore: Bump mocha to 12

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -33,7 +33,7 @@
                 "eslint-plugin-react-hooks": "^7.1.1",
                 "eslint-plugin-react-refresh": "^0.5.3",
                 "globals": "^17.8.0",
-                "mocha": "^11.7.6",
+                "mocha": "^12.0.0",
                 "prettier": "^3.9.6",
                 "stylelint": "^17.14.1",
                 "stylelint-config-standard": "^40.0.0",
@@ -11595,229 +11595,141 @@
             "license": "MIT"
         },
         "node_modules/mocha": {
-            "version": "11.7.6",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
-            "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-12.0.0.tgz",
+            "integrity": "sha512-NYNh5IFt6WYqm9bi4601m7vix8MZdXC0DwS4gY6WhXO2RgJWhivhISVmq1oklCif18OSI9l+vx5Mdm5oh1XGiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "browser-stdout": "^1.3.1",
-                "chokidar": "^4.0.1",
+                "chokidar": "^5.0.0",
                 "debug": "^4.3.5",
-                "diff": "^7.0.0",
-                "escape-string-regexp": "^4.0.0",
+                "diff": "^9.0.0",
                 "find-up": "^5.0.0",
-                "glob": "^10.4.5",
-                "he": "^1.2.0",
+                "glob": "^13.0.0",
                 "is-path-inside": "^3.0.3",
-                "js-yaml": "^4.1.0",
-                "log-symbols": "^4.1.0",
-                "minimatch": "^9.0.5",
+                "is-unicode-supported": "^0.1.0",
+                "js-yaml": "^5.0.0",
+                "minimatch": "^10.2.2",
                 "ms": "^2.1.3",
                 "picocolors": "^1.1.1",
-                "serialize-javascript": "^6.0.2",
-                "strip-json-comments": "^3.1.1",
+                "serialize-javascript": "^7.0.2",
+                "strip-json-comments": "^5.0.3",
                 "supports-color": "^8.1.1",
-                "workerpool": "^9.2.0",
-                "yargs": "^17.7.2",
-                "yargs-parser": "^21.1.1",
-                "yargs-unparser": "^2.0.0"
+                "workerpool": "^10.0.0"
             },
             "bin": {
-                "_mocha": "bin/_mocha",
                 "mocha": "bin/mocha.js"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/mocha/node_modules/@isaacs/cliui": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^5.1.2",
-                "string-width-cjs": "npm:string-width@^4.2.0",
-                "strip-ansi": "^7.0.1",
-                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-                "wrap-ansi": "^8.1.0",
-                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/mocha/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+        "node_modules/mocha/node_modules/chokidar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "readdirp": "^5.0.0"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">= 20.19.0"
             },
             "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/mocha/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/mocha/node_modules/diff": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+            "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
             }
         },
-        "node_modules/mocha/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/mocha/node_modules/glob": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/mocha/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/mocha/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/mocha/node_modules/path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
-            }
-        },
-        "node_modules/mocha/node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+        "node_modules/mocha/node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
             "engines": {
-                "node": ">=12"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/mocha/node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+        "node_modules/mocha/node_modules/js-yaml": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+            "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
+                "argparse": "^2.0.1"
             },
+            "bin": {
+                "js-yaml": "bin/js-yaml.mjs"
+            }
+        },
+        "node_modules/mocha/node_modules/readdirp": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+            "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": ">= 20.19.0"
             },
             "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/mocha/node_modules/strip-json-comments": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+            "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/modern-tar": {
@@ -17249,9 +17161,9 @@
             }
         },
         "node_modules/workerpool": {
-            "version": "9.3.4",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-            "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-10.0.3.tgz",
+            "integrity": "sha512-6z2Iis68Wqth93/G/wJP9u+R3O+d2XTlgWChGCwuT1qLbBsOYueGRZuJ++v3mtDP5KjYdy+WzvWC+VWETSVXJA==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -17758,7 +17670,7 @@
                 "autoprefixer": "^10.5.4",
                 "cssnano": "^8.0.2",
                 "cssnano-preset-advanced": "^8.0.2",
-                "mocha": "^11.7.6",
+                "mocha": "^12.0.0",
                 "postcss": "^8.5.25",
                 "postcss-nesting": "^14.0.1",
                 "replace-in-file": "^8.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.8.0",
-        "mocha": "^11.7.6",
+        "mocha": "^12.0.0",
         "prettier": "^3.9.6",
         "stylelint": "^17.14.1",
         "stylelint-config-standard": "^40.0.0",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -28,7 +28,7 @@
         "autoprefixer": "^10.5.4",
         "cssnano": "^8.0.2",
         "cssnano-preset-advanced": "^8.0.2",
-        "mocha": "^11.7.6",
+        "mocha": "^12.0.0",
         "postcss": "^8.5.25",
         "postcss-nesting": "^14.0.1",
         "replace-in-file": "^8.4.0",


### PR DESCRIPTION
## Description

https://mochajs.org/blog/mocha-12-stable/

> The changes in Mocha 12 should require few, if any, changes in user applications. Most end-users should not be affected by Mocha 12’s breaking changes.

This is supposed to fix a security advisory by bumping `diff`: https://github.com/advisories/GHSA-73rr-hh4g-fpgx

## Testing

yes

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
