### PR TITLE
desktop: Fix 32-bit builds with freetype

### DIFF
--- a/frontend-utils/src/backends/ui/freetype_font_renderer.rs
+++ b/frontend-utils/src/backends/ui/freetype_font_renderer.rs
@@ -169,7 +169,11 @@ impl FontRenderer for FreetypeFontRenderer {
 
 /// Converts a FreeType 26.6 fixed-point value (1/64th of a pixel) to Twips
 /// (1/20th of a pixel), rounding to the nearest twip.
-fn convert_26_6_to_twips(value_26_6: i64) -> Twips {
+///
+/// Note: the FreeType type differs between 64-bit and 32-bit architectures,
+/// hence the `Into<i64>`.
+fn convert_26_6_to_twips(value_26_6: impl Into<i64>) -> Twips {
+    let value_26_6 = value_26_6.into();
     let whole_pixels = (value_26_6 / 64) as i32;
 
     let fractional_twips = (value_26_6 % 64) as f64 / 64.0 * 20.0;


### PR DESCRIPTION
## Description

* Fixes https://github.com/ruffle-rs/ruffle/issues/24627

FreeType types differ between architectures, so take that into account.

## Testing

Covered by tests on 64-bit, untested on 32-bit.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [x] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
