### PR TITLE
chore: Bump gc-arena to 0.7.0, hashbrown to 0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,12 +2104,13 @@ dependencies = [
 
 [[package]]
 name = "gc-arena"
-version = "0.5.3"
-source = "git+https://github.com/kyren/gc-arena.git?rev=75671ae03f53718357b741ed4027560f14e90836#75671ae03f53718357b741ed4027560f14e90836"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160a11f93020eea95cb4c59e2eda2e4c6353f75aa4fbb01f2bf8729b2e4d6dd2"
 dependencies = [
  "enum-map",
  "gc-arena-derive",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "slotmap",
  "smallvec",
@@ -2117,8 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "gc-arena-derive"
-version = "0.5.3"
-source = "git+https://github.com/kyren/gc-arena.git?rev=75671ae03f53718357b741ed4027560f14e90836#75671ae03f53718357b741ed4027560f14e90836"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3d24b051bd5a5f44e66bac510393d3d484ef776bb560f6504668239f35959a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4844,7 +4846,7 @@ version = "0.5.0"
 dependencies = [
  "fnv",
  "gc-arena",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "quick-xml",
  "regress",
  "ruffle_macros",
@@ -4882,7 +4884,7 @@ dependencies = [
  "fnv",
  "futures",
  "gc-arena",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "id3",
  "image",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ egui-winit = "0.36.1"
 clap = { version = "4.6.1", features = ["derive"] }
 cpal = "0.16.0"
 anyhow = "1.0"
-gc-arena = { git = "https://github.com/kyren/gc-arena.git", rev = "75671ae03f53718357b741ed4027560f14e90836", features = ["enum-map", "hashbrown", "indexmap", "slotmap", "smallvec"] }
+gc-arena = { version = "0.7.0", features = ["enum-map", "hashbrown", "indexmap", "slotmap", "smallvec"] }
 slotmap = "1.1.1"
 async-channel = "2.5.0"
 bitflags = "2.12.1"
@@ -107,7 +107,7 @@ rayon = "1.12.0"
 sha2 = "0.10.9"
 indexmap = "2.13.0"
 fnv = "1.0.7"
-hashbrown = "0.16.1"
+hashbrown = "0.17.1"
 fluent-templates = "0.13.3"
 lzma-rs = "0.3.0"
 tempfile = "3.27.0"

--- a/deny.toml
+++ b/deny.toml
@@ -84,7 +84,6 @@ unknown-git = "deny"
 # github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
-    "kyren", # for `gc-arena`
 ]
 
 [advisories]


### PR DESCRIPTION
## Description

Now that https://github.com/ruffle-rs/ruffle/pull/24520/ dropped `hashbrown` 0.15, let's move closer to perhaps dropping 0.16 as well.
After this, only https://github.com/Traverse-Research/gpu-allocator/pull/302 and our `regress` fork (`regras3`) will pull it in. For the latter, upstream already allows 0.17, we'll just have to update our fork: https://github.com/ridiculousfish/regress/commit/ec27815b6b8462b45e291370b387405e15070521

Changelogs linked for convenience:
 - https://github.com/kyren/gc-arena/blob/master/CHANGELOG.md
 - https://github.com/rust-lang/hashbrown/blob/main/CHANGELOG.md

## Testing

I hope automated tests + :crab: "builds therefore correct" is enough here.

## Checklist

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
