### PR TITLE
wgpu: Mark profiler end-of-frame, fixes #24605

### DIFF
--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -477,12 +477,6 @@ impl GuiController {
             }
         }
 
-        if let Some(player) = player.as_deref_mut() {
-            let renderer =
-                <dyn Any>::downcast_mut::<WgpuRenderBackend<MovieView>>(player.renderer_mut())
-                    .expect("Renderer must be correct type");
-            renderer.profiler_mut().resolve_queries(&mut encoder);
-        }
         command_buffers.push(encoder.finish());
         self.descriptors.queue.submit(command_buffers);
 
@@ -499,19 +493,6 @@ impl GuiController {
         tracing_tracy::client::frame_mark();
         #[cfg(feature = "tracy_images")]
         self.tracy_frame_captures.finish_frame();
-        if let Some(player) = player.as_deref_mut() {
-            let renderer =
-                <dyn Any>::downcast_mut::<WgpuRenderBackend<MovieView>>(player.renderer_mut())
-                    .expect("Renderer must be correct type");
-            renderer
-                .profiler_mut()
-                .end_frame()
-                .expect("Frame should end successfully");
-            let timestamp_period = renderer.descriptors().queue.get_timestamp_period();
-            renderer
-                .profiler_mut()
-                .process_finished_frame(timestamp_period);
-        }
     }
 
     pub fn show_context_menu(

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -283,14 +283,6 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
         })
     }
 
-    pub fn profiler(&self) -> &GpuProfiler {
-        &self.profiler
-    }
-
-    pub fn profiler_mut(&mut self) -> &mut GpuProfiler {
-        &mut self.profiler
-    }
-
     fn register_shape_internal(
         &mut self,
         shape: DistilledShape,
@@ -668,11 +660,18 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
             LayerRef::None,
             &mut self.texture_pool,
         );
+        self.profiler
+            .resolve_queries(&mut self.active_frame.command_encoder);
         self.active_frame.staging_belt.finish();
 
         self.active_frame
             .submit_for_target(&self.descriptors, &self.target, frame_output);
         self.offscreen_texture_pool = TexturePool::new();
+        self.profiler
+            .end_frame()
+            .expect("Frame should end successfully");
+        let timestamp_period = self.descriptors.queue.get_timestamp_period();
+        self.profiler.process_finished_frame(timestamp_period);
     }
 
     #[instrument(level = "debug", skip_all)]


### PR DESCRIPTION
## Description

We disable the actual profiling part of the profiler, but I guess it has some internal per-frame housekeeping that still requires us to tell it the end of a frame. This PR does that always, not just in desktop. I think I'll look into if wgpu-profiler noop mode can possibly be made to be even more noop than this, I guess :D

## Testing

I manually tested desktop with and without profiling, and it seems fine.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
