### PR TITLE
build: Use ESM instead for all of the web core build

### DIFF
--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -1,5 +1,6 @@
 {
     "name": "ruffle-core",
+    "type": "module",
     "version": "0.6.0",
     "description": "Core bindings for Ruffle",
     "license": "(MIT OR Apache-2.0)",

--- a/web/packages/core/tools/bundle_css.ts
+++ b/web/packages/core/tools/bundle_css.ts
@@ -2,7 +2,6 @@ import { replaceInFileSync } from "replace-in-file";
 import fs from "fs";
 import postcss from "postcss";
 import cssnanoPlugin from "cssnano";
-// @ts-expect-error TS7016 We don't care about the types, if it doesn't work that's fine
 import postcssNesting from "postcss-nesting";
 
 const originalCss = fs

--- a/web/packages/core/tools/set_version.ts
+++ b/web/packages/core/tools/set_version.ts
@@ -2,6 +2,7 @@ import { replaceInFileSync } from "replace-in-file";
 import childProcess from "child_process";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 
 let buildDate = new Date().toISOString();
 let versionNumber = process.env["npm_package_version"] ?? "";
@@ -37,6 +38,8 @@ interface VersionInformation {
 let versionSeal: VersionInformation;
 
 if (process.env["ENABLE_VERSION_SEAL"] === "true") {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
     const sealFile = path.resolve(__dirname, "../../../version_seal.json");
     if (fs.existsSync(sealFile)) {
         console.log("Using version seal");

--- a/web/packages/core/tools/tsconfig.json
+++ b/web/packages/core/tools/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "@tsconfig/strictest/tsconfig.json",
     "compilerOptions": {
         "composite": true,
-        "module": "commonjs",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
         "target": "ES2021",
         "rootDir": ".",
     },

--- a/web/packages/core/tsconfig.json
+++ b/web/packages/core/tsconfig.json
@@ -2,8 +2,8 @@
     "extends": "@tsconfig/strictest/tsconfig.json",
     "compilerOptions": {
         "composite": true,
-        "module": "es2020",
-        "moduleResolution": "node",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
         "target": "es2021",
         "rootDir": "src",
         "outDir": "dist",

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -116,6 +116,12 @@ export default function (/** @type {Record<string, any>} */ env, _argv) {
                     test: /\.ts$/i,
                     use: "ts-loader",
                 },
+                {
+                    test: /\.m?js$/,
+                    resolve: {
+                        fullySpecified: false,
+                    },
+                },
             ],
         },
         resolve: {

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -26,6 +26,16 @@ export default function (_env, _argv) {
             chunkFilename: "core.ruffle.[contenthash].js",
             clean: true,
         },
+        module: {
+            rules: [
+                {
+                    test: /\.m?js$/,
+                    resolve: {
+                        fullySpecified: false,
+                    },
+                },
+            ],
+        },
         performance: {
             assetFilter: (assetFilename) =>
                 !/\.(map|wasm)$/i.test(assetFilename),


### PR DESCRIPTION
## Description

Use ESM for all of the web core build, including the parts that were using CommonJS

## Testing

- `npm install`
- `npm run build:dual-wasm-repro`
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run wdio --workspaces --if-present -- --headless --parallel --edge --firefox --chrome`

And check CI

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
