### PR TITLE
chore: Mark all caret tests as flaky

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,9 +1,10 @@
 # TODO: Figure out why these specific tests are flaky on CI, fix them, then delete this file.
-# `visual/edittext/edittext_caret_empty` is flaky on Windows for some reason.
+# Tests related to the caret are flaky on Windows for some reason. Maybe because
+# it blinks too fast?
 [[profile.ci.overrides]]
 filter = """
 test(from_gnash/misc-ming.all/getTimer_test) or \
-test(visual/edittext/edittext_caret_empty) or \
+test(edittext_caret) or \
 test(avm2/graphics_round_rects) or \
 test(avm2/stage3d_errors_atf) or \
 test(avm1/netstream_play_flv) or \


### PR DESCRIPTION
## Description

For some reason tests related to the caret on Windows are flaky: https://github.com/ruffle-rs/ruffle/actions/runs/34402568813/job/102637809147#step:9:5189

## Testing
N/A
<!-- How can we test this PR? -->

<!--
If possible, please follow our [test guidelines](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines)
to make a SWF test which should fail before this PR, and pass after it. This
helps us protect against breaking your changes in the future.

If applicable, add unit tests or web integration tests, but don't test SWF
behavior with unit tests. Describe what you added!

Note that in most cases, it's obligatory to add a SWF test for every
observable change you make!

If you need help with making tests, or do not believe this change is easily
automatically testable, please describe how we can verify the changes ourselves.
If there is real world content that we can test on, that helps a lot!
-->

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
