### PR TITLE
core: Implement glyph cache eviction for font renderers

### DIFF
--- a/core/src/debug_ui/font.rs
+++ b/core/src/debug_ui/font.rs
@@ -1,6 +1,6 @@
 use crate::debug_ui::{ItemToSave, Message};
 use crate::font::{
-    Font, FontAtlas, FontAtlases, FontFace, FontLike, FontRenderer, Glyph, GlyphSource,
+    Font, FontAtlas, FontAtlases, FontFace, FontLike, FontRendererGlyphSource, Glyph, GlyphSource,
 };
 use egui::{CollapsingHeader, Grid, TextEdit, Ui, Window};
 use fnv::FnvHashMap;
@@ -172,16 +172,9 @@ impl FontWindow {
                 GlyphSource::FontFace { face, .. } => {
                     self.show_glyph_source_font_face(ui, font, face, messages)
                 }
-                GlyphSource::ExternalRenderer {
-                    glyph_cache,
-                    kerning_cache,
-                    font_renderer,
-                } => self.show_glyph_source_external_renderer(
-                    ui,
-                    glyph_cache,
-                    kerning_cache,
-                    font_renderer.as_ref(),
-                ),
+                GlyphSource::ExternalRenderer(glyph_source) => {
+                    self.show_glyph_source_external_renderer(ui, glyph_source)
+                }
                 GlyphSource::Empty => {
                     ui.weak("This font has no glyphs.");
                 }
@@ -235,38 +228,30 @@ impl FontWindow {
     fn show_glyph_source_external_renderer(
         &self,
         ui: &mut Ui,
-        glyph_cache: &RefCell<FnvHashMap<u16, Option<Glyph>>>,
-        kerning_cache: &RefCell<FnvHashMap<(u16, u16), Twips>>,
-        font_renderer: &dyn FontRenderer,
+        glyph_source: &FontRendererGlyphSource,
     ) {
         Grid::new(ui.id().with("glyph-source-table"))
             .num_columns(2)
             .striped(true)
             .show(ui, |ui| {
                 ui.label("Renderer");
-                ui.label(format!("{font_renderer:?}"));
+                ui.label(format!("{:?}", glyph_source.font_renderer()));
                 ui.end_row();
 
                 ui.label("Glyph Cache Size");
                 ui.horizontal(|ui| {
-                    ui.label(format!("{}", glyph_cache.borrow().len()));
-                    if ui.button("Clear").clicked() {
-                        glyph_cache.borrow_mut().clear();
-                    }
+                    ui.label(format!("{}", glyph_source.glyph_cache_size()));
                 });
                 ui.end_row();
 
                 ui.label("Kerning Cache Size");
                 ui.horizontal(|ui| {
-                    ui.label(format!("{}", kerning_cache.borrow().len()));
-                    if ui.button("Clear").clicked() {
-                        kerning_cache.borrow_mut().clear();
-                    }
+                    ui.label(format!("{}", glyph_source.kerning_cache_size()));
                 });
                 ui.end_row();
             });
 
-        if let Some(atlases) = font_renderer.atlases() {
+        if let Some(atlases) = glyph_source.font_renderer().atlases() {
             self.show_glyph_atlases(ui, atlases);
         }
     }

--- a/core/src/debug_ui/font.rs
+++ b/core/src/debug_ui/font.rs
@@ -249,6 +249,22 @@ impl FontWindow {
                     ui.label(format!("{}", glyph_source.kerning_cache_size()));
                 });
                 ui.end_row();
+
+                ui.label("Sweep Count");
+                ui.label(format!("{}", glyph_source.sweep_count()));
+                ui.end_row();
+
+                ui.label("Swept Glyphs");
+                ui.label(format!("{}", glyph_source.swept_glyphs_count()));
+                ui.end_row();
+
+                ui.label("Swept Kerning Pairs");
+                ui.label(format!("{}", glyph_source.swept_kerning_count()));
+                ui.end_row();
+
+                if ui.button("Sweep Caches").clicked() {
+                    glyph_source.sweep_caches(true);
+                }
             });
 
         if let Some(atlases) = glyph_source.font_renderer().atlases() {

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -210,6 +210,12 @@ impl GlyphSource {
             GlyphSource::Empty => FontMetrics::ZERO,
         }
     }
+
+    pub fn sweep_caches(&self) {
+        if let GlyphSource::ExternalRenderer(glyph_source) = self {
+            glyph_source.sweep_caches(false);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Collect, Hash)]
@@ -519,6 +525,10 @@ impl<'gc> Font<'gc> {
 
     pub fn has_layout(self) -> bool {
         self.0.has_layout
+    }
+
+    pub fn sweep_caches(&self) {
+        self.0.glyphs.sweep_caches();
     }
 }
 

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -12,6 +12,7 @@ pub use font_descriptor::FontDescriptor;
 pub use font_face::{FontFace, FontFileData};
 pub use font_like::{EvalParameters, FontLike, GlyphResolution};
 pub use font_renderer::FontRenderer;
+pub use font_renderer::FontRendererGlyphSource;
 pub use font_set::FontSet;
 pub use glyph::Glyph;
 pub use text_render_settings::TextRenderSettings;
@@ -21,8 +22,6 @@ use crate::prelude::*;
 use crate::string::WStr;
 use gc_arena::{Collect, Gc, Mutation};
 use ruffle_render::backend::RenderBackend;
-
-use std::cell::{Ref, RefCell};
 use std::hash::{Hash, Hasher};
 
 pub use swf::TextGridFit;
@@ -134,15 +133,7 @@ pub(crate) enum GlyphSource {
         face: FontFace,
         metrics: FontMetrics,
     },
-    ExternalRenderer {
-        /// Maps Unicode code points to glyphs rendered by the renderer.
-        glyph_cache: RefCell<fnv::FnvHashMap<u16, Option<Glyph>>>,
-
-        /// Maps Unicode pairs to kerning provided by the renderer.
-        kerning_cache: RefCell<fnv::FnvHashMap<(u16, u16), Twips>>,
-
-        font_renderer: Box<dyn FontRenderer>,
-    },
+    ExternalRenderer(FontRendererGlyphSource),
     Empty,
 }
 
@@ -151,7 +142,7 @@ impl GlyphSource {
         match self {
             GlyphSource::Memory { glyphs, .. } => glyphs.get(index).map(GlyphRef::Direct),
             GlyphSource::FontFace { .. } => None, // Unsupported.
-            GlyphSource::ExternalRenderer { .. } => None, // Unsupported.
+            GlyphSource::ExternalRenderer(_) => None, // Unsupported.
             GlyphSource::Empty => None,
         }
     }
@@ -172,25 +163,8 @@ impl GlyphSource {
                 }
             }
             GlyphSource::FontFace { face, .. } => face.get_glyph(code_point).map(GlyphRef::Direct),
-            GlyphSource::ExternalRenderer {
-                glyph_cache,
-                font_renderer,
-                ..
-            } => {
-                let character = code_point;
-                let code_point = code_point as u16;
-
-                glyph_cache
-                    .borrow_mut()
-                    .entry(code_point)
-                    .or_insert_with(|| font_renderer.render_glyph(character));
-
-                let glyph = Ref::filter_map(glyph_cache.borrow(), |v| {
-                    v.get(&code_point).unwrap_or(&None).as_ref()
-                })
-                .ok();
-
-                glyph.map(GlyphRef::Ref)
+            GlyphSource::ExternalRenderer(glyph_source) => {
+                glyph_source.get_by_code_point(code_point)
             }
             GlyphSource::Empty => None,
         }
@@ -200,7 +174,9 @@ impl GlyphSource {
         match self {
             GlyphSource::Memory { kerning_pairs, .. } => !kerning_pairs.is_empty(),
             GlyphSource::FontFace { face, .. } => face.has_kerning_info(),
-            GlyphSource::ExternalRenderer { font_renderer, .. } => font_renderer.has_kerning_info(),
+            GlyphSource::ExternalRenderer(glyph_source) => {
+                glyph_source.font_renderer().has_kerning_info()
+            }
             GlyphSource::Empty => false,
         }
     }
@@ -217,18 +193,8 @@ impl GlyphSource {
                     .unwrap_or_default()
             }
             GlyphSource::FontFace { face, .. } => face.get_kerning_offset(left, right),
-            GlyphSource::ExternalRenderer {
-                kerning_cache,
-                font_renderer,
-                ..
-            } => {
-                let (Ok(left_cp), Ok(right_cp)) = (left.try_into(), right.try_into()) else {
-                    return Twips::ZERO;
-                };
-                *kerning_cache
-                    .borrow_mut()
-                    .entry((left_cp, right_cp))
-                    .or_insert_with(|| font_renderer.calculate_kerning(left, right))
+            GlyphSource::ExternalRenderer(glyph_source) => {
+                glyph_source.get_kerning_offset(left, right)
             }
             GlyphSource::Empty => Twips::ZERO,
         }
@@ -238,7 +204,9 @@ impl GlyphSource {
         match self {
             GlyphSource::Memory { metrics, .. } => *metrics,
             GlyphSource::FontFace { metrics, .. } => *metrics,
-            GlyphSource::ExternalRenderer { font_renderer, .. } => font_renderer.get_font_metrics(),
+            GlyphSource::ExternalRenderer(glyph_source) => {
+                glyph_source.font_renderer().get_font_metrics()
+            }
             GlyphSource::Empty => FontMetrics::ZERO,
         }
     }
@@ -476,11 +444,7 @@ impl<'gc> Font<'gc> {
         Font(Gc::new(
             gc_context,
             FontData {
-                glyphs: GlyphSource::ExternalRenderer {
-                    glyph_cache: RefCell::new(fnv::FnvHashMap::default()),
-                    kerning_cache: RefCell::new(fnv::FnvHashMap::default()),
-                    font_renderer,
-                },
+                glyphs: GlyphSource::ExternalRenderer(FontRendererGlyphSource::new(font_renderer)),
                 scale,
                 descriptor,
                 font_type: FontType::Device,

--- a/core/src/font/font_renderer.rs
+++ b/core/src/font/font_renderer.rs
@@ -1,8 +1,6 @@
-use std::cell::{Ref, RefCell};
-
-use swf::Twips;
-
 use crate::font::{FontAtlases, FontMetrics, Glyph, glyph::GlyphRef};
+use std::cell::{Cell, Ref, RefCell};
+use swf::Twips;
 
 pub trait FontRenderer: std::fmt::Debug {
     fn scale(&self) -> f32;
@@ -21,14 +19,27 @@ pub trait FontRenderer: std::fmt::Debug {
 }
 
 #[derive(Debug)]
+pub struct CachedValue<T> {
+    value: T,
+    used: bool,
+}
+
+type CacheMap<K, V> = RefCell<fnv::FnvHashMap<K, CachedValue<V>>>;
+
+#[derive(Debug)]
 pub struct FontRendererGlyphSource {
     font_renderer: Box<dyn FontRenderer>,
 
     /// Maps Unicode code points to glyphs rendered by the renderer.
-    glyph_cache: RefCell<fnv::FnvHashMap<u16, Option<Glyph>>>,
+    glyph_cache: CacheMap<u16, Option<Glyph>>,
 
     /// Maps Unicode pairs to kerning provided by the renderer.
-    kerning_cache: RefCell<fnv::FnvHashMap<(u16, u16), Twips>>,
+    kerning_cache: CacheMap<(u16, u16), Twips>,
+
+    sweep_caches: Cell<bool>,
+    sweep_count: Cell<usize>,
+    swept_glyphs_count: Cell<usize>,
+    swept_kerning_count: Cell<usize>,
 }
 
 impl FontRendererGlyphSource {
@@ -37,6 +48,10 @@ impl FontRendererGlyphSource {
             font_renderer,
             glyph_cache: RefCell::new(fnv::FnvHashMap::default()),
             kerning_cache: RefCell::new(fnv::FnvHashMap::default()),
+            sweep_caches: Cell::new(false),
+            sweep_count: Cell::new(0),
+            swept_glyphs_count: Cell::new(0),
+            swept_kerning_count: Cell::new(0),
         }
     }
 
@@ -48,6 +63,18 @@ impl FontRendererGlyphSource {
         self.kerning_cache.borrow().len()
     }
 
+    pub fn sweep_count(&self) -> usize {
+        self.sweep_count.get()
+    }
+
+    pub fn swept_glyphs_count(&self) -> usize {
+        self.swept_glyphs_count.get()
+    }
+
+    pub fn swept_kerning_count(&self) -> usize {
+        self.swept_kerning_count.get()
+    }
+
     pub fn font_renderer(&self) -> &dyn FontRenderer {
         self.font_renderer.as_ref()
     }
@@ -56,13 +83,19 @@ impl FontRendererGlyphSource {
         let character = code_point;
         let code_point = code_point as u16;
 
-        self.glyph_cache
-            .borrow_mut()
-            .entry(code_point)
-            .or_insert_with(|| self.font_renderer.render_glyph(character));
+        let mut cache = self.glyph_cache.borrow_mut();
+        let entry = cache.entry(code_point).or_insert_with(|| {
+            self.sweep_caches.set(true);
+            CachedValue {
+                value: self.font_renderer.render_glyph(character),
+                used: false,
+            }
+        });
+        entry.used = true;
+        drop(cache);
 
         let glyph = Ref::filter_map(self.glyph_cache.borrow(), |v| {
-            v.get(&code_point).unwrap_or(&None).as_ref()
+            v.get(&code_point).and_then(|entry| entry.value.as_ref())
         })
         .ok();
 
@@ -74,10 +107,36 @@ impl FontRendererGlyphSource {
             return Twips::ZERO;
         };
 
-        *self
-            .kerning_cache
-            .borrow_mut()
-            .entry((left_cp, right_cp))
-            .or_insert_with(|| self.font_renderer.calculate_kerning(left, right))
+        let mut cache = self.kerning_cache.borrow_mut();
+        let entry = cache.entry((left_cp, right_cp)).or_insert_with(|| {
+            self.sweep_caches.set(true);
+            CachedValue {
+                value: self.font_renderer.calculate_kerning(left, right),
+                used: false,
+            }
+        });
+        entry.used = true;
+        entry.value
     }
+
+    pub fn sweep_caches(&self, force: bool) {
+        if force || self.sweep_caches.replace(false) {
+            self.sweep_count.set(self.sweep_count.get().wrapping_add(1));
+
+            let swept_glyphs = retain_used(&self.glyph_cache);
+            self.swept_glyphs_count
+                .set(self.swept_glyphs_count.get().wrapping_add(swept_glyphs));
+
+            let swept_kerning = retain_used(&self.kerning_cache);
+            self.swept_kerning_count
+                .set(self.swept_kerning_count.get().wrapping_add(swept_kerning));
+        }
+    }
+}
+
+fn retain_used<K, V>(cache: &CacheMap<K, V>) -> usize {
+    let mut cache = cache.borrow_mut();
+    let before = cache.len();
+    cache.retain(|_, entry| std::mem::replace(&mut entry.used, false));
+    before - cache.len()
 }

--- a/core/src/font/font_renderer.rs
+++ b/core/src/font/font_renderer.rs
@@ -1,6 +1,8 @@
+use std::cell::{Ref, RefCell};
+
 use swf::Twips;
 
-use crate::font::{FontAtlases, FontMetrics, Glyph};
+use crate::font::{FontAtlases, FontMetrics, Glyph, glyph::GlyphRef};
 
 pub trait FontRenderer: std::fmt::Debug {
     fn scale(&self) -> f32;
@@ -15,5 +17,67 @@ pub trait FontRenderer: std::fmt::Debug {
 
     fn atlases(&self) -> Option<&FontAtlases> {
         None
+    }
+}
+
+#[derive(Debug)]
+pub struct FontRendererGlyphSource {
+    font_renderer: Box<dyn FontRenderer>,
+
+    /// Maps Unicode code points to glyphs rendered by the renderer.
+    glyph_cache: RefCell<fnv::FnvHashMap<u16, Option<Glyph>>>,
+
+    /// Maps Unicode pairs to kerning provided by the renderer.
+    kerning_cache: RefCell<fnv::FnvHashMap<(u16, u16), Twips>>,
+}
+
+impl FontRendererGlyphSource {
+    pub fn new(font_renderer: Box<dyn FontRenderer>) -> Self {
+        Self {
+            font_renderer,
+            glyph_cache: RefCell::new(fnv::FnvHashMap::default()),
+            kerning_cache: RefCell::new(fnv::FnvHashMap::default()),
+        }
+    }
+
+    pub fn glyph_cache_size(&self) -> usize {
+        self.glyph_cache.borrow().len()
+    }
+
+    pub fn kerning_cache_size(&self) -> usize {
+        self.kerning_cache.borrow().len()
+    }
+
+    pub fn font_renderer(&self) -> &dyn FontRenderer {
+        self.font_renderer.as_ref()
+    }
+
+    pub fn get_by_code_point(&self, code_point: char) -> Option<GlyphRef<'_>> {
+        let character = code_point;
+        let code_point = code_point as u16;
+
+        self.glyph_cache
+            .borrow_mut()
+            .entry(code_point)
+            .or_insert_with(|| self.font_renderer.render_glyph(character));
+
+        let glyph = Ref::filter_map(self.glyph_cache.borrow(), |v| {
+            v.get(&code_point).unwrap_or(&None).as_ref()
+        })
+        .ok();
+
+        glyph.map(GlyphRef::Ref)
+    }
+
+    pub fn get_kerning_offset(&self, left: char, right: char) -> Twips {
+        let (Ok(left_cp), Ok(right_cp)) = (left.try_into(), right.try_into()) else {
+            return Twips::ZERO;
+        };
+
+        *self
+            .kerning_cache
+            .borrow_mut()
+            .entry((left_cp, right_cp))
+            .or_insert_with(|| self.font_renderer.calculate_kerning(left, right))
     }
 }

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -756,6 +756,14 @@ impl<'gc> Library<'gc> {
     pub fn avm2_class_registry_mut(&mut self) -> &mut Avm2ClassRegistry<'gc> {
         &mut self.avm2_class_registry
     }
+
+    /// Evicts cached font resources that haven't been used, across all device
+    /// fonts. Meant to be called once per rendered frame.
+    pub fn sweep_font_caches(&self) {
+        for font in self.device_fonts.iter_all() {
+            font.sweep_caches();
+        }
+    }
 }
 
 #[derive(Collect, Default)]
@@ -851,5 +859,9 @@ impl<'gc> FontMap<'gc> {
 
     pub fn all(&self) -> Vec<Font<'gc>> {
         self.0.values().copied().collect()
+    }
+
+    pub fn iter_all(&self) -> impl Iterator<Item = Font<'gc>> {
+        self.0.values().copied()
     }
 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2128,6 +2128,9 @@ impl Player {
                 };
 
             let commands = render_context.commands;
+
+            gc_root.library.sweep_font_caches();
+
             (cache_draws, commands)
         });
 

--- a/frontend-utils/src/backends/ui/freetype_font_renderer.rs
+++ b/frontend-utils/src/backends/ui/freetype_font_renderer.rs
@@ -21,10 +21,18 @@ pub enum Error {
     FreetypeError(#[from] freetype::Error),
 }
 
-#[derive(Debug)]
 pub struct FreetypeFontRenderer {
     face: freetype::Face,
     atlases: FontAtlases,
+}
+
+impl std::fmt::Debug for FreetypeFontRenderer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FreetypeFontRenderer")
+            .field("family_name", &self.face.family_name())
+            .field("style_name", &self.face.style_name())
+            .finish()
+    }
 }
 
 impl FreetypeFontRenderer {


### PR DESCRIPTION
## Description

Previously glyph cache could only grow. This was not that problematic
when we rendered glyphs in one size only. However, after adding proper
glyph scaling, the cache would grow very quickly.

This patch adds glyph cache eviction, where unused glyphs and kerning
pairs are swept on each frame, but only when new entries were added to
the cache. This prevents iterating over all resources each frame, but
at the same time allows eviction when new glyphs or kerning pairs appear
to make space for them.

When it comes to resource usage, this solution is relatively close to
optimal in the current state, because we don't deallocate font atlas
pages. It is however suboptimal performance-wise in cases when glyphs
disappear and appear on screen (e.g. scrolling text).

This should however be a good starting point for the glyph scaling work
and can be improved later when we have a better idea of how everything
works together in Ruffle.

## Testing

Correctness tests exist, performance-wise there are counters for sweeps in the debug UI so we can see how often they happen.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
