### PR TITLE
🤖 web: Release disconnected players and cancel obsolete loads

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -143,6 +143,15 @@ Pass `--headless` to hide the browser windows. This is useful and recommended in
 Pass `--spec <name>` to filter a test based on name. For example, `--spec external_interface` to tests with `external_interface` in the path.
 
 
+### Player garbage collection
+The `garbage_collection` tests are opt-in and require local Firefox with geckodriver's `--allow-system-access` support:
+
+```sh
+RUFFLE_TEST_GC=1 npm run wdio --workspace=ruffle-selfhosted -- --firefox --headless --spec garbage_collection
+```
+
+This enables privileged garbage collection in the disposable test profile and uses classic WebDriver. BiDi shadow-root instrumentation can itself retain the elements being measured. The tests are skipped in other browsers and on BrowserStack.
+
 ### Testing tips!
 If debugging a failing test, use `await browser.pause(100000);` in the test file to pause it, and don't start the test with `--headless`.
 That way you can actually see what's happening, and manually get involved to debug it.

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -30,6 +30,25 @@ import { createRuffleBuilder } from "../../load-ruffle";
 import { lookupElement } from "../register-element";
 import { configureBuilder } from "../builder";
 
+type DownloadProgress = {
+    callback: ((bytesLoaded: number, bytesTotal: number) => void) | null;
+};
+
+/**
+ * Forward progress without closing over a player or its load activation.
+ *
+ * @param progress The callback holder, cleared on completion or cancellation.
+ * @param bytesLoaded The number of bytes downloaded.
+ * @param bytesTotal The total download size.
+ */
+function reportDownloadProgress(
+    progress: DownloadProgress,
+    bytesLoaded: number,
+    bytesTotal: number,
+): void {
+    progress.callback?.(bytesLoaded, bytesTotal);
+}
+
 const DIMENSION_REGEX = /^\s*(\d+(\.\d+)?(%)?)/;
 
 let isAudioContextUnmuted = false;
@@ -742,15 +761,23 @@ export class InnerPlayer {
             );
         }
 
+        const progress: DownloadProgress = {
+            callback: this.onRuffleDownloadProgress.bind(this),
+        };
+        const clearProgress = () => {
+            progress.callback = null;
+        };
+        signal.addEventListener("abort", clearProgress, { once: true });
         const [builder, zipWriterClass] = await createRuffleBuilder(
-            (loaded, total) => {
-                if (!signal.aborted) {
-                    this.onRuffleDownloadProgress(loaded, total);
-                }
-            },
-        ).catch((e) => {
-            throw new LoadRuffleWasmError(e);
-        });
+            reportDownloadProgress.bind(null, progress),
+        )
+            .catch((e) => {
+                throw new LoadRuffleWasmError(e);
+            })
+            .finally(() => {
+                clearProgress();
+                signal.removeEventListener("abort", clearProgress);
+            });
         let instance: RuffleHandle;
         try {
             if (signal.aborted) {
@@ -914,6 +941,7 @@ export class InnerPlayer {
      * Destroys the currently running instance of Ruffle.
      */
     destroy(): void {
+        this.stopSplashAnimation();
         this.loadController?.abort();
         this.loadController = null;
         this.stopBackgroundTick();
@@ -2358,7 +2386,14 @@ export class InnerPlayer {
         }
     }
 
+    private stopSplashAnimation(): void {
+        this.splashScreen
+            .querySelector<SVGAnimationElement>("animateTransform")
+            ?.endElement();
+    }
+
     private hideSplashScreen(): void {
+        this.stopSplashAnimation();
         this.splashScreen.classList.add("hidden");
         this.container.classList.remove("hidden");
     }
@@ -2366,6 +2401,9 @@ export class InnerPlayer {
     private showSplashScreen(): void {
         this.splashScreen.classList.remove("hidden");
         this.container.classList.add("hidden");
+        this.splashScreen
+            .querySelector<SVGAnimationElement>("animateTransform")
+            ?.beginElement();
     }
 
     protected setMetadata(metadata: MovieMetadata) {

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -201,6 +201,13 @@ export class InnerPlayer {
     private newZipWriter: (() => ZipWriter) | null;
     private lastActivePlayingState: boolean;
 
+    private connectedDocument: Document | null = null;
+    private loadController: AbortController | null = null;
+    private readonly onPointerDown = this.checkIfTouch.bind(this);
+    private readonly onHideContextMenu = this.hideContextMenu.bind(this);
+    private readonly onUnmuteOverlayClicked =
+        this.unmuteOverlayClicked.bind(this);
+
     // Non-null while ticking in the background (BackgroundExecutionMode.MainThread).
     // Uses a ping-pong ack to avoid message queue build-up if the main thread falls behind.
     // Set when the tab is hidden, cleared when it becomes visible again or the player is destroyed.
@@ -308,10 +315,6 @@ export class InnerPlayer {
 
         this.contextMenuElement.dir = detectBrowserDirection();
 
-        document.documentElement.addEventListener(
-            "pointerdown",
-            this.checkIfTouch.bind(this),
-        );
         this.element.addEventListener(
             "contextmenu",
             this.showContextMenu.bind(this),
@@ -350,7 +353,47 @@ export class InnerPlayer {
 
         this.lastActivePlayingState = false;
         this.backgroundWorker = null;
-        this.setupTabVisibilityHandling();
+    }
+
+    /** Attach document listeners only while the player is connected. */
+    connect(): void {
+        if (this.connectedDocument) {
+            return;
+        }
+        const document = this.element.ownerDocument;
+        this.connectedDocument = document;
+        document.documentElement.addEventListener(
+            "pointerdown",
+            this.onPointerDown,
+        );
+        document.addEventListener("visibilitychange", this.onVisibilityChange);
+    }
+
+    /** Release document references and cancel work for a removed player. */
+    disconnect(): void {
+        const document = this.connectedDocument;
+        if (document) {
+            document.documentElement.removeEventListener(
+                "pointerdown",
+                this.onPointerDown,
+            );
+            document.removeEventListener(
+                "visibilitychange",
+                this.onVisibilityChange,
+            );
+            document.documentElement.removeEventListener(
+                "click",
+                this.onHideContextMenu,
+            );
+            document.documentElement.removeEventListener(
+                "pointerup",
+                this.onHideContextMenu,
+            );
+            this.connectedDocument = null;
+        }
+        this.hideContextMenu();
+        this.clearLongPressTimer();
+        this.destroy();
     }
 
     addFSCommandHandler(handler: (command: string, args: string) => void) {
@@ -471,44 +514,43 @@ export class InnerPlayer {
     }
 
     /**
-     * Sets up an event listener for tab visibility changes, responding
+     * Responds to tab visibility changes
      * according to the configured {@link BackgroundExecutionMode}.
      *
      * See: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
      * @ignore
      * @internal
      */
-    private setupTabVisibilityHandling(): void {
-        document.addEventListener("visibilitychange", () => {
-            if (!this.instance) {
-                return;
-            }
-            const mode =
-                this.loadedConfig?.backgroundExecutionMode ??
-                BackgroundExecutionMode.None;
-            if (document.hidden) {
-                this.lastActivePlayingState = this.instance.is_playing();
-                if (mode === BackgroundExecutionMode.MainThread) {
-                    this.instance.enable_background_tick_mode();
-                    if (this.lastActivePlayingState) {
-                        this.startBackgroundTick();
-                    }
-                } else {
-                    this.instance.pause();
+    private readonly onVisibilityChange = (): void => {
+        const document = this.connectedDocument;
+        if (!document || !this.instance) {
+            return;
+        }
+        const mode =
+            this.loadedConfig?.backgroundExecutionMode ??
+            BackgroundExecutionMode.None;
+        if (document.hidden) {
+            this.lastActivePlayingState = this.instance.is_playing();
+            if (mode === BackgroundExecutionMode.MainThread) {
+                this.instance.enable_background_tick_mode();
+                if (this.lastActivePlayingState) {
+                    this.startBackgroundTick();
                 }
             } else {
-                if (mode === BackgroundExecutionMode.MainThread) {
-                    this.stopBackgroundTick();
-                    this.instance.restart_animation_loop();
-                }
-                if (this.lastActivePlayingState) {
-                    this.instance.play();
-                }
-                // Browsers may auto-suspend AudioContext in background tabs.
-                this.instance.audio_context()?.resume();
+                this.instance.pause();
             }
-        });
-    }
+        } else {
+            if (mode === BackgroundExecutionMode.MainThread) {
+                this.stopBackgroundTick();
+                this.instance.restart_animation_loop();
+            }
+            if (this.lastActivePlayingState) {
+                this.instance.play();
+            }
+            // Browsers may auto-suspend AudioContext in background tabs.
+            this.instance.audio_context()?.resume();
+        }
+    };
 
     /**
      * Starts a background tick loop while the tab is hidden.
@@ -672,25 +714,21 @@ export class InnerPlayer {
      *
      * @private
      */
-    private async ensureFreshInstance(): Promise<void> {
-        this.destroy();
-
-        if (
-            this.loadedConfig &&
-            this.loadedConfig.splashScreen !== false &&
-            this.loadedConfig.preloader !== false
-        ) {
+    private async ensureFreshInstance(
+        config: URLLoadOptions | DataLoadOptions,
+        signal: AbortSignal,
+    ): Promise<boolean> {
+        if (config.splashScreen !== false && config.preloader !== false) {
             this.showSplashScreen();
         }
-        if (this.loadedConfig && this.loadedConfig.preloader === false) {
+        if (config.preloader === false) {
             console.warn(
                 "The configuration option preloader has been replaced with splashScreen. If you own this website, please update the configuration.",
             );
         }
         if (
-            this.loadedConfig &&
-            this.loadedConfig.maxExecutionDuration &&
-            typeof this.loadedConfig.maxExecutionDuration !== "number"
+            config.maxExecutionDuration &&
+            typeof config.maxExecutionDuration !== "number"
         ) {
             console.warn(
                 "Configuration: An obsolete format for duration for 'maxExecutionDuration' was used, " +
@@ -698,60 +736,74 @@ export class InnerPlayer {
                     "'{secs: 15, nanos: 0}'.",
             );
         }
-        if (
-            this.loadedConfig &&
-            typeof this.loadedConfig.contextMenu === "boolean"
-        ) {
+        if (typeof config.contextMenu === "boolean") {
             console.warn(
                 'The configuration option contextMenu no longer takes a boolean. Use "on", "off", or "rightClickOnly".',
             );
         }
 
         const [builder, zipWriterClass] = await createRuffleBuilder(
-            this.onRuffleDownloadProgress.bind(this),
+            (loaded, total) => {
+                if (!signal.aborted) {
+                    this.onRuffleDownloadProgress(loaded, total);
+                }
+            },
         ).catch((e) => {
-            console.error(`Serious error loading Ruffle: ${e}`);
-            const error = new LoadRuffleWasmError(e);
-            this.panic(error);
-            throw error;
+            throw new LoadRuffleWasmError(e);
         });
-        this.newZipWriter = zipWriterClass;
-        configureBuilder(builder, this.loadedConfig || {});
-        builder.setVolume(this.volumeSettings.get_volume());
+        let instance: RuffleHandle;
+        try {
+            if (signal.aborted) {
+                return false;
+            }
+            this.newZipWriter = zipWriterClass;
+            configureBuilder(builder, config);
+            builder.setVolume(this.volumeSettings.get_volume());
 
-        if (this.loadedConfig?.fontSources) {
-            for (const url of this.loadedConfig.fontSources) {
+            for (const url of config.fontSources ?? []) {
                 try {
-                    const response = await fetch(url);
-                    builder.addFont(
-                        url,
-                        new Uint8Array(await response.arrayBuffer()),
-                    );
+                    const response = await fetch(url, { signal });
+                    if (signal.aborted) {
+                        return false;
+                    }
+                    const data = await response.arrayBuffer();
+                    if (signal.aborted) {
+                        return false;
+                    }
+                    builder.addFont(url, new Uint8Array(data));
                 } catch (error) {
+                    if (signal.aborted) {
+                        return false;
+                    }
                     console.warn(
                         `Couldn't download font source from ${url}`,
                         error,
                     );
                 }
             }
-        }
 
-        for (const key in this.loadedConfig?.defaultFonts) {
-            const names = (
-                this.loadedConfig.defaultFonts as {
-                    [key: string]: Array<string>;
+            for (const key in config.defaultFonts) {
+                const names = (
+                    config.defaultFonts as {
+                        [key: string]: Array<string>;
+                    }
+                )[key];
+                if (names) {
+                    builder.setDefaultFont(key, names);
                 }
-            )[key];
-            if (names) {
-                builder.setDefaultFont(key, names);
             }
-        }
 
-        this.instance = await builder.build(this.container, this).catch((e) => {
-            console.error(`Serious error loading Ruffle: ${e}`);
-            this.panic(e);
-            throw e;
-        });
+            instance = await builder.build(this.container, this);
+        } finally {
+            // build() clones the Rust builder, so its JS wrapper can be freed
+            // on success, cancellation, or failure.
+            builder.free();
+        }
+        if (signal.aborted) {
+            instance.destroy();
+            return false;
+        }
+        this.instance = instance;
 
         this.rendererDebugInfo = this.instance!.renderer_debug_info();
 
@@ -790,6 +842,9 @@ export class InnerPlayer {
                     resolve();
                 }, 200);
             });
+            if (signal.aborted) {
+                return false;
+            }
             this.container.style.visibility = "";
         }
 
@@ -797,25 +852,21 @@ export class InnerPlayer {
 
         // Treat invalid values as `AutoPlay.Auto`.
         if (
-            !this.loadedConfig ||
-            this.loadedConfig.autoplay === AutoPlay.On ||
-            (this.loadedConfig.autoplay !== AutoPlay.Off &&
+            config.autoplay === AutoPlay.On ||
+            (config.autoplay !== AutoPlay.Off &&
                 this.audioState() === "running")
         ) {
             this.play();
 
             if (this.audioState() !== "running") {
                 // Treat invalid values as `UnmuteOverlay.Visible`.
-                if (
-                    !this.loadedConfig ||
-                    this.loadedConfig.unmuteOverlay !== UnmuteOverlay.Hidden
-                ) {
+                if (config.unmuteOverlay !== UnmuteOverlay.Hidden) {
                     this.unmuteOverlay.style.display = "block";
                 }
 
                 this.container.addEventListener(
                     "click",
-                    this.unmuteOverlayClicked.bind(this),
+                    this.onUnmuteOverlayClicked,
                     {
                         once: true,
                     },
@@ -834,6 +885,7 @@ export class InnerPlayer {
         } else {
             this.playButton.style.display = "block";
         }
+        return true;
     }
 
     /**
@@ -862,8 +914,19 @@ export class InnerPlayer {
      * Destroys the currently running instance of Ruffle.
      */
     destroy(): void {
+        this.loadController?.abort();
+        this.loadController = null;
+        this.stopBackgroundTick();
+        this.container.style.visibility = "";
+        this.container.removeEventListener(
+            "click",
+            this.onUnmuteOverlayClicked,
+        );
         if (this.instance) {
-            this.stopBackgroundTick();
+            const audioContext = this.instance.audio_context();
+            if (audioContext) {
+                audioContext.onstatechange = null;
+            }
             this.instance.destroy();
             this.instance = null;
             this.metadata = null;
@@ -976,6 +1039,10 @@ export class InnerPlayer {
             return;
         }
 
+        this.destroy();
+        const controller = new AbortController();
+        this.loadController = controller;
+
         try {
             this.loadedConfig = {
                 ...DEFAULT_CONFIG,
@@ -1002,7 +1069,13 @@ export class InnerPlayer {
                     this.loadedConfig.backgroundColor;
             }
 
-            await this.ensureFreshInstance();
+            const ready = await this.ensureFreshInstance(
+                this.loadedConfig,
+                controller.signal,
+            );
+            if (!ready || controller.signal.aborted) {
+                return;
+            }
 
             if ("url" in options) {
                 console.log(`Loading SWF file ${options.url}`);
@@ -1022,6 +1095,9 @@ export class InnerPlayer {
                 );
             }
         } catch (e) {
+            if (controller.signal.aborted) {
+                return;
+            }
             console.error(`Serious error occurred loading SWF file: ${e}`);
             const err = new LoadBeginError(e as string);
             this.panic(err);
@@ -1668,7 +1744,8 @@ export class InnerPlayer {
     }
 
     private showContextMenu(event: MouseEvent | PointerEvent): void {
-        if (this.panicked) {
+        const document = this.connectedDocument;
+        if (this.panicked || !document) {
             return;
         }
 
@@ -1698,7 +1775,7 @@ export class InnerPlayer {
             this.contextMenuSupported = true;
             document.documentElement.addEventListener(
                 "click",
-                this.hideContextMenu.bind(this),
+                this.onHideContextMenu,
                 {
                     once: true,
                 },
@@ -1706,7 +1783,7 @@ export class InnerPlayer {
         } else {
             document.documentElement.addEventListener(
                 "pointerup",
-                this.hideContextMenu.bind(this),
+                this.onHideContextMenu,
                 { once: true },
             );
             event.stopPropagation();

--- a/web/packages/core/src/internal/player/ruffle-player-element.tsx
+++ b/web/packages/core/src/internal/player/ruffle-player-element.tsx
@@ -72,6 +72,7 @@ export class RufflePlayerElement extends HTMLElement implements PlayerElement {
     }
 
     connectedCallback(): void {
+        this.#inner.connect();
         this.#inner.updateStyles();
     }
 
@@ -90,7 +91,7 @@ export class RufflePlayerElement extends HTMLElement implements PlayerElement {
     }
 
     disconnectedCallback(): void {
-        this.#inner.destroy();
+        this.#inner.disconnect();
     }
 
     async reload(): Promise<void> {

--- a/web/packages/core/src/internal/ui/splash-screen.tsx
+++ b/web/packages/core/src/internal/ui/splash-screen.tsx
@@ -37,7 +37,23 @@ export function SplashScreen() {
                     cx="33"
                     cy="33"
                     r="30"
-                ></circle>
+                >
+                    {/* Firefox can retain detached CSS animation targets in its
+                        restyle queue. SVG animation avoids retaining the player.
+                        tsx-dom does not yet type the SMIL attributes. */}
+                    <animateTransform
+                        xmlns="http://www.w3.org/2000/svg"
+                        {...{
+                            attributeName: "transform",
+                            type: "rotate",
+                            from: "0 33 33",
+                            to: "360 33 33",
+                            dur: "1.5s",
+                            repeatCount: "indefinite",
+                            begin: "indefinite",
+                        }}
+                    />
+                </circle>
             </svg>
             <div class="loadbar">
                 <div class="loadbar-inner"></div>

--- a/web/packages/core/src/internal/ui/static-styles.css
+++ b/web/packages/core/src/internal/ui/static-styles.css
@@ -388,14 +388,6 @@
     stroke-dasharray: 180;
     stroke-dashoffset: 135;
     stroke: var(--ruffle-orange);
-    transform-origin: 50% 50%;
-    animation: rotate 1.5s linear infinite;
-}
-
-@keyframes rotate {
-    to {
-        transform: rotate(360deg);
-    }
 }
 
 #virtual-keyboard {

--- a/web/packages/selfhosted/test/js_api/garbage_collection.ts
+++ b/web/packages/selfhosted/test/js_api/garbage_collection.ts
@@ -1,0 +1,95 @@
+import { expect } from "chai";
+import { Player, Setup } from "ruffle-core";
+import { injectRuffleAndWait } from "../utils.js";
+
+declare global {
+    interface Window {
+        memoryTest: {
+            player: Player.PlayerElement;
+            removed: WeakRef<Player.PlayerElement>[];
+        };
+    }
+}
+
+/** Run GC and cycle collection in the disposable Firefox test profile. */
+async function collectGarbage() {
+    await browser.setMozContext("chrome");
+    try {
+        // Use the classic WebDriver command: BiDi execution ignores moz/context.
+        await browser.executeScript(
+            `return new Promise(resolve => {
+                Cc["@mozilla.org/memory-reporter-manager;1"]
+                    .getService(Ci.nsIMemoryReporterManager)
+                    .minimizeMemoryUsage(() => resolve());
+            });`,
+            [],
+        );
+    } finally {
+        await browser.setMozContext("content");
+    }
+}
+
+describe("Player garbage collection", () => {
+    beforeEach(async function () {
+        if (
+            process.env["RUFFLE_TEST_GC"] !== "1" ||
+            !browser.isFirefox ||
+            process.argv.includes("--browserstack")
+        ) {
+            this.skip();
+        }
+        await browser.url("http://localhost:4567/test_assets/js_api.html");
+        await injectRuffleAndWait(browser);
+        await browser.execute(async () => {
+            const player = (window.RufflePlayer as Setup.PublicAPI)
+                .newest()!
+                .createPlayer();
+            document.getElementById("test-container")!.appendChild(player);
+            window.memoryTest = { player, removed: [] };
+            await player.ruffle().load("/test_assets/example.swf");
+        });
+    });
+
+    for (const waitForMetadata of [false, true]) {
+        it(`collects removed players ${waitForMetadata ? "after metadata" : "during SWF loading"}, with cold and cached WASM`, async () => {
+            for (let batch = 0; batch < 3; batch++) {
+                await browser.execute(async (waitForMetadata) => {
+                    const state = window.memoryTest;
+                    for (let i = 0; i < 20; i++) {
+                        state.removed.push(new WeakRef(state.player));
+                        state.player.remove();
+                        state.player = (window.RufflePlayer as Setup.PublicAPI)
+                            .newest()!
+                            .createPlayer();
+                        document
+                            .getElementById("test-container")!
+                            .appendChild(state.player);
+                        const loaded = waitForMetadata
+                            ? new Promise<void>((resolve) =>
+                                  state.player.addEventListener(
+                                      "loadeddata",
+                                      () => resolve(),
+                                      { once: true },
+                                  ),
+                              )
+                            : Promise.resolve();
+                        await state.player
+                            .ruffle()
+                            .load("/test_assets/example.swf");
+                        await loaded;
+                    }
+                }, waitForMetadata);
+                await collectGarbage();
+                const retained = await browser.execute(() =>
+                    window.memoryTest.removed.flatMap((ref, index) =>
+                        ref.deref() ? [index] : [],
+                    ),
+                );
+                expect(
+                    retained,
+                    `retained players after batch ${batch}`,
+                ).to.deep.equal([]);
+            }
+        });
+    }
+});

--- a/web/packages/selfhosted/test/js_api/lifecycle.ts
+++ b/web/packages/selfhosted/test/js_api/lifecycle.ts
@@ -280,6 +280,38 @@ describe("Player lifecycle", () => {
         expect(result).to.deep.equal({ error: "", canvases: 0, readyState: 0 });
     });
 
+    it("animates the splash screen again after cancelling and reconnecting", async () => {
+        for (let attempt = 0; attempt < 2; attempt++) {
+            await browser.execute(() => {
+                document
+                    .getElementById("test-container")!
+                    .appendChild(window.lifecycleTest.player);
+            });
+            await deferLoad("font");
+            await browser.waitUntil(
+                async () =>
+                    await browser.execute(() => {
+                        const circle =
+                            window.lifecycleTest.player.shadowRoot!.querySelector<SVGCircleElement>(
+                                ".spinner",
+                            )!;
+                        const matrix = circle.getCTM();
+                        return matrix !== null && Math.abs(matrix.b) > 0.1;
+                    }),
+                { timeoutMsg: "Expected the loading spinner to rotate" },
+            );
+            await browser.execute(async () => {
+                const state = window.lifecycleTest;
+                state.player.remove();
+                state.release();
+                const error = await state.pending;
+                if (error) {
+                    throw new Error(error);
+                }
+            });
+        }
+    });
+
     it("still reloads and plays after reconnection", async () => {
         await browser.execute(async () => {
             const player = window.lifecycleTest.player;

--- a/web/packages/selfhosted/test/js_api/lifecycle.ts
+++ b/web/packages/selfhosted/test/js_api/lifecycle.ts
@@ -1,0 +1,297 @@
+import { expect } from "chai";
+import { Player, Setup } from "ruffle-core";
+import { injectRuffleAndWait, playAndMonitor } from "../utils.js";
+
+declare global {
+    interface Window {
+        lifecycleTest: {
+            player: Player.PlayerElement;
+            pending: Promise<string>;
+            entered: Promise<void>;
+            release: (fail?: boolean) => void;
+            signal: AbortSignal | null;
+        };
+    }
+}
+
+/** Hold one asynchronous load boundary, including responses that ignore abort. */
+async function deferLoad(stage: "wasm" | "font" | "font body") {
+    await browser.execute((stage) => {
+        const state = window.lifecycleTest;
+        let entered!: () => void;
+        state.entered = new Promise<void>((resolve) => (entered = resolve));
+        const gate = new Promise<boolean | undefined>(
+            (resolve) => (state.release = resolve),
+        );
+        const fetch = window.fetch;
+        window.fetch = async (input, init) => {
+            const url = String(input);
+            if (
+                stage === "wasm"
+                    ? url.endsWith(".wasm")
+                    : url.endsWith("/delayed-font.ttf")
+            ) {
+                window.fetch = fetch;
+                state.signal = init?.signal ?? null;
+                if (stage === "font body") {
+                    const response = new Response();
+                    response.arrayBuffer = async () => {
+                        entered();
+                        await gate;
+                        return new ArrayBuffer(0);
+                    };
+                    return response;
+                }
+                entered();
+                if (await gate) {
+                    throw new Error("Delayed download failed");
+                }
+                return stage === "wasm" ? fetch(input, init) : new Response();
+            }
+            return fetch(input, init);
+        };
+        state.pending = state.player
+            .ruffle()
+            .load({
+                url: "/test_assets/example.swf",
+                ...(stage !== "wasm"
+                    ? { fontSources: ["/delayed-font.ttf"] }
+                    : {}),
+            })
+            .then(() => "", String);
+    }, stage);
+    await browser.execute(async () => await window.lifecycleTest.entered);
+}
+
+describe("Player lifecycle", () => {
+    beforeEach(async () => {
+        await browser.url("http://localhost:4567/test_assets/js_api.html");
+        await injectRuffleAndWait(browser);
+        await browser.execute(() => {
+            const player = (window.RufflePlayer as Setup.PublicAPI)
+                .newest()!
+                .createPlayer();
+            player.id = "ruffle-player";
+            document.getElementById("test-container")!.appendChild(player);
+            window.lifecycleTest = {
+                player,
+                pending: Promise.resolve(""),
+                entered: Promise.resolve(),
+                release: () => {},
+                signal: null,
+            };
+        });
+    });
+
+    it("releases document listeners, including an open context menu, on every removal", async () => {
+        const counts = await browser.execute(() => {
+            const active = new Set<EventListenerOrEventListenerObject>();
+            const restore: (() => void)[] = [];
+            for (const target of [document, document.documentElement]) {
+                const add = target.addEventListener;
+                const remove = target.removeEventListener;
+                target.addEventListener = function (
+                    type: string,
+                    listener: EventListenerOrEventListenerObject | null,
+                    options?: boolean | AddEventListenerOptions,
+                ) {
+                    if (listener) {
+                        active.add(listener);
+                        add.call(this, type, listener, options);
+                    }
+                };
+                target.removeEventListener = function (
+                    type: string,
+                    listener: EventListenerOrEventListenerObject | null,
+                    options?: boolean | EventListenerOptions,
+                ) {
+                    if (listener) {
+                        active.delete(listener);
+                        remove.call(this, type, listener, options);
+                    }
+                };
+                restore.push(() => {
+                    target.addEventListener = add;
+                    target.removeEventListener = remove;
+                });
+            }
+            const player = (window.RufflePlayer as Setup.PublicAPI)
+                .newest()!
+                .createPlayer();
+            const counts = [active.size];
+            try {
+                for (let i = 0; i < 3; i++) {
+                    document
+                        .getElementById("test-container")!
+                        .appendChild(player);
+                    counts.push(active.size);
+                    player.dispatchEvent(new MouseEvent("contextmenu"));
+                    player.remove();
+                    counts.push(active.size);
+                }
+            } finally {
+                player.remove();
+                restore.forEach((fn) => fn());
+            }
+            return counts;
+        });
+        expect(counts).to.deep.equal([0, 2, 0, 2, 0, 2, 0]);
+    });
+
+    for (const stage of ["wasm", "font", "font body"] as const) {
+        it(`does not resurrect a player removed during ${stage} loading`, async () => {
+            await deferLoad(stage);
+            const result = await browser.execute(async () => {
+                const state = window.lifecycleTest;
+                state.player.remove();
+                state.release();
+                const error = await state.pending;
+                return {
+                    error,
+                    canvases:
+                        state.player.shadowRoot!.querySelectorAll("canvas")
+                            .length,
+                    playing: state.player.isPlaying,
+                    readyState: state.player.ruffle().readyState,
+                };
+            });
+            expect(result).to.deep.equal({
+                error: "",
+                canvases: 0,
+                playing: false,
+                readyState: 0,
+            });
+            if (stage !== "wasm") {
+                expect(
+                    await browser.execute(
+                        () => window.lifecycleTest.signal?.aborted,
+                    ),
+                ).to.equal(true);
+            }
+        });
+
+        it(`preserves a newer load when an earlier ${stage} load finishes`, async () => {
+            await deferLoad(stage);
+            await browser.execute(async (stage) => {
+                const state = window.lifecycleTest;
+                const next = state.player.ruffle().load({
+                    url: "/test_assets/example.swf",
+                });
+                // The WASM download is shared; other work belongs to one load.
+                if (stage === "wasm") {
+                    state.release();
+                }
+                await next;
+                state.player.ruffle().volume = 0.25;
+                state.release();
+                const error = await state.pending;
+                if (error) {
+                    throw new Error(error);
+                }
+            }, stage);
+            await playAndMonitor(
+                browser,
+                await browser.$("#ruffle-player").getElement(),
+            );
+            const result = await browser.execute(() => ({
+                volume: window.lifecycleTest.player.ruffle().volume,
+                canvases:
+                    window.lifecycleTest.player.shadowRoot!.querySelectorAll(
+                        "canvas",
+                    ).length,
+            }));
+            expect(result).to.deep.equal({ volume: 0.25, canvases: 1 });
+        });
+    }
+
+    it("ignores an obsolete load failure after reconnection", async () => {
+        await deferLoad("font");
+        await browser.execute(async () => {
+            const state = window.lifecycleTest;
+            state.player.remove();
+            document
+                .getElementById("test-container")!
+                .appendChild(state.player);
+            await state.player.ruffle().load("/test_assets/example.swf");
+            state.release(true);
+            const error = await state.pending;
+            if (error) {
+                throw new Error(error);
+            }
+        });
+        await playAndMonitor(
+            browser,
+            await browser.$("#ruffle-player").getElement(),
+        );
+        expect(
+            await browser.execute(
+                () =>
+                    window.lifecycleTest.player.shadowRoot!.querySelectorAll(
+                        "canvas",
+                    ).length,
+            ),
+        ).to.equal(1);
+    });
+
+    it("cancels removal during the Firefox audio startup delay", async function () {
+        if (browser.capabilities.browserName?.toLowerCase() !== "firefox") {
+            this.skip();
+        }
+        const result = await browser.execute(async () => {
+            const player = window.lifecycleTest.player;
+            const setTimeout = window.setTimeout;
+            let entered!: () => void;
+            const waiting = new Promise<void>((resolve) => (entered = resolve));
+            let release!: () => void;
+            window.setTimeout = ((
+                handler: TimerHandler,
+                timeout?: number,
+                ...args: unknown[]
+            ) => {
+                if (timeout === 200 && typeof handler === "function") {
+                    window.setTimeout = setTimeout;
+                    release = () => handler(...args);
+                    entered();
+                    return 0;
+                }
+                return setTimeout(handler, timeout, ...args);
+            }) as typeof window.setTimeout;
+            const originalResume = AudioContext.prototype.resume;
+            AudioContext.prototype.resume = async () => {};
+            try {
+                const pending = player
+                    .ruffle()
+                    .load("/test_assets/example.swf")
+                    .then(() => "", String);
+                await waiting;
+                player.remove();
+                release();
+                return {
+                    error: await pending,
+                    canvases:
+                        player.shadowRoot!.querySelectorAll("canvas").length,
+                    readyState: player.ruffle().readyState,
+                };
+            } finally {
+                window.setTimeout = setTimeout;
+                AudioContext.prototype.resume = originalResume;
+            }
+        });
+        expect(result).to.deep.equal({ error: "", canvases: 0, readyState: 0 });
+    });
+
+    it("still reloads and plays after reconnection", async () => {
+        await browser.execute(async () => {
+            const player = window.lifecycleTest.player;
+            await player.ruffle().load("/test_assets/example.swf");
+            await player.ruffle().reload();
+            player.remove();
+            document.getElementById("test-container")!.appendChild(player);
+            await player.ruffle().reload();
+        });
+        await playAndMonitor(
+            browser,
+            await browser.$("#ruffle-player").getElement(),
+        );
+    });
+});

--- a/web/packages/selfhosted/wdio.conf.ts
+++ b/web/packages/selfhosted/wdio.conf.ts
@@ -50,9 +50,20 @@ if (firefox) {
     if (headless) {
         args.push("-headless");
     }
+    // The opt-in memory tests use Firefox's privileged GC API.
+    // Classic WebDriver avoids BiDi's shadow-root instrumentation retaining DOM nodes.
+    // geckodriver supports this flag, but its npm types do not list it yet.
+    const driverOptions: WebdriverIO.GeckodriverOptions & {
+        allowSystemAccess?: boolean;
+    } = {};
+    if (process.env["RUFFLE_TEST_GC"] === "1") {
+        driverOptions.allowSystemAccess = true;
+    }
     capabilities.push({
         "wdio:maxInstances": maxInstances,
         browserName: "firefox",
+        "wdio:geckodriverOptions": driverOptions,
+        "wdio:enforceWebDriverClassic": process.env["RUFFLE_TEST_GC"] === "1",
         "moz:firefoxOptions": {
             args,
         },
@@ -239,7 +250,7 @@ export const config: WebdriverIO.Config = {
     },
 
     async beforeSuite() {
-        if (!browserstack) {
+        if (!browserstack && browser.isBidi) {
             await browser.sessionSubscribe({ events: ["log.entryAdded"] });
             browser.on("log.entryAdded", (entryAdded) => {
                 console.log(


### PR DESCRIPTION
## Description

Replacing Flash elements without navigating the document, as on z0r.de, can retain removed players. Document listeners retain `InnerPlayer`, and asynchronous initialization can recreate a removed instance or overwrite a newer load.

Scope document listeners to connection/disconnection and cancel obsolete initialization. Abort font requests, discard late-built instances, free builders, and preserve the shared WASM download for other players. Cancelled loads resolve without starting a movie or showing an obsolete error; normal reloads and reconnection remain supported.

Also release the player captured by the shared WASM download's progress callback. Forward progress through a disposable holder cleared on completion, failure, or cancellation.

Firefox can additionally retain the splash spinner through `nsPresContext -> EffectCompositor::mElementsToRestyle -> circle -> shadow root -> player`, even after JS listeners and the native player are released. Replace the CSS rotation with SVG `animateTransform`, keeping the same appearance and duration, and explicitly start/stop it with the splash screen's lifecycle.

## Testing

- 11 lifecycle tests cover removal, overlapping loads, asynchronous boundaries, context menus, reconnection, playback, and restarting the spinner after cancellation. Nine of the original ten fail on the original implementation.
- Two opt-in Firefox GC tests replace 60 players each, both during loading and after metadata is available. Both fail on the preceding lifecycle-only commit and pass with these additional changes.
- A separate bounded probe finishes 250 replacements with zero removed players retained after GC. A 60-replacement probe that waits for SWF metadata also retains zero. These use the existing local `example.swf` fixture and explicit GC; they do not establish memory behavior for arbitrary SWFs or eliminate all possible Firefox memory growth.
- `npm test`: 59 passing. TypeScript checks, ESLint, Stylelint, and formatting pass. The production self-hosted bundle builds successfully with the existing Rust WASM build.
- Normal Firefox JS API/polyfill run: all 45 spec files pass (the opt-in GC cases are skipped in that run and pass separately).

Run the memory regressions from `web` after building:

```sh
RUFFLE_TEST_GC=1 npm run wdio --workspace=ruffle-selfhosted -- --firefox --headless --spec garbage_collection
```

The opt-in flag enables privileged GC only in the disposable Firefox test profile and disables BiDi shadow-root instrumentation, which otherwise retains measured elements. Application code does not force GC. No SWF behavior changes or additional SWF fixtures are introduced.

## Checklist

- [ ] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [ ] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.

Opened as a draft pending human self-review and upstream CI. The account owner will handle maintainer discussions. Please apply the `llm` label if contributor permissions do not allow it.
