### PR TITLE
desktop,web: Handle bitmap glyphs with no ink properly

### DIFF
--- a/core/src/font/atlas.rs
+++ b/core/src/font/atlas.rs
@@ -39,6 +39,9 @@ impl FontAtlas {
     /// Allocates space for `bitmap` in the atlas and copies it in, starting a
     /// fresh atlas page if none of the existing ones have room left.
     pub fn new_glyph(&self, bitmap: Bitmap<'_>, tx: Twips, ty: Twips) -> FontAtlasGlyph {
+        // Do not allocate space in font atlases for empty bitmaps, use empty glyphs instead.
+        assert!(bitmap.width() != 0 && bitmap.height() != 0);
+
         let mut data = self.0.borrow_mut();
 
         let atlas_region = match data.pages.iter().find_map(|page| allocate(page, &bitmap)) {
@@ -478,12 +481,10 @@ mod test {
     }
 
     #[test]
+    #[should_panic]
     fn zero_sized_glyph() {
         let atlas = font_atlas(8, 8);
-        let glyph = atlas.new_glyph(Bitmap::empty(BitmapFormat::Rgba), Twips::ZERO, Twips::ZERO);
-
-        assert!(glyph.atlas_region().is_empty());
-        assert_eq!(atlas.pages().len(), 1);
+        atlas.new_glyph(Bitmap::empty(BitmapFormat::Rgba), Twips::ZERO, Twips::ZERO);
     }
 
     #[test]

--- a/frontend-utils/src/backends/ui/freetype_font_renderer.rs
+++ b/frontend-utils/src/backends/ui/freetype_font_renderer.rs
@@ -83,6 +83,13 @@ impl FreetypeFontRenderer {
         let glyph = self.face.glyph();
         let bitmap = glyph.bitmap();
         let advance = convert_26_6_to_twips(glyph.advance().x);
+
+        // Glyphs with no ink (e.g. space) have an empty bitmap. Skip the
+        // atlas entirely for these.
+        if bitmap.width() == 0 || bitmap.rows() == 0 {
+            return Ok(Glyph::whitespace(character, advance));
+        }
+
         let tx = Twips::from_pixels(glyph.bitmap_left() as f64);
 
         // `bitmap_top` is the distance from the baseline up to the top of
@@ -92,11 +99,9 @@ impl FreetypeFontRenderer {
         let bitmap_top = Twips::from_pixels(glyph.bitmap_top() as f64);
         let ty = self.ascent() - bitmap_top;
 
-        // Glyphs with no ink (e.g. space) have an empty bitmap, but a
-        // zero-sized texture isn't allowed, so clamp to at least 1x1.
         let bitmap = Bitmap::new(
-            (bitmap.width() as u32).max(1),
-            (bitmap.rows() as u32).max(1),
+            bitmap.width() as u32,
+            bitmap.rows() as u32,
             BitmapFormat::Rgba,
             convert_bitmap(&bitmap)?,
         );

--- a/web/src/ui/canvas_font_renderer.rs
+++ b/web/src/ui/canvas_font_renderer.rs
@@ -110,11 +110,17 @@ impl CanvasFontRenderer {
         let metrics = self.ctx.measure_text(text)?;
 
         let bitmap_width = metrics.actual_bounding_box_left() + metrics.actual_bounding_box_right();
-        let bitmap_width = bitmap_width.max(1.0).ceil() as i32; // TODO Support empty bitmaps.
+        let bitmap_width = bitmap_width.ceil() as i32;
         let bitmap_height =
             metrics.actual_bounding_box_ascent() + metrics.actual_bounding_box_descent();
-        let bitmap_height = bitmap_height.max(1.0).ceil() as i32; // TODO Support empty bitmaps.
+        let bitmap_height = bitmap_height.ceil() as i32;
         let advance = Twips::from_pixels(metrics.width());
+
+        // Glyphs with no ink will produce empty bitmaps.
+        if bitmap_width <= 0 || bitmap_height <= 0 {
+            return Ok(Glyph::whitespace(character, advance));
+        }
+
         let bitmap_tx = -metrics.actual_bounding_box_left();
         let bitmap_ty = -metrics.actual_bounding_box_ascent();
 


### PR DESCRIPTION
## Description

Return an empty glyph with advance instead of allocating a 1x1 bitmap for it.

## Testing

Tested manually.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
