### PR TITLE
build(deps-dev): bump typescript from 5.9.3 to 6.0.3 in /web

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,7 +42,7 @@
                 "ts-loader": "^9.6.2",
                 "tsx": "^4.23.13",
                 "typedoc-plugin-mdn-links": "^5.1.1",
-                "typescript": "^5.9.3",
+                "typescript": "^6.0.3",
                 "typescript-eslint": "^8.69.0",
                 "webdriverio": "^9.31.7",
                 "webpack": "^5.110.3",
@@ -16141,9 +16141,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -17512,7 +17512,7 @@
                 "tsx": "^4.23.13",
                 "tsx-dom": "^3.1.0",
                 "typedoc": "^0.28.20",
-                "typescript": "^5.9.3"
+                "typescript": "^6.0.3"
             }
         },
         "packages/demo": {
@@ -17528,7 +17528,7 @@
                 "@types/react": "^19.2.18",
                 "@types/react-dom": "^19.2.7",
                 "@vitejs/plugin-react": "^6.1.1",
-                "typescript": "^5.9.3",
+                "typescript": "^6.0.3",
                 "vite": "^8.2.2"
             }
         },
@@ -17583,7 +17583,7 @@
                 "jsonwebtoken": "^9.0.3",
                 "ts-loader": "^9.6.2",
                 "tsx": "^4.23.13",
-                "typescript": "^5.9.3",
+                "typescript": "^6.0.3",
                 "webpack-cli": "^7.2.3"
             }
         },

--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,7 @@
         "ts-loader": "^9.6.2",
         "tsx": "^4.23.13",
         "typedoc-plugin-mdn-links": "^5.1.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.69.0",
         "webdriverio": "^9.31.7",
         "webpack": "^5.110.3",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -36,7 +36,7 @@
         "tsx": "^4.23.13",
         "tsx-dom": "^3.1.0",
         "typedoc": "^0.28.20",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
     },
     "sideEffects": false
 }

--- a/web/packages/core/src/internal/player/inner.tsx
+++ b/web/packages/core/src/internal/player/inner.tsx
@@ -57,19 +57,6 @@ declare global {
     interface AudioSession {
         type?: string;
     }
-    // See https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1615
-    type OrientationLockType =
-        | "any"
-        | "landscape"
-        | "landscape-primary"
-        | "landscape-secondary"
-        | "natural"
-        | "portrait"
-        | "portrait-primary"
-        | "portrait-secondary";
-    interface ScreenOrientation extends EventTarget {
-        lock(orientation: OrientationLockType): Promise<void>;
-    }
 }
 
 /**

--- a/web/packages/core/tools/tsconfig.json
+++ b/web/packages/core/tools/tsconfig.json
@@ -6,6 +6,7 @@
         "moduleResolution": "NodeNext",
         "target": "ES2021",
         "rootDir": ".",
+		"types": ["node"],
     },
     "include": ["."],
 }

--- a/web/packages/demo/package.json
+++ b/web/packages/demo/package.json
@@ -21,7 +21,7 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.7",
         "@vitejs/plugin-react": "^6.1.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^8.2.2"
     }
 }

--- a/web/packages/extension/jsconfig.json
+++ b/web/packages/extension/jsconfig.json
@@ -2,8 +2,8 @@
     "extends": "@tsconfig/strictest/tsconfig.json",
     "compilerOptions": {
         "lib": ["es2021"],
-        "module": "es2022",
-        "moduleResolution": "node",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
         "target": "es2021",
         "resolveJsonModule": true,
         "maxNodeModuleJsDepth": 0,

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -25,7 +25,7 @@
         "archiver": "^7.0.1",
         "json5": "^2.2.3",
         "ts-loader": "^9.6.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "webpack-cli": "^7.2.3",
         "axios": "^1.20.0",
         "form-data": "^4.0.6",

--- a/web/packages/extension/tsconfig.json
+++ b/web/packages/extension/tsconfig.json
@@ -1,10 +1,11 @@
 {
     "extends": "@tsconfig/strictest/tsconfig.json",
     "compilerOptions": {
-        "module": "es2020",
-        "moduleResolution": "node",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
         "target": "es2021",
         "rootDir": "src",
+		"types": ["chrome", "firefox-webext-browser"],
     },
     "include": ["src/**/*"],
     "references": [{ "path": "../core" }],

--- a/web/packages/selfhosted/tsconfig.json
+++ b/web/packages/selfhosted/tsconfig.json
@@ -2,8 +2,8 @@
     "extends": "@tsconfig/strictest/tsconfig.json",
     "compilerOptions": {
         "composite": true,
-        "module": "es2020",
-        "moduleResolution": "node",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
         "target": "es2021",
         "rootDir": ".",
         "outDir": "dist",

--- a/web/packages/selfhosted/wdio.conf.ts
+++ b/web/packages/selfhosted/wdio.conf.ts
@@ -1,5 +1,4 @@
 import type { Services } from "@wdio/types";
-import { BrowserStackCapabilities } from "@wdio/types/build/Capabilities";
 
 const capabilities: WebdriverIO.Capabilities[] = [];
 const services: Services.ServiceEntry[] = [];
@@ -70,14 +69,14 @@ if (browserstack) {
     const buildIdentifier =
         process.env["BROWSERSTACK_BUILD_ID"] || crypto.randomUUID();
     const buildName = process.env["BROWSERSTACK_BUILD_NAME"] || buildIdentifier;
-    const bsOptions: BrowserStackCapabilities = {
+    const bsOptions = {
         buildName,
         buildIdentifier,
         projectName: "Ruffle Selfhosted",
         networkLogs: true,
         consoleLogs: "info",
         idleTimeout: 300, // Max time the browser's main thread can be blocked
-    };
+    } as const;
     services.push([
         "browserstack",
         {


### PR DESCRIPTION
## Description

Bumps [typescript](https://github.com/microsoft/TypeScript) from 5.9.3 to 6.0.3.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/microsoft/TypeScript/releases">typescript's releases</a>.</em></p>
<blockquote>
<h2>TypeScript 6.0.3</h2>
<p>For release notes, check out the <a href="https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/">release announcement blog post</a>.</p>
<ul>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.0%22">fixed issues query for TypeScript 6.0.0 (Beta)</a>.</li>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.1%22">fixed issues query for TypeScript 6.0.1 (RC)</a>.</li>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.2%22">fixed issues query for TypeScript 6.0.2 (Stable)</a>.</li>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.3%22">fixed issues query for TypeScript 6.0.3 (Stable)</a>.</li>
</ul>
<p>Downloads are available on:</p>
<ul>
<li><a href="https://www.npmjs.com/package/typescript">npm</a></li>
</ul>
<h2>TypeScript 6.0</h2>
<p>For release notes, check out the <a href="https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/">release announcement blog post</a>.</p>
<ul>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.0%22">fixed issues query for TypeScript 6.0.0 (Beta)</a>.</li>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.1%22">fixed issues query for TypeScript 6.0.1 (RC)</a>.</li>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.2%22">fixed issues query for TypeScript 6.0.2 (Stable)</a>.</li>
</ul>
<p>Downloads are available on:</p>
<ul>
<li><a href="https://www.npmjs.com/package/typescript">npm</a></li>
</ul>
<h2>TypeScript 6.0.1 RC</h2>
<p>For release notes, check out the <a href="https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-rc/">release announcement blog post</a>.</p>
<ul>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.0%22">fixed issues query for TypeScript 6.0.0 (Beta)</a>.</li>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.1%22">fixed issues query for TypeScript 6.0.1 (RC)</a>.</li>
</ul>
<p>Downloads are available on:</p>
<ul>
<li><a href="https://www.npmjs.com/package/typescript">npm</a></li>
</ul>
<h2>TypeScript 6.0 Beta</h2>
<p>For release notes, check out the <a href="https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-beta/">release announcement</a>.</p>
<ul>
<li><a href="https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&amp;q=milestone%3A%22TypeScript+6.0.0%22+is%3Aclosed+">fixed issues query for Typescript 6.0.0 (Beta)</a>.</li>
</ul>
<p>Downloads are available on:</p>
<ul>
<li><a href="https://www.npmjs.com/package/typescript">npm</a></li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>Viewable in <a href="https://github.com/microsoft/TypeScript/compare/v5.9.3...v6.0.3">compare view</a></li>
</ul>
</details>

## Testing

- `npm install`
- `npm run build:dual-wasm-repro`
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run wdio --workspaces --if-present -- --headless --parallel --edge --firefox --chrome`

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [ ] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [x] An LLM was involved in the authoring of this code.
