### PR TITLE
build: Remove direct tsx dependency and use direct node compilation

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -40,7 +40,6 @@
                 "stylelint-prettier": "^5.0.3",
                 "terser-webpack-plugin": "^5.6.1",
                 "ts-loader": "^9.6.2",
-                "tsx": "^4.23.13",
                 "typedoc-plugin-mdn-links": "^5.1.1",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.69.0",
@@ -17509,7 +17508,6 @@
                 "postcss": "^8.5.28",
                 "postcss-nesting": "^14.0.1",
                 "replace-in-file": "^9.0.0",
-                "tsx": "^4.23.13",
                 "tsx-dom": "^3.1.0",
                 "typedoc": "^0.28.20",
                 "typescript": "^5.9.3"
@@ -17582,7 +17580,6 @@
                 "json5": "^2.2.3",
                 "jsonwebtoken": "^9.0.3",
                 "ts-loader": "^9.6.2",
-                "tsx": "^4.23.13",
                 "typescript": "^5.9.3",
                 "webpack-cli": "^7.2.3"
             }

--- a/web/package.json
+++ b/web/package.json
@@ -40,7 +40,6 @@
         "stylelint-prettier": "^5.0.3",
         "terser-webpack-plugin": "^5.6.1",
         "ts-loader": "^9.6.2",
-        "tsx": "^4.23.13",
         "typedoc-plugin-mdn-links": "^5.1.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.69.0",
@@ -61,6 +60,6 @@
         "docs": "npm run docs --workspaces --if-present",
         "lint": "npm run checkTypes --workspaces --if-present && eslint . && stylelint **.css",
         "format": "eslint . --fix && stylelint --fix **.css",
-        "version-seal": "cross-env ENABLE_VERSION_SEAL=true tsx packages/core/tools/set_version.ts"
+        "version-seal": "cross-env ENABLE_VERSION_SEAL=true node packages/core/tools/set_version.ts"
     }
 }

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -11,7 +11,7 @@
         "dist/"
     ],
     "scripts": {
-        "prebuild": "tsx tools/build_wasm.ts",
+        "prebuild": "node tools/build_wasm.ts",
         "build": "tsc --build --force",
         "postbuild": "node tools/set_version.ts && node tools/bundle_texts.ts && node tools/bundle_css.ts",
         "docs": "typedoc",
@@ -33,7 +33,6 @@
         "postcss": "^8.5.28",
         "postcss-nesting": "^14.0.1",
         "replace-in-file": "^9.0.0",
-        "tsx": "^4.23.13",
         "tsx-dom": "^3.1.0",
         "typedoc": "^0.28.20",
         "typescript": "^5.9.3"

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -7,9 +7,9 @@
     "type": "module",
     "scripts": {
         "build": "tsc -p jsconfig.json && npm run build:generic && npm run build:firefox",
-        "build:generic": "webpack --env generic && tsx tools/inject_plugin_polyfill.ts && tsx tools/zip.ts dist/ruffle_extension.zip",
-        "build:firefox": "webpack --env firefox && tsx tools/inject_plugin_polyfill.ts && tsx tools/zip.ts dist/firefox_unsigned.xpi && npm run sign-firefox",
-        "sign-firefox": "tsx tools/submit_xpi.ts dist/firefox_unsigned.xpi ../../../reproducible-source.zip",
+        "build:generic": "webpack --env generic && node tools/inject_plugin_polyfill.ts && node tools/zip.ts dist/ruffle_extension.zip",
+        "build:firefox": "webpack --env firefox && node tools/inject_plugin_polyfill.ts && node tools/zip.ts dist/firefox_unsigned.xpi && npm run sign-firefox",
+        "sign-firefox": "node tools/submit_xpi.ts dist/firefox_unsigned.xpi ../../../reproducible-source.zip",
         "checkTypes": "tsc --noemit && tsc --noemit -p tools"
     },
     "dependencies": {
@@ -29,7 +29,6 @@
         "webpack-cli": "^7.2.3",
         "axios": "^1.20.0",
         "form-data": "^4.0.6",
-        "jsonwebtoken": "^9.0.3",
-        "tsx": "^4.23.13"
+        "jsonwebtoken": "^9.0.3"
     }
 }


### PR DESCRIPTION
## Description

Direct node compilation is faster and is equivalent if using just erasable types: https://nodejs.org/learn/typescript/run-natively. `tsc` is still used for actual type checking

`tsx` is still a transitive dependency:
```
npm ls tsx
ruffle@0.6.0 .../web
├─┬ @wdio/cli@9.31.7
│ └── tsx@4.23.13
└─┬ ruffle-demo@0.6.0 -> ./packages/demo
  └─┬ vite@8.2.2
    └── tsx@4.23.13 deduped
```

## Testing

Build locally and/or check CI

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
