### PR TITLE
wgpu: Index into "dynamic transforms" via instancing, rather than dynamic buffer offsets

### DIFF
--- a/render/wgpu/shaders/alpha_mask.wgsl
+++ b/render/wgpu/shaders/alpha_mask.wgsl
@@ -5,14 +5,14 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+@group(1) @binding(0) var<uniform> transforms: array<common__Transforms, max_transforms>;
 @group(2) @binding(0) var maskee_texture: texture_2d<f32>;
 @group(2) @binding(1) var mask_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
-fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+fn main_vertex(in: common__VertexInput, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
+    let pos = common__globals.global_matrix * transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/alpha_mask.wgsl
+++ b/render/wgpu/shaders/alpha_mask.wgsl
@@ -12,7 +12,7 @@ struct VertexOutput {
 
 @vertex
 fn main_vertex(in: common__VertexInput, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = common__globals.global_matrix * (transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0));
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -15,7 +15,7 @@ override late_saturate: bool = false;
 
 @vertex
 fn main_vertex(in: common__VertexInputUv, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = common__globals.global_matrix * (transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0));
     return VertexOutput(pos, in.uv.xy / in.uv.z, transforms[instanceIndex].mult_color, transforms[instanceIndex].add_color);
 }
 

--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -8,15 +8,15 @@ struct VertexOutput {
     @location(2) add_color: vec4<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+@group(1) @binding(0) var<uniform> transforms: array<common__Transforms, max_transforms>;
 @group(2) @binding(0) var texture: texture_2d<f32>;
 @group(2) @binding(1) var texture_sampler: sampler;
 override late_saturate: bool = false;
 
 @vertex
-fn main_vertex(in: common__VertexInputUv) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
-    return VertexOutput(pos, in.uv.xy / in.uv.z, transforms.mult_color, transforms.add_color);
+fn main_vertex(in: common__VertexInputUv, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
+    let pos = common__globals.global_matrix * transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    return VertexOutput(pos, in.uv.xy / in.uv.z, transforms[instanceIndex].mult_color, transforms[instanceIndex].add_color);
 }
 
 @fragment

--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -4,6 +4,8 @@
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,
+    @location(1) mult_color: vec4<f32>,
+    @location(2) add_color: vec4<f32>,
 };
 
 @group(1) @binding(0) var<uniform> transforms: common__Transforms;
@@ -14,7 +16,7 @@ override late_saturate: bool = false;
 @vertex
 fn main_vertex(in: common__VertexInputUv) -> VertexOutput {
     let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
-    return VertexOutput(pos, in.uv.xy / in.uv.z);
+    return VertexOutput(pos, in.uv.xy / in.uv.z, transforms.mult_color, transforms.add_color);
 }
 
 @fragment
@@ -24,7 +26,7 @@ fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     // Unmultiply alpha, apply color transform, remultiply alpha.
     if (color.a > 0.0) {
         color = vec4<f32>(color.rgb / color.a, color.a);
-        color = color * transforms.mult_color + transforms.add_color;
+        color = color * in.mult_color + in.add_color;
         if (!late_saturate) {
             color = saturate(color);
         }

--- a/render/wgpu/shaders/blend/alpha.wgsl
+++ b/render/wgpu/shaders/blend/alpha.wgsl
@@ -5,14 +5,13 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/blend/darken.wgsl
+++ b/render/wgpu/shaders/blend/darken.wgsl
@@ -5,14 +5,13 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/blend/difference.wgsl
+++ b/render/wgpu/shaders/blend/difference.wgsl
@@ -5,14 +5,13 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/blend/erase.wgsl
+++ b/render/wgpu/shaders/blend/erase.wgsl
@@ -5,14 +5,13 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/blend/hardlight.wgsl
+++ b/render/wgpu/shaders/blend/hardlight.wgsl
@@ -5,14 +5,13 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/blend/invert.wgsl
+++ b/render/wgpu/shaders/blend/invert.wgsl
@@ -5,14 +5,13 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/blend/lighten.wgsl
+++ b/render/wgpu/shaders/blend/lighten.wgsl
@@ -5,14 +5,13 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/blend/multiply.wgsl
+++ b/render/wgpu/shaders/blend/multiply.wgsl
@@ -5,14 +5,13 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/blend/overlay.wgsl
+++ b/render/wgpu/shaders/blend/overlay.wgsl
@@ -5,14 +5,13 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var parent_texture: texture_2d<f32>;
 @group(2) @binding(1) var current_texture: texture_2d<f32>;
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     let uv = vec2<f32>(in.position.xy);
     return VertexOutput(pos, uv);
 }

--- a/render/wgpu/shaders/color.wgsl
+++ b/render/wgpu/shaders/color.wgsl
@@ -12,12 +12,12 @@ struct VertexOutput {
     @location(0) color: vec4<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+@group(1) @binding(0) var<uniform> transforms: array<common__Transforms, max_transforms>;
 
 @vertex
-fn main_vertex(in: VertexInput) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
-    let color = saturate(in.color * transforms.mult_color + transforms.add_color);
+fn main_vertex(in: VertexInput, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
+    let pos = common__globals.global_matrix * transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let color = saturate(in.color * transforms[instanceIndex].mult_color + transforms[instanceIndex].add_color);
     return VertexOutput(pos, vec4<f32>(color.rgb * color.a, color.a));
 }
 

--- a/render/wgpu/shaders/color.wgsl
+++ b/render/wgpu/shaders/color.wgsl
@@ -16,7 +16,7 @@ struct VertexOutput {
 
 @vertex
 fn main_vertex(in: VertexInput, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = common__globals.global_matrix * (transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0));
     let color = saturate(in.color * transforms[instanceIndex].mult_color + transforms[instanceIndex].add_color);
     return VertexOutput(pos, vec4<f32>(color.rgb * color.a, color.a));
 }

--- a/render/wgpu/shaders/copy.wgsl
+++ b/render/wgpu/shaders/copy.wgsl
@@ -7,13 +7,12 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
 @group(2) @binding(0) var texture: texture_2d<f32>;
 @group(2) @binding(1) var texture_sampler: sampler;
 
 @vertex
 fn main_vertex(in: common__VertexInputUv) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = vec4<f32>((in.position.x * 2.0) - 1.0, -(in.position.y * 2.0) + 1.0, 0.0, 1.0);
     return VertexOutput(pos, in.uv.xy / in.uv.z);
 }
 

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -3,6 +3,8 @@
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,
+    @location(1) mult_color: vec4<f32>,
+    @location(2) add_color: vec4<f32>,
 };
 
 @group(1) @binding(0) var<uniform> transforms: common__Transforms;
@@ -21,7 +23,7 @@ struct Gradient {
 @vertex
 fn main_vertex(in: common__VertexInputUv) -> VertexOutput {
     let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
-    return VertexOutput(pos, in.uv.xy / in.uv.z);
+    return VertexOutput(pos, in.uv.xy / in.uv.z, transforms.mult_color, transforms.add_color);
 }
 
 fn find_t(uv: vec2<f32>) -> f32 {
@@ -68,7 +70,7 @@ fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     if (gradient.interpolation != 0) {
         color = common__linear_to_srgb(color);
     }
-    let out = saturate(color * transforms.mult_color + transforms.add_color);
+    let out = saturate(color * in.mult_color + in.add_color);
     let alpha = saturate(out.a);
     return vec4<f32>(out.rgb * alpha, alpha);
 }

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -7,7 +7,7 @@ struct VertexOutput {
     @location(2) add_color: vec4<f32>,
 };
 
-@group(1) @binding(0) var<uniform> transforms: common__Transforms;
+@group(1) @binding(0) var<uniform> transforms: array<common__Transforms, max_transforms>;
 
 struct Gradient {
     focal_point: f32,
@@ -21,9 +21,9 @@ struct Gradient {
 @group(2) @binding(2) var texture_sampler: sampler;
 
 @vertex
-fn main_vertex(in: common__VertexInputUv) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
-    return VertexOutput(pos, in.uv.xy / in.uv.z, transforms.mult_color, transforms.add_color);
+fn main_vertex(in: common__VertexInputUv, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
+    let pos = common__globals.global_matrix * transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    return VertexOutput(pos, in.uv.xy / in.uv.z, transforms[instanceIndex].mult_color, transforms[instanceIndex].add_color);
 }
 
 fn find_t(uv: vec2<f32>) -> f32 {

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -22,7 +22,7 @@ struct Gradient {
 
 @vertex
 fn main_vertex(in: common__VertexInputUv, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
-    let pos = common__globals.global_matrix * transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let pos = common__globals.global_matrix * (transforms[instanceIndex].world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0));
     return VertexOutput(pos, in.uv.xy / in.uv.z, transforms[instanceIndex].mult_color, transforms[instanceIndex].add_color);
 }
 

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -295,9 +295,12 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                 .tessellate_shape_with_scale(shape, bitmap_source, scale);
 
         let mut draws = Vec::with_capacity(lyon_mesh.draws.len());
-        let mut uniform_buffer = BufferBuilder::new_for_uniform(&self.descriptors.limits);
-        let mut vertex_buffer = BufferBuilder::new_for_vertices(&self.descriptors.limits);
-        let mut index_buffer = BufferBuilder::new_for_vertices(&self.descriptors.limits);
+        let mut uniform_buffer = BufferBuilder::new(
+            &self.descriptors.limits,
+            self.descriptors.limits.min_uniform_buffer_offset_alignment,
+        );
+        let mut vertex_buffer = BufferBuilder::new(&self.descriptors.limits, 0);
+        let mut index_buffer = BufferBuilder::new(&self.descriptors.limits, 0);
         let mut gradients = Vec::with_capacity(lyon_mesh.gradients.len());
 
         for gradient in lyon_mesh.gradients {

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -629,7 +629,6 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                     texture.texture.format(),
                     &texture.texture.create_view(&Default::default()),
                     target.color_view(),
-                    target.whole_frame_bind_group(&self.descriptors),
                     target.globals(),
                     target.color_texture().sample_count(),
                     &mut scope.scope("Copy filtered to CAB"),

--- a/render/wgpu/src/buffer_builder.rs
+++ b/render/wgpu/src/buffer_builder.rs
@@ -17,6 +17,7 @@ impl BufferBuilder {
         Self {
             inner: Vec::new(),
             align_mask: if alignment > 0 {
+                assert!(alignment.is_power_of_two());
                 (alignment - 1) as usize
             } else {
                 0

--- a/render/wgpu/src/buffer_builder.rs
+++ b/render/wgpu/src/buffer_builder.rs
@@ -13,19 +13,11 @@ pub struct BufferBuilder {
 pub struct BufferFull;
 
 impl BufferBuilder {
-    pub fn new_for_vertices(limits: &wgpu::Limits) -> Self {
+    pub fn new(limits: &wgpu::Limits, alignment: u32) -> Self {
         Self {
             inner: Vec::new(),
-            align_mask: 0,
-            limit: limits.max_buffer_size,
-        }
-    }
-
-    pub fn new_for_uniform(limits: &wgpu::Limits) -> Self {
-        Self {
-            inner: Vec::new(),
-            align_mask: if limits.min_uniform_buffer_offset_alignment > 0 {
-                (limits.min_uniform_buffer_offset_alignment - 1) as usize
+            align_mask: if alignment > 0 {
+                (alignment - 1) as usize
             } else {
                 0
             },

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -83,7 +83,7 @@ impl Descriptors {
                             label: create_debug_label!("Copy pipeline layout").as_deref(),
                             bind_group_layouts: &[
                                 Some(&self.bind_layouts.globals),
-                                Some(&self.bind_layouts.transforms),
+                                None,
                                 Some(&self.bind_layouts.bitmap),
                             ],
                             immediate_size: 0,

--- a/render/wgpu/src/dynamic_transforms.rs
+++ b/render/wgpu/src/dynamic_transforms.rs
@@ -25,7 +25,7 @@ impl DynamicTransforms {
         });
         let vertex_buffer = descriptors.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
-            size: (mem::size_of::<PosUvVertex>() as u64 * ESTIMATED_OBJECTS_PER_CHUNK)
+            size: (mem::size_of::<PosUvVertex>() as u64 * 4 * ESTIMATED_OBJECTS_PER_CHUNK)
                 .min(descriptors.limits.max_buffer_size),
             usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,

--- a/render/wgpu/src/dynamic_transforms.rs
+++ b/render/wgpu/src/dynamic_transforms.rs
@@ -10,13 +10,16 @@ pub struct DynamicTransforms {
     pub bind_group: wgpu::BindGroup,
 }
 
+pub fn transforms_per_draw(limits: &wgpu::Limits) -> u64 {
+    let maximum = limits.max_uniform_buffer_binding_size / size_of::<Transforms>() as u64;
+    maximum.min(ESTIMATED_OBJECTS_PER_CHUNK)
+}
+
 impl DynamicTransforms {
     pub fn new(descriptors: &Descriptors) -> Self {
         let buffer = descriptors.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
-            size: (mem::size_of::<Transforms>() as u64 * ESTIMATED_OBJECTS_PER_CHUNK)
-                .min(descriptors.limits.max_uniform_buffer_binding_size)
-                .min(descriptors.limits.max_buffer_size),
+            size: transforms_per_draw(&descriptors.limits) * size_of::<Transforms>() as u64,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -34,11 +37,7 @@ impl DynamicTransforms {
                 layout: &descriptors.bind_layouts.transforms,
                 entries: &[wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                        buffer: &buffer,
-                        offset: 0,
-                        size: wgpu::BufferSize::new(mem::size_of::<Transforms>() as u64),
-                    }),
+                    resource: buffer.as_entire_binding(),
                 }],
             });
         Self {

--- a/render/wgpu/src/layouts.rs
+++ b/render/wgpu/src/layouts.rs
@@ -17,7 +17,7 @@ impl BindLayouts {
         let transforms = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                visibility: wgpu::ShaderStages::VERTEX,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: true,

--- a/render/wgpu/src/layouts.rs
+++ b/render/wgpu/src/layouts.rs
@@ -1,3 +1,4 @@
+use crate::dynamic_transforms::transforms_per_draw;
 use crate::globals::GlobalsUniform;
 use crate::{GradientUniforms, Transforms};
 
@@ -20,9 +21,9 @@ impl BindLayouts {
                 visibility: wgpu::ShaderStages::VERTEX,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: true,
+                    has_dynamic_offset: false,
                     min_binding_size: wgpu::BufferSize::new(
-                        std::mem::size_of::<Transforms>() as u64
+                        transforms_per_draw(&device.limits()) * size_of::<Transforms>() as u64,
                     ),
                 },
                 count: None,

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -137,11 +137,8 @@ impl Pipelines {
             PrimitiveTopology::TriangleList,
         );
 
-        let complex_blend_bindings = vec![
-            Some(&bind_layouts.globals),
-            Some(&bind_layouts.transforms),
-            Some(&bind_layouts.blend),
-        ];
+        let complex_blend_bindings =
+            vec![Some(&bind_layouts.globals), None, Some(&bind_layouts.blend)];
 
         let complex_blend_pipelines = enum_map! {
             blend => create_shape_pipeline(

--- a/render/wgpu/src/shaders.rs
+++ b/render/wgpu/src/shaders.rs
@@ -1,4 +1,5 @@
 use crate::blend::ComplexBlend;
+use crate::dynamic_transforms::transforms_per_draw;
 use enum_map::{EnumMap, enum_map};
 use ruffle_render::shader_source::SHADER_FILTER_COMMON;
 
@@ -25,13 +26,25 @@ pub struct Shaders {
 
 impl Shaders {
     pub fn new(device: &wgpu::Device) -> Self {
-        let color_shader = make_shader(device, "color.wgsl", include_str!("../shaders/color.wgsl"));
+        let max_transforms = transforms_per_draw(&device.limits());
+        let color_shader = make_shader(
+            device,
+            "color.wgsl",
+            include_str!("../shaders/color.wgsl"),
+            max_transforms,
+        );
         let bitmap_shader = make_shader(
             device,
             "bitmap.wgsl",
             include_str!("../shaders/bitmap.wgsl"),
+            max_transforms,
         );
-        let copy_shader = make_shader(device, "copy.wgsl", include_str!("../shaders/copy.wgsl"));
+        let copy_shader = make_shader(
+            device,
+            "copy.wgsl",
+            include_str!("../shaders/copy.wgsl"),
+            max_transforms,
+        );
         let color_matrix_filter = make_filter_shader(
             device,
             "filter/color_matrix.wgsl",
@@ -61,23 +74,25 @@ impl Shaders {
             device,
             "gradient.wgsl",
             include_str!("../shaders/gradient.wgsl"),
+            max_transforms,
         );
         let alpha_mask_shader = make_shader(
             device,
             "alpha_mask.wgsl",
             include_str!("../shaders/alpha_mask.wgsl"),
+            max_transforms,
         );
 
         let blend_shaders = enum_map! {
-            ComplexBlend::Multiply => make_shader(device, "blend/multiply.wgsl", include_str!("../shaders/blend/multiply.wgsl")),
-            ComplexBlend::Lighten => make_shader(device, "blend/lighten.wgsl", include_str!("../shaders/blend/lighten.wgsl")),
-            ComplexBlend::Darken => make_shader(device, "blend/darken.wgsl", include_str!("../shaders/blend/darken.wgsl")),
-            ComplexBlend::Difference => make_shader(device, "blend/difference.wgsl", include_str!("../shaders/blend/difference.wgsl")),
-            ComplexBlend::Invert => make_shader(device, "blend/invert.wgsl", include_str!("../shaders/blend/invert.wgsl")),
-            ComplexBlend::Alpha => make_shader(device, "blend/alpha.wgsl", include_str!("../shaders/blend/alpha.wgsl")),
-            ComplexBlend::Erase => make_shader(device, "blend/erase.wgsl", include_str!("../shaders/blend/erase.wgsl")),
-            ComplexBlend::Overlay => make_shader(device, "blend/overlay.wgsl", include_str!("../shaders/blend/overlay.wgsl")),
-            ComplexBlend::HardLight => make_shader(device, "blend/hardlight.wgsl", include_str!("../shaders/blend/hardlight.wgsl")),
+            ComplexBlend::Multiply => make_shader(device, "blend/multiply.wgsl", include_str!("../shaders/blend/multiply.wgsl"), max_transforms),
+            ComplexBlend::Lighten => make_shader(device, "blend/lighten.wgsl", include_str!("../shaders/blend/lighten.wgsl"), max_transforms),
+            ComplexBlend::Darken => make_shader(device, "blend/darken.wgsl", include_str!("../shaders/blend/darken.wgsl"), max_transforms),
+            ComplexBlend::Difference => make_shader(device, "blend/difference.wgsl", include_str!("../shaders/blend/difference.wgsl"), max_transforms),
+            ComplexBlend::Invert => make_shader(device, "blend/invert.wgsl", include_str!("../shaders/blend/invert.wgsl"), max_transforms),
+            ComplexBlend::Alpha => make_shader(device, "blend/alpha.wgsl", include_str!("../shaders/blend/alpha.wgsl"), max_transforms),
+            ComplexBlend::Erase => make_shader(device, "blend/erase.wgsl", include_str!("../shaders/blend/erase.wgsl"), max_transforms),
+            ComplexBlend::Overlay => make_shader(device, "blend/overlay.wgsl", include_str!("../shaders/blend/overlay.wgsl"), max_transforms),
+            ComplexBlend::HardLight => make_shader(device, "blend/hardlight.wgsl", include_str!("../shaders/blend/hardlight.wgsl"), max_transforms),
         };
 
         Self {
@@ -96,11 +111,18 @@ impl Shaders {
     }
 }
 
-fn make_shader(device: &wgpu::Device, name: &str, source: &str) -> wgpu::ShaderModule {
+fn make_shader(
+    device: &wgpu::Device,
+    name: &str,
+    source: &str,
+    max_transforms: u64,
+) -> wgpu::ShaderModule {
     let common = include_str!("../shaders/common.wgsl");
     device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: create_debug_label!("Shader {name}").as_deref(),
-        source: wgpu::ShaderSource::Wgsl(format!("{common}\n{source}").into()),
+        source: wgpu::ShaderSource::Wgsl(
+            format!("{common}\nconst max_transforms = {max_transforms};\n{source}").into(),
+        ),
     })
 }
 fn make_filter_shader(device: &wgpu::Device, name: &str, source: &str) -> wgpu::ShaderModule {

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -177,10 +177,11 @@ impl Surface {
                         },
                     );
                     render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
+                    render_pass.set_bind_group(1, &dynamic_transforms.bind_group, &[]);
                     let mut renderer = CommandRenderer::new(
                         &self.pipelines,
                         descriptors,
-                        dynamic_transforms,
+                        &dynamic_transforms.vertex_buffer,
                         num_masks,
                         mask_state,
                         needs_stencil,

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -332,7 +332,6 @@ impl Surface {
                         );
                     }
 
-                    render_pass.set_bind_group(1, target.whole_frame_bind_group(descriptors), &[0]);
                     render_pass.set_bind_group(2, &blend_bind_group, &[]);
 
                     render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos.slice(..));

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -94,7 +94,6 @@ impl Surface {
             self.format,
             frame_view,
             target.color_view(),
-            target.whole_frame_bind_group(descriptors),
             target.globals(),
             1,
             draw_encoder,

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -28,7 +28,7 @@ pub struct CommandRenderer<'encoder> {
     num_masks: u32,
     mask_state: MaskState,
     needs_stencil: bool,
-    dynamic_transforms: &'encoder DynamicTransforms,
+    dynamic_vertex_buffer: &'encoder wgpu::Buffer,
 }
 
 impl<'encoder> CommandRenderer<'encoder> {
@@ -36,7 +36,7 @@ impl<'encoder> CommandRenderer<'encoder> {
     pub fn new(
         pipelines: &'encoder Pipelines,
         descriptors: &'encoder Descriptors,
-        dynamic_transforms: &'encoder DynamicTransforms,
+        dynamic_vertex_buffer: &'encoder wgpu::Buffer,
         num_masks: u32,
         mask_state: MaskState,
         needs_stencil: bool,
@@ -47,7 +47,7 @@ impl<'encoder> CommandRenderer<'encoder> {
             mask_state,
             descriptors,
             needs_stencil,
-            dynamic_transforms,
+            dynamic_vertex_buffer,
         }
     }
 
@@ -227,10 +227,9 @@ impl<'encoder> CommandRenderer<'encoder> {
             &descriptors.bitmap_samplers,
         );
         self.prep_bitmap(render_pass, &bind.bind_group, blend_mode, render_stage3d);
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
         let vertex_slice = if let Some(vertex_offset) = vertex_offset {
-            self.dynamic_transforms.vertex_buffer.slice(vertex_offset..)
+            self.dynamic_vertex_buffer.slice(vertex_offset..)
         } else {
             self.descriptors.quad.vertices_pos_uv.slice(..)
         };
@@ -252,8 +251,6 @@ impl<'encoder> CommandRenderer<'encoder> {
         blend_mode: TrivialBlend,
     ) {
         self.prep_bitmap(render_pass, bind_group, blend_mode, false);
-
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
         self.draw(
             render_pass,
@@ -295,7 +292,6 @@ impl<'encoder> CommandRenderer<'encoder> {
                     self.prep_bitmap(render_pass, &binds.bind_group, TrivialBlend::Normal, false);
                 }
             }
-            render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
             self.draw(
                 render_pass,
@@ -321,8 +317,6 @@ impl<'encoder> CommandRenderer<'encoder> {
 
         self.prep_alpha_mask(render_pass, bind_group);
 
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
-
         self.draw(
             render_pass,
             self.descriptors.quad.vertices_pos.slice(..),
@@ -339,8 +333,6 @@ impl<'encoder> CommandRenderer<'encoder> {
     pub fn draw_rect(&self, render_pass: &mut wgpu::RenderPass<'encoder>, instance_index: u32) {
         self.prep_color(render_pass);
 
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
-
         self.draw(
             render_pass,
             self.descriptors.quad.vertices_pos_color.slice(..),
@@ -356,8 +348,6 @@ impl<'encoder> CommandRenderer<'encoder> {
         instance_index: u32,
     ) {
         self.prep_lines(render_pass);
-
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
         self.draw(
             render_pass,

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -74,7 +74,7 @@ impl<'encoder> CommandRenderer<'encoder> {
         match command {
             DrawCommand::RenderBitmap {
                 bitmap,
-                transform_buffer,
+                instance_index,
                 vertex_offset,
                 smoothing,
                 blend_mode,
@@ -82,7 +82,7 @@ impl<'encoder> CommandRenderer<'encoder> {
             } => self.render_bitmap(
                 render_pass,
                 bitmap,
-                *transform_buffer,
+                *instance_index,
                 *smoothing,
                 *blend_mode,
                 *render_stage3d,
@@ -91,21 +91,21 @@ impl<'encoder> CommandRenderer<'encoder> {
             DrawCommand::RenderTexture {
                 _texture,
                 binds,
-                transform_buffer,
+                instance_index,
                 blend_mode,
-            } => self.render_texture(render_pass, *transform_buffer, binds, *blend_mode),
+            } => self.render_texture(render_pass, *instance_index, binds, *blend_mode),
             DrawCommand::RenderShape {
                 shape,
-                transform_buffer,
-            } => self.render_shape(render_pass, shape, *transform_buffer),
-            DrawCommand::DrawRect { transform_buffer } => {
-                self.draw_rect(render_pass, *transform_buffer)
+                instance_index,
+            } => self.render_shape(render_pass, shape, *instance_index),
+            DrawCommand::DrawRect { instance_index } => {
+                self.draw_rect(render_pass, *instance_index)
             }
-            DrawCommand::DrawLine { transform_buffer } => {
-                self.draw_lines::<false>(render_pass, *transform_buffer)
+            DrawCommand::DrawLine { instance_index } => {
+                self.draw_lines::<false>(render_pass, *instance_index)
             }
-            DrawCommand::DrawLineRect { transform_buffer } => {
-                self.draw_lines::<true>(render_pass, *transform_buffer)
+            DrawCommand::DrawLineRect { instance_index } => {
+                self.draw_lines::<true>(render_pass, *instance_index)
             }
             DrawCommand::PushMask => self.push_mask(render_pass),
             DrawCommand::ActivateMask => self.activate_mask(render_pass),
@@ -115,8 +115,8 @@ impl<'encoder> CommandRenderer<'encoder> {
                 maskee,
                 mask,
                 binds,
-                transform_buffer,
-            } => self.render_alpha_mask(render_pass, maskee, mask, binds, *transform_buffer),
+                instance_index,
+            } => self.render_alpha_mask(render_pass, maskee, mask, binds, *instance_index),
         }
     }
 
@@ -196,11 +196,12 @@ impl<'encoder> CommandRenderer<'encoder> {
         vertices: wgpu::BufferSlice<'encoder>,
         indices: wgpu::BufferSlice<'encoder>,
         num_indices: u32,
+        instance_index: u32,
     ) {
         render_pass.set_vertex_buffer(0, vertices);
         render_pass.set_index_buffer(indices, wgpu::IndexFormat::Uint32);
 
-        render_pass.draw_indexed(0..num_indices, 0, 0..1);
+        render_pass.draw_indexed(0..num_indices, 0, instance_index..(instance_index + 1));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -208,7 +209,7 @@ impl<'encoder> CommandRenderer<'encoder> {
         &self,
         render_pass: &mut wgpu::RenderPass<'encoder>,
         bitmap: &'encoder BitmapHandle,
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
         smoothing: bool,
         blend_mode: TrivialBlend,
         render_stage3d: bool,
@@ -226,7 +227,7 @@ impl<'encoder> CommandRenderer<'encoder> {
             &descriptors.bitmap_samplers,
         );
         self.prep_bitmap(render_pass, &bind.bind_group, blend_mode, render_stage3d);
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
         let vertex_slice = if let Some(vertex_offset) = vertex_offset {
             self.dynamic_transforms.vertex_buffer.slice(vertex_offset..)
@@ -239,25 +240,27 @@ impl<'encoder> CommandRenderer<'encoder> {
             vertex_slice,
             self.descriptors.quad.indices.slice(..),
             6,
+            instance_index,
         );
     }
 
     pub fn render_texture(
         &self,
         render_pass: &mut wgpu::RenderPass<'encoder>,
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
         bind_group: &'encoder wgpu::BindGroup,
         blend_mode: TrivialBlend,
     ) {
         self.prep_bitmap(render_pass, bind_group, blend_mode, false);
 
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
         self.draw(
             render_pass,
             self.descriptors.quad.vertices_pos_uv.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
+            instance_index,
         );
     }
 
@@ -265,7 +268,7 @@ impl<'encoder> CommandRenderer<'encoder> {
         &self,
         render_pass: &mut wgpu::RenderPass<'encoder>,
         shape: &'encoder ShapeHandle,
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
     ) {
         let mesh = as_mesh(shape);
         for draw in &mesh.draws {
@@ -292,13 +295,14 @@ impl<'encoder> CommandRenderer<'encoder> {
                     self.prep_bitmap(render_pass, &binds.bind_group, TrivialBlend::Normal, false);
                 }
             }
-            render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
+            render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
             self.draw(
                 render_pass,
                 mesh.vertex_buffer.slice(draw.vertices.clone()),
                 mesh.index_buffer.slice(draw.indices.clone()),
                 num_indices,
+                instance_index,
             );
         }
     }
@@ -309,7 +313,7 @@ impl<'encoder> CommandRenderer<'encoder> {
         _maskee: &PoolOrArcTexture,
         _mask: &PoolOrArcTexture,
         bind_group: &'encoder wgpu::BindGroup,
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
     ) {
         if cfg!(feature = "render_debug_labels") {
             render_pass.push_debug_group("render_alpha_mask");
@@ -317,13 +321,14 @@ impl<'encoder> CommandRenderer<'encoder> {
 
         self.prep_alpha_mask(render_pass, bind_group);
 
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
         self.draw(
             render_pass,
             self.descriptors.quad.vertices_pos.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
+            instance_index,
         );
 
         if cfg!(feature = "render_debug_labels") {
@@ -331,31 +336,28 @@ impl<'encoder> CommandRenderer<'encoder> {
         }
     }
 
-    pub fn draw_rect(
-        &self,
-        render_pass: &mut wgpu::RenderPass<'encoder>,
-        transform_buffer: wgpu::DynamicOffset,
-    ) {
+    pub fn draw_rect(&self, render_pass: &mut wgpu::RenderPass<'encoder>, instance_index: u32) {
         self.prep_color(render_pass);
 
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
         self.draw(
             render_pass,
             self.descriptors.quad.vertices_pos_color.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
+            instance_index,
         );
     }
 
     pub fn draw_lines<const RECT: bool>(
         &self,
         render_pass: &mut wgpu::RenderPass<'encoder>,
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
     ) {
         self.prep_lines(render_pass);
 
-        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[transform_buffer]);
+        render_pass.set_bind_group(1, &self.dynamic_transforms.bind_group, &[]);
 
         self.draw(
             render_pass,
@@ -366,6 +368,7 @@ impl<'encoder> CommandRenderer<'encoder> {
                 self.descriptors.quad.indices_line.slice(..)
             },
             if RECT { 5 } else { 2 },
+            instance_index,
         );
     }
 
@@ -434,7 +437,7 @@ pub enum ChunkBlendMode {
 pub enum DrawCommand {
     RenderBitmap {
         bitmap: BitmapHandle,
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
         vertex_offset: Option<wgpu::BufferAddress>,
         smoothing: bool,
         blend_mode: TrivialBlend,
@@ -443,27 +446,27 @@ pub enum DrawCommand {
     RenderTexture {
         _texture: PoolOrArcTexture,
         binds: wgpu::BindGroup,
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
         blend_mode: TrivialBlend,
     },
     RenderAlphaMask {
         maskee: PoolOrArcTexture,
         mask: PoolOrArcTexture,
         binds: wgpu::BindGroup,
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
     },
     RenderShape {
         shape: ShapeHandle,
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
     },
     DrawRect {
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
     },
     DrawLine {
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
     },
     DrawLineRect {
-        transform_buffer: wgpu::DynamicOffset,
+        instance_index: u32,
     },
     PushMask,
     ActivateMask,
@@ -596,10 +599,7 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
         descriptors: &'encoder Descriptors,
         dynamic_transforms: &'encoder DynamicTransforms,
     ) -> BufferBuilder {
-        let mut transforms = BufferBuilder::new(
-            &descriptors.limits,
-            descriptors.limits.min_uniform_buffer_offset_alignment,
-        );
+        let mut transforms = BufferBuilder::new(&descriptors.limits, 0);
         transforms.set_buffer_limit(dynamic_transforms.buffer.size());
         transforms
     }
@@ -647,15 +647,11 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
         matrix: Matrix,
         tz: f64,
         color_transform: ColorTransform,
-        command_builder: impl FnOnce(wgpu::DynamicOffset) -> DrawCommand,
+        command_builder: impl FnOnce(u32) -> DrawCommand,
     ) {
-        self.add_to_current_with_vertices(
-            matrix,
-            tz,
-            color_transform,
-            None,
-            |transform_buffer, _| command_builder(transform_buffer),
-        )
+        self.add_to_current_with_vertices(matrix, tz, color_transform, None, |instance_index, _| {
+            command_builder(instance_index)
+        })
     }
 
     fn add_to_current_with_vertices(
@@ -664,7 +660,7 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
         tz: f64,
         color_transform: ColorTransform,
         vertices: Option<&[PosUvVertex]>,
-        command_builder: impl FnOnce(wgpu::DynamicOffset, Option<wgpu::BufferAddress>) -> DrawCommand,
+        command_builder: impl FnOnce(u32, Option<wgpu::BufferAddress>) -> DrawCommand,
     ) {
         let transform = Transforms {
             world_matrix: [
@@ -686,7 +682,7 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
             vertices.map(|v| self.vertices.add(v)).transpose(),
         ) {
             self.current.push(command_builder(
-                transform_range.start as wgpu::DynamicOffset,
+                (transform_range.start as usize / size_of::<Transforms>()) as u32,
                 vertices_range.map(|v| v.start),
             ));
         } else {
@@ -712,7 +708,7 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
                     .expect("Buffer must be able to fit a new thing, it was just emptied")
             });
             self.current.push(command_builder(
-                transform_range.start as wgpu::DynamicOffset,
+                (transform_range.start as usize / size_of::<Transforms>()) as u32,
                 vertices_range.map(|v| v.start),
             ));
         }
@@ -792,10 +788,10 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
                     transform.matrix,
                     transform.tz,
                     transform.color_transform,
-                    |transform_buffer| DrawCommand::RenderTexture {
+                    |instance_index| DrawCommand::RenderTexture {
                         _texture: texture,
                         binds: bind_group,
-                        transform_buffer,
+                        instance_index,
                         blend_mode,
                     },
                 );
@@ -864,9 +860,9 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
             transform.tz,
             transform.color_transform,
             Some(vertices),
-            |transform_buffer, vertex_offset| DrawCommand::RenderBitmap {
+            |instance_index, vertex_offset| DrawCommand::RenderBitmap {
                 bitmap,
-                transform_buffer,
+                instance_index,
                 vertex_offset,
                 smoothing,
                 blend_mode: TrivialBlend::Normal,
@@ -888,9 +884,9 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
             matrix,
             transform.tz,
             transform.color_transform,
-            |transform_buffer| DrawCommand::RenderBitmap {
+            |instance_index| DrawCommand::RenderBitmap {
                 bitmap,
-                transform_buffer,
+                instance_index,
                 vertex_offset: None,
                 smoothing: false,
                 blend_mode: TrivialBlend::Normal,
@@ -904,9 +900,9 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
             transform.matrix,
             transform.tz,
             transform.color_transform,
-            |transform_buffer| DrawCommand::RenderShape {
+            |instance_index| DrawCommand::RenderShape {
                 shape,
-                transform_buffer,
+                instance_index,
             },
         );
     }
@@ -916,7 +912,7 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
             matrix,
             0.0,
             ColorTransform::multiply_from(color),
-            |transform_buffer| DrawCommand::DrawRect { transform_buffer },
+            |instance_index| DrawCommand::DrawRect { instance_index },
         );
     }
 
@@ -932,7 +928,7 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
                 matrix,
                 0.0,
                 ColorTransform::multiply_from(color),
-                |transform_buffer| DrawCommand::DrawLine { transform_buffer },
+                |instance_index| DrawCommand::DrawLine { instance_index },
             );
         }
     }
@@ -949,7 +945,7 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
                 matrix,
                 0.0,
                 ColorTransform::multiply_from(color),
-                |transform_buffer| DrawCommand::DrawLineRect { transform_buffer },
+                |instance_index| DrawCommand::DrawLineRect { instance_index },
             );
         }
     }
@@ -1038,12 +1034,12 @@ impl CommandHandler for WgpuCommandHandler<'_, '_> {
                 label: None,
             });
 
-        self.add_to_current(matrix, 0.0, Default::default(), |transform_buffer| {
+        self.add_to_current(matrix, 0.0, Default::default(), |instance_index| {
             DrawCommand::RenderAlphaMask {
                 maskee,
                 mask,
                 binds,
-                transform_buffer,
+                instance_index,
             }
         });
     }

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -596,7 +596,10 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
         descriptors: &'encoder Descriptors,
         dynamic_transforms: &'encoder DynamicTransforms,
     ) -> BufferBuilder {
-        let mut transforms = BufferBuilder::new_for_uniform(&descriptors.limits);
+        let mut transforms = BufferBuilder::new(
+            &descriptors.limits,
+            descriptors.limits.min_uniform_buffer_offset_alignment,
+        );
         transforms.set_buffer_limit(dynamic_transforms.buffer.size());
         transforms
     }
@@ -605,7 +608,7 @@ impl<'encoder, 'global: 'encoder> WgpuCommandHandler<'encoder, 'global> {
         descriptors: &'encoder Descriptors,
         dynamic_transforms: &'encoder DynamicTransforms,
     ) -> BufferBuilder {
-        let mut vertices = BufferBuilder::new_for_vertices(&descriptors.limits);
+        let mut vertices = BufferBuilder::new(&descriptors.limits, 0);
         vertices.set_buffer_limit(dynamic_transforms.vertex_buffer.size());
         vertices
     }

--- a/render/wgpu/src/surface/target.rs
+++ b/render/wgpu/src/surface/target.rs
@@ -1,9 +1,7 @@
-use crate::Transforms;
 use crate::backend::RenderTargetMode;
 use crate::buffer_pool::{AlwaysCompatible, PoolEntry, TexturePool};
 use crate::descriptors::Descriptors;
 use crate::globals::Globals;
-use crate::utils::create_buffer_with_data;
 use crate::utils::run_copy_pipeline;
 use std::cell::OnceCell;
 use std::sync::Arc;
@@ -200,7 +198,6 @@ pub struct CommandTarget {
     size: wgpu::Extent3d,
     format: wgpu::TextureFormat,
     sample_count: u32,
-    whole_frame_bind_group: OnceCell<(wgpu::Buffer, wgpu::BindGroup)>,
     color_needs_clear: OnceCell<bool>,
     render_target_mode: RenderTargetMode,
 }
@@ -234,8 +231,6 @@ impl CommandTarget {
                 pool,
             )
         };
-
-        let whole_frame_bind_group = OnceCell::new();
 
         let (frame_buffer, resolve_buffer) =
             if let RenderTargetMode::ExistingWithColor(texture, _) = &render_target_mode {
@@ -309,7 +304,6 @@ impl CommandTarget {
             size,
             format,
             sample_count,
-            whole_frame_bind_group,
             color_needs_clear: OnceCell::new(),
             render_target_mode,
         }
@@ -346,10 +340,6 @@ impl CommandTarget {
 
     pub fn globals(&self) -> &Globals {
         &self.globals
-    }
-
-    pub fn whole_frame_bind_group(&self, descriptors: &Descriptors) -> &wgpu::BindGroup {
-        get_whole_frame_bind_group(&self.whole_frame_bind_group, descriptors, self.size)
     }
 
     pub fn color_attachments(&self) -> Option<wgpu::RenderPassColorAttachment<'_>> {
@@ -450,43 +440,4 @@ impl CommandTarget {
             .map(|b| b.texture())
             .unwrap_or_else(|| self.frame_buffer.texture())
     }
-}
-
-fn get_whole_frame_bind_group<'a>(
-    once_cell: &'a OnceCell<(wgpu::Buffer, wgpu::BindGroup)>,
-    descriptors: &Descriptors,
-    size: wgpu::Extent3d,
-) -> &'a wgpu::BindGroup {
-    &once_cell
-        .get_or_init(|| {
-            let transform = Transforms {
-                world_matrix: [
-                    [size.width as f32, 0.0, 0.0, 0.0],
-                    [0.0, size.height as f32, 0.0, 0.0],
-                    [0.0, 0.0, 1.0, 0.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ],
-                mult_color: [1.0, 1.0, 1.0, 1.0],
-                add_color: [0.0, 0.0, 0.0, 0.0],
-            };
-            let transforms_buffer = create_buffer_with_data(
-                &descriptors.device,
-                bytemuck::cast_slice(&[transform]),
-                wgpu::BufferUsages::UNIFORM,
-                create_debug_label!("Whole-frame transforms buffer"),
-            );
-            let whole_frame_bind_group =
-                descriptors
-                    .device
-                    .create_bind_group(&wgpu::BindGroupDescriptor {
-                        layout: &descriptors.bind_layouts.transforms,
-                        entries: &[wgpu::BindGroupEntry {
-                            binding: 0,
-                            resource: transforms_buffer.as_entire_binding(),
-                        }],
-                        label: create_debug_label!("Whole-frame transforms bind group").as_deref(),
-                    });
-            (transforms_buffer, whole_frame_bind_group)
-        })
-        .1
 }

--- a/render/wgpu/src/surface/target.rs
+++ b/render/wgpu/src/surface/target.rs
@@ -287,7 +287,6 @@ impl CommandTarget {
                     format,
                     frame_buffer.texture.view(),
                     &texture.create_view(&Default::default()),
-                    get_whole_frame_bind_group(&whole_frame_bind_group, descriptors, size),
                     &globals,
                     sample_count,
                     encoder,

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -196,13 +196,11 @@ pub fn supported_sample_count(
     sample_count
 }
 
-#[expect(clippy::too_many_arguments)]
 pub fn run_copy_pipeline(
     descriptors: &Descriptors,
     format: wgpu::TextureFormat,
     frame_view: &wgpu::TextureView,
     input: &wgpu::TextureView,
-    whole_frame_bind_group: &wgpu::BindGroup,
     globals: &Globals,
     sample_count: u32,
     encoder: &mut CommandEncoder,
@@ -249,7 +247,6 @@ pub fn run_copy_pipeline(
     render_pass.set_pipeline(&pipeline);
     render_pass.set_bind_group(0, globals.bind_group(), &[]);
 
-    render_pass.set_bind_group(1, whole_frame_bind_group, &[0]);
     render_pass.set_bind_group(2, &copy_bind_group, &[]);
 
     render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos_uv.slice(..));


### PR DESCRIPTION
## Description

With dynamic buffer offsets, every offset must be aligned to `min_uniform_buffer_offset_alignment` - effectively 256, especially on web. This turns 96 bytes into 256 bytes, more than doubling our required memory per draw call. For real numbers - we have "200 objects per chunk of draw calls", so this turns "one chunk of draw calls" from 51kb of memory down to 19kb.

Using a large array that's fixed in size but indexed via instanceid, we don't need to be subjected to alignment rules and we save all that memory. Bonus points for not needing to constantly rebind the buffer every single draw, that should help remove some overhead on web too (and will be helpful for later trying to combine N draw calls into a single draw).

Could not measure any performance impact on desktop but web is where the real savings should be, especially in terms of memory.

## Testing

I've tested it manually but further testing, especially on heavier content or weaker devices, would be very appreciated.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [X] All of my commits are properly scoped, compile successfully, and pass all tests.
- [X] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
