### PR TITLE
core: Store LayoutContext on LayoutBuilder

### DIFF
--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -20,6 +20,8 @@ use swf::{Rectangle, Twips};
 
 /// Accumulates state while incrementally laying out a run of text.
 pub struct LayoutBuilder<'a, 'gc> {
+    context: &'a mut dyn LayoutContext<'gc>,
+
     /// The movie this layout context is pulling fonts from.
     movie: Arc<SwfMovie>,
 
@@ -104,6 +106,7 @@ pub struct LayoutBuilder<'a, 'gc> {
 
 impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
     fn new(
+        context: &'a mut dyn LayoutContext<'gc>,
         movie: Arc<SwfMovie>,
         max_bounds: Twips,
         text: &'a WStr,
@@ -112,6 +115,7 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
         font_type: FontType,
     ) -> Self {
         Self {
+            context,
             movie,
             cursor: Default::default(),
             font_set: None,
@@ -135,20 +139,14 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
         }
     }
 
-    fn lay_out_spans(&mut self, context: &mut dyn LayoutContext<'gc>, fs: &'a FormatSpans) {
+    fn lay_out_spans(&mut self, fs: &'a FormatSpans) {
         for (span_start, _end, span_text, span) in fs.iter_spans() {
-            self.lay_out_span(context, span_start, span_text, span);
+            self.lay_out_span(span_start, span_text, span);
         }
     }
 
-    fn lay_out_span(
-        &mut self,
-        context: &mut dyn LayoutContext<'gc>,
-        span_start: usize,
-        span_text: &'a WStr,
-        span: &TextSpan,
-    ) {
-        let font_set = self.resolve_font(context, span);
+    fn lay_out_span(&mut self, span_start: usize, span_text: &'a WStr, span: &TextSpan) {
+        let font_set = self.resolve_font(span);
         self.font_set = Some(font_set);
         self.newspan(span);
 
@@ -167,9 +165,7 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
             };
 
             match delimiter {
-                Some(b'\n' | b'\r') => {
-                    self.newline(context, span_start + slice_start - 1, span, true)
-                }
+                Some(b'\n' | b'\r') => self.newline(span_start + slice_start - 1, span, true),
                 Some(b'\t') => self.tab(),
                 _ => {}
             }
@@ -203,7 +199,7 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
                                 "wrap_line is supposed to return nonzero if is_start_of_line"
                             );
                         }
-                        self.newline(context, start + next_breakpoint, span, false);
+                        self.newline(start + next_breakpoint, span, false);
 
                         let next_dim = self.wrap_dimensions(span);
 
@@ -229,7 +225,7 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
                         break;
                     }
 
-                    self.newline(context, start + next_breakpoint, span, false);
+                    self.newline(start + next_breakpoint, span, false);
                     let next_dim = self.wrap_dimensions(span);
 
                     width = next_dim.0;
@@ -284,7 +280,6 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
     /// parameter will result in no empty lines being added.
     fn fixup_line(
         &mut self,
-        context: &mut dyn LayoutContext<'gc>,
         last_line: bool,
         final_line_of_para: bool,
         end: usize,
@@ -343,7 +338,7 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
         );
 
         if self.current_line_span.bullet && self.is_first_line && box_count > 0 {
-            self.append_bullet(context, &self.current_line_span.clone());
+            self.append_bullet(&self.current_line_span.clone());
         }
 
         let baseline_adjustment = self.max_ascent;
@@ -438,14 +433,8 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
     ///
     /// The parameter `end_of_para` specifies whether the line was the last line
     /// of the current paragraph (i.e. it contained an explicit newline).
-    fn newline(
-        &mut self,
-        context: &mut dyn LayoutContext<'gc>,
-        end: usize,
-        span: &TextSpan,
-        end_of_para: bool,
-    ) {
-        self.fixup_line(context, false, end_of_para, end, span);
+    fn newline(&mut self, end: usize, span: &TextSpan, end_of_para: bool) {
+        self.fixup_line(false, end_of_para, end, span);
 
         self.cursor.set_x(Twips::ZERO);
         self.cursor += (
@@ -511,11 +500,7 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
         }
     }
 
-    fn resolve_font(
-        &mut self,
-        context: &mut dyn LayoutContext<'gc>,
-        span: &TextSpan,
-    ) -> FontSet<'gc> {
+    fn resolve_font(&mut self, span: &TextSpan) -> FontSet<'gc> {
         fn new_empty_font<'gc>(
             context: &mut dyn LayoutContext<'gc>,
             span: &TextSpan,
@@ -547,7 +532,8 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
         // Note that the SWF can still contain a DefineFont tag with no glyphs/layout info in this case (see #451).
         // In an ideal world, device fonts would search for a matching font on the system and render it in some way.
         if self.font_type.is_embedded()
-            && let Some(font) = context
+            && let Some(font) = self
+                .context
                 .get_embedded_font_by_name(
                     &font_name,
                     self.font_type,
@@ -557,12 +543,12 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
                 )
                 .filter(|f| f.has_glyphs())
         {
-            return FontSet::from_one_font(context.gc(), font);
+            return FontSet::from_one_font(self.context.gc(), font);
         }
         // TODO: If set to use embedded fonts and we couldn't find any matching font, show nothing
         // However - at time of writing, we don't support DefineFont4. If we matched this behaviour,
         // then a bunch of SWFs would just show no text suddenly.
-        // return new_empty_font(context, span, self.font_type);
+        // return new_empty_font(self.context, span, self.font_type);
 
         // Specifying multiple font names is supported only for device fonts.
         let font_names: Vec<&str> = font_name.split(",").collect();
@@ -571,21 +557,26 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
 
             // Check if the font name is one of the known default fonts.
             if let Some(default_font) = DefaultFont::from_name(font_name) {
-                let fonts = context.default_font(default_font, span.style.bold, span.style.italic);
-                if let Some(font_sort) = FontSet::from_fonts(context.gc(), &fonts) {
+                let fonts =
+                    self.context
+                        .default_font(default_font, span.style.bold, span.style.italic);
+                if let Some(font_sort) = FontSet::from_fonts(self.context.gc(), &fonts) {
                     return font_sort;
                 } else {
                     let font_desc = describe_font(span);
                     tracing::error!(
                         "Known default device font not found: {font_desc}, text will be missing"
                     );
-                    return new_empty_font(context, span, self.font_type);
+                    return new_empty_font(self.context, span, self.font_type);
                 }
             }
 
-            let fonts =
-                context.get_or_sort_device_fonts(font_name, span.style.bold, span.style.italic);
-            if let Some(font_sort) = FontSet::from_fonts(context.gc(), &fonts) {
+            let fonts = self.context.get_or_sort_device_fonts(
+                font_name,
+                span.style.bold,
+                span.style.italic,
+            );
+            if let Some(font_sort) = FontSet::from_fonts(self.context.gc(), &fonts) {
                 return font_sort;
             }
         }
@@ -618,15 +609,17 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
             }
         };
 
-        let fonts = context.default_font(default_font, span.style.bold, span.style.italic);
-        if let Some(font_sort) = FontSet::from_fonts(context.gc(), &fonts) {
+        let fonts = self
+            .context
+            .default_font(default_font, span.style.bold, span.style.italic);
+        if let Some(font_sort) = FontSet::from_fonts(self.context.gc(), &fonts) {
             font_sort
         } else {
             let font_desc = describe_font(span);
             tracing::error!(
                 "Fallback font not found ({default_font:?}) for: {font_desc}, text will be missing"
             );
-            new_empty_font(context, span, self.font_type)
+            new_empty_font(self.context, span, self.font_type)
         }
     }
 
@@ -686,8 +679,8 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
     /// The bullet will always be placed at the start of the current line. It
     /// should be appended after line fixup has completed, but before the text
     /// cursor is moved down.
-    fn append_bullet(&mut self, context: &mut dyn LayoutContext<'gc>, span: &TextSpan) {
-        let bullet_font = self.resolve_font(context, span);
+    fn append_bullet(&mut self, span: &TextSpan) {
+        let bullet_font = self.resolve_font(span);
         let mut bullet_cursor = self.cursor;
 
         bullet_cursor.set_x(
@@ -769,13 +762,9 @@ impl<'a, 'gc> LayoutBuilder<'a, 'gc> {
     }
 
     /// Destroy the layout context, returning the newly constructed layout list.
-    fn end_layout(
-        mut self,
-        context: &mut dyn LayoutContext<'gc>,
-        fs: &'a FormatSpans,
-    ) -> Layout<'gc> {
+    fn end_layout(mut self, fs: &'a FormatSpans) -> Layout<'gc> {
         let last_span = fs.last_span().expect("At least one span should be present");
-        self.fixup_line(context, true, true, fs.displayed_text().len(), last_span);
+        self.fixup_line(true, true, fs.displayed_text().len(), last_span);
 
         let text_size = self.text_size_bounds.unwrap_or_default();
         Layout {
@@ -841,6 +830,7 @@ fn lower_from_text_spans_known_width<'gc>(
     font_type: FontType,
 ) -> Layout<'gc> {
     let mut builder = LayoutBuilder::new(
+        context,
         movie,
         bounds,
         fs.displayed_text(),
@@ -848,10 +838,8 @@ fn lower_from_text_spans_known_width<'gc>(
         is_word_wrap,
         font_type,
     );
-
-    builder.lay_out_spans(context, fs);
-
-    builder.end_layout(context, fs)
+    builder.lay_out_spans(fs);
+    builder.end_layout(fs)
 }
 
 /// A `Layout` represents a fully laid-out text field.


### PR DESCRIPTION
## Description

This simplifies code a lot and gets rid of passing LayoutContext as parameter everywhere.

## Testing

Should be covered by existing tests.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
