### PR TITLE
ci: Add Linux x86_32 release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,11 @@ jobs:
             os: ubuntu-24.04
             DESKTOP_FEATURES: jpegxr,fontconfig-dlopen
 
+          - build_name: linux-x86_32
+            os: ubuntu-24.04
+            target: i686-unknown-linux-gnu
+            DESKTOP_FEATURES: jpegxr,fontconfig-dlopen
+
           - build_name: linux-aarch64
             os: ubuntu-24.04-arm
             DESKTOP_FEATURES: jpegxr,fontconfig-dlopen
@@ -176,11 +181,20 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Install Linux dependencies
-        if: runner.os == 'Linux'
+      - name: Install Linux x64 dependencies
+        if: runner.os == 'Linux' && matrix.target == ''
         run: |
           sudo apt-get update
           sudo apt install -y ${{ env.LINUX_DEPENDENCIES }}
+
+      - name: Install Linux i386 dependencies
+        if: matrix.target == 'i686-unknown-linux-gnu'
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt install -y gcc-multilib $(for p in ${{ env.LINUX_DEPENDENCIES }}; do echo "$p:i386"; done)
+          echo "PKG_CONFIG_ALLOW_CROSS=1" | tee -a $GITHUB_ENV
+          echo "PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu/pkgconfig" | tee -a $GITHUB_ENV
 
       - name: Install WiX
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Description

* Related to https://github.com/ruffle-rs/ruffle/issues/24627
* Related to https://github.com/ruffle-rs/ruffle/issues/7197

This should build Ruffle for Linux 32-bit and attach binaries to releases.

## Testing

This is completely untested, and if it works, it will fail the next build due to https://github.com/ruffle-rs/ruffle/issues/24627. I feel like the easiest approach is to test it the next nightly build, because testing GHA is just painful.

This should not break other builds as changes are minimal.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
