### PR TITLE
core: Remove bitmap glyphs in favor of atlas glyphs

### DIFF
--- a/core/src/font/glyph.rs
+++ b/core/src/font/glyph.rs
@@ -4,12 +4,8 @@ use crate::font::FontAtlasGlyph;
 use crate::prelude::*;
 use ruffle_render::backend::null::NullBitmapSource;
 use ruffle_render::backend::{RenderBackend, ShapeHandle};
-use ruffle_render::bitmap::{Bitmap, BitmapInfo};
-use ruffle_render::error::Error;
 use ruffle_render::transform::Transform;
-
-use std::cell::{Cell, OnceCell, Ref, RefCell};
-use std::rc::Rc;
+use std::cell::{Ref, RefCell};
 
 #[derive(Debug, Clone)]
 enum SwfGlyphOrShape {
@@ -43,25 +39,12 @@ impl SwfGlyphOrShape {
 #[derive(Clone, Debug)]
 pub enum GlyphRenderData {
     Shape(ShapeHandle),
-    Bitmap {
-        info: BitmapInfo,
-        tx: Twips,
-        ty: Twips,
-    },
     AtlasGlyph(FontAtlasGlyph),
 }
 
 impl GlyphRenderData {
     pub fn from_shape(shape_handle: ShapeHandle) -> Self {
         Self::Shape(shape_handle)
-    }
-
-    pub fn from_bitmap(bitmap_info: BitmapInfo, tx: Twips, ty: Twips) -> Self {
-        Self::Bitmap {
-            info: bitmap_info,
-            tx,
-            ty,
-        }
     }
 
     pub fn from_atlas(atlas_glyph: FontAtlasGlyph) -> Self {
@@ -73,7 +56,6 @@ impl GlyphRenderData {
 enum GlyphShape {
     Swf(Box<RefCell<SwfGlyphOrShape>>),
     Drawing(Box<Drawing>),
-    Bitmap(Rc<GlyphBitmap<'static>>),
     AtlasGlyph(FontAtlasGlyph),
     None,
 }
@@ -88,10 +70,6 @@ impl GlyphShape {
                     && ruffle_render::shape_utils::shape_hit_test(shape, point, local_matrix)
             }
             GlyphShape::Drawing(drawing) => drawing.hit_test(point, local_matrix),
-            GlyphShape::Bitmap(_) => {
-                // TODO Implement this.
-                true
-            }
             GlyphShape::AtlasGlyph(_) => {
                 // TODO Implement this.
                 true
@@ -113,74 +91,12 @@ impl GlyphShape {
             GlyphShape::Drawing(drawing) => drawing
                 .register_or_replace(renderer)
                 .map(GlyphRenderData::from_shape),
-            GlyphShape::Bitmap(bitmap) => bitmap
-                .get_bitmap_info_or_register(renderer)
-                .as_ref()
-                .inspect_err(|err| {
-                    tracing::error!(
-                        "Failed to register glyph as a bitmap: {err}, glyphs will be missing"
-                    )
-                })
-                .ok()
-                .cloned()
-                .map(|info| GlyphRenderData::from_bitmap(info, bitmap.tx, bitmap.ty)),
             GlyphShape::AtlasGlyph(atlas_glyph) => atlas_glyph
                 .atlas_handle(renderer)
                 .as_ref()
                 .map(|_| GlyphRenderData::from_atlas(atlas_glyph.clone())),
             GlyphShape::None => None,
         }
-    }
-}
-
-/// A Bitmap that can be registered to a RenderBackend.
-struct GlyphBitmap<'a> {
-    bitmap: Cell<Option<Bitmap<'a>>>,
-    handle: OnceCell<Result<BitmapInfo, Error>>,
-
-    /// Translation in x to be applied before rendering the glyph.
-    tx: Twips,
-
-    /// Translation in y to be applied before rendering the glyph.
-    ty: Twips,
-}
-
-impl<'a> std::fmt::Debug for GlyphBitmap<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GlyphBitmap")
-            .field("handle", &self.handle)
-            .finish()
-    }
-}
-
-impl<'a> GlyphBitmap<'a> {
-    pub fn new(bitmap: Bitmap<'a>, tx: Twips, ty: Twips) -> Self {
-        Self {
-            bitmap: Cell::new(Some(bitmap)),
-            handle: OnceCell::new(),
-            tx,
-            ty,
-        }
-    }
-
-    pub fn get_bitmap_info_or_register(
-        &self,
-        renderer: &mut dyn RenderBackend,
-    ) -> &Result<BitmapInfo, Error> {
-        self.handle.get_or_init(|| {
-            let bitmap = self
-                .bitmap
-                .take()
-                .expect("Bitmap should be available before registering");
-            let width = bitmap.width();
-            let height = bitmap.height();
-            let handle = renderer.register_bitmap(bitmap)?;
-            Ok(BitmapInfo {
-                handle,
-                width,
-                height,
-            })
-        })
     }
 }
 
@@ -227,20 +143,6 @@ impl Glyph {
         }
     }
 
-    pub fn from_bitmap(
-        character: char,
-        bitmap: Bitmap<'static>,
-        advance: Twips,
-        tx: Twips,
-        ty: Twips,
-    ) -> Self {
-        Self {
-            shape: GlyphShape::Bitmap(Rc::new(GlyphBitmap::new(bitmap, tx, ty))),
-            advance,
-            character,
-        }
-    }
-
     pub fn from_atlas(character: char, atlas_glyph: FontAtlasGlyph, advance: Twips) -> Self {
         Self {
             shape: GlyphShape::AtlasGlyph(atlas_glyph),
@@ -273,7 +175,6 @@ impl Glyph {
         match self.shape {
             GlyphShape::Swf(_) => true,
             GlyphShape::Drawing(_) => true,
-            GlyphShape::Bitmap(_) => false,
             GlyphShape::AtlasGlyph(_) => false,
             GlyphShape::None => false,
         }
@@ -295,23 +196,6 @@ impl Glyph {
                 context
                     .commands
                     .render_shape(shape_handle, context.transform_stack.transform());
-            }
-            GlyphRenderData::Bitmap { info, tx, ty } => {
-                context.transform_stack.push(&Transform {
-                    matrix: Matrix::translate(tx, ty),
-                    ..Default::default()
-                });
-
-                let region = info.full_region();
-                context.commands.render_bitmap(
-                    info.handle,
-                    context.transform_stack.transform(),
-                    true,
-                    ruffle_render::bitmap::PixelSnapping::Auto,
-                    region,
-                );
-
-                context.transform_stack.pop();
             }
             GlyphRenderData::AtlasGlyph(atlas_glyph) => {
                 let handle = atlas_glyph.atlas_handle(context.renderer);


### PR DESCRIPTION
## Description

Bitmap glyphs registered every single glyph as a separate bitmap, they were replaced with atlas glyphs that are more efficient.

They are unused, so this patch removes them.

## Testing

N/A

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
