### PR TITLE
desktop: Add shell completion subcommand via clap_complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4904,6 +4913,7 @@ dependencies = [
  "bytemuck",
  "chrono",
  "clap",
+ "clap_complete",
  "cpal",
  "dirs",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ egui_extras = { version = "0.36.1", default-features = false }
 egui-wgpu = "0.36.1"
 egui-winit = "0.36.1"
 clap = { version = "4.6.1", features = ["derive"] }
+clap_complete = "4.6"
 cpal = "0.16.0"
 anyhow = "1.0"
 gc-arena = { version = "0.7.0", features = ["enum-map", "hashbrown", "indexmap", "slotmap", "smallvec"] }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 clap = { workspace = true }
+clap_complete = { workspace = true }
 cpal = { workspace = true }
 egui = { workspace = true }
 egui_extras = { workspace = true, default-features = false, features = ["image"] }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 clap = { workspace = true }
-clap_complete = { workspace = true }
+clap_complete = { workspace = true, optional = true }
 cpal = { workspace = true }
 egui = { workspace = true }
 egui_extras = { workspace = true, default-features = false, features = ["image"] }
@@ -82,6 +82,7 @@ OriginalFilename = "ruffle.exe"
 
 [features]
 default = ["software_video", "external_video", "lzma", "fontconfig", "freetype"]
+shell-completions = ["dep:clap_complete"]
 jpegxr = ["ruffle_core/jpegxr"]
 
 # core features

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -1,10 +1,7 @@
 use crate::RUFFLE_VERSION;
 use crate::preferences::storage::StorageBackend;
 use anyhow::{Error, anyhow};
-use clap::Parser;
-#[cfg(feature = "shell-completions")]
-use clap::Subcommand;
-use clap::ValueEnum;
+use clap::{Parser, ValueEnum};
 #[cfg(feature = "shell-completions")]
 use clap_complete::Shell;
 use ruffle_core::backend::navigator::SocketMode;
@@ -45,9 +42,10 @@ fn get_default_cache_directory() -> std::path::PathBuf {
     subcommand_negates_reqs = true
 )]
 pub struct Opt {
+    /// Generate shell completions for the specified shell
     #[cfg(feature = "shell-completions")]
-    #[clap(subcommand)]
-    pub command: Option<Commands>,
+    #[arg(long = "completions", value_enum)]
+    pub completions: Option<Shell>,
 
     /// Path or URL of a Flash movie (SWF) to play.
     #[clap(name = "FILE", value_parser(parse_movie_file_or_url))]
@@ -510,15 +508,4 @@ pub enum FilesystemAccessMode {
 
     /// Ask the user before accessing the filesystem non-interactively.
     Ask,
-}
-
-#[cfg(feature = "shell-completions")]
-#[derive(Debug, Clone, Subcommand)]
-pub enum Commands {
-    /// Generate shell completions for the specified shell
-    Completions {
-        /// Shell to generate completions for
-        #[arg(value_enum)]
-        shell: Shell,
-    },
 }

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -1,7 +1,8 @@
 use crate::RUFFLE_VERSION;
 use crate::preferences::storage::StorageBackend;
 use anyhow::{Error, anyhow};
-use clap::{Parser, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 use ruffle_core::backend::navigator::SocketMode;
 use ruffle_core::config::Letterbox;
 use ruffle_core::events::{GamepadButton, KeyCode};
@@ -37,8 +38,12 @@ fn get_default_cache_directory() -> std::path::PathBuf {
     name = "Ruffle",
     author,
     version = RUFFLE_VERSION,
+    subcommand_negates_reqs = true
 )]
 pub struct Opt {
+    #[clap(subcommand)]
+    pub command: Option<Commands>,
+
     /// Path or URL of a Flash movie (SWF) to play.
     #[clap(name = "FILE", value_parser(parse_movie_file_or_url))]
     pub movie_url: Option<Url>,
@@ -500,4 +505,14 @@ pub enum FilesystemAccessMode {
 
     /// Ask the user before accessing the filesystem non-interactively.
     Ask,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum Commands {
+    /// Generate shell completions for the specified shell
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: Shell,
+    },
 }

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -1,7 +1,11 @@
 use crate::RUFFLE_VERSION;
 use crate::preferences::storage::StorageBackend;
 use anyhow::{Error, anyhow};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::Parser;
+#[cfg(feature = "shell-completions")]
+use clap::Subcommand;
+use clap::ValueEnum;
+#[cfg(feature = "shell-completions")]
 use clap_complete::Shell;
 use ruffle_core::backend::navigator::SocketMode;
 use ruffle_core::config::Letterbox;
@@ -41,6 +45,7 @@ fn get_default_cache_directory() -> std::path::PathBuf {
     subcommand_negates_reqs = true
 )]
 pub struct Opt {
+    #[cfg(feature = "shell-completions")]
     #[clap(subcommand)]
     pub command: Option<Commands>,
 
@@ -507,6 +512,7 @@ pub enum FilesystemAccessMode {
     Ask,
 }
 
+#[cfg(feature = "shell-completions")]
 #[derive(Debug, Clone, Subcommand)]
 pub enum Commands {
     /// Generate shell completions for the specified shell

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -27,8 +27,6 @@ use app::App;
 #[cfg(feature = "shell-completions")]
 use clap::CommandFactory;
 use clap::Parser;
-#[cfg(feature = "shell-completions")]
-use cli::Commands;
 use cli::Opt;
 use rfd::MessageDialogResult;
 use ruffle_core::StaticCallstack;
@@ -156,7 +154,7 @@ fn main() -> Result<(), Error> {
     let opt = Opt::parse();
 
     #[cfg(feature = "shell-completions")]
-    if let Some(Commands::Completions { shell }) = opt.command {
+    if let Some(shell) = opt.completions {
         let mut cmd = Opt::command();
         clap_complete::generate(shell, &mut cmd, "ruffle", &mut std::io::stdout());
         return Ok(());

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -24,8 +24,8 @@ mod windows;
 use crate::preferences::GlobalPreferences;
 use anyhow::{Context, Error};
 use app::App;
-use clap::Parser;
-use cli::Opt;
+use clap::{CommandFactory, Parser};
+use cli::{Commands, Opt};
 use rfd::MessageDialogResult;
 use ruffle_core::StaticCallstack;
 use std::cell::RefCell;
@@ -150,6 +150,13 @@ fn main() -> Result<(), Error> {
     let _console = windows::Console::attach();
 
     let opt = Opt::parse();
+
+    if let Some(Commands::Completions { shell }) = opt.command {
+        let mut cmd = Opt::command();
+        clap_complete::generate(shell, &mut cmd, "ruffle", &mut std::io::stdout());
+        return Ok(());
+    }
+
     let preferences = GlobalPreferences::load(opt)?;
 
     let logs_path = &preferences.cli.cache_directory.join("log");

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -24,8 +24,12 @@ mod windows;
 use crate::preferences::GlobalPreferences;
 use anyhow::{Context, Error};
 use app::App;
-use clap::{CommandFactory, Parser};
-use cli::{Commands, Opt};
+#[cfg(feature = "shell-completions")]
+use clap::CommandFactory;
+use clap::Parser;
+#[cfg(feature = "shell-completions")]
+use cli::Commands;
+use cli::Opt;
 use rfd::MessageDialogResult;
 use ruffle_core::StaticCallstack;
 use std::cell::RefCell;
@@ -151,6 +155,7 @@ fn main() -> Result<(), Error> {
 
     let opt = Opt::parse();
 
+    #[cfg(feature = "shell-completions")]
     if let Some(Commands::Completions { shell }) = opt.command {
         let mut cmd = Opt::command();
         clap_complete::generate(shell, &mut cmd, "ruffle", &mut std::io::stdout());


### PR DESCRIPTION
## Description

<!--
Please explain the changes made within this PR and the context around them.
Why did you make this change; does it add a feature, or fix a bug? Be sure to
link to any content or issues that it affects!

Please also remember that each commit message should describe its own changes
too.
-->

Add shell completion generation support to the desktop CLI via `clap_complete`.
A new `completions` subcommand is added, allowing users to generate shell
completions for bash, zsh, fish, and other shells supported by clap_complete.

Usage:
```
ruffle completions bash | source
ruffle completions zsh | source
ruffle completions fish | source
```
Note: Before testing zsh completions, make sure to run autoload -Uz compinit && compinit
in your interactive shell (or add it to .zshrc) to initialize the completion system.

I'm not familiar with elvish and powershell, which is also supported by clap_complete. The way for usage adn test here is just for three common unix shells.

## Testing

<!-- How can we test this PR? -->

<!--
If possible, please follow our [test guidelines](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines)
to make a SWF test which should fail before this PR, and pass after it. This
helps us protect against breaking your changes in the future.

If applicable, add unit tests or web integration tests, but don't test SWF
behavior with unit tests. Describe what you added!

Note that in most cases, it's obligatory to add a SWF test for every
observable change you make!

If you need help with making tests, or do not believe this change is easily
automatically testable, please describe how we can verify the changes ourselves.
If there is real world content that we can test on, that helps a lot!
-->

- Run cargo run -- completions bash and verify valid bash completion output
- Run cargo run -- completions zsh and verify valid zsh completion output
- Run cargo run -- completions fish and verify valid fish completion output
- Verify cargo clippy and cargo fmt pass on ruffle_desktop

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
- [x] LLM helps me write this pr message and git commit message because I'm not a native English Speaker and not that good at wrting.
