### PR TITLE
avm2: Optimize method calls on parametrized Vectors to CallNative

### DIFF
--- a/core/src/avm2/optimizer/type_aware.rs
+++ b/core/src/avm2/optimizer/type_aware.rs
@@ -2224,7 +2224,17 @@ fn maybe_optimize_static_call<'gc>(
 
     let declared_params = speculated_method.resolved_param_config();
 
-    if receiver.class.is_some_and(|c| c.is_final())
+    let is_static_call = receiver.class.is_some_and(|c| {
+        // The speculated method is known to be the right method if either
+        //  - the class of the receiver is final, as final classes cannot have
+        //    subclasses with different methods
+        //  - the class is a parametrized vector class, as parametrized vector
+        //    classes do not have subclasses with different methods
+
+        c.is_final() || c.param().is_some()
+    });
+
+    if is_static_call
         && let MethodKind::Native {
             native_method,
             fast_call: true,


### PR DESCRIPTION
## Description

Parametrized vector classes, e.g. `Vector.<MovieClip>`, aren't actually marked `final`, so our static call optimization logic wasn't considering them for optimizations. However, since no user classes can create subclasses of them, they're effectively final. This PR makes the optimizer take that into account.

This allows us to speed up some vector operations: for example, `vector.length` accesses are now four times as fast, as they're going through the `callnative` op rather than `callmethod`. I don't see any noticeable impact on real SWFs, though.

## Testing

This is a performance improvement

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
