### PR TITLE
render: Preserve minimum-width strokes under collapsed transforms

### DIFF
--- a/render/src/tessellator.rs
+++ b/render/src/tessellator.rs
@@ -1,4 +1,5 @@
 use crate::bitmap::BitmapSource;
+use crate::matrix::Matrix;
 use crate::shape_utils::{DistilledShape, DrawCommand, DrawPath, GradientType};
 use indexmap::IndexSet;
 use lyon::path::Path;
@@ -21,6 +22,116 @@ pub struct ShapeTessellator {
 }
 
 const TESSELLATION_EPSILON: f32 = 0.0000001;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OneDimensionalAxis {
+    Horizontal,
+    Vertical,
+}
+
+/// Metadata for a tessellated one-dimensional stroke whose width was promoted
+/// to Ruffle's minimum one-device-pixel width.
+///
+/// WGPU/WebGL expand strokes into triangles before applying the display-object
+/// transform. If that transform completely collapses the local axis
+/// perpendicular to this line, the expanded stroke becomes zero-area geometry.
+#[derive(Clone, Copy, Debug)]
+pub struct OneDimensionalHairline {
+    axis: OneDimensionalAxis,
+    anchor: swf::Point<swf::Twips>,
+    tessellation_scale: f32,
+}
+
+impl OneDimensionalHairline {
+    fn from_shape(shape: &DistilledShape<'_>, tessellation_scale: f32) -> Option<Self> {
+        let tessellation_scale = tessellation_scale.abs();
+        if !tessellation_scale.is_finite() || tessellation_scale <= TESSELLATION_EPSILON {
+            return None;
+        }
+
+        let axis = if shape.edge_bounds.y_min == shape.edge_bounds.y_max
+            && shape.edge_bounds.x_min != shape.edge_bounds.x_max
+        {
+            OneDimensionalAxis::Horizontal
+        } else if shape.edge_bounds.x_min == shape.edge_bounds.x_max
+            && shape.edge_bounds.y_min != shape.edge_bounds.y_max
+        {
+            OneDimensionalAxis::Vertical
+        } else {
+            return None;
+        };
+
+        let minimum_local_width = 1.0 / tessellation_scale;
+
+        // Keep this path deliberately narrow: the whole shape must consist of
+        // strokes that are using ShapeTessellator's minimum-width rule.
+        if shape.paths.is_empty()
+            || !shape.paths.iter().all(|path| match path {
+                DrawPath::Stroke { style, .. } => {
+                    (style.width().to_pixels() as f32) <= minimum_local_width
+                }
+                DrawPath::Fill { .. } => false,
+            })
+        {
+            return None;
+        }
+
+        Some(Self {
+            axis,
+            anchor: swf::Point::new(shape.edge_bounds.x_min, shape.edge_bounds.y_min),
+            tessellation_scale,
+        })
+    }
+
+    pub fn adjust_matrix(self, matrix: &mut Matrix) {
+        let anchor_before = *matrix * self.anchor;
+
+        match self.axis {
+            OneDimensionalAxis::Horizontal => {
+                if matrix.c != 0.0 || matrix.d != 0.0 {
+                    return;
+                }
+
+                let surviving_length = matrix.a.hypot(matrix.b);
+                if surviving_length <= TESSELLATION_EPSILON {
+                    return;
+                }
+
+                matrix.c = -matrix.b / surviving_length * self.tessellation_scale;
+                matrix.d = matrix.a / surviving_length * self.tessellation_scale;
+            }
+            OneDimensionalAxis::Vertical => {
+                if matrix.a != 0.0 || matrix.b != 0.0 {
+                    return;
+                }
+
+                let surviving_length = matrix.c.hypot(matrix.d);
+                if surviving_length <= TESSELLATION_EPSILON {
+                    return;
+                }
+
+                matrix.a = matrix.d / surviving_length * self.tessellation_scale;
+                matrix.b = -matrix.c / surviving_length * self.tessellation_scale;
+            }
+        }
+
+        // Changing the unused basis shifts an offset line by a constant amount.
+        // Compensate so the transformed centerline remains unchanged.
+        let anchor_after = *matrix * self.anchor;
+        matrix.tx = swf::Twips::new(
+            matrix
+                .tx
+                .get()
+                .wrapping_add(anchor_before.x.get().wrapping_sub(anchor_after.x.get())),
+        );
+        matrix.ty = swf::Twips::new(
+            matrix
+                .ty
+                .get()
+                .wrapping_add(anchor_before.y.get().wrapping_sub(anchor_after.y.get())),
+        );
+    }
+}
 
 impl ShapeTessellator {
     pub fn new() -> Self {
@@ -55,6 +166,7 @@ impl ShapeTessellator {
         self.gradients = IndexSet::new();
         self.lyon_mesh = VertexBuffers::new();
 
+        let one_dimensional_hairline = OneDimensionalHairline::from_shape(&shape, scale);
         for path in shape.paths {
             let (fill_style, lyon_path, next_is_stroke) = match &path {
                 DrawPath::Fill {
@@ -244,6 +356,7 @@ impl ShapeTessellator {
         Mesh {
             draws: std::mem::take(&mut self.mesh),
             gradients: std::mem::take(&mut self.gradients).into_iter().collect(),
+            one_dimensional_hairline,
         }
     }
 
@@ -276,6 +389,7 @@ impl Default for ShapeTessellator {
 pub struct Mesh {
     pub draws: Vec<Draw>,
     pub gradients: Vec<Gradient>,
+    pub one_dimensional_hairline: Option<OneDimensionalHairline>,
 }
 
 pub struct Draw {
@@ -469,5 +583,133 @@ impl StrokeVertexConstructor<Vertex> for RuffleVertexCtor {
             y: vertex.position().y,
             color: self.color,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one_dimensional_stroke_shape<'a>(
+        style: &'a swf::LineStyle,
+        bounds: swf::Rectangle<swf::Twips>,
+    ) -> DistilledShape<'a> {
+        DistilledShape {
+            paths: vec![DrawPath::Stroke {
+                style,
+                is_closed: false,
+                commands: vec![
+                    DrawCommand::MoveTo(swf::Point::new(bounds.x_min, bounds.y_min)),
+                    DrawCommand::LineTo(swf::Point::new(bounds.x_max, bounds.y_max)),
+                ],
+            }],
+            shape_bounds: bounds,
+            edge_bounds: bounds,
+            id: 0,
+        }
+    }
+
+    fn assert_points_near(left: swf::Point<swf::Twips>, right: swf::Point<swf::Twips>) {
+        assert!((left.x.get() - right.x.get()).abs() <= 1);
+        assert!((left.y.get() - right.y.get()).abs() <= 1);
+    }
+
+    #[test]
+    fn one_dimensional_hairline_horizontal_like_n() {
+        let style = swf::LineStyle::new().with_width(swf::Twips::new(1));
+        let bounds = swf::Rectangle {
+            x_min: swf::Twips::new(-2560),
+            x_max: swf::Twips::new(2560),
+            y_min: swf::Twips::ZERO,
+            y_max: swf::Twips::ZERO,
+        };
+        let start = swf::Point::new(bounds.x_min, bounds.y_min);
+        let end = swf::Point::new(bounds.x_max, bounds.y_max);
+        let shape = one_dimensional_stroke_shape(&style, bounds);
+        let metadata = OneDimensionalHairline::from_shape(&shape, 0.08).unwrap();
+
+        let mut matrix = Matrix::scale(0.1171875, 0.0);
+        let start_before = matrix * start;
+        let end_before = matrix * end;
+
+        metadata.adjust_matrix(&mut matrix);
+
+        assert_points_near(matrix * start, start_before);
+        assert_points_near(matrix * end, end_before);
+        assert!((matrix.c.hypot(matrix.d) - 0.08).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn one_dimensional_hairline_preserves_offset_rotated_line() {
+        let style = swf::LineStyle::new().with_width(swf::Twips::new(1));
+        let bounds = swf::Rectangle {
+            x_min: swf::Twips::new(-100),
+            x_max: swf::Twips::new(300),
+            y_min: swf::Twips::new(40),
+            y_max: swf::Twips::new(40),
+        };
+        let start = swf::Point::new(bounds.x_min, bounds.y_min);
+        let end = swf::Point::new(bounds.x_max, bounds.y_max);
+        let shape = one_dimensional_stroke_shape(&style, bounds);
+        let metadata = OneDimensionalHairline::from_shape(&shape, 0.15).unwrap();
+
+        let mut matrix = Matrix {
+            a: 0.1,
+            b: 0.2,
+            c: 0.0,
+            d: 0.0,
+            tx: swf::Twips::new(25),
+            ty: swf::Twips::new(50),
+        };
+        let start_before = matrix * start;
+        let end_before = matrix * end;
+
+        metadata.adjust_matrix(&mut matrix);
+
+        assert_points_near(matrix * start, start_before);
+        assert_points_near(matrix * end, end_before);
+        assert!((matrix.c.hypot(matrix.d) - 0.15).abs() <= f32::EPSILON);
+        assert!((matrix.a * matrix.c + matrix.b * matrix.d).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn one_dimensional_hairline_vertical() {
+        let style = swf::LineStyle::new().with_width(swf::Twips::new(1));
+        let bounds = swf::Rectangle {
+            x_min: swf::Twips::new(40),
+            x_max: swf::Twips::new(40),
+            y_min: swf::Twips::new(-100),
+            y_max: swf::Twips::new(300),
+        };
+        let shape = one_dimensional_stroke_shape(&style, bounds);
+        let metadata = OneDimensionalHairline::from_shape(&shape, 0.2).unwrap();
+
+        let mut matrix = Matrix::scale(0.0, 0.25);
+        metadata.adjust_matrix(&mut matrix);
+
+        assert!((matrix.a.hypot(matrix.b) - 0.2).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn one_dimensional_hairline_rejects_thick_or_two_dimensional_shapes() {
+        let thick_style = swf::LineStyle::new().with_width(swf::Twips::new(400));
+        let horizontal = swf::Rectangle {
+            x_min: swf::Twips::new(-100),
+            x_max: swf::Twips::new(100),
+            y_min: swf::Twips::ZERO,
+            y_max: swf::Twips::ZERO,
+        };
+        let thick_shape = one_dimensional_stroke_shape(&thick_style, horizontal);
+        assert!(OneDimensionalHairline::from_shape(&thick_shape, 1.0).is_none());
+
+        let thin_style = swf::LineStyle::new().with_width(swf::Twips::new(1));
+        let area = swf::Rectangle {
+            x_min: swf::Twips::new(-100),
+            x_max: swf::Twips::new(100),
+            y_min: swf::Twips::new(-100),
+            y_max: swf::Twips::new(100),
+        };
+        let area_shape = one_dimensional_stroke_shape(&thin_style, area);
+        assert!(OneDimensionalHairline::from_shape(&area_shape, 1.0).is_none());
     }
 }

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -17,7 +17,7 @@ use ruffle_render::matrix::Matrix;
 use ruffle_render::quality::StageQuality;
 use ruffle_render::shape_utils::{DistilledShape, GradientType};
 use ruffle_render::tessellator::{
-    Gradient as TessGradient, ShapeTessellator, Vertex as TessVertex,
+    Gradient as TessGradient, OneDimensionalHairline, ShapeTessellator, Vertex as TessVertex,
 };
 use ruffle_render::transform::Transform;
 use ruffle_web_common::{JsError, JsResult};
@@ -568,12 +568,13 @@ impl WebGlRenderBackend {
         shape: DistilledShape,
         bitmap_source: &dyn BitmapSource,
         scale: f32,
-    ) -> Result<Vec<Draw>, Error> {
+    ) -> Result<(Vec<Draw>, Option<OneDimensionalHairline>), Error> {
         use ruffle_render::tessellator::DrawType as TessDrawType;
 
         let lyon_mesh =
             self.shape_tessellator
                 .tessellate_shape_with_scale(shape, bitmap_source, scale);
+        let one_dimensional_hairline = lyon_mesh.one_dimensional_hairline;
 
         let mut draws = Vec::with_capacity(lyon_mesh.draws.len());
         for draw in lyon_mesh.draws {
@@ -699,7 +700,7 @@ impl WebGlRenderBackend {
             }
         }
 
-        Ok(draws)
+        Ok((draws, one_dimensional_hairline))
     }
 
     /// Creates and binds a new VAO.
@@ -1051,8 +1052,9 @@ impl RenderBackend for WebGlRenderBackend {
         scale: f32,
     ) -> ShapeHandle {
         let mesh = match self.register_shape_internal(shape, bitmap_source, scale) {
-            Ok(draws) => Mesh {
+            Ok((draws, one_dimensional_hairline)) => Mesh {
                 draws,
+                one_dimensional_hairline,
                 gl2: self.gl2.clone(),
                 vao_ext: self.vao_ext.clone(),
             },
@@ -1060,6 +1062,7 @@ impl RenderBackend for WebGlRenderBackend {
                 log::error!("Couldn't register shape: {e:?}");
                 Mesh {
                     draws: vec![],
+                    one_dimensional_hairline: None,
                     gl2: self.gl2.clone(),
                     vao_ext: self.vao_ext.clone(),
                 }
@@ -1367,13 +1370,19 @@ impl CommandHandler for WebGlRenderBackend {
     }
 
     fn render_shape(&mut self, shape: ShapeHandle, transform: Transform) {
+        let mesh = as_mesh(&shape);
+        let mut matrix = transform.matrix;
+        if let Some(hairline) = mesh.one_dimensional_hairline {
+            hairline.adjust_matrix(&mut matrix);
+        }
+
         let world_matrix = [
-            [transform.matrix.a, transform.matrix.b, 0.0, 0.0],
-            [transform.matrix.c, transform.matrix.d, 0.0, 0.0],
+            [matrix.a, matrix.b, 0.0, 0.0],
+            [matrix.c, matrix.d, 0.0, 0.0],
             [0.0, 0.0, 1.0, 0.0],
             [
-                transform.matrix.tx.to_pixels() as f32,
-                transform.matrix.ty.to_pixels() as f32,
+                matrix.tx.to_pixels() as f32,
+                matrix.ty.to_pixels() as f32,
                 0.0,
                 1.0,
             ],
@@ -1384,7 +1393,6 @@ impl CommandHandler for WebGlRenderBackend {
 
         self.set_stencil_state();
 
-        let mesh = as_mesh(&shape);
         for draw in &mesh.draws {
             // Ignore strokes when drawing a mask stencil.
             let num_indices = if self.mask_state != MaskState::DrawMaskStencil
@@ -1651,6 +1659,7 @@ struct Mesh {
     gl2: Option<Gl2>,
     vao_ext: OesVertexArrayObject,
     draws: Vec<Draw>,
+    one_dimensional_hairline: Option<OneDimensionalHairline>,
 }
 
 impl Drop for Mesh {

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -301,6 +301,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
         let lyon_mesh =
             self.shape_tessellator
                 .tessellate_shape_with_scale(shape, bitmap_source, scale);
+        let one_dimensional_hairline = lyon_mesh.one_dimensional_hairline;
 
         let mut draws = Vec::with_capacity(lyon_mesh.draws.len());
         let mut uniform_buffer = BufferBuilder::new_for_uniform(&self.descriptors.limits);
@@ -356,6 +357,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
             draws,
             vertex_buffer,
             index_buffer,
+            one_dimensional_hairline,
         }
     }
 

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -8,7 +8,9 @@ use wgpu::util::DeviceExt;
 use crate::buffer_builder::BufferBuilder;
 use ruffle_render::backend::{ShapeHandle, ShapeHandleImpl};
 use ruffle_render::bitmap::BitmapSource;
-use ruffle_render::tessellator::{Bitmap, Draw as LyonDraw, DrawType as TessDrawType, Gradient};
+use ruffle_render::tessellator::{
+    Bitmap, Draw as LyonDraw, DrawType as TessDrawType, Gradient, OneDimensionalHairline,
+};
 use swf::{CharacterId, GradientInterpolation};
 
 /// How big to make gradient textures. Larger will keep more detail, but be slower and use more memory.
@@ -19,6 +21,7 @@ pub struct Mesh {
     pub draws: Vec<Draw>,
     pub vertex_buffer: wgpu::Buffer,
     pub index_buffer: wgpu::Buffer,
+    pub one_dimensional_hairline: Option<OneDimensionalHairline>,
 }
 
 impl ShapeHandleImpl for Mesh {}

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -885,14 +885,17 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
     }
 
     fn render_shape(&mut self, shape: ShapeHandle, transform: Transform) {
-        self.add_to_current(
-            transform.matrix,
-            transform.color_transform,
-            |transform_buffer| DrawCommand::RenderShape {
+        let mut matrix = transform.matrix;
+        if let Some(hairline) = as_mesh(&shape).one_dimensional_hairline {
+            hairline.adjust_matrix(&mut matrix);
+        }
+
+        self.add_to_current(matrix, transform.color_transform, |transform_buffer| {
+            DrawCommand::RenderShape {
                 shape,
                 transform_buffer,
-            },
-        );
+            }
+        });
     }
 
     fn draw_rect(&mut self, color: Color, matrix: Matrix) {


### PR DESCRIPTION
(Fix of #24565, which github won't let me reopen because it fails to synchronize after a force-push. Apologies for multiple PRs)

## Description

We've been working on [a Tool-Assisted Speedrun for the whole N game](https://github.com/Perdu/nv14_TAS/tree/main). As we're getting closer to the end of this tremendous task, it appears more and more urgent to get [the display bug](#21776) in Ruffle fixed, so we can submit our TAS to TASvideos.org. This bug was partially fixed in #23011, but the display of the core of the body of the player itself is still incorrect. As this has been stalled for years (#21776 is not the first report), I took the liberty at firing ChatGPT at the problem. I don't know what the repo's policy around AI-generated patches is, but I hope it will at least hint maintainers at a solution.

The proposed solution does fix the visual problem. See the following screenshots (watch the ninja in the bottom left corner):
- original Flash:
<img width="798" height="641" alt="Capture d’écran du 2026-08-29 15-51-47" src="https://github.com/user-attachments/assets/abc3a22d-b529-4eff-93cb-05389c785a0d" />
- Current ruffle version: 
<img width="925" height="752" alt="Capture d’écran du 2026-08-29 15-49-21" src="https://github.com/user-attachments/assets/e2dba20d-d303-4c02-be2d-d2fb7307b131" />
- with the patch: 
<img width="929" height="749" alt="Capture d’écran du 2026-08-29 15-48-46" src="https://github.com/user-attachments/assets/c0d297b8-6c93-4351-9068-cc068938e6f7" />

Moreover, as a test case, ChatGPT also gave me [an .swf file](https://github.com/Perdu/nv14_TAS/blob/main/volume/n_v14_graphical_issue_fix.swf) that does solve the display problem in the current (unpatched) version of ruffle. This at least constitutes a strong workaround for us. Original swf can be found [here](https://github.com/Perdu/nv14_TAS/blob/main/external/n_v14.swf).

Disclaimer: I am not knowledgable enough about flash and ruffle internals to know about any possible side-effect or performance issue brought by this patch. All I know is that I test, it does build and fix the issue.

With all of that said, here's the ChatGPT-redacted PR:
## Summary

Fix the remaining player rendering issue from #21776 without modifying
display-object transforms in core.

#23011 made very thin strokes scale-aware during tessellation and fixed most
of the missing outlines in N 1.4, but the ninja body remained invisible.

The ninja uses a one-dimensional stroked `DefineShape` under placement
matrices whose perpendicular basis is exactly zero, for example:

```text
[ 0.1171875  0 ]
[ 0           0 ]
```

WGPU/WebGL expand strokes into triangles in local space and apply the final
display-object matrix afterwards. A zero perpendicular basis therefore
collapses even a minimum-width tessellated stroke back to zero-area geometry.

Canvas does not have this problem because it transforms the path before
applying stroke width.

## Fix

`ShapeTessellator` now attaches a small `OneDimensionalHairline` metadata
record to its output mesh when all of the following are true:

- the shape's edge bounds are exactly one-dimensional;
- the shape contains only strokes; and
- every stroke is using the minimum-width rule from the tessellator.

The metadata records the line axis, an anchor point, and the scale at which
the mesh was tessellated.

WGPU and WebGL preserve this metadata on their backend-specific shape meshes.
At draw time, if the final display transform completely collapses the axis
perpendicular to that line, the backend reconstructs only that missing basis
as a perpendicular vector whose magnitude matches the tessellation scale.
Translation is compensated so the original transformed centerline remains
unchanged.

This keeps the compatibility handling in the tessellation/rendering layer
where the stroke triangles are actually collapsed. Core and Canvas are
unchanged.

## Why the reconstructed magnitude is the tessellation scale

The minimum local stroke width used by `ShapeTessellator` is `1 / scale`.
Giving the restored perpendicular basis magnitude `scale` maps that minimum
width back to exactly one device pixel.

## Scope / performance

The metadata is computed once when a shape is tessellated. The common WGPU
and WebGL draw paths pay only an `Option` check. Matrix adjustment runs only
for tagged one-dimensional minimum-width stroke meshes whose perpendicular
basis is exactly zero.

No allocations or additional draw calls are introduced.

Filled shapes, two-dimensional shapes, thicker strokes, Canvas, and ordinary
(non-collapsed) transforms are unchanged.

## Verification

The root cause was verified in both directions with N 1.4:

1. With unmodified Ruffle, changing only the ninja placement matrices from
   `scaleY = 0` to a nonzero value makes the ninja body render.
2. With the original, unmodified SWF, preserving a perpendicular basis for
   the tessellated stroke makes the ninja body render.

## Tests

Unit tests cover:

- the horizontal collapsed-axis case used by N;
- an offset/rotated horizontal line;
- the vertical equivalent;
- preservation of the original transformed centerline; and
- rejection of thick strokes and two-dimensional geometry.

Manual regression: original N 1.4 `n_v14.swf`.

Closes #21776.

Related: #23011.



## Checklist


- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
