### PR TITLE
avm2: Fix stub reporting for Error

### DIFF
--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -306,6 +306,33 @@ impl Definition {
             }
         }
 
+        // Some builtin classes (e.g. `Error`) construct their prototype as a typed
+        // instance of their own class, so that assignments like `prototype.name =
+        // "Error"` in the static initializer resolve through the VTable to a slot
+        // rather than the dynamic property map walked above. Walk those slots too,
+        // so such properties aren't misreported as unimplemented.
+        if prototype.instance_class() == i_class {
+            for class_trait in i_class.traits() {
+                if !class_trait.name().namespace().is_public() {
+                    continue;
+                }
+                if let TraitKind::Slot { default_value, .. } = class_trait.kind() {
+                    let trait_name = class_trait.name().local_name();
+                    if let Ok(current_value) =
+                        Value::from(prototype).get_public_property(trait_name, activation)
+                        && !current_value.strict_eq(default_value)
+                    {
+                        Self::add_prototype_value(
+                            trait_name,
+                            current_value,
+                            &mut definition.prototype,
+                            activation,
+                        );
+                    }
+                }
+            }
+        }
+
         Self::fill_traits(
             activation.avm2(),
             c_class.traits(),


### PR DESCRIPTION
## Description

Error.prototype is built as a typed Error instance rather than a plain dynamic object, so prototype.name/prototype.message resolve through the VTable to slots instead of dynamic properties. The specification generator only scanned dynamic properties, so these correctly implemented properties were falsely reported as missing.

## Testing

Diffing avm2_report.json before/after shows that those Error.prototype props are now reported as implemented.

## Checklist

<!-- Please check the lines that are applicable. You do not need to check every box to open a PR. -->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
