### PR TITLE
core: Group arguments for triggering a goto in a GotoInfo struct

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -8,7 +8,8 @@ use crate::avm1::{ArrayBuilder, Object, Value, fscommand, globals, scope};
 use crate::backend::navigator::{NavigationMethod, Request};
 use crate::context::UpdateContext;
 use crate::display_object::{
-    DisplayObject, DisplayObjectContainer, MovieClip, TDisplayObject, TDisplayObjectContainer,
+    DisplayObject, DisplayObjectContainer, GotoInfo, MovieClip, StopOrPlay, TDisplayObject,
+    TDisplayObjectContainer,
 };
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use crate::loader::MovieLoaderVMData;
@@ -1479,7 +1480,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         if let Some(clip) = self.target_clip() {
             if let Some(clip) = clip.as_movie_clip() {
                 // The frame on the stack is 0-based, not 1-based.
-                clip.goto_frame(self.context, action.frame + 1, true);
+                let goto_info = GotoInfo {
+                    frame: action.frame + 1,
+                    stop_or_play: StopOrPlay::Stop,
+                };
+
+                clip.goto_frame(self.context, goto_info);
             } else {
                 avm_error!(self, "GotoFrame failed: Target is not a MovieClip");
             }
@@ -1494,11 +1500,18 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // Param can either be a frame number or a frame label.
         if let Some(clip) = self.target_clip_or_root().as_movie_clip() {
             let frame = self.context.avm1.pop();
+
+            let stop_or_play = if action.set_playing {
+                StopOrPlay::Play
+            } else {
+                StopOrPlay::Stop
+            };
+
             let _ = globals::movie_clip::goto_frame(
                 clip,
                 self,
                 &[frame],
-                !action.set_playing,
+                stop_or_play,
                 action.scene_offset,
             );
         } else {
@@ -1512,7 +1525,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             if let Some(clip) = clip.as_movie_clip() {
                 let label = action.label.decode(self.encoding());
                 if let Some(frame) = clip.frame_label_to_number(&label, self.context) {
-                    clip.goto_frame(self.context, frame, true);
+                    let goto_info = GotoInfo {
+                        frame,
+                        stop_or_play: StopOrPlay::Stop,
+                    };
+
+                    clip.goto_frame(self.context, goto_info);
                 } else {
                     avm_warn!(self, "GoToLabel: Frame label '{:?}' not found", label);
                 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -9,7 +9,9 @@ use crate::avm1::property_decl::{DeclContext, PropertyOrder, StaticDeclarations,
 use crate::avm1::{self, ArrayBuilder, Object, Value};
 use crate::backend::navigator::NavigationMethod;
 use crate::context::UpdateContext;
-use crate::display_object::{Bitmap, BoundsMode, EditText, MovieClip, TInteractiveObject};
+use crate::display_object::{
+    Bitmap, BoundsMode, EditText, GotoInfo, MovieClip, StopOrPlay, TInteractiveObject,
+};
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::prelude::*;
 use crate::string::AvmString;
@@ -1097,7 +1099,7 @@ fn goto_and_play<'gc>(
     activation: &mut Activation<'_, 'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    goto_frame(movie_clip, activation, args, false, 0)
+    goto_frame(movie_clip, activation, args, StopOrPlay::Play, 0)
 }
 
 fn goto_and_stop<'gc>(
@@ -1105,14 +1107,14 @@ fn goto_and_stop<'gc>(
     activation: &mut Activation<'_, 'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    goto_frame(movie_clip, activation, args, true, 0)
+    goto_frame(movie_clip, activation, args, StopOrPlay::Stop, 0)
 }
 
 pub fn goto_frame<'gc>(
     movie_clip: MovieClip<'gc>,
     activation: &mut Activation<'_, 'gc>,
     args: &[Value<'gc>],
-    stop: bool,
+    stop_or_play: StopOrPlay,
     scene_offset: u16,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mut call_frame = None;
@@ -1153,7 +1155,12 @@ pub fn goto_frame<'gc>(
         let frame = frame.wrapping_add(i32::from(scene_offset));
         let frame = frame.saturating_add(1);
         if frame > 0 {
-            clip.goto_frame(activation.context, frame as u16, stop);
+            let goto_info = GotoInfo {
+                frame: frame as u16,
+                stop_or_play,
+            };
+
+            clip.goto_frame(activation.context, goto_info);
         }
     }
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -8,7 +8,7 @@ use crate::avm2::function::FunctionArgs;
 use crate::avm2::object::ArrayObject;
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
-use crate::display_object::{MovieClip, Scene};
+use crate::display_object::{GotoInfo, MovieClip, Scene, StopOrPlay};
 use crate::string::{AvmString, WString};
 
 /// Implements `addFrameScript`, an undocumented method of `MovieClip` used to
@@ -362,7 +362,7 @@ pub fn goto_and_play<'gc>(
         let frame_or_label = args.get_value(0);
         let scene = args.try_get_string(1);
 
-        goto_frame(activation, mc, frame_or_label, scene, false)?;
+        goto_frame(activation, mc, frame_or_label, scene, StopOrPlay::Play)?;
     }
 
     Ok(Value::Undefined)
@@ -383,7 +383,7 @@ pub fn goto_and_stop<'gc>(
         let frame_or_label = args.get_value(0);
         let scene = args.try_get_string(1);
 
-        goto_frame(activation, mc, frame_or_label, scene, true)?;
+        goto_frame(activation, mc, frame_or_label, scene, StopOrPlay::Stop)?;
     }
 
     Ok(Value::Undefined)
@@ -394,7 +394,7 @@ pub fn goto_frame<'gc>(
     mc: MovieClip<'gc>,
     frame_or_label: Value<'gc>,
     scene_str: Option<AvmString<'gc>>,
-    stop: bool,
+    stop_or_play: StopOrPlay,
 ) -> Result<(), Error<'gc>> {
     let scene = match scene_str {
         None => mc
@@ -451,7 +451,12 @@ pub fn goto_frame<'gc>(
         }
     };
 
-    mc.goto_frame(activation.context, frame.max(1) as u16, stop);
+    let goto_info = GotoInfo {
+        frame: frame.max(1) as u16,
+        stop_or_play,
+    };
+
+    mc.goto_frame(activation.context, goto_info);
 
     Ok(())
 }
@@ -546,7 +551,12 @@ pub fn prev_scene<'gc>(
             length: _,
         }) = mc.previous_scene()
     {
-        mc.goto_frame(activation.context, start, false);
+        let goto_info = GotoInfo {
+            frame: start,
+            stop_or_play: StopOrPlay::Play,
+        };
+
+        mc.goto_frame(activation.context, goto_info);
     }
 
     Ok(Value::Undefined)
@@ -569,7 +579,12 @@ pub fn next_scene<'gc>(
             length: _,
         }) = mc.next_scene()
     {
-        mc.goto_frame(activation.context, start, false);
+        let goto_info = GotoInfo {
+            frame: start,
+            stop_or_play: StopOrPlay::Play,
+        };
+
+        mc.goto_frame(activation.context, goto_info);
     }
 
     Ok(Value::Undefined)

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -15,9 +15,9 @@ use crate::debug_ui::handle::{
 };
 use crate::debug_ui::movie::open_movie_button;
 use crate::display_object::{
-    AutoSizeMode, Avm2Button, Bitmap, BoundsMode, ButtonState, DisplayObject, EditText,
-    InteractiveObject, LayoutDebugBoxesFlag, MovieClip, RenderMask, Stage, TDisplayObject,
-    TDisplayObjectContainer, TInteractiveObject,
+    AutoSizeMode, Avm2Button, Bitmap, BoundsMode, ButtonState, DisplayObject, EditText, GotoInfo,
+    InteractiveObject, LayoutDebugBoxesFlag, MovieClip, RenderMask, Stage, StopOrPlay,
+    TDisplayObject, TDisplayObjectContainer, TInteractiveObject,
 };
 use crate::focus_tracker::Highlight;
 use crate::font::{Font, FontDescriptor, FontLike};
@@ -1205,10 +1205,20 @@ impl DisplayObjectWindow {
                             if object.current_frame() != frame {
                                 ui.horizontal(|ui| {
                                     if ui.button("Stop").clicked() {
-                                        object.goto_frame(context, frame, true);
+                                        let goto_info = GotoInfo {
+                                            frame,
+                                            stop_or_play: StopOrPlay::Stop,
+                                        };
+
+                                        object.goto_frame(context, goto_info);
                                     }
                                     if ui.button("Play").clicked() {
-                                        object.goto_frame(context, frame, false);
+                                        let goto_info = GotoInfo {
+                                            frame,
+                                            stop_or_play: StopOrPlay::Play,
+                                        };
+
+                                        object.goto_frame(context, goto_info);
                                     }
                                 });
                             } else {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -59,7 +59,7 @@ pub use graphic::Graphic;
 pub use interactive::{Avm2MousePick, InteractiveObject, TInteractiveObject};
 pub use loader_display::LoaderDisplay;
 pub use morph_shape::MorphShape;
-pub use movie_clip::{MovieClip, MovieClipHandle, MovieClipWeak, Scene};
+pub use movie_clip::{GotoInfo, MovieClip, MovieClipHandle, MovieClipWeak, Scene, StopOrPlay};
 use ruffle_render::backend::{BitmapCacheEntry, RenderBackend};
 use ruffle_render::bitmap::{BitmapInfo, PixelSnapping};
 use ruffle_render::blend::ExtendedBlendMode;

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -842,7 +842,12 @@ impl<'gc> MovieClip<'gc> {
 
     pub fn next_frame(self, context: &mut UpdateContext<'gc>) {
         if self.current_frame() < self.header_frames() {
-            self.goto_frame(context, self.current_frame() + 1, true);
+            let goto_info = GotoInfo {
+                frame: self.current_frame() + 1,
+                stop_or_play: StopOrPlay::Stop,
+            };
+
+            self.goto_frame(context, goto_info);
         }
     }
 
@@ -852,7 +857,12 @@ impl<'gc> MovieClip<'gc> {
 
     pub fn prev_frame(self, context: &mut UpdateContext<'gc>) {
         if self.current_frame() > 1 {
-            self.goto_frame(context, self.current_frame() - 1, true);
+            let goto_info = GotoInfo {
+                frame: self.current_frame() - 1,
+                stop_or_play: StopOrPlay::Stop,
+            };
+
+            self.goto_frame(context, goto_info);
         }
     }
 
@@ -884,16 +894,15 @@ impl<'gc> MovieClip<'gc> {
     ///
     /// This is treated as an 'explicit' goto: frame scripts and other frame
     /// lifecycle events will be retriggered.
-    pub fn goto_frame(self, context: &mut UpdateContext<'gc>, frame: FrameNumber, stop: bool) {
+    pub fn goto_frame(self, context: &mut UpdateContext<'gc>, goto_info: GotoInfo) {
         // Stop first, in case we need to kill and restart the stream sound.
-        if stop {
-            self.stop(context);
-        } else {
-            self.play();
+        match goto_info.stop_or_play {
+            StopOrPlay::Stop => self.stop(context),
+            StopOrPlay::Play => self.play(),
         }
 
         // Clamp frame number in bounds.
-        let frame = frame.max(1);
+        let frame = goto_info.frame.max(1);
 
         // AVM2 does not allow a clip to goto while it is executing a frame script.
         // The goto is instead queued and run once the frame script is completed.
@@ -2920,7 +2929,12 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
             && let Some(frame_number) = self.frame_label_to_number(frame_name, context)
             && self.is_button_mode(context)
         {
-            self.goto_frame(context, frame_number, true);
+            let goto_info = GotoInfo {
+                frame: frame_number,
+                stop_or_play: StopOrPlay::Stop,
+            };
+
+            self.goto_frame(context, goto_info);
         }
 
         let mut handled = ClipEventResult::NotHandled;
@@ -4680,6 +4694,19 @@ impl Default for PreloadProgress {
             has_end_tag: Cell::new(false),
         }
     }
+}
+
+/// Information about a goto
+#[derive(Clone, Copy)]
+pub struct GotoInfo {
+    pub frame: FrameNumber,
+    pub stop_or_play: StopOrPlay,
+}
+
+#[derive(Clone, Copy)]
+pub enum StopOrPlay {
+    Stop,
+    Play,
 }
 
 /// Data shared between all instances of a movie clip.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -30,8 +30,8 @@ use crate::context_menu::{
 };
 use crate::display_object::Avm2MousePick;
 use crate::display_object::{
-    EditText, InteractiveObject, Stage, StageAlign, StageDisplayState, StageScaleMode,
-    TInteractiveObject, WindowMode,
+    EditText, GotoInfo, InteractiveObject, Stage, StageAlign, StageDisplayState, StageScaleMode,
+    StopOrPlay, TInteractiveObject, WindowMode,
 };
 use crate::events::GamepadButton;
 use crate::events::PlayerNotification;
@@ -889,7 +889,12 @@ impl Player {
             .root_clip()
             .and_then(|root| root.as_movie_clip())
         {
-            mc.goto_frame(context, 1, true)
+            let goto_info = GotoInfo {
+                frame: 1,
+                stop_or_play: StopOrPlay::Stop,
+            };
+
+            mc.goto_frame(context, goto_info);
         }
     }
     fn forward_root_movie(context: &mut UpdateContext<'_>) {


### PR DESCRIPTION
## Description

Place both the frame number and whether the goto should cause the MovieClip to stop or start playing in a struct `GotoInfo`, and add a new enum, StopOrPlay, to replace the confusing boolean "stop" values that were being passed around.

In a follow-up PR, I'll make `MovieClipData.queued_goto_frame` store a `GotoInfo` instead of just a `FrameNumber`. This will allow us to implement queued goto play/stop more cleanly.

No functional changes.

## Testing

No functional changes.

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have [made or updated tests](https://github.com/ruffle-rs/ruffle/blob/master/CONTRIBUTING.md#test-guidelines) where possible.
- [x] All of my commits are properly scoped, compile successfully, and pass all tests.
- [x] This PR does not make sense to split up into smaller PRs.
- [ ] An LLM was involved in the authoring of this code.
