### PR TITLE
core: Move font color to EvalParameters

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -803,8 +803,7 @@ impl DisplayObjectWindow {
                         ui.end_row();
 
                         for lbox in line.boxes_iter() {
-                            if let Some((text, format, font_set, _, _)) =
-                                lbox.as_renderable_text(text)
+                            if let Some((text, format, font_set, _)) = lbox.as_renderable_text(text)
                             {
                                 for i in 0..text.len() {
                                     let code = text.at(i);
@@ -871,7 +870,7 @@ impl DisplayObjectWindow {
                         ui.label(format!("{}–{}", lbox.start(), lbox.end()));
                         ui.end_row();
 
-                        if let Some((_, _, font_set, _, _)) = lbox.as_renderable_text(text) {
+                        if let Some((_, _, font_set, _)) = lbox.as_renderable_text(text) {
                             ui.label("Main Font");
                             show_font(ui, context, messages, font_set.main_font());
                             ui.end_row();

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -833,17 +833,6 @@ impl<'gc> EditText<'gc> {
         self.relayout(context);
     }
 
-    /// Construct a base text transform for a particular `EditText` span.
-    ///
-    /// This `text_transform` is separate from and relative to the base
-    /// transform that this `EditText` automatically gets by virtue of being a
-    /// `DisplayObject`.
-    pub fn text_transform(self, color: Color) -> Transform {
-        let mut transform: Transform = Default::default();
-        transform.color_transform.set_mult_color(color);
-        transform
-    }
-
     /// Returns the variable that this text field is bound to.
     pub fn variable(self) -> Option<AvmString<'gc>> {
         self.0.variable.get()
@@ -1273,7 +1262,7 @@ impl<'gc> EditText<'gc> {
         // We're cheating a bit and not actually rendering text using the OS/web.
         // Instead, we embed an SWF version of Noto Sans to use as the "device font", and render
         // it the same as any other SWF outline text.
-        if let Some((text, _tf, font, params, color)) =
+        if let Some((text, _tf, font, params)) =
             lbox.as_renderable_text(self.0.text_spans.borrow().displayed_text())
         {
             let metrics = font.metrics();
@@ -1283,7 +1272,6 @@ impl<'gc> EditText<'gc> {
             let mut caret_x = Twips::ZERO;
             font.evaluate(
                 text,
-                self.text_transform(color),
                 params,
                 |pos, transform, glyph, advance, x| {
                     if glyph.renderable(context) {
@@ -1315,7 +1303,7 @@ impl<'gc> EditText<'gc> {
             );
 
             if caret.is_some() {
-                self.render_caret(context, caret_x, caret_height, color, render_state);
+                self.render_caret(context, caret_x, caret_height, params.color, render_state);
             }
 
             if let LayoutContent::Text {
@@ -1325,7 +1313,7 @@ impl<'gc> EditText<'gc> {
                 // Draw underline
                 let underline_y = ascent + (max_descent / 2);
                 let underline_width = lbox.bounds().width();
-                self.render_underline(context, underline_width, underline_y, color);
+                self.render_underline(context, underline_width, underline_y, params.color);
             }
         }
 
@@ -1629,24 +1617,19 @@ impl<'gc> EditText<'gc> {
             matrix = matrix.inverse().expect("Invertible layout matrix");
             let local_position = matrix * position;
 
-            if let Some((text, _tf, font, params, color)) =
+            if let Some((text, _tf, font, params)) =
                 layout_box.as_renderable_text(self.0.text_spans.borrow().text())
             {
                 let mut result = 0;
-                font.evaluate(
-                    text,
-                    self.text_transform(color),
-                    params,
-                    |pos, _transform, _glyph, advance, x| {
-                        if local_position.x >= x {
-                            if local_position.x > x + (advance / 2) {
-                                result = string_utils::next_char_boundary(text, pos);
-                            } else {
-                                result = pos;
-                            }
+                font.evaluate(text, params, |pos, _transform, _glyph, advance, x| {
+                    if local_position.x >= x {
+                        if local_position.x > x + (advance / 2) {
+                            result = string_utils::next_char_boundary(text, pos);
+                        } else {
+                            result = pos;
                         }
-                    },
-                );
+                    }
+                });
                 if let LayoutContent::Text { start, .. } = layout_box.content() {
                     return Some(result + start);
                 }

--- a/core/src/font/font_like.rs
+++ b/core/src/font/font_like.rs
@@ -21,16 +21,21 @@ pub struct EvalParameters {
     /// pairs of letters, separate from the ordinary width between glyphs. This
     /// parameter allows enabling or disabling that feature.
     pub kerning: bool,
+
+    /// The color to render the font with.
+    pub color: swf::Color,
 }
 
 impl EvalParameters {
     /// Convert the formatting on a text span over to font evaluation
     /// parameters.
     pub fn from_span(span: &TextSpan) -> Self {
+        let color = swf::Color::from_rgb(span.font.color.to_rgb(), 0xFF);
         Self {
             height: Twips::from_pixels(span.font.size),
             letter_spacing: Twips::from_pixels(span.font.letter_spacing),
             kerning: span.font.kerning,
+            color,
         }
     }
 
@@ -86,10 +91,12 @@ pub trait FontLike<'gc> {
     fn evaluate(
         &self,
         text: &WStr, // TODO: take an `IntoIterator<Item=char>`, to not depend on string representation?
-        mut transform: Transform,
         params: EvalParameters,
         mut glyph_func: impl FnMut(usize, &Transform, GlyphRef, Twips, Twips),
     ) {
+        let mut transform: Transform = Default::default();
+        transform.color_transform.set_mult_color(params.color);
+
         let baseline = self.metrics().ascent(params.height);
 
         // TODO [KJ] I'm not sure whether we should iterate over characters here or over code units.
@@ -154,14 +161,9 @@ pub trait FontLike<'gc> {
     fn measure(&self, text: &WStr, params: EvalParameters) -> Twips {
         let mut width = Twips::ZERO;
 
-        self.evaluate(
-            text,
-            Default::default(),
-            params,
-            |_pos, _transform, _glyph, advance, x| {
-                width = width.max(x + advance);
-            },
-        );
+        self.evaluate(text, params, |_pos, _transform, _glyph, advance, x| {
+            width = width.max(x + advance);
+        });
 
         width
     }

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -302,7 +302,7 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
         let mut line_size_bounds = None;
         let mut box_count: i32 = 0;
         for linebox in self.boxes.iter_mut() {
-            let (text, _tf, font_set, params, _color) =
+            let (text, _tf, font_set, params) =
                 linebox.as_renderable_text(self.text).expect("text");
 
             // Flash ignores trailing spaces when aligning lines, so should we
@@ -1128,10 +1128,6 @@ pub enum LayoutContent<'gc> {
         #[collect(require_static)]
         params: EvalParameters,
 
-        /// The color to render the font with.
-        #[collect(require_static)]
-        color: swf::Color,
-
         /// List of end positions (relative to this box) for each character.
         ///
         /// By having this here, we do not have to reevaluate the font
@@ -1170,10 +1166,6 @@ pub enum LayoutContent<'gc> {
         /// this text.
         #[collect(require_static)]
         params: EvalParameters,
-
-        /// The color to render the font with.
-        #[collect(require_static)]
-        color: swf::Color,
     },
 
     /// A layout box containing a drawing.
@@ -1222,7 +1214,7 @@ impl<'gc> LayoutBox<'gc> {
         let params = EvalParameters::from_span(span);
         let mut char_end_pos = Vec::with_capacity(end - start);
 
-        font_set.evaluate(text, Default::default(), params, |_, _, _, advance, x| {
+        font_set.evaluate(text, params, |_, _, _, advance, x| {
             char_end_pos.push(x + advance);
         });
 
@@ -1234,7 +1226,6 @@ impl<'gc> LayoutBox<'gc> {
                 text_format: span.get_text_format(),
                 font_set,
                 params,
-                color: span.font.color,
                 char_end_pos,
                 underline: span.style.underline,
             },
@@ -1252,7 +1243,6 @@ impl<'gc> LayoutBox<'gc> {
                 text_format: span.get_text_format(),
                 font_set,
                 params,
-                color: span.font.color,
             },
         }
     }
@@ -1296,13 +1286,7 @@ impl<'gc> LayoutBox<'gc> {
     pub fn as_renderable_text<'a>(
         &self,
         text: &'a WStr,
-    ) -> Option<(
-        &'a WStr,
-        &TextFormat,
-        FontSet<'gc>,
-        EvalParameters,
-        swf::Color,
-    )> {
+    ) -> Option<(&'a WStr, &TextFormat, FontSet<'gc>, EvalParameters)> {
         match &self.content {
             LayoutContent::Text {
                 start,
@@ -1310,27 +1294,18 @@ impl<'gc> LayoutBox<'gc> {
                 text_format,
                 font_set,
                 params,
-                color,
                 ..
-            } => Some((
-                text.slice(*start..*end)?,
-                text_format,
-                *font_set,
-                *params,
-                swf::Color::from_rgb(color.to_rgb(), 0xFF),
-            )),
+            } => Some((text.slice(*start..*end)?, text_format, *font_set, *params)),
             LayoutContent::Bullet {
                 text_format,
                 font_set,
                 params,
-                color,
                 ..
             } => Some((
                 WStr::from_units(&[0x2022u16]),
                 text_format,
                 *font_set,
                 *params,
-                swf::Color::from_rgb(color.to_rgb(), 0xFF),
             )),
             LayoutContent::Drawing { .. } => None,
         }

--- a/core/src/html/line_wrapping.rs
+++ b/core/src/html/line_wrapping.rs
@@ -208,6 +208,7 @@ mod tests {
             height,
             letter_spacing,
             kerning,
+            color: swf::Color::BLACK,
         }
     }
 


### PR DESCRIPTION
## Description

Previously it was passed next to them, but evaluate() itself needs the color as well. It was just passed in a weird way using transform.

This simplifies the code and passes font color within EvalParameters.

## Testing

Tests exist

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
